### PR TITLE
Add parameter to not deploy bots on dry runs

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -86,7 +86,7 @@ jobs:
 
   - job: DeployBotCoordinator
     displayName: Deploy Bot Coordinator Azure Function
-    condition: and(eq(variables['Build.SourceBranchName'], 'master'), not(parameters.skipBotDeployment))
+    condition: eq(variables['Build.SourceBranchName'], 'master')
     dependsOn: RnwNpmPublish
     pool:
       vmImage: $(VmImage)
@@ -113,12 +113,13 @@ jobs:
          frozenLockfile: false
          production: true # Avoid devDependencies
 
-      - task: AzureFunctionApp@1
-        inputs:
-          azureSubscription: cxe-rnw-azure
-          appType: functionApp
-          appName: rnw-bot-coordinator
-          package: $(Build.StagingDirectory)\bot-coordinator
+      - ${{ if not(parameters.skipBotDeployment) }}:
+        - task: AzureFunctionApp@1
+          inputs:
+            azureSubscription: cxe-rnw-azure
+            appType: functionApp
+            appName: rnw-bot-coordinator
+            package: $(Build.StagingDirectory)\bot-coordinator
 
   - job: RnwNativeBuildDesktop
     displayName: Build Desktop

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -9,6 +9,10 @@ parameters:
   displayName: Skip Git Push
   type: boolean
   default: false
+- name: skipBotDeployment
+  displayName: Skip Deploying Bots to Azure Functions
+  type: boolean
+  default: false
 
 variables:
   - template: variables/msbuild.yml
@@ -82,7 +86,7 @@ jobs:
 
   - job: DeployBotCoordinator
     displayName: Deploy Bot Coordinator Azure Function
-    condition: eq(variables['Build.SourceBranchName'], 'master')
+    condition: and(eq(variables['Build.SourceBranchName'], 'master'), not(parameters.skipBotDeployment))
     dependsOn: RnwNpmPublish
     pool:
       vmImage: $(VmImage)


### PR DESCRIPTION
Danny added parameters to avoid publishing NPM packages or pushing git commits. This adds a similar flag for skipping Azure Functions deployment.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6927)