### PR TITLE
[0.64] react-native-windows package should include jest preset/setup files

### DIFF
--- a/change/react-native-windows-2021-01-22-13-53-12-jest64.json
+++ b/change/react-native-windows-2021-01-22-13-53-12-jest64.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "react-native-windows package should include jest preset/setup files",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-01-22T21:53:12.930Z"
+}

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -93,6 +93,7 @@
     "/Folly",
     "/generate.js",
     "/include",
+    "/jest",
     "/JSI",
     "/Libraries",
     "!/Libraries/**/*.windesktop.*",


### PR DESCRIPTION
These files make it much easier to setup jest tests running for react-native-windows.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6934)