### PR TITLE
Restore some SDL warnings (first pass)

### DIFF
--- a/change/react-native-windows-0553c349-bdaf-4bcc-ad68-074f1f4f5d7a.json
+++ b/change/react-native-windows-0553c349-bdaf-4bcc-ad68-074f1f4f5d7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove disabling 4018 4055 4146 4242",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -250,7 +250,7 @@
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)stubs;$(FollyDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>FOLLY_NO_CONFIG;NOMINMAX;_CRT_SECURE_NO_WARNINGS;WINAPI_PARTITION_APP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4018;4146;4244;4251;4267;4293;4305;4800;4804;4310;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4251;4267;4293;4305;4800;4804;4310;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -8,11 +8,8 @@
 #include "LinkingManagerModule.h"
 #include "Unicode.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <cxxreact/Instance.h>
 #include <cxxreact/JsArgumentHelpers.h>
-#pragma warning(pop)
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -13,10 +13,7 @@
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/Instance.h>
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <cxxreact/JsArgumentHelpers.h>
-#pragma warning(pop)
 
 #include <unknwnbase.h>
 

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -14,11 +14,8 @@
 #include "Unicode.h"
 #include "Utilities.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <cxxreact/Instance.h>
 #include <cxxreact/JsArgumentHelpers.h>
-#pragma warning(pop)
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactNativeHeaders.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactNativeHeaders.h
@@ -11,7 +11,6 @@
 
 #pragma warning(disable : 4995)
 #pragma warning(disable : 4068)
-#pragma warning(disable : 4146)
 #pragma warning(disable : 4100)
 #pragma warning(disable : 4324) // structure was padded due to alignment specifier
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactNativeHeaders.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactNativeHeaders.h
@@ -9,7 +9,6 @@
 
 #pragma warning(push)
 
-#pragma warning(disable : 4995)
 #pragma warning(disable : 4068)
 #pragma warning(disable : 4100)
 #pragma warning(disable : 4324) // structure was padded due to alignment specifier

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -11,10 +11,7 @@
 #include <folly/dynamic.h>
 #include <iomanip>
 
-#pragma warning(push)
-#pragma warning(disable : 4995)
 #include <locale>
-#pragma warning(pop)
 
 namespace winrt {
 using namespace Windows::Foundation;

--- a/vnext/Mso/comUtil/qiCastCore.h
+++ b/vnext/Mso/comUtil/qiCastCore.h
@@ -62,10 +62,6 @@ Mso::CntPtr<TTarget> qi_cast(const TSource *piSource, const IID &riid = __uuidof
   return qi_cast<TTarget, TSource *>(piSourceNonConst, riid);
 }
 
-#pragma warning(push)
-#pragma warning(disable : 4995) // VerifyElseCrashSz gives "warning C4995: 'IsDebuggerPresent': name was marked as
-                                // #pragma deprecated"
-
 /**
   qi_cast_or_crash<Type>(source, optional riid)
 
@@ -91,8 +87,6 @@ Mso::CntPtr<TTarget> qi_cast_or_crash(const TSource *piSource, const IID &riid =
   VerifyElseCrashSzTag(target, "Query interface failed.", 0x022054c4 /* tag_cifte */);
   return target;
 }
-
-#pragma warning(pop)
 
 /**
   simpleqi_cast<Type>(source, optional riid)

--- a/vnext/Mso/debugAssertApi/debugAssertApi.h
+++ b/vnext/Mso/debugAssertApi/debugAssertApi.h
@@ -72,8 +72,7 @@ Suppressed warnings in Assert macros:
   25064 - OACR function called twice in macro
 */
 #define AssertDetails_Statement_Begin \
-  __pragma(warning(push))             \
-      __pragma(warning(disable : 4127 4389 6239 25037 25038 25039 25041 25042 25064 25306)) do {
+  __pragma(warning(push)) __pragma(warning(disable : 4127 4389 6239 25037 25038 25039 25041 25042 25064 25306)) do {
 #define AssertDetails_Statement_End \
   }                                 \
   while (0)                         \

--- a/vnext/Mso/debugAssertApi/debugAssertApi.h
+++ b/vnext/Mso/debugAssertApi/debugAssertApi.h
@@ -61,7 +61,6 @@ if (FAssertDo(f)) { ... } // same as "if (f) { ... } else Assert(false);"
 /**
 Suppressed warnings in Assert macros:
   C4127 - if/while loop condition is a constant
-  C4018 - signed/unsigned compare was converted to unsigned/unsigned compare
   C4389 - operation involved signed/unsigned variables
    6239 - OACR left expression is always false
   25011 - OACR missing 'break' or '__fallthrough' statement
@@ -74,7 +73,7 @@ Suppressed warnings in Assert macros:
 */
 #define AssertDetails_Statement_Begin \
   __pragma(warning(push))             \
-      __pragma(warning(disable : 4127 4018 4389 6239 25037 25038 25039 25041 25042 25064 25306)) do {
+      __pragma(warning(disable : 4127 4389 6239 25037 25038 25039 25041 25042 25064 25306)) do {
 #define AssertDetails_Statement_End \
   }                                 \
   while (0)                         \

--- a/vnext/Mso/object/queryCast.h
+++ b/vnext/Mso/object/queryCast.h
@@ -41,8 +41,6 @@ Here we provide a number of helper templates to implement QueryCast for a type:
                                 // inaccessible or deleted
 #pragma warning(disable : 4626) // assignment operator could not be generated because a base class assignment operator
                                 // is inaccessible or deleted
-#pragma warning(disable : 4995) // 'IsDebuggerPresent': name was marked as #pragma deprecated. It is part of
-                                // VerifyElseCrash macro.
 
 namespace Mso {
 

--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -4,14 +4,13 @@
   <PropertyGroup>
     <!-- Office pre-disabled warnings -->
     <!--
-        C4146 - unary minus operator applied to unsigned type, result still unsigned
         C4201 - nonstandard extension used : nameless struct/union
         C4505 - 'function' : unreferenced local function has been removed
         C4456 - declaration of 'identifier' hides previous local declaration
         C4458 - declaration of 'identifier' hides class member
         C4702 - unreachable code
       -->
-    <OfficePreDisabledWarnings>4146;4201;4505;4456;4458;4702</OfficePreDisabledWarnings>
+    <OfficePreDisabledWarnings>4201;4505;4456;4458;4702</OfficePreDisabledWarnings>
     <!--
         The following list matches the list in ..\make.inc
           C4068 - unknown pragma

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -76,7 +76,7 @@
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32;_CRT_SECURE_NO_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;RN_EXPORT=;JSI_EXPORT=;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4715;4146;4251;4800;4804;4305;4722;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4715;4251;4800;4804;4305;4722;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PreprocessToFile>false</PreprocessToFile>
     </ClCompile>
     <Link>

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -22,7 +22,7 @@
 #include <winrt/Windows.Web.Http.h>
 
 #pragma warning(push)
-#pragma warning(disable : 4146 4244 4068 4251 4101 4267 4804 4309)
+#pragma warning(disable : 4244 4068 4251 4101 4267 4804 4309)
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/MessageQueueThread.h>
 #pragma warning(pop)

--- a/vnext/Shared/Executors/WebSocketJSExecutor.h
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.h
@@ -3,13 +3,10 @@
 
 #pragma once
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <DevServerHelper.h>
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/JSModulesUnbundle.h>
 #include <cxxreact/MessageQueueThread.h>
-#pragma warning(pop)
 
 #include <WebSocketJSExecutorFactory.h>
 

--- a/vnext/Shared/Modules/NetworkingModule.cpp
+++ b/vnext/Shared/Modules/NetworkingModule.cpp
@@ -15,11 +15,8 @@
 #include "Unicode.h"
 #include "Utilities.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <cxxreact/Instance.h>
 #include <cxxreact/JsArgumentHelpers.h>
-#pragma warning(pop)
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage

--- a/vnext/Shared/Modules/SourceCodeModule.h
+++ b/vnext/Shared/Modules/SourceCodeModule.h
@@ -3,10 +3,7 @@
 
 #pragma once
 
-#pragma warning(push)
-#pragma warning(disable : 4146)
 #include <cxxreact/CxxModule.h>
-#pragma warning(pop)
 
 #include <folly/dynamic.h>
 


### PR DESCRIPTION
Removes some "disable warnings" that are not needed. These warnings are required per SDL.
- C4018 - 'expression' : signed/unsigned mismatch
- C4146 - unary minus operator applied to unsigned type, result still unsigned
- C4995 - 'function': name was marked as #pragma deprecated

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6961)