### PR TITLE
Inspector (Hermes direct debugger) integration

### DIFF
--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -13,12 +13,16 @@
     <!-- This property sets the CscTask to print the full path of the csharp file on errors and warnings rather than just the filename. -->
     <GenerateFullPaths>true</GenerateFullPaths>
 
+    <!-- This property controls whether the React Native inspector (Hermes direct debugger) gets built  -->
+    <EnableHermesInspector>false</EnableHermesInspector>
+
     <!-- 
       SourceLink is disabled by default since customer projects are still building our projects and therefore we don't want to force customers to use this.
       The PR (windows-vs-pr.yml) and CI (publish.yml() turn it back on.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <FollyVersion>2020.10.05.00</FollyVersion>
+    <FollyVersion Condition="'$(EnableHermesInspector)' == 'true'">2020.01.13.00</FollyVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -67,6 +67,35 @@
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp" />
     <ClCompile Include="$(FollyDir)\folly\memory\detail\MallocImpl.cpp" />
   </ItemGroup>
+  <ItemGroup Condition="'$(EnableHermesInspector)' == 'true'">
+    <ClCompile Include="$(FollyDir)\folly\ExceptionWrapper.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(FollyDir)\folly\Executor.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\SharedMutex.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\concurrency/CacheLocality.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\detail/AsyncTrace.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="$(FollyDir)\folly\detail/Futex.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="$(FollyDir)\folly\detail/MemoryIdler.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\detail/StaticSingletonManager.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(FollyDir)\folly\detail/ThreadLocalDetail.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/detail/AtFork.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\detail\UniqueInstance.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="$(FollyDir)\folly\executors/ExecutorWithPriority.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\executors/InlineExecutor.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\executors/TimedDrivableExecutor.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="$(FollyDir)\folly\executors/QueuedImmediateExecutor.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/io/async/Request.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="$(FollyDir)\folly/memory/MallctlHelper.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/portability/SysMembarrier.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/synchronization/AsymmetricMemoryBarrier.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/synchronization/Hazptr.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/synchronization/ParkingLot.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/synchronization/WaitOptions.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/synchronization\SanitizeThread.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/lang/CString.cpp" />
+    <ClCompile Include="$(FollyDir)\folly/lang/SafeAssert.cpp" />
+    <ClCompile Include="posix_stubs.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)"/>
+    <ClCompile Include="windows_portability_tinyimp.cpp" DisableSpecificWarnings="4541;4459;%(DisableSpecificWarnings)" />
+  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\AtomicBitSet.h" />
     <ClInclude Include="$(FollyDir)\folly\AtomicHashArray-inl.h" />

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -28,6 +28,30 @@
     <Filter Include="Source Files\portability">
       <UniqueIdentifier>{9ad1fbe7-56fb-40d8-b0a2-ac0d6d0799e3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\synchronization">
+      <UniqueIdentifier>{4733e5f7-9adc-400b-818d-0a954bc323d5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\executors">
+      <UniqueIdentifier>{8dfbd8ba-04a2-4c1f-a1ce-c26b7b1433e7}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\concurrency">
+      <UniqueIdentifier>{ea59fc9b-7653-499c-95db-2d1e6c60d758}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\detail">
+      <UniqueIdentifier>{f169a8ed-4c45-43d5-a9f4-eefcaee3472c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\stubs">
+      <UniqueIdentifier>{6e96a796-0eb8-49f9-bdb7-6228fcb996ed}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\io">
+      <UniqueIdentifier>{5f0fc44f-3113-4c6f-8438-ab1392bc20ce}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\io\sync">
+      <UniqueIdentifier>{3fe83345-3e54-407a-bf64-c207f54fb54d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\memory">
+      <UniqueIdentifier>{e8896126-a833-4848-a3e1-8432015a4c95}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(FollyDir)\folly\lang\Assume.cpp">
@@ -71,6 +95,87 @@
     </ClCompile>
     <ClCompile Include="$(FollyDir)\folly\Unicode.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\ExceptionWrapper.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\Executor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/synchronization/AsymmetricMemoryBarrier.cpp">
+      <Filter>Source Files\synchronization</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\SharedMutex.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/synchronization/Hazptr.cpp">
+      <Filter>Source Files\synchronization</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/synchronization/ParkingLot.cpp">
+      <Filter>Source Files\synchronization</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/synchronization/WaitOptions.cpp">
+      <Filter>Source Files\synchronization</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/synchronization\SanitizeThread.cpp">
+      <Filter>Source Files\synchronization</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\executors/ExecutorWithPriority.cpp">
+      <Filter>Source Files\executors</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\executors/InlineExecutor.cpp">
+      <Filter>Source Files\executors</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\executors/QueuedImmediateExecutor.cpp">
+      <Filter>Source Files\executors</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\executors/TimedDrivableExecutor.cpp">
+      <Filter>Source Files\executors</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/lang/CString.cpp">
+      <Filter>Source Files\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/lang/SafeAssert.cpp">
+      <Filter>Source Files\lang</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\concurrency/CacheLocality.cpp">
+      <Filter>Source Files\concurrency</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail/AsyncTrace.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/detail/AtFork.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail/MemoryIdler.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail/Futex.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail/StaticSingletonManager.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail/ThreadLocalDetail.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="posix_stubs.cpp">
+      <Filter>Source Files\stubs</Filter>
+    </ClCompile>
+    <ClCompile Include="windows_portability_tinyimp.cpp">
+      <Filter>Source Files\stubs</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/portability/SysMembarrier.cpp">
+      <Filter>Source Files\portability</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/io/async/Request.cpp">
+      <Filter>Source Files\io\sync</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly\detail\UniqueInstance.cpp">
+      <Filter>Source Files\detail</Filter>
+    </ClCompile>
+    <ClCompile Include="$(FollyDir)\folly/memory/MallctlHelper.cpp">
+      <Filter>Source Files\memory</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Folly/posix_stubs.cpp
+++ b/vnext/Folly/posix_stubs.cpp
@@ -1,0 +1,24 @@
+#include <cstdlib>
+#include <sys/types.h>
+
+extern "C" {
+  int getrusage(int who, struct rusage *usage) {
+    std::abort();
+    return 0;
+  }
+
+  void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+    std::abort();
+    return nullptr;
+  }
+
+  int mlock(const void *addr, size_t len) {
+    std::abort();
+    return 0;
+  }
+
+  int mprotect(void *addr, size_t len, int prot) {
+    std::abort();
+    return 0;
+  }
+}

--- a/vnext/Folly/windows_portability_tinyimp.cpp
+++ b/vnext/Folly/windows_portability_tinyimp.cpp
@@ -1,0 +1,84 @@
+#include <folly/portability/PThread.h>
+
+#include <folly/portability/Sched.h>
+#include <folly/portability/Time.h>
+#include <folly/portability/Windows.h>
+
+namespace folly {
+namespace portability {
+namespace pthread {
+int pthread_key_create(pthread_key_t *key, void (*destructor)(void *)) {
+  DWORD newKey = FlsAlloc(nullptr);
+
+#pragma warning(push)
+#pragma warning(disable : 4312)
+  *key = reinterpret_cast<pthread_key_t>(newKey);
+#pragma warning(pop)
+
+  return 0;
+}
+
+int pthread_key_delete(pthread_key_t key) {
+#pragma warning(push)
+#pragma warning(disable : 4311)
+#pragma warning(disable : 4302)
+  DWORD index = reinterpret_cast<DWORD>(key);
+#pragma warning(pop)
+
+  FlsFree(index);
+  return 0;
+}
+
+void *pthread_getspecific(pthread_key_t key) {
+#pragma warning(push)
+#pragma warning(disable : 4311)
+#pragma warning(disable : 4302)
+  DWORD index = reinterpret_cast<DWORD>(key);
+#pragma warning(pop)
+
+  return FlsGetValue(index);
+}
+
+int pthread_setspecific(pthread_key_t key, const void *value) {
+#pragma warning(push)
+#pragma warning(disable : 4311)
+#pragma warning(disable : 4302)
+  DWORD index = reinterpret_cast<DWORD>(key);
+#pragma warning(pop)
+
+  int ret = FlsSetValue(index, const_cast<void *>(value));
+  if (ret != 0)
+    return 0;
+  else
+    return 1;
+  return 0;
+}
+} // namespace pthread
+} // namespace portability
+} // namespace folly
+
+
+
+#define _SC_NPROCESSORS_CONF 2
+namespace folly {
+namespace portability {
+namespace unistd {
+long sysconf(int tp) {
+  if (tp == _SC_NPROCESSORS_CONF)
+    return 0;
+
+  std::abort();
+  return 0;
+}
+} // namespace unistd
+} // namespace portability
+} // namespace folly
+
+int nanosleep(const struct timespec *request, struct timespec *remain) {
+  Sleep((DWORD)((request->tv_sec * 1000) + (request->tv_nsec / 1000000)));
+  if (remain != nullptr) {
+    remain->tv_nsec = 0;
+    remain->tv_sec = 0;
+  }
+  return 0;
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -359,7 +359,8 @@ void ReactInstanceWin::Initialize() noexcept {
             switch (m_options.JsiEngine) {
               case JSIEngine::Hermes:
 #if defined(USE_HERMES)
-                devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
+                devSettings->jsiRuntimeHolder =
+                    std::make_shared<facebook::react::HermesRuntimeHolder>(devSettings, m_jsMessageThread.Load());
                 devSettings->inlineSourceMap = false;
                 break;
 #endif

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -75,8 +75,9 @@
         %(AdditionalIncludeDirectories);
       </AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32;_CRT_SECURE_NO_WARNINGS;FOLLY_NO_CONFIG;NOMINMAX;RN_EXPORT=;JSI_EXPORT=;WIN32;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(EnableHermesInspector)' == 'true'">HERMES_INSPECTOR_FOLLY_KLUDGE;HERMES_ENABLE_DEBUGGER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ForcedUsingFiles />
-      <DisableSpecificWarnings>4715;4146;4251;4800;4804;4305;4722;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4244;4018;4541;4267;4715;4146;4251;4800;4804;4305;4722;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PreprocessToFile>false</PreprocessToFile>
     </ClCompile>
     <Link>
@@ -87,6 +88,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
+    <Import Project="$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets') AND '$(UseHermes)' == 'true' AND '$(EnableHermesInspector)' == 'true'" />
   </ImportGroup>
   <ItemGroup>
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\instrumentation.h" />
@@ -124,6 +126,27 @@
     <ClInclude Include="$(YogaDir)\yoga\YGMacros.h" />
     <ClInclude Include="$(YogaDir)\yoga\YGNodeList.h" />
     <ClInclude Include="$(YogaDir)\yoga\Yoga.h" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EnableHermesInspector)' == 'true'">
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Inspector.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\InspectorState.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\RuntimeAdapter.h" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\Thread.h" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\SerialExecutor.h" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\CallbackOStream.h" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Exceptions.h" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\AsyncPauseState.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\AutoAttachUtils.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Connection.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\ConnectionDemux.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageConverters.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageInterfaces.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypes.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypesInlines.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Registration.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\RemoteObjectsTable.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsinspector\InspectorInterfaces.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\executor\JSITracing.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\CxxNativeModule.cpp" />
@@ -178,6 +201,23 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModuleUtils.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\samples\ReactCommon\NativeSampleTurboCxxModuleSpecJSI.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\samples\ReactCommon\SampleTurboCxxModule.cpp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(EnableHermesInspector)' == 'true'">
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Inspector.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\InspectorState.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\RuntimeAdapter.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\Thread.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\SerialExecutor.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\CallbackOStream.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Connection.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\ConnectionDemux.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageConverters.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypes.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Registration.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\RemoteObjectsTable.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\jsinspector\InspectorInterfaces.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\executor\JSITracing.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\AutoAttachUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vnext/ReactCommon/ReactCommon.vcxproj.filters
+++ b/vnext/ReactCommon/ReactCommon.vcxproj.filters
@@ -58,6 +58,24 @@
     <Filter Include="react\renderer\mounting">
       <UniqueIdentifier>{836654a8-cee1-4d6d-ae20-bd2fb86710f7}</UniqueIdentifier>
     </Filter>
+    <Filter Include="hermes">
+      <UniqueIdentifier>{7094e9f9-ca16-42d9-bd72-768387ec0fd6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hermes\inspector">
+      <UniqueIdentifier>{193b8653-23ca-4554-8909-4015a86e3a0e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hermes\inspector\chrome">
+      <UniqueIdentifier>{b9013cb6-83ab-4c53-b445-4253494f81f5}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hermes\inspector\detail">
+      <UniqueIdentifier>{a4887182-2ebc-49ab-b71c-2a6a6aa9226e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="reactperflogger">
+      <UniqueIdentifier>{b5350bb0-1b1d-4dc8-af10-2c9670ba89c0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="jsinspector">
+      <UniqueIdentifier>{ca229a51-6ce8-432f-8b06-8c6375e88a4a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\CxxNativeModule.cpp">
@@ -150,7 +168,6 @@
     <ClCompile Include="$(YogaDir)\yoga\event\event.cpp">
       <Filter>yoga\event</Filter>
     </ClCompile>
-    <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\BridgeNativeModulePerfLogger.cpp" />
     <ClCompile Include=".\Yoga.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\samples\ReactCommon\NativeSampleTurboCxxModuleSpecJSI.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\samples\ReactCommon\SampleTurboCxxModule.cpp" />
@@ -166,6 +183,63 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\mounting\TransactionTelemetry.cpp">
       <Filter>react\renderer\mounting</Filter>
     </ClCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Inspector.cpp">
+      <Filter>hermes\inspector</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\InspectorState.cpp">
+      <Filter>hermes\inspector</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\RuntimeAdapter.cpp">
+      <Filter>hermes\inspector</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\Thread.h">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\Thread.cpp">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\SerialExecutor.h">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\SerialExecutor.cpp">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\CallbackOStream.h">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\detail\CallbackOStream.cpp">
+      <Filter>hermes\inspector\detail</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\AsyncPauseState.h">
+      <Filter>hermes\inspector</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\BridgeNativeModulePerfLogger.cpp">
+      <Filter>reactperflogger</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Connection.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\ConnectionDemux.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageConverters.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypes.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Registration.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\RemoteObjectsTable.cpp">
+      <Filter>hermes\inspector\chrome</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Exceptions.h">
+      <Filter>hermes\inspector</Filter>
+    </CLCompile>
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\jsinspector\InspectorInterfaces.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\executor\JSITracing.cpp" />
+    <CLCompile Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\AutoAttachUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\stubs\sys\mman.h">
@@ -288,7 +362,49 @@
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModule.h">
       <Filter>turbomodule\core</Filter>
     </ClInclude>
-    <ClInclude Include="$(ReactNativeDir)\ReactCommon\callinvoker\ReactCommon\CallInvoker.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\Inspector.h">
+      <Filter>hermes\inspector</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\InspectorState.h">
+      <Filter>hermes\inspector</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\RuntimeAdapter.h">
+      <Filter>hermes\inspector</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\AutoAttachUtils.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\callinvoker\ReactCommon\CallInvoker.h">
+      <Filter>jscallinvoker\ReactCommon</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Connection.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\ConnectionDemux.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageConverters.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageInterfaces.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypes.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\MessageTypesInlines.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\Registration.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\inspector\chrome\RemoteObjectsTable.h">
+      <Filter>hermes\inspector\chrome</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsinspector\InspectorInterfaces.h">
+      <Filter>jsinspector</Filter>
+    </ClInclude>
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\hermes\executor\JSITracing.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vnext/Shared/DevServerHelper.h
+++ b/vnext/Shared/DevServerHelper.h
@@ -59,6 +59,18 @@ class DevServerHelper {
         PackagerOpenStackFrameUrlFormat, GetDeviceLocalHost(sourceBundleHost, sourceBundlePort).c_str());
   }
 
+  static std::string get_InspectorDeviceUrl(
+      const std::string &packagerHost,
+      const uint16_t packagerPort,
+      const std::string &deviceName,
+      const std::string &packageName) {
+    return string_format(
+        InspectorDeviceUrlFormat,
+        GetDeviceLocalHost(packagerHost, packagerPort).c_str(),
+        deviceName.c_str(),
+        packageName.c_str());
+  }
+
   static constexpr const char DefaultPackagerHost[] = "localhost";
   static const uint16_t DefaultPackagerPort = 8081;
 
@@ -79,6 +91,7 @@ class DevServerHelper {
   static constexpr const char PackagerConnectionUrlFormat[] = "ws://%s/message";
   static constexpr const char PackagerStatusUrlFormat[] = "http://%s/status";
   static constexpr const char PackagerOpenStackFrameUrlFormat[] = "https://%s/open-stack-frame";
+  static constexpr const char InspectorDeviceUrlFormat[] = "ws://%s/inspector/device?name=%s&app=%s";
 
   static constexpr const char PackagerOkStatus[] = "packager-status:running";
   const int LongPollFailureDelayMs = 5000;

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -61,6 +61,9 @@ struct DevSettings {
   /// Enables debugging directly in the JavaScript engine.
   bool useDirectDebugger{false};
 
+  /// Enables React Native Hermes Inspector.
+  bool useHermesInspector{true};
+
   /// For direct debugging, break on the next line of JavaScript executed
   bool debuggerBreakOnNextLine{false};
 

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -14,6 +14,10 @@
 #include <memory>
 #include <string>
 
+#if defined(HERMES_ENABLE_DEBUGGER)
+#include <InspectorPackagerConnection.h>
+#endif
+
 namespace facebook {
 namespace react {
 struct DevSettings;
@@ -43,8 +47,15 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
       std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
 
+  virtual void startInspector(const std::string &packagerHost, const uint16_t packagerPort) override;
+  virtual void stopInspector() override;
+
  private:
   std::atomic_bool m_cancellation_token;
+
+#if defined(HERMES_ENABLE_DEBUGGER)
+  std::unique_ptr<InspectorPackagerConnection> m_InspectorPackagerConnection;
+#endif
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -3,31 +3,109 @@
 
 #include "pch.h"
 
-#include <hermes/hermes.h>
+#include <memory>
 #include <mutex>
+
+#include <hermes/hermes.h>
+#include <hermes/DebuggerAPI.h>
 #include "HermesRuntimeHolder.h"
+#include <cxxreact/MessageQueueThread.h>
+#include <cxxreact/SystraceSection.h>
+#include <JSI/decorator.h>
+
+#if defined(HERMES_ENABLE_DEBUGGER)
+#include <hermes/inspector/Inspector.h>
+#include <hermes/inspector/chrome/Registration.h>
+#include <jsinspector/InspectorInterfaces.h>
+#endif
 
 using namespace facebook;
 
 namespace facebook {
 namespace react {
 
-std::shared_ptr<jsi::Runtime> HermesRuntimeHolder::getRuntime() noexcept {
-  std::call_once(once_flag_, [this]() { initRuntime(); });
+namespace {
 
-  if (!runtime_)
-    std::terminate();
-
-  // ChakraJsiRuntime is not thread safe as of now.
-  if (own_thread_id_ != std::this_thread::get_id())
-    std::terminate();
-
-  return runtime_;
+std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeSystraced(
+    const ::hermes::vm::RuntimeConfig &runtimeConfig) {
+  SystraceSection s("HermesExecutorFactory::makeHermesRuntimeSystraced");
+  return hermes::makeHermesRuntime(runtimeConfig);
 }
 
+#ifdef HERMES_ENABLE_DEBUGGER
+class HermesExecutorRuntimeAdapter : public facebook::hermes::inspector::RuntimeAdapter {
+ public:
+  HermesExecutorRuntimeAdapter(
+      std::shared_ptr<jsi::Runtime> runtime,
+      facebook::hermes::HermesRuntime &hermesRuntime,
+      std::shared_ptr<MessageQueueThread> thread)
+      : m_runtime(runtime), m_hermesRuntime(hermesRuntime), m_thread(std::move(thread)) {}
+
+  virtual ~HermesExecutorRuntimeAdapter() = default;
+
+  jsi::Runtime &getRuntime() override {
+    return *m_runtime;
+  }
+
+  facebook::hermes::debugger::Debugger &getDebugger() override {
+    return m_hermesRuntime.getDebugger();
+  }
+
+  void tickleJs() override {
+    // The queue will ensure that runtime_ is still valid when this
+    // gets invoked.
+    m_thread->runOnQueue([&runtime = m_runtime]() {
+      auto func = runtime->global().getPropertyAsFunction(*runtime, "__tickleJs");
+      func.call(*runtime);
+    });
+  }
+
+ private:
+  std::shared_ptr<jsi::Runtime> m_runtime;
+  facebook::hermes::HermesRuntime &m_hermesRuntime;
+
+  std::shared_ptr<MessageQueueThread> m_thread;
+};
+#endif
+
+} // namespace
+
+std::shared_ptr<jsi::Runtime> HermesRuntimeHolder::getRuntime() noexcept {
+  std::call_once(m_once_flag, [this]() { initRuntime(); });
+
+  if (!m_runtime)
+    std::terminate();
+
+  // Make sure that the runtime instance is not consumed from multiple threads.
+  if (m_own_thread_id != std::this_thread::get_id())
+     std::terminate();
+
+  return m_runtime;
+}
+
+HermesRuntimeHolder::HermesRuntimeHolder(
+      std::shared_ptr<facebook::react::DevSettings> devSettings,
+    std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept
+    : m_devSettings(devSettings), m_jsQueue(jsQueue) {} 
+
 void HermesRuntimeHolder::initRuntime() noexcept {
-  runtime_ = facebook::hermes::makeHermesRuntime();
-  own_thread_id_ = std::this_thread::get_id();
+  ::hermes::vm::RuntimeConfig runtimeConfig = ::hermes::vm::RuntimeConfig();
+  std::unique_ptr<facebook::hermes::HermesRuntime> hermesRuntime = makeHermesRuntimeSystraced(runtimeConfig);
+  facebook::hermes::HermesRuntime &hermesRuntimeRef = *hermesRuntime;
+
+  m_runtime = std::move(hermesRuntime);
+  m_own_thread_id = std::this_thread::get_id();
+
+#ifdef HERMES_ENABLE_DEBUGGER
+  auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(m_runtime, hermesRuntimeRef, m_jsQueue);
+  facebook::hermes::inspector::chrome::enableDebugging(std::move(adapter), "Hermes React Native");
+#endif
+
+  // Add js engine information to Error.prototype so in error reporting we
+  // can send this information.
+  auto errorPrototype =
+      m_runtime->global().getPropertyAsObject(*m_runtime, "Error").getPropertyAsObject(*m_runtime, "prototype");
+  errorPrototype.setProperty(*m_runtime, "jsEngine", "hermes");
 }
 
 } // namespace react

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <JSI/Shared/RuntimeHolder.h>
+#include <JSI/RuntimeHolder.h>
 
 #include <jsi/jsi.h>
 #include <thread>
+
+#include <DevSettings.h>
 
 namespace facebook {
 namespace react {
@@ -14,12 +16,19 @@ class HermesRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
 
+HermesRuntimeHolder(
+      std::shared_ptr<facebook::react::DevSettings> devSettings,
+      std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;
+
  private:
   void initRuntime() noexcept;
-  std::shared_ptr<facebook::jsi::Runtime> runtime_;
+  std::shared_ptr<facebook::jsi::Runtime> m_runtime;
 
-  std::once_flag once_flag_;
-  std::thread::id own_thread_id_;
+  std::once_flag m_once_flag;
+  std::thread::id m_own_thread_id;
+
+  std::shared_ptr<facebook::react::DevSettings> m_devSettings;
+  std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
 };
 
 } // namespace react

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -21,6 +21,8 @@ struct IDevSupportManager {
       const uint16_t sourceBundlePort,
       std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
+  virtual void startInspector(const std::string &packagerHost, const uint16_t packagerPort) = 0;
+  virtual void stopInspector() = 0;
 };
 
 std::shared_ptr<IDevSupportManager> CreateDevSupportManager();

--- a/vnext/Shared/InspectorPackagerConnection.cpp
+++ b/vnext/Shared/InspectorPackagerConnection.cpp
@@ -1,0 +1,176 @@
+
+#include "pch.h"
+
+#include <folly/json.h>
+#include "InspectorPackagerConnection.h"
+
+namespace Microsoft::ReactNative {
+
+namespace {
+
+struct InspectorProtocol {
+  static constexpr const char InspectorMessage_EVENT[] = "event";
+  static constexpr const char InspectorMessage_PAGEID[] = "pageId";
+  static constexpr const char InspectorMessage_PAYLOAD[] = "payload";
+
+  static constexpr const char InspectorMessage_eventName_wrappedEvent[] = "wrappedEvent";
+  static constexpr const char InspectorMessage_eventName_getPages[] = "getPages";
+  static constexpr const char InspectorMessage_eventName_connect[] = "connect";
+  static constexpr const char InspectorMessage_eventName_disconnect[] = "disconnect";
+
+  enum class EventType { GetPages, WrappedEvent, Connect, Disconnect };
+
+  static EventType getEventType(const folly::dynamic &messageFromPackager) {
+    std::string event = messageFromPackager.at(InspectorProtocol::InspectorMessage_EVENT).getString();
+    if (!event.compare(InspectorMessage_eventName_getPages))
+      return EventType::GetPages;
+    if (!event.compare(InspectorMessage_eventName_wrappedEvent))
+      return EventType::WrappedEvent;
+    if (!event.compare(InspectorMessage_eventName_connect))
+      return EventType::Connect;
+    if (!event.compare(InspectorMessage_eventName_disconnect))
+      return EventType::Disconnect;
+    assert(false && "Unknown event!");
+    std::abort();
+  }
+
+  static folly::dynamic getMessageForPackager(EventType eventType, folly::dynamic &&payload) {
+    folly::dynamic response = folly::dynamic::object;
+
+    switch (eventType) {
+      case EventType::GetPages:
+        response[InspectorProtocol::InspectorMessage_EVENT] = InspectorProtocol::InspectorMessage_eventName_getPages;
+        break;
+      case EventType::WrappedEvent:
+        response[InspectorProtocol::InspectorMessage_EVENT] =
+            InspectorProtocol::InspectorMessage_eventName_wrappedEvent;
+        break;
+      case EventType::Connect:
+        response[InspectorProtocol::InspectorMessage_EVENT] = InspectorProtocol::InspectorMessage_eventName_connect;
+        break;
+      case EventType::Disconnect:
+        response[InspectorProtocol::InspectorMessage_EVENT] = InspectorProtocol::InspectorMessage_eventName_disconnect;
+        break;
+      default:
+        assert(false && "Unknown event Type.");
+        std::abort();
+    }
+
+    response[InspectorProtocol::InspectorMessage_PAYLOAD] = std::move(payload);
+    return response;
+  }
+
+  static folly::dynamic getGetPagesResponseForPackagerPayload(
+      const std::vector<facebook::react::InspectorPage> &pages) {
+    folly::dynamic payload = folly::dynamic::array;
+    for (facebook::react::InspectorPage page : pages) {
+      folly::dynamic pageDyn = folly::dynamic::object;
+      pageDyn["id"] = page.id;
+      pageDyn["title"] = page.title;
+      pageDyn["vm"] = page.vm;
+
+      pageDyn["isLastBundleDownloadSuccess"] = true;
+      pageDyn["bundleUpdateTimestamp"] = "0";
+
+      payload.push_back(pageDyn);
+    }
+    return payload;
+  }
+
+  static folly::dynamic getVMResponseForPackagerPayload(int64_t pageId, std::string &&messageFromVM) {
+    folly::dynamic payload = folly::dynamic::object;
+    payload[InspectorProtocol::InspectorMessage_eventName_wrappedEvent] = messageFromVM;
+    payload[InspectorProtocol::InspectorMessage_PAGEID] = pageId;
+    return payload;
+  }
+
+  static folly::dynamic getVMResponseOnDisconnectForPackagerPayload(int64_t pageId) {
+    folly::dynamic payload = folly::dynamic::object;
+    payload[InspectorProtocol::InspectorMessage_PAGEID] = pageId;
+    return payload;
+  }
+};
+
+} // namespace
+
+RemoteConnection::RemoteConnection(int64_t pageId, const InspectorPackagerConnection &packagerConnection)
+    : m_packagerConnection(packagerConnection), m_pageId(pageId) {}
+
+void RemoteConnection::onMessage(std::string message) {
+  folly::dynamic response = InspectorProtocol::getMessageForPackager(
+      InspectorProtocol::EventType::WrappedEvent,
+      InspectorProtocol::getVMResponseForPackagerPayload(m_pageId, std::move(message)));
+  std::string responsestr = folly::toJson(response);
+  m_packagerConnection.sendMessageToPackager(std::move(responsestr));
+}
+
+void RemoteConnection::onDisconnect() {
+  folly::dynamic response = InspectorProtocol::getMessageForPackager(
+      InspectorProtocol::EventType::Disconnect,
+      InspectorProtocol::getVMResponseOnDisconnectForPackagerPayload(m_pageId));
+
+  std::string responsestr = folly::toJson(response);
+  m_packagerConnection.sendMessageToPackager(std::move(responsestr));
+}
+
+void InspectorPackagerConnection::sendMessageToPackager(std::string &&message) const {
+  m_packagerWebSocketConnection->Send(std::move(message));
+}
+
+void InspectorPackagerConnection::sendMessageToVM(int64_t pageId, std::string &&message) {
+  m_localConnections[pageId]->sendMessage(std::move(message));
+}
+
+InspectorPackagerConnection::InspectorPackagerConnection(std::string &&url) {
+  std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
+  m_packagerWebSocketConnection =
+      std::make_shared<Microsoft::React::WinRTWebSocketResource>(std::move(url), std::move(certExceptions));
+
+  m_packagerWebSocketConnection->SetOnError([this](const Microsoft::React::IWebSocketResource::Error &err) {
+    assert(false && "Websocket connection failed !");
+  });
+
+  m_packagerWebSocketConnection->SetOnMessage([this](size_t length, const std::string &message, bool isBinary) {
+    assert(!isBinary && "We don't expect any binary messages !");
+    folly::dynamic messageDyn = folly::parseJson(message);
+
+    InspectorProtocol::EventType eventType = InspectorProtocol::getEventType(messageDyn);
+    switch (eventType) {
+      case InspectorProtocol::EventType::GetPages: {
+        std::vector<facebook::react::InspectorPage> inspetorPages = facebook::react::getInspectorInstance().getPages();
+        folly::dynamic response = InspectorProtocol::getMessageForPackager(
+            InspectorProtocol::EventType::GetPages,
+            InspectorProtocol::getGetPagesResponseForPackagerPayload(inspetorPages));
+
+        std::string responsestr = folly::toJson(response);
+        sendMessageToPackager(std::move(responsestr));
+      } break;
+
+      case InspectorProtocol::EventType::WrappedEvent: {
+        folly::dynamic payload = messageDyn[InspectorProtocol::InspectorMessage_PAYLOAD];
+        int64_t pageId = payload[InspectorProtocol::InspectorMessage_PAGEID].asInt();
+        std::string wrappedEvent = payload[InspectorProtocol::InspectorMessage_eventName_wrappedEvent].getString();
+        sendMessageToVM(pageId, std::move(wrappedEvent));
+      } break;
+
+      case InspectorProtocol::EventType::Connect: {
+        folly::dynamic payload = messageDyn[InspectorProtocol::InspectorMessage_PAYLOAD];
+        int64_t pageId = payload[InspectorProtocol::InspectorMessage_PAGEID].asInt();
+        m_localConnections[pageId] = facebook::react::getInspectorInstance().connect(
+            static_cast<int>(pageId), std::make_unique<RemoteConnection>(pageId, *this));
+      } break;
+
+      case InspectorProtocol::EventType::Disconnect: {
+        folly::dynamic payload = messageDyn[InspectorProtocol::InspectorMessage_PAYLOAD];
+        int64_t pageId = payload[InspectorProtocol::InspectorMessage_PAGEID].asInt();
+        m_localConnections.erase(pageId);
+      } break;
+    }
+  });
+
+  Microsoft::React::IWebSocketResource::Protocols protocols;
+  Microsoft::React::IWebSocketResource::Options options;
+  m_packagerWebSocketConnection->Connect(protocols, options);
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/InspectorPackagerConnection.h
+++ b/vnext/Shared/InspectorPackagerConnection.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <hermes/hermes.h>
+#include <hermes/DebuggerAPI.h>
+#include <hermes/inspector/Inspector.h>
+#include <hermes/inspector/chrome/Registration.h>
+#include <jsinspector/InspectorInterfaces.h>
+
+#include <WinRTWebSocketResource.h>
+
+
+namespace Microsoft::ReactNative {
+
+class InspectorPackagerConnection final {
+ public:
+  InspectorPackagerConnection(std::string&& url);
+  
+ private:
+  friend class RemoteConnection;
+  void sendMessageToPackager(std::string &&message) const;
+  void sendMessageToVM(int64_t pageId, std::string &&message);
+  
+  std::unordered_map<int64_t, std::unique_ptr<facebook::react::ILocalConnection>> m_localConnections;
+  std::shared_ptr<Microsoft::React::WinRTWebSocketResource> m_packagerWebSocketConnection;
+};
+
+class RemoteConnection : public facebook::react::IRemoteConnection {
+ public:
+  RemoteConnection(int64_t pageId, const InspectorPackagerConnection &packagerConnection);
+  void onMessage(std::string message) override;
+  void onDisconnect() override;
+
+ private:
+  int64_t m_pageId;
+  const InspectorPackagerConnection &m_packagerConnection;
+};
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/InstanceManager.cpp
+++ b/vnext/Shared/InstanceManager.cpp
@@ -35,6 +35,10 @@ std::shared_ptr<InstanceWrapper> CreateReactInstance(
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<MessageQueueThread> nativeQueue,
     std::shared_ptr<DevSettings> devSettings) noexcept {
+
+  if (devSettings->useHermesInspector)
+    GetSharedDevManager()->startInspector(devSettings->sourceBundleHost, devSettings->sourceBundlePort);
+
   // Now create the instance
   std::shared_ptr<InstanceWrapper> inner = InstanceImpl::MakeNoBundle(
       std::move(instance),

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -352,7 +352,7 @@ InstanceImpl::InstanceImpl(
       switch (m_devSettings->jsiEngineOverride) {
         case JSIEngineOverride::Hermes:
 #if defined(USE_HERMES)
-          m_devSettings->jsiRuntimeHolder = std::make_shared<HermesRuntimeHolder>();
+          m_devSettings->jsiRuntimeHolder = std::make_shared<HermesRuntimeHolder>(m_devSettings, m_jsThread);
           m_devSettings->inlineSourceMap = false;
           break;
 #else

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -9,6 +9,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(MSBuildThisFileDirectory)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions Condition="'$(EnableHermesInspector)' == 'true'">HERMES_INSPECTOR_FOLLY_KLUDGE;HERMES_ENABLE_DEBUGGER;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings Condition="'$(EnableHermesInspector)' == 'true'">4267;4541;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -29,6 +31,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)HermesRuntimeHolder.cpp">
       <ExcludedFromBuild Condition="'$(UseHermes)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.cpp" Condition="'$(EnableHermesInspector)' == 'true'" />
     <ClCompile Include="$(MSBuildThisFileDirectory)InstanceManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JSBigAbiString.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JSI\ChakraApi.cpp" />
@@ -67,6 +70,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)AsyncStorage\AsyncStorageManager.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AsyncStorage\FollyDynamicConverter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AsyncStorage\KeyValueStorage.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ByteArrayBuffer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ChakraApi.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ChakraRuntime.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -362,6 +362,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ScriptStore.h">
       <Filter>Header Files\JSI</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)etw\build.bat">

--- a/vnext/stubs/glog/logging.h
+++ b/vnext/stubs/glog/logging.h
@@ -14,6 +14,12 @@
 #define DCHECK(b) !(b) && GlogStub::LogMessageFatal{}.stream()
 
 #ifdef DEBUG
+#define DCHECK_LT(v1, v2) CHECK((v1) < (v2))
+#else
+#define DCHECK_LT(v1, v2)
+#endif
+
+#ifdef DEBUG
 #define DCHECK_GT(v1, v2) CHECK((v1) > (v2))
 #else
 #define DCHECK_GT(v1, v2)
@@ -31,11 +37,22 @@
 #define DCHECK_GE(v1, v2)
 #endif
 
+#define CHECK_EQ(v1, v2) CHECK((v1) == (v2))
+
 #ifdef DEBUG
 #define DCHECK_EQ(v1, v2) CHECK((v1) == (v2))
 #else
 #define DCHECK_EQ(v1, v2)
 #endif
+
+#ifdef DEBUG
+#define DCHECK_NE(v1, v2) CHECK((v1) != (v2))
+#else
+#define DCHECK_NE(v1, v2)
+#endif
+
+
+
 
 namespace GlogStub {
 
@@ -69,6 +86,7 @@ inline std::ostream &GetNullLog() noexcept {
 }
 
 #define LOG(b) GlogStub::GetNullLog()
+#define LOG_FIRST_N(severity, n) GlogStub::GetNullLog()
 #endif
 
 } // namespace GlogStub


### PR DESCRIPTION
This PR has changes to enable Hermes Inspector (direct debugger) in RNW. All the changes are behind an msbuild property 'EnableHermesInspector', which is set to false by default, for now. 

Turning on the property will override the Folly version to an year old one, which allows a folly::future to be built in windows. We are investigating on ways to avoid Folly downgrade.

In order to use inspector, do the following,
1. Set USE_HERMES to 'true' in vnext\PropertySheets\JSEngine.props
2. Set EnableHermesInspector to 'true' in vnext\Directory.Build.props
3. Clean and rebuild the solution.
4. After launching the RNW application, navigate to chrome://inspect in Chrome or Edge.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/react-native-windows/pull/6964)