### PR TITLE
Enforce triage for changes going into 0.64-stable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
-# Global Catch-All
-* @microsoft/react-native-windows-write
-
-# API Review for DEF/IDL file changes
-/vnext/**/*.def @microsoft/react-native-windows-api-review @microsoft/react-native-windows-write
-/vnext/**/*.idl @microsoft/react-native-windows-api-review @microsoft/react-native-windows-write
+# Enforce changes going into a stable branch are triaged
+* @microsoft/react-native-windows-backport-triage


### PR DESCRIPTION
As we approach release, we're tightening the bar for changes to be merged into the 0.64-stable branch. Require that PRs merged into the branch are looked at by triage approvers.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6897)