### PR TITLE
Add warning to release creation script when publishing multiple releases

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -72,7 +72,7 @@ jobs:
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
-      - script: npx --ignore-existing @rnw-scripts/create-github-releases --authToken $(githubAuthToken)
+      - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'master') }} )
 

--- a/change/@rnw-scripts-create-github-releases-db60a644-c294-4dc0-8fd6-58148494ab59.json
+++ b/change/@rnw-scripts-create-github-releases-db60a644-c294-4dc0-8fd6-58148494ab59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add warning to release creation script when publishing multiple releases",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -71,6 +71,7 @@ const argv = yargs
     yes: {
       alias: 'y',
       describe: 'Automatically confirm any warnings',
+      type: 'boolean',
       demandOption: false,
     },
   })


### PR DESCRIPTION
The release creation script works by finding locally published git tags (such as one just created by beachball) without an associated GitHub release, then creating a release if changelog information can be determined.

Creating release notes for all missing tags is useful as release notes will self-correct if a single job failed, and missing notes can be quickly fixed if issues arise. It also means a tag cannot opt-our of having release notes though.

Before automating release note creation, we removed many old tags that we didn't want to show up in the releases view. These are still present on many local machines though, and at one point were pushed back to the repository, seemingly erroneously.

GitHub's API will not check validity of tags, so it is possible to run the script locally and create many, many releases that don't point to anything, creating mass email spam for those subscribed to RNW notifications as well.

This change attempts to catch that case by requiring explicit acknowledgement before creating multiple relases outside of a CI scenario. This should make running the script locally less dangerous.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6895)