### PR TITLE
Setup full env in publish

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -75,7 +75,6 @@ jobs:
 
       - template: ../templates/build-rnw.yml
         parameters:
-          yarnBuildCmd: build
           project: vnext/ReactWindows-Desktop.sln
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -67,7 +67,6 @@
 
                 - template: ../templates/build-rnw.yml
                   parameters:
-                    yarnBuildCmd: build
                     project: vnext/Microsoft.ReactNative.sln
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
@@ -121,8 +120,6 @@
                     arguments: -NoPrompt -Tags buildLab
                     
                 - template: ../templates/prepare-env.yml
-                  parameters:
-                    yarnBuildCmd: build
 
                 - task: NuGetCommand@2
                   displayName: NuGet restore

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -49,10 +49,7 @@ jobs:
 
       - template: templates/configure-git.yml
 
-      - template: templates/yarn-install.yml
-
-      - script: yarn build
-        displayName: yarn build
+      - template: templates/prepare-env.yml
 
       - script: |
           echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -12,7 +12,6 @@ parameters:
   buildPlatform: x64
   buildConfiguration: Debug
   msbuildArguments: ''
-  yarnBuildCmd: build
   multicoreBuild: false
 
   # Visual Studio Installer
@@ -30,7 +29,6 @@ steps:
       vsComponents: ${{ parameters.vsComponents }}
       listVsComponents: ${{ parameters.listVsComponents }}
       installVsComponents: ${{ parameters.installVsComponents }}
-      yarnBuildCmd: ${{ parameters.yarnBuildCmd }}
       debug: ${{ parameters.debug }}
 
   - task: NuGetCommand@2

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -1,7 +1,6 @@
 # Steps to checkout, install node_modules, yarn build, install SDK and install VS dependencies
 
 parameters:
-  yarnBuildCmd: build
   debug: false
 
   # Visual Studio Installer
@@ -47,9 +46,9 @@ steps:
   - template: yarn-install.yml
 
   - task: CmdLine@2
-    displayName: yarn ${{ parameters.yarnBuildCmd }}
+    displayName: yarn build
     inputs:
-      script: yarn ${{ parameters.yarnBuildCmd }}
+      script: yarn build
 
   - task: PowerShell@2
     displayName: List Visual Studio Components


### PR DESCRIPTION
`yarn install` now requires Python. Our publish only does partial environment setup compares to PR pipelines. Do the full setup to align them and prevent publish failures.

This adds about 30-45 seconds to publish time.

This change additionally removes the `yarnBuildCmd` parameter that was being used to differentiate between `build` and `buildci`, as `yarn buildci` no longer exists.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6878)