### PR TITLE
Show TS Stack Traces on Uncaught CLI Exception

### DIFF
--- a/change/@rnw-scripts-create-github-releases-765556a8-2f59-4d64-a09b-5744c6a267a9.json
+++ b/change/@rnw-scripts-create-github-releases-765556a8-2f59-4d64-a09b-5744c6a267a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-format-files-35cf3696-d0d2-4f22-a102-fbbb1107be9d.json
+++ b/change/@rnw-scripts-format-files-35cf3696-d0d2-4f22-a102-fbbb1107be9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "@rnw-scripts/format-files",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-integrate-rn-2a4c8845-1d05-42e5-af93-04db70cb2fdf.json
+++ b/change/@rnw-scripts-integrate-rn-2a4c8845-1d05-42e5-af93-04db70cb2fdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-promote-release-bd579eb8-bef3-4ae6-b031-9a844133555a.json
+++ b/change/@rnw-scripts-promote-release-bd579eb8-bef3-4ae6-b031-9a844133555a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-take-screenshot-012d98b3-d17e-4ff0-a3ba-6ffe056580b1.json
+++ b/change/@rnw-scripts-take-screenshot-012d98b3-d17e-4ff0-a3ba-6ffe056580b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "@rnw-scripts/take-screenshot",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-66d1f409-77b7-4783-96b7-cd40cdbbef78.json
+++ b/change/react-native-platform-override-66d1f409-77b7-4783-96b7-cd40cdbbef78.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-38b27314-e544-4861-865c-1506fb830205.json
+++ b/change/react-native-windows-38b27314-e544-4861-865c-1506fb830205.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-codegen-cf62f93a-3a2f-428b-83b0-e4d6d5428752.json
+++ b/change/react-native-windows-codegen-cf62f93a-3a2f-428b-83b0-e4d6d5428752.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "react-native-windows-codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-214ab6e8-12d9-46b4-9bf0-9fc92f8851e0.json
+++ b/change/react-native-windows-init-214ab6e8-12d9-46b4-9bf0-9fc92f8851e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Show TS Stack Traces on Uncaught CLI Exception",
+  "packageName": "react-native-windows-init",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/bin.js
+++ b/packages/@rnw-scripts/create-github-releases/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/createGithubReleases');

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -20,6 +20,7 @@
     "lodash": "^4.17.15",
     "semver": "^7.3.2",
     "simple-git": "^1.131.0",
+    "source-map-support": "^0.5.19",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/packages/@rnw-scripts/format-files/bin.js
+++ b/packages/@rnw-scripts/format-files/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/formatFiles');

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "async": "^3.2.0",
-    "clang-format": "1.5.0"
+    "clang-format": "1.5.0",
+    "source-map-support": "^0.5.19"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.1.6",

--- a/packages/@rnw-scripts/integrate-rn/bin.js
+++ b/packages/@rnw-scripts/integrate-rn/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/integrateRN.js');

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -21,6 +21,7 @@
     "ora": "^3.4.0",
     "react-native-platform-override": "^1.4.7",
     "semver": "^7.3.2",
+    "source-map-support": "^0.5.19",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/packages/@rnw-scripts/promote-release/bin.js
+++ b/packages/@rnw-scripts/promote-release/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/promoteRelease');

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -17,6 +17,7 @@
     "@react-native-windows/package-utils": "^0.0.0-canary.12",
     "chalk": "^4.1.0",
     "simple-git": "^1.131.0",
+    "source-map-support": "^0.5.19",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/packages/@rnw-scripts/take-screenshot/bin.js
+++ b/packages/@rnw-scripts/take-screenshot/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/takeScreenshot');

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "screenshot-desktop": "^1.12.2",
+    "source-map-support": "^0.5.19",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/packages/react-native-platform-override/bin.js
+++ b/packages/react-native-platform-override/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/Cli');

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -35,6 +35,7 @@
     "ora": "^3.4.0",
     "semver": "^7.3.2",
     "simple-git": "^1.131.0",
+    "source-map-support": "^0.5.19",
     "upath": "^1.2.0",
     "yargs": "^15.4.1"
   },

--- a/packages/react-native-windows-codegen/bin.js
+++ b/packages/react-native-windows-codegen/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/Cli');

--- a/packages/react-native-windows-codegen/package.json
+++ b/packages/react-native-windows-codegen/package.json
@@ -22,6 +22,7 @@
     "globby": "^9.2.0",
     "mustache": "^4.0.1",
     "react-native-tscodegen": "0.66.1",
+    "source-map-support": "^0.5.19",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/packages/react-native-windows-init/bin.js
+++ b/packages/react-native-windows-init/bin.js
@@ -7,6 +7,5 @@
  * @format
  */
 
-// Yarn will fail to link workspace binaries if they haven't been built yet. Add
-// a simple JS file to forward to the CLI which is built after install.
+require('source-map-support').install();
 require('./lib-commonjs/Cli');

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -24,6 +24,7 @@
     "npm-registry": "^0.1.13",
     "prompts": "^2.3.0",
     "semver": "^7.3.2",
+    "source-map-support": "^0.5.19",
     "valid-url": "^1.0.9",
     "yargs": "^15.4.1"
   },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -48,6 +48,7 @@
     "react-refresh": "^0.4.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "^0.20.1",
+    "source-map-support": "^0.5.19",
     "stacktrace-parser": "^0.1.3",
     "use-subscription": "^1.0.0",
     "whatwg-fetch": "^3.0.0",

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -1,4 +1,6 @@
 // @ts-check
+require('source-map-support').install();
+
 const cli = require('@react-native-windows/cli');
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,7 +4774,7 @@ eslint-plugin-prettier@3.1.2:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@4.0.7, eslint-plugin-react-hooks@^4.0.4, eslint-plugin-react-hooks@^4.0.7:
+eslint-plugin-react-hooks@^4.0.4, eslint-plugin-react-hooks@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.7.tgz#19f9e3d07dd3a0fb9e6f0f07153707feedea8108"
   integrity sha512-5PuW2OMHQyMLr/+MqTluYN3/NeJJ1RuvmEp5TR9Xl2gXKxvcusUZuMz8XBUtbELNaiRYWs693LQs0cljKuuHRQ==
@@ -6181,6 +6181,11 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
 is-callable@^1.1.4, is-callable@^1.2.0, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -7220,7 +7225,26 @@ keyv@^4.0.0:
   dependencies:
     json-buffer "3.0.1"
 
-kind-of@6.0.3, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
+  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+
+kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -8227,7 +8251,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8242,10 +8266,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0, node-notifier@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.0.tgz#46c5bbecbb796d4a803f646cea5bc91403f2ff38"
-  integrity sha512-SkwNwGnMMlSPrcoeH4CSo9XyWe72acAHEJGDdPdB+CyBVHsIYaTQ4U/1wk3URsyzC75xZLg2vzU2YaALlqDF1Q==
+node-notifier@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
+  integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
   dependencies:
     growly "^1.3.0"
     is-wsl "^2.2.0"
@@ -9982,6 +10006,14 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-support@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
 source-map-support@^0.5.6, source-map-support@^0.5.9:
   version "0.5.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4774,7 +4774,7 @@ eslint-plugin-prettier@3.1.2:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.0.4, eslint-plugin-react-hooks@^4.0.7:
+eslint-plugin-react-hooks@4.0.7, eslint-plugin-react-hooks@^4.0.4, eslint-plugin-react-hooks@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.7.tgz#19f9e3d07dd3a0fb9e6f0f07153707feedea8108"
   integrity sha512-5PuW2OMHQyMLr/+MqTluYN3/NeJJ1RuvmEp5TR9Xl2gXKxvcusUZuMz8XBUtbELNaiRYWs693LQs0cljKuuHRQ==
@@ -6181,11 +6181,6 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-  integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-
 is-callable@^1.1.4, is-callable@^1.2.0, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
@@ -7225,26 +7220,7 @@ keyv@^4.0.0:
   dependencies:
     json-buffer "3.0.1"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@6.0.3, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -8251,7 +8227,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
-node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8266,10 +8242,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-8.0.1.tgz#f86e89bbc925f2b068784b31f382afdc6ca56be1"
-  integrity sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
+node-notifier@^8.0.0, node-notifier@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.0.tgz#46c5bbecbb796d4a803f646cea5bc91403f2ff38"
+  integrity sha512-SkwNwGnMMlSPrcoeH4CSo9XyWe72acAHEJGDdPdB+CyBVHsIYaTQ4U/1wk3URsyzC75xZLg2vzU2YaALlqDF1Q==
   dependencies:
     growly "^1.3.0"
     is-wsl "^2.2.0"


### PR DESCRIPTION
This change makes our bin stubs load `source-map-support` to show TypeScript stack traces on exception. It internally works by registering its own uncaught exception handler, and mutating the Error object. This is a small dependency, so we're able to use it in production as well as development.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6959)