### PR TITLE
Try to fix bot deployment

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -104,11 +104,11 @@ jobs:
           Copy-Item yarn.lock $(Build.StagingDirectory)\bot-coordinator
 
           # devDependencies add bloat and might only exist in the monorepo
-          Get-Content ./packages/@react-native-windows/bot-coordinator/package.json |
+          Get-Content (Build.StagingDirectory)\bot-coordinator\package.json |
             ConvertFrom-Json |
             Select-Object -Property * -ExcludeProperty devDependencies |
             ConvertTo-Json |
-            Out-File test.json
+            Out-File (Build.StagingDirectory)\bot-coordinator\package.json
         displayName: Organizing for unhoisted dependencies
 
       - template: templates/yarn-install.yml

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -97,17 +97,24 @@ jobs:
       # Azure Functions expects a fully packagable folder with dependencies.
       # Reinstall them without hoisting.
       - powershell: |
-          Get-ChildItem "packages\@react-native-windows\bot-coordinator" 
-            | Where-Object{$_.Name -notin 'node_modules'} 
-            | Copy-Item -Destination $(Build.StagingDirectory)\bot-coordinator -Recurse
+          Get-ChildItem "packages\@react-native-windows\bot-coordinator" |
+            Where-Object{$_.Name -notin 'node_modules'} |
+            Copy-Item -Destination $(Build.StagingDirectory)\bot-coordinator -Recurse
+
           Copy-Item yarn.lock $(Build.StagingDirectory)\bot-coordinator
-        displayName: Organizing for unhoisted dependendencies
+
+          # devDependencies add bloat and might only exist in the monorepo
+          Get-Content ./packages/@react-native-windows/bot-coordinator/package.json |
+            ConvertFrom-Json |
+            Select-Object -Property * -ExcludeProperty devDependencies |
+            ConvertTo-Json |
+            Out-File test.json
+        displayName: Organizing for unhoisted dependencies
 
       - template: templates/yarn-install.yml
         parameters:
          workingDirectory: $(Build.StagingDirectory)\bot-coordinator
          frozenLockfile: false
-         production: true # Avoid devDependencies
 
       - task: AzureFunctionApp@1
         inputs:

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -2,20 +2,19 @@ parameters:
 - name: workingDirectory
   type: string
   default: .
-- name: production
-  type: boolean
-  default: false
 - name: frozenLockfile
   type: boolean
   default: true
+- name: extraArgs
+  type: string
+  default: --network-concurrency 40 --cache-folder \.yarnCache
 
 steps:
-  - script: |
-      echo ##vso[task.setvariable variable=FrozenLockfileArgs]--frozen-lockfile
-    displayName: Enable frozen-lockfile
-    condition: ${{ parameters.frozenLockfile }}
+  - ${{ if eq(parameters.frozenLockfile, true) }}:
+    - script: npx midgard-yarn@1.23.14 --frozen-lockfile --cwd ${{ parameters.workingDirectory }} ${{ parameters.extraArgs }}
+      displayName: midgard-yarn (faster yarn install)
 
-  - task: CmdLine@2
-    displayName: midgard-yarn (faster yarn install)
-    inputs:
-      script: npx midgard-yarn@1.23.14 --cwd ${{ parameters.workingDirectory }} --production=${{ parameters.production }} $(FrozenLockfileArgs) --network-concurrency 40 --cache-folder \.yarnCache
+  - ${{ if eq(parameters.frozenLockfile, false) }}:
+    - script: npx midgard-yarn@1.23.14 --cwd ${{ parameters.workingDirectory }} ${{ parameters.extraArgs }}
+      displayName: midgard-yarn (faster yarn install)
+

--- a/change/@react-native-windows-bot-coordinator-ae22026d-9e8f-47fd-8d12-2746c66d3a84.json
+++ b/change/@react-native-windows-bot-coordinator-ae22026d-9e8f-47fd-8d12-2746c66d3a84.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Publish bot coordinator package",
+  "packageName": "@react-native-windows/bot-coordinator",
+  "email": "nick@nickgerleman.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/bot-coordinator/package.json
+++ b/packages/@react-native-windows/bot-coordinator/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@react-native-windows/bot-coordinator",
-  "private": true,
-  "version": "1.0.0",
+  "version": "1.0.0-0",
   "license": "MIT",
   "description": "Azure functions application for coordinating react-native-windows bots",
   "scripts": {


### PR DESCRIPTION
Pipeline logic in bot deployment wasn't quite correct, which isn't super unexpected. This change fixes a couple of issues before trying to test deployement again.

1. Setting variables for the yarn install template only in the case of frozenLockfile: true, can create ordering issues
2. Powershell scripts with pipe characters on the wrong line

We also declare the bot coordinator as a public package so that beachball will warn if it depends on a private package (as those cannot work outside the monorepo).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6910)