### PR TITLE
Update "consume C# module" to support new .net native versions

### DIFF
--- a/change/react-native-windows-aa0093e6-70a0-4e91-a8dd-33a085d891c7.json
+++ b/change/react-native-windows-aa0093e6-70a0-4e91-a8dd-33a085d891c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add new .net native and UWP runtime versions",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/CppAppConsumeCSharpModule.props
+++ b/vnext/PropertySheets/CppAppConsumeCSharpModule.props
@@ -12,13 +12,22 @@
   <PropertyGroup Condition="'$(ConsumeCSharpModules)' == 'true'">
     <!-- Start Custom .NET Native properties -->
     <UseDotNetNativeToolchain Condition="'$(Configuration)'=='Release'">true</UseDotNetNativeToolchain>
+
+    <DotNetNativeVersion>DOTNET_NATIVE_VERSION_NOT_SET</DotNetNativeVersion>
     <DotNetNativeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.Native.Compiler\2.2.7-rel-27913-00\build\Microsoft.Net.Native.Compiler.props')">2.2.7-rel-27913-00</DotNetNativeVersion>
     <DotNetNativeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.Native.Compiler\2.2.8-rel-28605-00\build\Microsoft.Net.Native.Compiler.props')">2.2.8-rel-28605-00</DotNetNativeVersion>
+    <DotNetNativeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.Native.Compiler\2.2.9-rel-29512-01\build\Microsoft.Net.Native.Compiler.props')">2.2.9-rel-29512-01</DotNetNativeVersion>
+
+    <DotNetNativeRuntimeVersion>DOTNET_NATIVE_RUNTIME_VERSION_NOT_SET</DotNetNativeRuntimeVersion>
     <DotNetNativeRuntimeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary\2.2.7-rel-27913-00\build\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary.props')">2.2.7-rel-27913-00</DotNetNativeRuntimeVersion>
     <DotNetNativeRuntimeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary\2.2.7-rel-28605-00\build\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary.props')">2.2.7-rel-28605-00</DotNetNativeRuntimeVersion>
+    <DotNetNativeRuntimeVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary\2.2.8-rel-29512-01\build\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary.props')">2.2.8-rel-29512-01</DotNetNativeRuntimeVersion>
+    
     <!-- The name 'DotNetNativeVersion' is critical for restoring the right .NET framework libraries -->
+    <UWPCoreRuntimeSdkVersion>UWP_CORE_RUNTIME_SDK_VERSION_NOT_SET</UWPCoreRuntimeSdkVersion>
     <UWPCoreRuntimeSdkVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk\2.2.9\build\Microsoft.Net.UWPCoreRuntimeSdk.props')">2.2.9</UWPCoreRuntimeSdkVersion>
     <UWPCoreRuntimeSdkVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk\2.2.10\build\Microsoft.Net.UWPCoreRuntimeSdk.props')">2.2.10</UWPCoreRuntimeSdkVersion>
+    <UWPCoreRuntimeSdkVersion Condition="Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk\2.2.11\build\Microsoft.Net.UWPCoreRuntimeSdk.props')">2.2.11</UWPCoreRuntimeSdkVersion>
     <!-- End Custom .NET Native properties -->
   </PropertyGroup>
 


### PR DESCRIPTION
We'll want to make our logic more resilient to VS changes so we don't have to keep adding new versions but I want to unblock folks today, so pushing this fix out the door now and we can do the longer term thing separately :)

Fixes #6924 for the current version. Will file a new issue to track the longer term solution.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6925)