### PR TITLE
Install .net core 3.1

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -113,12 +113,6 @@
                   submodules: false
 
                 - task: PowerShell@2
-                  displayName: Display env
-                  inputs:
-                    targetType: "inline"
-                    script:  gci env:* | sort-object name
-
-                - task: PowerShell@2
                   displayName: "Check if this environment meets the development dependencies"
                   inputs:
                     targetType: filePath

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -113,6 +113,12 @@
                   submodules: false
 
                 - task: PowerShell@2
+                  displayName: Display env
+                  inputs:
+                    targetType: "inline"
+                    script:  gci env:* | sort-object name
+
+                - task: PowerShell@2
                   displayName: "Check if this environment meets the development dependencies"
                   inputs:
                     targetType: filePath

--- a/change/@rnw-scripts-create-github-releases-1c5f008e-3d42-4be3-add5-f455c3feea81.json
+++ b/change/@rnw-scripts-create-github-releases-1c5f008e-3d42-4be3-add5-f455c3feea81.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Use octokit instead of raw GitHub REST APIs",
-  "packageName": "@rnw-scripts/create-github-releases",
-  "email": "ngerlem@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-3ea3aaf3-7dcc-4fe3-a0dd-4428730bb709.json
+++ b/change/react-native-windows-3ea3aaf3-7dcc-4fe3-a0dd-4428730bb709.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Treat WS protocols as scalar/array",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-663c5c20-08c0-4b23-8377-318ae421cce4.json
+++ b/change/react-native-windows-663c5c20-08c0-4b23-8377-318ae421cce4.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Reduce number of windesktop forked files.",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-ad05eec2-7e56-4a04-a9e1-e9669b578b51.json
+++ b/change/react-native-windows-ad05eec2-7e56-4a04-a9e1-e9669b578b51.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add Python dependency to rnw-dependencies.ps1",
-  "packageName": "react-native-windows",
-  "email": "asklar@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-af8b02f2-8ac4-4496-9215-1af4253e4ed5.json
+++ b/change/react-native-windows-af8b02f2-8ac4-4496-9215-1af4253e4ed5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Install .net core 3.1 for CodeGen project",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-cb6bdb02-00b3-447c-9f28-0a37b02e9b70.json
+++ b/change/react-native-windows-cb6bdb02-00b3-447c-9f28-0a37b02e9b70.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix missing commit from python dep",
-  "packageName": "react-native-windows",
-  "email": "asklar@winse.microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-f75ccf0a-9fa8-45f5-b596-88461d774a72.json
+++ b/change/react-native-windows-f75ccf0a-9fa8-45f5-b596-88461d774a72.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fix ReactNotificationService for notifications between app and modules",
-  "packageName": "react-native-windows",
-  "email": "vmorozov@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/@react-native-windows/tester/CHANGELOG.json
+++ b/packages/@react-native-windows/tester/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@react-native-windows/tester",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "@react-native-windows/tester_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Bump react-native-windows to v0.0.0-canary.236",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "@react-native-windows/tester"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "@react-native-windows/tester_v0.0.1",
       "version": "0.0.1",

--- a/packages/@react-native-windows/tester/CHANGELOG.md
+++ b/packages/@react-native-windows/tester/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @react-native-windows/tester
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Bump react-native-windows to v0.0.0-canary.236 (asklar@winse.microsoft.com)
 
 ## 0.0.1
 

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "react-native": "0.0.0-6fd684150",
-    "react-native-windows": "^0.0.0-canary.235"
+    "react-native-windows": "^0.0.0-canary.236"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "0.1.6",
@@ -24,7 +24,7 @@
     "just-scripts": "^0.44.7",
     "react-native": "0.0.0-6fd684150",
     "react-native-platform-override": "^0.4.7",
-    "react-native-windows": "^0.0.0-canary.235",
+    "react-native-windows": "^0.0.0-canary.236",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/@rnw-scripts/create-github-releases/CHANGELOG.json
+++ b/packages/@rnw-scripts/create-github-releases/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@rnw-scripts/create-github-releases",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "@rnw-scripts/create-github-releases_v0.0.19",
+      "version": "0.0.19",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Use octokit instead of raw GitHub REST APIs",
+            "author": "ngerlem@microsoft.com",
+            "commit": "8979b4cb50c432a25b9bc5c741ce9601be369502",
+            "package": "@rnw-scripts/create-github-releases"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 13 Jan 2021 05:05:37 GMT",
       "tag": "@rnw-scripts/create-github-releases_v0.0.18",
       "version": "0.0.18",

--- a/packages/@rnw-scripts/create-github-releases/CHANGELOG.md
+++ b/packages/@rnw-scripts/create-github-releases/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @rnw-scripts/create-github-releases
 
-This log was last generated on Wed, 06 Jan 2021 05:06:51 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.19
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Patches
+
+- Use octokit instead of raw GitHub REST APIs (ngerlem@microsoft.com)
 
 ## 0.0.18
 

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rnw-scripts/create-github-releases",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",

--- a/packages/E2ETest/CHANGELOG.json
+++ b/packages/E2ETest/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "e2etest",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "e2etest_v0.0.54",
+      "version": "0.0.54",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Bump @react-native-windows/tester to v0.0.1",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "e2etest"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "e2etest_v0.0.54",
       "version": "0.0.54",

--- a/packages/E2ETest/CHANGELOG.md
+++ b/packages/E2ETest/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - e2etest
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.54
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Bump @react-native-windows/tester to v0.0.1 (asklar@winse.microsoft.com)
 
 ## 0.0.54
 

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -23,7 +23,7 @@
     "prompt-sync": "^4.2.0",
     "react": "17.0.1",
     "react-native": "0.0.0-6fd684150",
-    "react-native-windows": "0.0.0-canary.235"
+    "react-native-windows": "0.0.0-canary.236"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/IntegrationTest/CHANGELOG.json
+++ b/packages/IntegrationTest/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "integration-test",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "integration-test_v0.0.1",
+      "version": "0.0.1",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Bump react-native-windows to v0.0.0-canary.236",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "integration-test"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "integration-test_v0.0.1",
       "version": "0.0.1",

--- a/packages/IntegrationTest/CHANGELOG.md
+++ b/packages/IntegrationTest/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - integration-test
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.1
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Bump react-native-windows to v0.0.0-canary.236 (asklar@winse.microsoft.com)
 
 ## 0.0.1
 

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -13,7 +13,7 @@
     "chai": "^4.2.0",
     "react": "17.0.1",
     "react-native": "0.0.0-6fd684150",
-    "react-native-windows": "^0.0.0-canary.235"
+    "react-native-windows": "^0.0.0-canary.236"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/microsoft-reactnative-sampleapps/CHANGELOG.json
+++ b/packages/microsoft-reactnative-sampleapps/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "microsoft-reactnative-sampleapps",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "microsoft-reactnative-sampleapps_v0.0.54",
+      "version": "0.0.54",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Bump react-native-windows to v0.0.0-canary.236",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "microsoft-reactnative-sampleapps"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "microsoft-reactnative-sampleapps_v0.0.54",
       "version": "0.0.54",

--- a/packages/microsoft-reactnative-sampleapps/CHANGELOG.md
+++ b/packages/microsoft-reactnative-sampleapps/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - microsoft-reactnative-sampleapps
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.54
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Bump react-native-windows to v0.0.0-canary.236 (asklar@winse.microsoft.com)
 
 ## 0.0.54
 

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "17.0.1",
     "react-native": "0.0.0-6fd684150",
-    "react-native-windows": "0.0.0-canary.235"
+    "react-native-windows": "0.0.0-canary.236"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/playground/CHANGELOG.json
+++ b/packages/playground/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "playground",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "playground_v0.0.54",
+      "version": "0.0.54",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Bump @react-native-windows/tester to v0.0.1",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "playground"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "playground_v0.0.54",
       "version": "0.0.54",

--- a/packages/playground/CHANGELOG.md
+++ b/packages/playground/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - playground
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.54
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Bump @react-native-windows/tester to v0.0.1 (asklar@winse.microsoft.com)
 
 ## 0.0.54
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "@react-native-windows/tester": "0.0.1",
     "react": "17.0.1",
     "react-native": "0.0.0-6fd684150",
-    "react-native-windows": "0.0.0-canary.235"
+    "react-native-windows": "0.0.0-canary.236"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/vnext/CHANGELOG.json
+++ b/vnext/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "react-native-windows",
   "entries": [
     {
+      "date": "Sat, 16 Jan 2021 05:05:46 GMT",
+      "tag": "react-native-windows_v0.0.0-canary.236",
+      "version": "0.0.0-canary.236",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Fix missing commit from python dep",
+            "author": "asklar@winse.microsoft.com",
+            "commit": "e6de26b1e5ae2d74e55b38b0383e2e817b4bb150",
+            "package": "react-native-windows"
+          },
+          {
+            "comment": "Fix ReactNotificationService for notifications between app and modules",
+            "author": "vmorozov@microsoft.com",
+            "commit": "b703dd185c000fbc1a8957abdc4f3ba99db053ff",
+            "package": "react-native-windows"
+          },
+          {
+            "comment": "Treat WS protocols as scalar/array",
+            "author": "julio.rocha@microsoft.com",
+            "commit": "9d552eb866c88910ac2e629c2430ce00bd36970c",
+            "package": "react-native-windows"
+          },
+          {
+            "comment": "Reduce number of windesktop forked files.",
+            "author": "julio.rocha@microsoft.com",
+            "commit": "bbd1193b1a8ac51e84ce987dfb5671f91e6d0322",
+            "package": "react-native-windows"
+          },
+          {
+            "comment": "Add Python dependency to rnw-dependencies.ps1",
+            "author": "asklar@microsoft.com",
+            "commit": "7e64e480e2a589394bbdd50eae0801e9cc386d1a",
+            "package": "react-native-windows"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 15 Jan 2021 05:07:01 GMT",
       "tag": "react-native-windows_v0.0.0-canary.235",
       "version": "0.0.0-canary.235",

--- a/vnext/CHANGELOG.md
+++ b/vnext/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - react-native-windows
 
-This log was last generated on Fri, 15 Jan 2021 05:07:01 GMT and should not be manually modified.
+This log was last generated on Sat, 16 Jan 2021 05:05:46 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.0.0-canary.236
+
+Sat, 16 Jan 2021 05:05:46 GMT
+
+### Changes
+
+- Fix missing commit from python dep (asklar@winse.microsoft.com)
+- Fix ReactNotificationService for notifications between app and modules (vmorozov@microsoft.com)
+- Treat WS protocols as scalar/array (julio.rocha@microsoft.com)
+- Reduce number of windesktop forked files. (julio.rocha@microsoft.com)
+- Add Python dependency to rnw-dependencies.ps1 (asklar@microsoft.com)
 
 ## 0.0.0-canary.235
 

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -264,6 +264,17 @@ $requirements = @(
             & "${env:ProgramFiles}\Git\cmd\git.exe" clone https://github.com/microsoft/react-native-windows.git
         };
         Optional = $true
+    },
+    @{
+        Name = ".net core 3.1"
+        Tags = @('appDev');
+        Valid = try {
+            $x = dotnet --info | Where-Object { $_ -like  '*Microsoft.NETCore.App 3.1*'};
+            ($x -ne $null) -and ($x.Length -ge 1)
+        } catch { $false };
+        Install = {
+            & choco install -y dotnetcore-3.1-sdk
+        }
     }
 );
 

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -204,7 +204,8 @@ $requirements = @(
         Name = 'Python';
         Tags = @('rnwDev');
         Valid = try {
-            (choco list -l python3 | where-Object { $_ -like 'python3 *' }) -ne $null
+            # assume AzDO pipeline has Python installed
+            ($env:AGENT_ID -ne $null) -or ((choco list -l python3 | where-Object { $_ -like 'python3 *' }) -ne $null)
         } catch { $false; };
         Install = { choco install -y python3 };
     },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.0.0-canary.235",
+  "version": "0.0.0-canary.236",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The codegen project requires .net core 3.1 which was installed with VS when installing ".net desktop development", but 16.8 changes the default to .NET Core 5. 
Fixes #6511 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6894)