### PR TITLE
Stand up Bot Coordinator Azure Function 

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -80,6 +80,42 @@ jobs:
 
       - template: templates/publish-version-vars.yml
 
+  - job: DeployBotCoordinator
+    displayName: Deploy Bot Coordinator Azure Function
+    condition: eq(variables['Build.SourceBranchName'], 'master')
+    dependsOn: RnwNpmPublish
+    pool:
+      vmImage: $(VmImage)
+    timeoutInMinutes: 30
+    steps:
+      - template: templates/prepare-env.yml
+
+      # Bump in case the bot coordinator is dependent on other monorepo packages that were just published
+      - script: npx --no-install beachball bump
+        diplayName: beachball bump
+
+      # Azure Functions expects a fully packagable folder with dependencies.
+      # Reinstall them without hoisting.
+      - powershell: |
+          Get-ChildItem "packages\@react-native-windows\bot-coordinator" 
+            | Where-Object{$_.Name -notin 'node_modules'} 
+            | Copy-Item -Destination $(Build.StagingDirectory)\bot-coordinator -Recurse
+          Copy-Item yarn.lock $(Build.StagingDirectory)\bot-coordinator
+        displayName: Organizing for unhoisted dependendencies
+
+      - template: templates/yarn-install
+        parameters:
+         workingDirectory: $(Build.StagingDirectory)\bot-coordinator
+         frozenLockfile: false
+         production: true # Avoid devDependencies
+
+      - task: AzureFunctionApp@1
+        inputs:
+          azureSubscription: cxe-rnw-azure
+          appType: functionApp
+          appName: rnw-bot-coordinator
+          package: $(Build.StagingDirectory)\bot-coordinator
+
   - job: RnwNativeBuildDesktop
     displayName: Build Desktop
     dependsOn: RnwNpmPublish

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -1,5 +1,21 @@
+parameters:
+- name: workingDirectory
+  type: string
+  default: .
+- name: production
+  type: boolean
+  default: false
+- name: frozenLockfile
+  type: boolean
+  default: true
+
+variables:
+  ${{ if eq(parameters.frozenLockfile, true) }}:
+    frozenLockfileArgs: --frozen-lockfile
+  ${{ if eq(parameters.frozenLockfile, false) }}:
+    frozenLockfileArgs: ''
 steps:
   - task: CmdLine@2
     displayName: midgard-yarn (faster yarn install)
     inputs:
-      script: npx midgard-yarn@1.23.14 --network-concurrency 40 --frozen-lockfile --cache-folder \.yarnCache
+      script: npx midgard-yarn@1.23.14 --cwd ${{ parameters.workingDirectory }} --production=${{ parameters.production }} $(frozenLockfileArgs) --network-concurrency 40 --cache-folder \.yarnCache

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -9,13 +9,13 @@ parameters:
   type: boolean
   default: true
 
-variables:
-  ${{ if eq(parameters.frozenLockfile, true) }}:
-    frozenLockfileArgs: --frozen-lockfile
-  ${{ if eq(parameters.frozenLockfile, false) }}:
-    frozenLockfileArgs: ''
 steps:
+  - script: |
+      echo ##vso[task.setvariable variable=FrozenLockfileArgs]--frozen-lockfile
+    displayName: Enable frozen-lockfile
+    condition: ${{ parameters.frozenLockfile }}
+
   - task: CmdLine@2
     displayName: midgard-yarn (faster yarn install)
     inputs:
-      script: npx midgard-yarn@1.23.14 --cwd ${{ parameters.workingDirectory }} --production=${{ parameters.production }} $(frozenLockfileArgs) --network-concurrency 40 --cache-folder \.yarnCache
+      script: npx midgard-yarn@1.23.14 --cwd ${{ parameters.workingDirectory }} --production=${{ parameters.production }} $(FrozenLockfileArgs) --network-concurrency 40 --cache-folder \.yarnCache

--- a/change/react-native-windows-08284e22-e5ed-45af-b5f5-056623065466.json
+++ b/change/react-native-windows-08284e22-e5ed-45af-b5f5-056623065466.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Stand up Bot Coordinator Azure Function",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/bot-coordinator/.eslintrc.js
+++ b/packages/@react-native-windows/bot-coordinator/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  extends: ['@rnw-scripts'],
+  parserOptions: {tsconfigRootDir : __dirname},
+};

--- a/packages/@react-native-windows/bot-coordinator/.funcignore
+++ b/packages/@react-native-windows/bot-coordinator/.funcignore
@@ -1,0 +1,7 @@
+*.js.map
+*.ts
+.git*
+.vscode
+local.settings.json
+test
+tsconfig.json

--- a/packages/@react-native-windows/bot-coordinator/.gitignore
+++ b/packages/@react-native-windows/bot-coordinator/.gitignore
@@ -1,0 +1,8 @@
+# JS Outputs
+lib-commonjs
+
+# Azure Functions artifacts
+bin
+obj
+appsettings.json
+local.settings.json

--- a/packages/@react-native-windows/bot-coordinator/.vscode/launch.json
+++ b/packages/@react-native-windows/bot-coordinator/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to Node Functions",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "preLaunchTask": "func: host start"
+    },
+    {
+      "name": "vscode-jest-tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "../../../node_modules/jest/bin/jest.js",
+        "--runInBand",
+        "--config",
+        "../../@rnw-scripts/jest-debug-config/jest.debug.config.js",
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229,
+    },
+  ]
+}

--- a/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/function.json
+++ b/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/function.json
@@ -1,0 +1,11 @@
+{
+  "bindings": [
+    {
+      "name": "heartbeet",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "0 0 * * * *"
+    }
+  ],
+  "scriptFile": "../lib-commonjs/HeartbeatFunction/index.js"
+}

--- a/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/index.ts
+++ b/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/index.ts
@@ -1,0 +1,5 @@
+import { Context } from "@azure/functions"
+
+export default async (context: Context) => {
+    context.log('Hello world');
+};

--- a/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/readme.md
+++ b/packages/@react-native-windows/bot-coordinator/HeartbeatFunction/readme.md
@@ -1,0 +1,22 @@
+# @react-native-windows/bot-coordinator
+
+TBD
+
+## Running locally
+1. Ensure Azure Functions Core Tools is installed (e.g. through `choco install azure-functions-core-tools-3`)
+1. Copy `local.settings.example.json` to `local.settings.json` and add secrets. This file is ignored by Git.
+1. Run `yarn start` in the package root
+
+Functions can be invoked with arbitrary inputs by sending a REST request to localhost. E.g.
+
+```
+POST http://localhost:7071/admin/functions/HeartbeatFunction
+Content-Type: application/json
+
+{
+    "input": null
+}
+```
+
+## Deployment
+The Azure functions application is deployed nightly along with other artifacts published by the repo.

--- a/packages/@react-native-windows/bot-coordinator/host.json
+++ b/packages/@react-native-windows/bot-coordinator/host.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[1.*, 2.0.0)"
+  }
+}

--- a/packages/@react-native-windows/bot-coordinator/jest.config.js
+++ b/packages/@react-native-windows/bot-coordinator/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@rnw-scripts/jest-unittest-config');

--- a/packages/@react-native-windows/bot-coordinator/just-task.js
+++ b/packages/@react-native-windows/bot-coordinator/just-task.js
@@ -1,0 +1,1 @@
+require('@rnw-scripts/just-task');

--- a/packages/@react-native-windows/bot-coordinator/local.settings.example.json
+++ b/packages/@react-native-windows/bot-coordinator/local.settings.example.json
@@ -1,0 +1,7 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "[Azure Storage Connection String here]",
+    "FUNCTIONS_WORKER_RUNTIME": "node"
+  }
+}

--- a/packages/@react-native-windows/bot-coordinator/package.json
+++ b/packages/@react-native-windows/bot-coordinator/package.json
@@ -16,9 +16,9 @@
   "dependencies": {},
   "devDependencies": {
     "@azure/functions": "^1.0.2-beta2",
-    "@rnw-scripts/jest-unittest-config": "1.1.1",
-    "@rnw-scripts/just-task": "1.0.6",
-    "@rnw-scripts/ts-config": "1.1.0",
+    "@rnw-scripts/jest-unittest-config": "0.1.1",
+    "@rnw-scripts/just-task": "0.0.6",
+    "@rnw-scripts/ts-config": "0.1.0",
     "babel-jest": "^26.3.0",
     "eslint": "7.12.0",
     "jest": "^26.5.2",

--- a/packages/@react-native-windows/bot-coordinator/package.json
+++ b/packages/@react-native-windows/bot-coordinator/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@react-native-windows/bot-coordinator",
+  "private": true,
+  "version": "1.0.0",
+  "license": "MIT",
+  "description": "Azure functions application for coordinating react-native-windows bots",
+  "scripts": {
+    "build": "just-scripts build",
+    "clean": "just-scripts clean",
+    "lint": "just-scripts lint",
+    "lint:fix": "just-scripts lint:fix",
+    "start": "func start --typescript",
+    "test": "just-scripts test",
+    "watch": "just-scripts watch"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@azure/functions": "^1.0.2-beta2",
+    "@rnw-scripts/jest-unittest-config": "1.1.1",
+    "@rnw-scripts/just-task": "1.0.6",
+    "@rnw-scripts/ts-config": "1.1.0",
+    "babel-jest": "^26.3.0",
+    "eslint": "7.12.0",
+    "jest": "^26.5.2",
+    "just-scripts": "^0.44.7",
+    "prettier": "1.19.1",
+    "typescript": "^3.8.3"
+  }
+}

--- a/packages/@react-native-windows/bot-coordinator/proxies.json
+++ b/packages/@react-native-windows/bot-coordinator/proxies.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "http://json.schemastore.org/proxies",
+  "proxies": {}
+}

--- a/packages/@react-native-windows/bot-coordinator/tsconfig.json
+++ b/packages/@react-native-windows/bot-coordinator/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rnw-scripts/ts-config",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "exclude": ["lib-commonjs", "node_modules"]
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -210,6 +210,12 @@ $requirements = @(
         Install = { choco install -y python3 };
     },
     @{
+        Name = 'Azure Functions Core Tools';
+        Tags = @('rnwDev');
+        Valid = try { (Get-Command func -ErrorAction Stop) -ne $null } catch { $false };
+        Install = { choco install -y azure-functions-core-tools-3 };
+    },
+    @{
         Name = 'WinAppDriver';
         Tags = @('rnwDev');
         Valid = (Test-Path "${env:ProgramFiles(x86)}\Windows Application Driver\WinAppDriver.exe");

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -214,6 +214,7 @@ $requirements = @(
         Tags = @('rnwDev');
         Valid = try { (Get-Command func -ErrorAction Stop) -ne $null } catch { $false };
         Install = { choco install -y azure-functions-core-tools-3 };
+        Optional = $true;
     },
     @{
         Name = 'WinAppDriver';

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,6 +80,11 @@
     "@opentelemetry/api" "^0.10.2"
     tslib "^2.0.0"
 
+"@azure/functions@^1.0.2-beta2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@azure/functions/-/functions-1.2.2.tgz#8fcb6aa3a879d3be0dc3d68919f969b054bbe3f3"
+  integrity sha512-p/dDHq1sG/iAib+eDY4NxskWHoHW1WFzD85s0SfWxc2wVjJbxB0xz/zBF4s7ymjVgTu+0ceipeBk+tmpnt98oA==
+
 "@azure/logger@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.0.0.tgz#48b371dfb34288c8797e5c104f6c4fb45bf1772c"


### PR DESCRIPTION
This change adds a new package for the bot coordinator, adapting a template function app to engineering systems in our repo. Right now it does very little, and it mostly just structure and deployment.

Deployment of the function app is tied to nightly publish, partially for ease of use, but also to ensure changes to monorepo packages are reflected. Azure credentials are tied as a service connection to Pipelines, only for explicitly authorized pipelines (i.e. publish).

Validated building/running the function app locally. Have tested bits of the deploy, but not everything end to end. That might need some iteration based on how Azure Pipelines likes it, but its job is independent of the rest of publish so it shouldn't degrade it (apart from potential YAML parse errors).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6900)