### PR TITLE
Fix ReactNotificationService for notifications between app and modules

### DIFF
--- a/change/react-native-windows-f75ccf0a-9fa8-45f5-b596-88461d774a72.json
+++ b/change/react-native-windows-f75ccf0a-9fa8-45f5-b596-88461d774a72.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactNotificationService for notifications between app and modules",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
@@ -24,6 +24,8 @@ struct ReactNotificationId : ReactPropertyName {
   }
 };
 
+struct ReactNotificationService;
+
 struct ReactNotificationSubscription {
   ReactNotificationSubscription(std::nullptr_t = nullptr) noexcept {}
 
@@ -45,6 +47,8 @@ struct ReactNotificationSubscription {
   ReactPropertyName NotificationName() const noexcept {
     return ReactPropertyName{m_handle ? m_handle.NotificationName() : nullptr};
   };
+
+  ReactNotificationService NotificationService() const noexcept;
 
   // True if the subscription is still active.
   // This property is checked before notification handler is invoked.
@@ -297,6 +301,10 @@ struct ReactNotificationService {
 
  private:
   IReactNotificationService m_handle;
+};
+
+inline ReactNotificationService ReactNotificationSubscription::NotificationService() const noexcept {
+  return ReactNotificationService{m_handle ? m_handle.NotificationService() : nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -145,11 +145,13 @@
     <None Include="ExecuteJsiTests.js" />
     <None Include="JsiTurboModuleTests.js" />
     <None Include="ReactNativeHostTests.js" />
+    <None Include="ReactNotificationServiceTests.js" />
     <None Include="TurboModuleTests.js" />
     <None Include="packages.config" />
     <JsBundleEntry Include="ExecuteJsiTests.js" />
     <JsBundleEntry Include="JsiTurboModuleTests.js" />
     <JsBundleEntry Include="ReactNativeHostTests.js" />
+    <JsBundleEntry Include="ReactNotificationServiceTests.js" />
     <JsBundleEntry Include="TurboModuleTests.js" />
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.js
@@ -1,0 +1,3 @@
+import { NativeModules } from 'react-native';
+
+NativeModules.NotificationTestModule.runTest();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
@@ -18,6 +18,10 @@ namespace ReactNativeIntegrationTests {
 using namespace winrt::Microsoft::ReactNative;
 
 struct TestEvent {
+  TestEvent() = default;
+  template <typename TName, typename TValue>
+  TestEvent(TName &&name, TValue &&value) : EventName(std::forward<TName>(name)), Value(std::forward<TValue>(value)) {}
+
   std::string EventName;
   JSValue Value;
 };
@@ -33,6 +37,12 @@ struct TestEventService {
   // different to the one that runs the ObserveEvents method.
   // We will have a deadlock if this expectation is not met.
   static void LogEvent(std::string_view eventName, JSValue &&value) noexcept;
+
+  // Logs new event for value types that need an explicit call to JSValue constructor.
+  template <typename TValue>
+  static void LogEvent(std::string_view eventName, TValue &&value) noexcept {
+    LogEvent(eventName, JSValue{std::forward<TValue>(value)});
+  }
 
   // Blocks current thread and observes all incoming events until we see them all.
   static void ObserveEvents(winrt::array_view<const TestEvent> expectedEvents) noexcept;

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
@@ -12,6 +12,16 @@ namespace winrt::Microsoft::ReactNative::implementation {
 //=============================================================================
 
 ReactNotificationSubscription::ReactNotificationSubscription(
+    IReactNotificationSubscription const &parentSubscription,
+    weak_ref<ReactNotificationService> &&notificationService,
+    IReactPropertyName const &notificationName,
+    IReactDispatcher const &dispatcher) noexcept
+    : m_parentSubscription{parentSubscription},
+      m_notificationService{std::move(notificationService)},
+      m_notificationName{notificationName},
+      m_dispatcher{dispatcher} {}
+
+ReactNotificationSubscription::ReactNotificationSubscription(
     weak_ref<ReactNotificationService> &&notificationService,
     IReactPropertyName const &notificationName,
     IReactDispatcher const &dispatcher,
@@ -25,12 +35,16 @@ ReactNotificationSubscription::~ReactNotificationSubscription() noexcept {
   Unsubscribe();
 }
 
-IReactDispatcher ReactNotificationSubscription::Dispatcher() const noexcept {
-  return m_dispatcher;
+IReactNotificationService ReactNotificationSubscription::NotificationService() const noexcept {
+  return m_notificationService.get().as<IReactNotificationService>();
 }
 
 IReactPropertyName ReactNotificationSubscription::NotificationName() const noexcept {
   return m_notificationName;
+}
+
+IReactDispatcher ReactNotificationSubscription::Dispatcher() const noexcept {
+  return m_dispatcher;
 }
 
 bool ReactNotificationSubscription::IsSubscribed() const noexcept {
@@ -38,6 +52,10 @@ bool ReactNotificationSubscription::IsSubscribed() const noexcept {
 }
 
 void ReactNotificationSubscription::Unsubscribe() noexcept {
+  if (m_parentSubscription) {
+    m_parentSubscription.Unsubscribe();
+  }
+
   if (m_isSubscribed.exchange(false)) {
     if (auto notificationService = m_notificationService.get()) {
       notificationService->Unsubscribe(*this);
@@ -48,6 +66,7 @@ void ReactNotificationSubscription::Unsubscribe() noexcept {
 void ReactNotificationSubscription::CallHandler(
     IInspectable const &sender,
     IReactNotificationArgs const &args) noexcept {
+  VerifyElseCrashSz(!m_parentSubscription, "CallHandler must not be called on the child subscription.");
   if (IsSubscribed()) {
     if (m_dispatcher) {
       m_dispatcher.Post([thisPtr = get_strong(), sender, args]() noexcept {
@@ -127,10 +146,16 @@ IReactNotificationSubscription ReactNotificationService::Subscribe(
     IReactPropertyName const &notificationName,
     IReactDispatcher const &dispatcher,
     ReactNotificationHandler const &handler) noexcept {
-  auto subscription = make<ReactNotificationSubscription>(get_weak(), notificationName, dispatcher, handler);
+  // Make sure that parent notification service also subscribes to this notification.
+  auto parentSubscription = m_parentNotificationService
+      ? m_parentNotificationService.Subscribe(notificationName, dispatcher, handler)
+      : IReactNotificationSubscription{nullptr};
+  auto subscription = parentSubscription
+      ? make<ReactNotificationSubscription>(parentSubscription, get_weak(), notificationName, dispatcher)
+      : make<ReactNotificationSubscription>(get_weak(), notificationName, dispatcher, handler);
   ModifySubscriptions(
       notificationName, [&subscription](std::vector<IReactNotificationSubscription> const &snapshot) noexcept {
-        std::vector<IReactNotificationSubscription> newSnapshot(snapshot);
+        auto newSnapshot = std::vector<IReactNotificationSubscription>(snapshot);
         newSnapshot.push_back(subscription);
         return newSnapshot;
       });
@@ -138,10 +163,11 @@ IReactNotificationSubscription ReactNotificationService::Subscribe(
 }
 
 void ReactNotificationService::Unsubscribe(IReactNotificationSubscription const &subscription) noexcept {
+  // The subscription will call the parent Unsubscribe on its own.
   ModifySubscriptions(
       subscription.NotificationName(),
       [&subscription](std::vector<IReactNotificationSubscription> const &snapshot) noexcept {
-        std::vector<IReactNotificationSubscription> newSnapshot(snapshot);
+        auto newSnapshot = std::vector<IReactNotificationSubscription>(snapshot);
         auto it = std::find(newSnapshot.begin(), newSnapshot.end(), subscription);
         if (it != newSnapshot.end()) {
           newSnapshot.erase(it);
@@ -151,7 +177,8 @@ void ReactNotificationService::Unsubscribe(IReactNotificationSubscription const 
 }
 
 void ReactNotificationService::UnsubscribeAll() noexcept {
-  std::map<IReactPropertyName, SubscriptionSnapshotPtr> subscriptions;
+  // The subscription will call the parent Unsubscribe on its own.
+  decltype(m_subscriptions) subscriptions;
   {
     std::scoped_lock lock{m_mutex};
     subscriptions = std::move(m_subscriptions);
@@ -169,27 +196,27 @@ void ReactNotificationService::SendNotification(
     IReactPropertyName const &notificationName,
     IInspectable const &sender,
     IInspectable const &data) noexcept {
-  SubscriptionSnapshotPtr currentSnapshotPtr;
-
-  {
-    std::scoped_lock lock{m_mutex};
-    auto it = m_subscriptions.find(notificationName);
-    if (it != m_subscriptions.end()) {
-      currentSnapshotPtr = it->second;
-    }
-  }
-
-  // Call notification handlers outside of lock.
-  if (currentSnapshotPtr) {
-    for (auto &subscription : *currentSnapshotPtr) {
-      auto args = make<ReactNotificationArgs>(subscription, data);
-      get_self<ReactNotificationSubscription>(subscription)->CallHandler(sender, args);
-    }
-  }
-
-  // Call parent notification service
   if (m_parentNotificationService) {
+    // Notification are always sent from the root notification service.
     m_parentNotificationService.SendNotification(notificationName, sender, data);
+  } else {
+    SubscriptionSnapshotPtr currentSnapshotPtr;
+
+    {
+      std::scoped_lock lock{m_mutex};
+      auto it = m_subscriptions.find(notificationName);
+      if (it != m_subscriptions.end()) {
+        currentSnapshotPtr = it->second;
+      }
+    }
+
+    // Call notification handlers outside of lock.
+    if (currentSnapshotPtr) {
+      for (auto &subscription : *currentSnapshotPtr) {
+        auto args = make<ReactNotificationArgs>(subscription, data);
+        get_self<ReactNotificationSubscription>(subscription)->CallHandler(sender, args);
+      }
+    }
   }
 }
 

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.h
@@ -7,9 +7,17 @@
 #include <object/objectRefCount.h>
 #include <winrt/Microsoft.ReactNative.h>
 #include <atomic>
-#include <map>
 #include <mutex>
+#include <unordered_map>
 #include <vector>
+
+namespace std {
+
+// Specialization to use IReactPropertyName in std::unordered_map.
+template <>
+struct hash<winrt::Microsoft::ReactNative::IReactPropertyName> : winrt::impl::hash_base {};
+
+} // namespace std
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -30,6 +38,15 @@ struct ReactNotificationArgs : implements<ReactNotificationArgs, IReactNotificat
   IInspectable m_data;
 };
 
+// The ReactNotificationService manages notification subscriptions and sending messages.
+// A notification service may have a parent notification service most for the automatic
+// unsubscription when the notification service is deleted.
+// All notifications are always sent from the root notification service that doe snot have parent service.
+//
+// The ReactNotificationService is optimized for sending notifications vs modifying the list of subscriptions.
+// It means that it is very cheap to send messages vs adding or removing subscriptions.
+// It is done through the use of subscription snapshots. The list of the subscriptions is always immutable.
+// When we add or remove subscription, we create a new list of subscriptions and then atomically replace the old one.
 struct ReactNotificationService : implements<ReactNotificationService, IReactNotificationService> {
   ReactNotificationService();
   explicit ReactNotificationService(IReactNotificationService const parentNotificationService) noexcept;
@@ -52,6 +69,7 @@ struct ReactNotificationService : implements<ReactNotificationService, IReactNot
  private:
   // We treat subscription snapshots as immutable data.
   using SubscriptionSnapshot = std::vector<IReactNotificationSubscription>;
+  // To provide correct lifetime management, the snapshot must be ref-counted.
   using SubscriptionSnapshotPtr = Mso::RefCountedPtr<SubscriptionSnapshot>;
 
   void ModifySubscriptions(
@@ -59,9 +77,9 @@ struct ReactNotificationService : implements<ReactNotificationService, IReactNot
       Mso::FunctorRef<SubscriptionSnapshot(SubscriptionSnapshot const &)> const &modifySnapshot);
 
  private:
+  const IReactNotificationService m_parentNotificationService;
   std::mutex m_mutex;
-  std::map<IReactPropertyName, SubscriptionSnapshotPtr> m_subscriptions;
-  IReactNotificationService m_parentNotificationService;
+  std::unordered_map<IReactPropertyName, SubscriptionSnapshotPtr> m_subscriptions;
 };
 
 struct ReactNotificationServiceHelper {
@@ -72,12 +90,18 @@ struct ReactNotificationServiceHelper {
 
 struct ReactNotificationSubscription : implements<ReactNotificationSubscription, IReactNotificationSubscription> {
   ReactNotificationSubscription(
+      IReactNotificationSubscription const &parentSubscription,
+      weak_ref<ReactNotificationService> &&notificationService,
+      IReactPropertyName const &notificationName,
+      IReactDispatcher const &dispatcher) noexcept;
+  ReactNotificationSubscription(
       weak_ref<ReactNotificationService> &&notificationService,
       IReactPropertyName const &notificationName,
       IReactDispatcher const &dispatcher,
       ReactNotificationHandler const &handler) noexcept;
   ~ReactNotificationSubscription() noexcept;
 
+  IReactNotificationService NotificationService() const noexcept;
   IReactPropertyName NotificationName() const noexcept;
   IReactDispatcher Dispatcher() const noexcept;
   bool IsSubscribed() const noexcept;
@@ -85,10 +109,11 @@ struct ReactNotificationSubscription : implements<ReactNotificationSubscription,
   void CallHandler(IInspectable const &sender, IReactNotificationArgs const &args) noexcept;
 
  private:
-  weak_ref<ReactNotificationService> m_notificationService;
-  IReactPropertyName m_notificationName;
-  IReactDispatcher m_dispatcher;
-  ReactNotificationHandler m_handler;
+  const IReactNotificationSubscription m_parentSubscription{nullptr};
+  const weak_ref<ReactNotificationService> m_notificationService;
+  const IReactPropertyName m_notificationName;
+  const IReactDispatcher m_dispatcher;
+  const ReactNotificationHandler m_handler;
   std::atomic_bool m_isSubscribed{true};
 };
 

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.idl
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.idl
@@ -8,12 +8,20 @@ import "IReactPropertyBag.idl";
 
 namespace Microsoft.ReactNative {
 
+  // Forward declaration
+  interface IReactNotificationService;
+
   [webhosthidden]
   DOC_STRING(
     "A subscription to a notification.\n"
     "The subscription is removed when this object is deleted or the @.Unsubscribe method is called.")
   interface IReactNotificationSubscription
   {
+    DOC_STRING(
+      "The notification service for the subscription.\n"
+      "It can be null if @.IsSubscribed is true and the service is already deleted.")
+    IReactNotificationService NotificationService { get; };
+
     DOC_STRING("Name of the notification.")
     IReactPropertyName NotificationName { get; };
 


### PR DESCRIPTION
This PR addressed the issue described in #6836 and #6840.

The `ReactNotificationService` is used to send notifications between native modules, and between native modules and the app.
To provide automatic unsubscription on instance unload for all subscriptions created in native modules, we have implemented parent-child relationship between the `ReactNotificationService` ("parent") created in `ReactNativeHost::InstanceSettings` and in the `ReactContext` ("child"). The issue was that while notifications from the "child" service is propagated to the "parent", there was no mechanism to propagate them from the "parent" to "children".

In this PR we fix the issue. While we keep the same parent-child relationship, we change the way the notifications are sent and how we subscribe to them:

- All notifications are sent from the "root" service - the topmost "parent" service. SendNotification
  method called on the "child" service just calls "parent" service's SendNotification method.
- Subscriptions are added to services on all levels: a subscription added to a "child" service is also
  added to the "parent" service.
- When "child" subscription is removed, it also removes the corresponding subscription in the
  "parent" service.

Other related changes in this PR:

- Implemented `NotificationBetweenAppAndModule` test to verify the new behavior.
- Added `IReactNotificationSubscription::NotificationService` as a convenience property to be used in the notification handler.
- Switched to use `std::unordered_map` from `std::map` to keep subscriptions. It should have a better perf.
- Added ways to use implicitly explicit `JSValue` constructors in `TestEventService` and `TestEvent` .




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6877)