### PR TITLE
[0.64] Fix: Control with "AccessibilityRole" automatically get tab focus no matter the value of focusable prop (#6728)

### DIFF
--- a/change/react-native-windows-6b0a9e7b-b179-4854-91fa-a1752c5c89b7.json
+++ b/change/react-native-windows-6b0a9e7b-b179-4854-91fa-a1752c5c89b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "In Xaml, IsTabStop makes a control be able to receive focus or not so we also need to set it when IsFocusable is set.",
+  "packageName": "react-native-windows",
+  "email": "lamdoan@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -124,6 +124,9 @@ class ViewShadowNode : public ShadowNodeBase {
   }
   void IsFocusable(bool isFocusable) {
     m_isFocusable = isFocusable;
+
+    if (IsControl())
+      GetControl().IsTabStop(m_isFocusable);
   }
 
   bool IsHitTestBrushRequired() const {
@@ -190,6 +193,7 @@ class ViewShadowNode : public ShadowNodeBase {
     // shadow node to the view
     EnableFocusRing(EnableFocusRing());
     TabIndex(TabIndex());
+    IsFocusable(IsFocusable());
     static_cast<FrameworkElementViewManager *>(GetViewManager())->RefreshTransformMatrix(this);
   }
 


### PR DESCRIPTION
* In Xaml, IsTabStop makes a control be able to receive focus or not so we also need to set it when IsFocusable is set.

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/6969)