### PR TITLE
[0.63] react-native-windows package should include jest preset/setup files

### DIFF
--- a/change/react-native-windows-2021-01-22-13-43-17-jest63.json
+++ b/change/react-native-windows-2021-01-22-13-43-17-jest63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Include jest config files in package",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-22T21:43:17.356Z"
+}

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -81,6 +81,7 @@
     "/Folly",
     "/generate.js",
     "/include",
+    "/jest",
     "/JSI",
     "/Libraries",
     "!/Libraries/**/*.windesktop.*",


### PR DESCRIPTION
These files make it much easier to setup jest tests running for react-native-windows.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6932)