### PR TITLE
Pull after Beachball publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -73,7 +73,7 @@ jobs:
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
       # Beachball reverts to local state after publish, but we want the updates it added
-      - script: git pull
+      - script: git pull origin/${{ variables['Build.SourceBranchName'] }}
         displayName: git pull
 
       - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -72,6 +72,10 @@ jobs:
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
+      # Beachball reverts to local state after publish, but we want the updates it added
+      - script: git pull
+        displayName: git pull
+
       - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'master') }} )

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -65,9 +65,6 @@ steps:
       npx --no-install beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
-  - script: git pull
-    displayName: git pull
-
   - template: set-version-vars.yml
 
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -65,6 +65,9 @@ steps:
       npx --no-install beachball publish --branch origin/$(System.PullRequest.TargetBranch) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
+  - script: git pull
+    displayName: git pull
+
   - template: set-version-vars.yml
 
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)


### PR DESCRIPTION
Fixes #6907
Fixes #6632

Beachball changed behavior of the publish command to keep git state the same as pre-publish. This was by-design, but breaks our scripts which assume we have new version numbers along with new changelog entries.

This change runs git pull after publish, which *should* preserve previous behavior.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6914)