### PR TITLE
Parse WebSocket connect protocols as array

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -8,8 +8,14 @@ parameters:
 
 jobs:
   - job: Desktop
+    displayName: Desktop
     variables:
       - template: ../variables/vs2019.yml
+
+      # Enable if any issues RNTesterIntegrationTests::* become unstable.
+      - name: Desktop.IntegrationTests.SkipRNTester
+        value: false
+
       #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
       - name: Desktop.IntegrationTests.Filter
@@ -19,6 +25,7 @@ jobs:
           (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
           (FullyQualifiedName!~WebSocketModule_)&
           (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
+
       #6799 -
       #       HostFunctionTest              - Crashes under JSI/V8
       #       HostObjectProtoTest           - Crashes under JSI/V8
@@ -28,7 +35,7 @@ jobs:
           (FullyQualifiedName!~HostFunctionTest)&
           (FullyQualifiedName!~HostObjectProtoTest)&
           (FullyQualifiedName!~PreparedJavaScriptSourceTest)
-    displayName: Desktop
+
     strategy:
       matrix:
         # Start Continuous only
@@ -118,12 +125,14 @@ jobs:
           targetType: filePath # filePath | inline
           filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tfs\Start-TestServers.ps1
           arguments: -SourcesDirectory $(Build.SourcesDirectory)\vnext -Preload -SleepSeconds 120
+        condition: and(succeeded(), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))
 
       - task: PowerShell@2
         displayName: Check the metro bundle server
         inputs:
           targetType: 'inline'
           script: Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true"
+        condition: and(succeeded(), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))
 
       - task: VSTest@2
         displayName: Run Desktop Integration Tests
@@ -140,7 +149,7 @@ jobs:
           vsTestVersion: latest
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
         # Suspected debug assert in TestRunner hanging tests randomly. Run only on Release for now.
-        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
+        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))
 
       - template: ../templates/stop-packagers.yml
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -155,7 +155,7 @@ jobs:
           vsTestVersion: latest
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
         # Suspected debug assert in TestRunner hanging tests randomly. Run only on Release for now.
-        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))
+        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
 
       - template: ../templates/stop-packagers.yml
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -19,18 +19,12 @@ jobs:
       #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
       - name: Desktop.IntegrationTests.Filter
-        $[ if ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true') ]:
         value: >
           (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
           (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
           (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
           (FullyQualifiedName!~WebSocketModule_)&
           (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
-        $[ if eq(variables['Desktop.IntegrationTests.SkipRNTester'], 'true') ]:
-          value: >
-            (FullyQualifiedName!~RNTesterIntegrationTests::)&
-            (FullyQualifiedName!~WebSocketModule_)&
-            (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
 
       #6799 -
       #       HostFunctionTest              - Crashes under JSI/V8
@@ -86,6 +80,12 @@ jobs:
       - checkout: self
         clean: false
         submodules: false
+
+      - powershell: |
+          $newValue = '(FullyQualifiedName!~RNTesterIntegrationTests::)&' + $(Desktop.IntegrationTests.Filter)
+          Write-Host "##vso[task.setvariable variable=Desktop.IntegrationTests.Filter]$newValue"
+        displayName: Update Desktop.IntegrationTests.Filter
+        condition: and(succeeded(), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))
 
       - template: ../templates/build-rnw.yml
         parameters:

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -19,12 +19,18 @@ jobs:
       #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
       - name: Desktop.IntegrationTests.Filter
+        $[ if ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true') ]:
         value: >
           (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
           (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
           (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
           (FullyQualifiedName!~WebSocketModule_)&
           (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
+        $[ if eq(variables['Desktop.IntegrationTests.SkipRNTester'], 'true') ]:
+          value: >
+            (FullyQualifiedName!~RNTesterIntegrationTests::)&
+            (FullyQualifiedName!~WebSocketModule_)&
+            (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
 
       #6799 -
       #       HostFunctionTest              - Crashes under JSI/V8

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -82,7 +82,7 @@ jobs:
         submodules: false
 
       - powershell: |
-          $newValue = '(FullyQualifiedName!~RNTesterIntegrationTests::)&' + $(Desktop.IntegrationTests.Filter)
+          $newValue = '(FullyQualifiedName!~RNTesterIntegrationTests::)&' + "$(Desktop.IntegrationTests.Filter)"
           Write-Host "##vso[task.setvariable variable=Desktop.IntegrationTests.Filter]$newValue"
         displayName: Update Desktop.IntegrationTests.Filter
         condition: and(succeeded(), ne(variables['Desktop.IntegrationTests.SkipRNTester'], 'true'))

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -12,7 +12,6 @@ jobs:
       - template: ../variables/vs2019.yml
       #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
-      # windesktop is no longer bundling - Disable RNTesterIntegrationTests until fixed.
       - name: Desktop.IntegrationTests.Filter
         value: >
           (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -15,7 +15,9 @@ jobs:
       # windesktop is no longer bundling - Disable RNTesterIntegrationTests until fixed.
       - name: Desktop.IntegrationTests.Filter
         value: >
-          (FullyQualifiedName!=RNTesterIntegrationTests::)&
+          (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
+          (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
+          (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
           (FullyQualifiedName!~WebSocketModule_)&
           (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
       #6799 -

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -12,16 +12,16 @@ jobs:
       - template: ../variables/vs2019.yml
       #5059 - Disable failing or intermittent tests (IntegrationTestHarness,AsyncStorage,WebSocket,Logging).
       #5265 - WebSocketModuleIntegrationTest::WebSocketModule_Ping fails for Release
+      # windesktop is no longer bundling - Disable RNTesterIntegrationTests until fixed.
       - name: Desktop.IntegrationTests.Filter
         value: >
-          (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
-          (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
-          (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
+          (FullyQualifiedName!=RNTesterIntegrationTests::)&
           (FullyQualifiedName!~WebSocketModule_)&
           (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
-      # HostFunctionTest              - Crashes under JSI/V8
-      # HostObjectProtoTest           - Crashes under JSI/V8
-      # PreparedJavaScriptSourceTest  - Asserts/Fails under JSI/ChakraCore
+      #6799 -
+      #       HostFunctionTest              - Crashes under JSI/V8
+      #       HostObjectProtoTest           - Crashes under JSI/V8
+      #       PreparedJavaScriptSourceTest  - Asserts/Fails under JSI/ChakraCore
       - name: Desktop.UnitTests.Filter
         value: >
           (FullyQualifiedName!~HostFunctionTest)&
@@ -117,14 +117,12 @@ jobs:
           targetType: filePath # filePath | inline
           filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tfs\Start-TestServers.ps1
           arguments: -SourcesDirectory $(Build.SourcesDirectory)\vnext -Preload -SleepSeconds 120
-        condition: false # windesktop is no longer bundling
 
       - task: PowerShell@2
         displayName: Check the metro bundle server
         inputs:
           targetType: 'inline'
           script: Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windesktop&dev=true"
-        condition: false # windesktop is no longer bundling
 
       - task: VSTest@2
         displayName: Run Desktop Integration Tests
@@ -140,9 +138,8 @@ jobs:
           collectDumpOn: onAbortOnly
           vsTestVersion: latest
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
-        condition: false # windesktop is no longer bundling
         # Suspected debug assert in TestRunner hanging tests randomly. Run only on Release for now.
-        # condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
+        condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))
 
       - template: ../templates/stop-packagers.yml
 

--- a/change/react-native-windows-3ea3aaf3-7dcc-4fe3-a0dd-4428730bb709.json
+++ b/change/react-native-windows-3ea3aaf3-7dcc-4fe3-a0dd-4428730bb709.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Treat WS protocols as scalar/array",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -46,7 +46,9 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
   vector<tuple<string, CxxModule::Provider, shared_ptr<MessageQueueThread>>> extraModules{
       std::make_tuple(
           "AsyncLocalStorage",
-          []() -> unique_ptr<CxxModule> { return /*CreateAsyncStorageModule(L"ReactNativeAsyncStorage")*/ nullptr; },
+          []() -> unique_ptr<CxxModule> {
+            return /*CreateAsyncStorageModule(L"ReactNativeAsyncStorage")*/ nullptr;
+          }, // #6882
           nativeQueue),
       std::make_tuple(
           "WebSocketModule",

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -46,7 +46,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
   vector<tuple<string, CxxModule::Provider, shared_ptr<MessageQueueThread>>> extraModules{
       std::make_tuple(
           "AsyncLocalStorage",
-          []() -> unique_ptr<CxxModule> { return /*CreateAsyncStorageModule(L"ReactNativeAsyncStorage")*/nullptr; },
+          []() -> unique_ptr<CxxModule> { return /*CreateAsyncStorageModule(L"ReactNativeAsyncStorage")*/ nullptr; },
           nativeQueue),
       std::make_tuple(
           "WebSocketModule",

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -46,7 +46,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
   vector<tuple<string, CxxModule::Provider, shared_ptr<MessageQueueThread>>> extraModules{
       std::make_tuple(
           "AsyncLocalStorage",
-          []() -> unique_ptr<CxxModule> { return CreateAsyncStorageModule(L"ReactNativeAsyncStorage"); },
+          []() -> unique_ptr<CxxModule> { return /*CreateAsyncStorageModule(L"ReactNativeAsyncStorage")*/nullptr; },
           nativeQueue),
       std::make_tuple(
           "WebSocketModule",

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -109,6 +109,10 @@ TEST_CLASS (RNTesterIntegrationTests) {
     TestComponent("TimersTest");
   }
 
+  // AsyncStorage seems broken in Windows Desktop
+  BEGIN_TEST_METHOD_ATTRIBUTE(AsyncStorage)
+  TEST_IGNORE()
+  END_TEST_METHOD_ATTRIBUTE()
   TEST_METHOD(AsyncStorage) {
     TestComponent("AsyncStorageTest");
   }

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -109,7 +109,7 @@ TEST_CLASS (RNTesterIntegrationTests) {
     TestComponent("TimersTest");
   }
 
-  // AsyncStorage seems broken in Windows Desktop
+  // #6882 - AsyncStorage seems broken in Windows Desktop
   BEGIN_TEST_METHOD_ATTRIBUTE(AsyncStorage)
   TEST_IGNORE()
   END_TEST_METHOD_ATTRIBUTE()

--- a/vnext/ReactWindows-Desktop.sln
+++ b/vnext/ReactWindows-Desktop.sln
@@ -119,12 +119,12 @@ Global
 		include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|ARM64 = Release|ARM64
+		Debug|ARM64 = Debug|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.ActiveCfg = Debug|ARM64

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -55,9 +55,9 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
         dynamic protocolsDynamic = jsArgAsDynamic(args, 1);
         if (!protocolsDynamic.empty())
         {
-          for (const auto& protocol : protocolsDynamic.items())
+          for (const auto& protocol : protocolsDynamic)
           {
-            protocols.push_back(protocol.first.getString());
+            protocols.push_back(protocol.getString());
           }
         }
 

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -73,9 +73,10 @@ auto resume_in_queue(const Mso::DispatchQueue &queue) noexcept {
 } // resume_in_queue
 
 string HResultToString(hresult_error const &e) {
-  std::stringstream hexCode;
-  hexCode << "[0x" << std::hex << e.code() << "] ";
-  return hexCode.str() + winrt::to_string(e.message());
+  std::stringstream stream;
+  stream << "[0x" << std::hex << e.code() << "] " << winrt::to_string(e.message());
+
+  return stream.str();
 }
 
 string HResultToString(hresult &&result) {

--- a/vnext/src/IntegrationTests/WebSocketBinaryTest.js
+++ b/vnext/src/IntegrationTests/WebSocketBinaryTest.js
@@ -61,6 +61,10 @@ class WebSocketBinaryTest extends React.Component<{...}, State> {
   };
 
   _connect = () => {
+    // Test protocols parsing. No further use.
+    const scalarProtocolSocket = new WebSocket(this.state.url, "p0");
+    const vectorialProtocolSocket = new WebSocket(this.state.url, ["p1", "p2"]);
+
     const socket = new WebSocket(this.state.url);
     socket.binaryType = 'arraybuffer';
     WS_EVENTS.forEach(ev => socket.addEventListener(ev, this._onSocketEvent));

--- a/vnext/src/IntegrationTests/WebSocketBinaryTest.js
+++ b/vnext/src/IntegrationTests/WebSocketBinaryTest.js
@@ -28,6 +28,10 @@ type State = {
   lastMessage: ?ArrayBuffer,
   testMessage: ArrayBuffer,
   testExpectedResponse: ArrayBuffer,
+
+  scalarProtocolSocket: ?WebSocket,
+  vectorialProtocolSocket: ?WebSocket,
+
   ...
 };
 
@@ -41,6 +45,9 @@ class WebSocketBinaryTest extends React.Component<{...}, State> {
     lastMessage: null,
     testMessage: new Uint8Array([1, 2, 3]).buffer,
     testExpectedResponse: new Uint8Array([4, 5, 6, 7]).buffer,
+
+    scalarProtocolSocket: null,
+    vectorialProtocolSocket: null,
   };
 
   _waitFor = (condition: any, timeout: any, callback: any) => {
@@ -62,8 +69,8 @@ class WebSocketBinaryTest extends React.Component<{...}, State> {
 
   _connect = () => {
     // Test protocols parsing. No further use.
-    const scalarProtocolSocket = new WebSocket(this.state.url, "p0");
-    const vectorialProtocolSocket = new WebSocket(this.state.url, ["p1", "p2"]);
+    const scalarProtocolSocket = new WebSocket(this.state.url, 'p0');
+    const vectorialProtocolSocket = new WebSocket(this.state.url, ['p1', 'p2']);
 
     const socket = new WebSocket(this.state.url);
     socket.binaryType = 'arraybuffer';
@@ -71,6 +78,9 @@ class WebSocketBinaryTest extends React.Component<{...}, State> {
     this.setState({
       socket,
       socketState: socket.readyState,
+
+      scalarProtocolSocket: scalarProtocolSocket,
+      vectorialProtocolSocket: vectorialProtocolSocket,
     });
   };
 
@@ -163,6 +173,24 @@ class WebSocketBinaryTest extends React.Component<{...}, State> {
   testDisconnect: () => void = () => {
     this._disconnect();
     this._waitFor(this._socketIsDisconnected, 5, disconnectSucceeded => {
+      // Check correct initialization and readyState (OPEN)
+      if (
+        this.state.scalarProtocolSocket === null ||
+        this.state.scalarProtocolSocket?.readyState !== 1
+      ) {
+        console.log('Failed to initialize scalarProtocolSocket');
+        TestModule.markTestPassed(false);
+        return;
+      }
+      if (
+        this.state.vectorialProtocolSocket === null ||
+        this.state.vectorialProtocolSocket?.readyState !== 1
+      ) {
+        console.log('Failed to initialize vectorialProtocolSocket');
+        TestModule.markTestPassed(false);
+        return;
+      }
+
       TestModule.markTestPassed(disconnectSucceeded);
     });
   };

--- a/vnext/src/Libraries/Utilities/HMRClient.windesktop.js
+++ b/vnext/src/Libraries/Utilities/HMRClient.windesktop.js
@@ -5,12 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
 'use strict';
 
+const invariant = require('invariant');
+const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const Platform = require('./Platform');
+const prettyFormat = require('pretty-format');
+
+import getDevServer from '../Core/Devtools/getDevServer';
+import NativeRedBox from '../NativeModules/specs/NativeRedBox';
+import * as LogBoxData from '../LogBox/Data/LogBoxData';
+import type {ExtendedError} from '../Core/Devtools/parseErrorStack';
 
 //TODO: Implement for Desktop integration tests.
 // [Windesktop
@@ -18,14 +26,6 @@ let DevSettings = null;
 if (Platform.OS !== 'windesktop') {
   DevSettings = require('./DevSettings');
 }
-// Windesktop]
-const invariant = require('invariant');
-const MetroHMRClient = require('metro/src/lib/bundle-modules/HMRClient');
-const prettyFormat = require('pretty-format');
-
-import NativeRedBox from '../NativeModules/specs/NativeRedBox';
-import * as LogBoxData from '../LogBox/Data/LogBoxData';
-import type {ExtendedError} from '../Core/Devtools/parseErrorStack';
 
 const pendingEntryPoints = [];
 let hmrClient = null;
@@ -166,19 +166,26 @@ const HMRClient: HMRClientNativeInterface = {
     const client = new MetroHMRClient(`ws://${wsHost}/hot`);
     hmrClient = client;
 
+    const {fullBundleUrl} = getDevServer();
     pendingEntryPoints.push(
-      `ws://${wsHost}/hot?bundleEntry=${bundleEntry}&platform=${platform}`,
+      // HMRServer understands regular bundle URLs, so prefer that in case
+      // there are any important URL parameters we can't reconstruct from
+      // `setup()`'s arguments.
+      fullBundleUrl ??
+        // The ws://.../hot?bundleEntry= format is an alternative to specifying
+        // a regular HTTP bundle URL.
+        `ws://${wsHost}/hot?bundleEntry=${bundleEntry}&platform=${platform}`,
     );
 
     client.on('connection-error', e => {
-      let error = `Cannot connect to the Metro server.
+      let error = `Cannot connect to Metro.
 
 Try the following to fix the issue:
-- Ensure that the Metro server is running and available on the same network`;
+- Ensure that Metro is running and available on the same network`;
 
       if (Platform.OS === 'ios') {
         error += `
-- Ensure that the Metro server URL is correctly set in AppDelegate`;
+- Ensure that the Metro URL is correctly set in AppDelegate`;
       } else {
         error += `
 - Ensure that your device/emulator is connected to your machine and has USB debugging enabled - run 'adb devices' to see a list of connected devices
@@ -221,12 +228,12 @@ Error: ${e.message}`;
       if (data.type === 'GraphNotFoundError') {
         client.close();
         setHMRUnavailableReason(
-          'The Metro server has restarted since the last edit. Reload to reconnect.',
+          'Metro has restarted since the last edit. Reload to reconnect.',
         );
       } else if (data.type === 'RevisionNotFoundError') {
         client.close();
         setHMRUnavailableReason(
-          'The Metro server and the client are out of sync. Reload to reconnect.',
+          'Metro and the client are out of sync. Reload to reconnect.',
         );
       } else {
         currentCompileErrorMessage = `${data.type} ${data.message}`;
@@ -238,7 +245,7 @@ Error: ${e.message}`;
 
     client.on('close', data => {
       LoadingView.hide();
-      setHMRUnavailableReason('Disconnected from the Metro server.');
+      setHMRUnavailableReason('Disconnected from Metro.');
     });
 
     if (isEnabled) {
@@ -270,7 +277,7 @@ function setHMRUnavailableReason(reason) {
 }
 
 function registerBundleEntryPoints(client) {
-  if (hmrUnavailableReason) {
+  if (hmrUnavailableReason != null) {
     DevSettings.reload('Bundle Splitting – Metro disconnected');
     return;
   }


### PR DESCRIPTION
See React Native's JavasCript WebSocket spec:
```
  constructor(
    url: string,
    protocols: ?string | ?Array<string>,
    options: ?{headers?: {origin?: string, ...}, ...},
  )
...
```

Current `WebSocketModule` implementation expects an object (similar to options), which will crash if a scalar or array of strings is passed.
This change:
- Fixes the `folly::dynamic` argument handling.
- Enhances existing JavaScript-driven validation to cover this use case (currently not part of CI).
- Re-enables Desktop integration tests for both native and JavaScript coverage (may scale down due to registered bundling issues).

Requesting backport down to `0.62` due to this being a crash-inducing bug.

## Pre-merge checklist
- [ ] Assess Desktop JavaScript tests (`RNTesterIntegrationTests`).
- [ ] Add validations for `options` parameter.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6866)