### PR TITLE
[0.64] Bump Beachball to 1.49.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "devDependencies": {
-    "beachball": "^1.32.0",
+    "beachball": "^1.49.0",
     "husky": "^4.2.5",
     "lage": "^0.24.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3787,10 +3787,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.32.0:
-  version "1.43.1"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.43.1.tgz#694e86cd0277aa1c7e4288a0f276c8b41d7f4d8b"
-  integrity sha512-TqC0fpHg2fnCMoz5W36cGo3ParO9hZaf2TNxclSe30Ztm4Hzkwc3SeEXe6UmHTXy3a6TL8hJdWp1sSa6FZHBUg==
+beachball@^1.49.0:
+  version "1.49.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.49.0.tgz#82095efb6900802fe3a7d06ea6c24de52bb882a2"
+  integrity sha512-eAqLYEEuHlKmguMo44VK4jcQxwDWU9+FSDWeyowSwdsfA5VKRBvNo4P5rqD7cdKMmWxEDk/5yeMQIciFbXa5Nw==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"
@@ -3804,7 +3804,8 @@ beachball@^1.32.0:
     semver "^6.1.1"
     toposort "^2.0.2"
     uuid "^8.3.1"
-    yargs-parser "^13.1.0"
+    workspace-tools "^0.10.2"
+    yargs-parser "^20.2.4"
 
 big-integer@^1.6.44, big-integer@^1.6.7:
   version "1.6.44"
@@ -12386,6 +12387,23 @@ workspace-tools@^0.10.0, workspace-tools@^0.10.1:
     multimatch "^4.0.0"
     read-yaml-file "^2.0.0"
 
+workspace-tools@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/workspace-tools/-/workspace-tools-0.10.2.tgz#e5d04c8aa67ed534c364a94baef3039367a2a8a8"
+  integrity sha512-g4WkDpGF1OunuiL/eQ93rOqKYI9l0SPrYEKV/58flToD5K1uBy4uCqM5wMUR+1WkOI7AzLoo6By+x/Qn3y9qrw==
+  dependencies:
+    "@pnpm/lockfile-file" "^3.0.7"
+    "@pnpm/logger" "^3.2.2"
+    "@yarnpkg/lockfile" "^1.1.0"
+    find-up "^4.1.0"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^9.0.0"
+    git-url-parse "^11.1.2"
+    globby "^11.0.0"
+    jju "^1.4.0"
+    multimatch "^4.0.0"
+    read-yaml-file "^2.0.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -12592,7 +12610,7 @@ yaml@^1.10.0, yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@^11.1.1, yargs-parser@^13.0.0, yargs-parser@^13.1.0, yargs-parser@^13.1.2, yargs-parser@^15.0.0, yargs-parser@^18.1.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3:
+yargs-parser@^11.1.1, yargs-parser@^13.0.0, yargs-parser@^13.1.2, yargs-parser@^15.0.0, yargs-parser@^18.1.1, yargs-parser@^18.1.2, yargs-parser@^18.1.3, yargs-parser@^20.2.4:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==


### PR DESCRIPTION
This version of Beachball will create chagelog entries for bumps of package dependencies. This is reflected for CLI updates as "Bump @react-native-windows/cli to foo" instead of omitting the cause of a change.

See https://github.com/microsoft/react-native-windows/issues/6523

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6896)