### PR TITLE
[0.64] Background/Foreground app state handlers should be registered from the xaml thread

### DIFF
--- a/change/react-native-windows-4227d9cf-19b4-4f5a-8170-0ea553f63dc9.json
+++ b/change/react-native-windows-4227d9cf-19b4-4f5a-8170-0ea553f63dc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Background/Foreground app state handlers should be registered from the xaml thread",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "AppStateModule.h"
+#include <Utils/Helpers.h>
 #include <XamlUtils.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include "Unicode.h"
@@ -13,26 +14,33 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
   m_context = reactContext;
   m_active = true;
 
-  if (auto currentApp = xaml::TryGetCurrentApplication()) {
-    m_enteredBackgroundRevoker = currentApp.EnteredBackground(
-        winrt::auto_revoke,
-        [weakThis = weak_from_this()](
-            winrt::IInspectable const & /*sender*/,
-            winrt::Windows::ApplicationModel::EnteredBackgroundEventArgs const & /*e*/) noexcept {
-          if (auto strongThis = weakThis.lock()) {
-            strongThis->SetActive(false);
-          }
-        });
+  // We need to register for notifications from the XAML thread.
+  if (auto dispatcher = reactContext.UIDispatcher()) {
+    dispatcher.Post([this]() {
+      if (auto currentApp = xaml::TryGetCurrentApplication()) {
+        m_enteredBackgroundRevoker = currentApp.EnteredBackground(
+            winrt::auto_revoke,
+            [weakThis = weak_from_this()](
+                winrt::IInspectable const & /*sender*/,
+                winrt::Windows::ApplicationModel::EnteredBackgroundEventArgs const & /*e*/) noexcept {
+              if (auto strongThis = weakThis.lock()) {
+                strongThis->SetActive(false);
+              }
+            });
 
-    m_leavingBackgroundRevoker = currentApp.LeavingBackground(
-        winrt::auto_revoke,
-        [weakThis = weak_from_this()](
-            winrt::IInspectable const & /*sender*/,
-            winrt::Windows::ApplicationModel::LeavingBackgroundEventArgs const & /*e*/) noexcept {
-          if (auto strongThis = weakThis.lock()) {
-            strongThis->SetActive(true);
-          }
-        });
+        m_leavingBackgroundRevoker = currentApp.LeavingBackground(
+            winrt::auto_revoke,
+            [weakThis = weak_from_this()](
+                winrt::IInspectable const & /*sender*/,
+                winrt::Windows::ApplicationModel::LeavingBackgroundEventArgs const & /*e*/) noexcept {
+              if (auto strongThis = weakThis.lock()) {
+                strongThis->SetActive(true);
+              }
+            });
+      } else {
+        assert(react::uwp::IsXamlIsland());
+      }
+    });
   }
 }
 
@@ -56,7 +64,7 @@ void AppState::RemoveListeners(double /*count*/) noexcept {
 
 void AppState::SetActive(bool active) noexcept {
   m_active = active;
-  AppStateDidChange({m_active ? "active" : "background"});
+  m_context.JSDispatcher().Post([this]() { AppStateDidChange({m_active ? "active" : "background"}); });
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -34,11 +34,11 @@ void DeviceInfoHolder::InitDeviceInfoHolder(
 
     auto const &displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 
-    if (xaml::Window::Current()) {
-      auto const &window = xaml::Window::Current().CoreWindow();
+    if (auto window = xaml::Window::Current()) {
+      auto const &coreWindow = window.CoreWindow();
 
       deviceInfoHolder->m_sizeChangedRevoker =
-          window.SizeChanged(winrt::auto_revoke, [weakHolder = std::weak_ptr(deviceInfoHolder)](auto &&, auto &&) {
+          coreWindow.SizeChanged(winrt::auto_revoke, [weakHolder = std::weak_ptr(deviceInfoHolder)](auto &&, auto &&) {
             if (auto strongHolder = weakHolder.lock()) {
               strongHolder->updateDeviceInfo();
             }


### PR DESCRIPTION
Fixes #6943 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6956)