### PR TITLE
[missed commit] Python dependency in rnw-dependencies

### DIFF
--- a/change/react-native-windows-cb6bdb02-00b3-447c-9f28-0a37b02e9b70.json
+++ b/change/react-native-windows-cb6bdb02-00b3-447c-9f28-0a37b02e9b70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix missing commit from python dep",
+  "packageName": "react-native-windows",
+  "email": "asklar@winse.microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -204,8 +204,8 @@ $requirements = @(
         Name = 'Python';
         Tags = @('rnwDev');
         Valid = try {
-            return (choco list -l python3 | where-Object { $_ -like 'python3 *' }) -ne $null
-        } catch { return false; };
+            (choco list -l python3 | where-Object { $_ -like 'python3 *' }) -ne $null
+        } catch { $false; };
         Install = { choco install -y python3 };
     },
     @{


### PR DESCRIPTION
Looks like I had forgotten to push this commit when fixing the python dep.

Fixes #6876 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6893)