### PR TITLE
Fix startup crash on RS3

### DIFF
--- a/change/react-native-windows-2f9e933a-0ef8-4ee6-af39-dd343420ccab.json
+++ b/change/react-native-windows-2f9e933a-0ef8-4ee6-af39-dd343420ccab.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "App crashes at startup on RS3 because of RS4+ API usage",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -418,7 +418,9 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
   altLeft.Modifiers(winrt::Windows::System::VirtualKeyModifiers::Menu);
 
   // Hide keyboard accelerator tooltips
-  rootElement.KeyboardAcceleratorPlacementMode(xaml::Input::KeyboardAcceleratorPlacementMode::Hidden);
+  if (react::uwp::IsRS4OrHigher()) {
+    rootElement.KeyboardAcceleratorPlacementMode(xaml::Input::KeyboardAcceleratorPlacementMode::Hidden);
+  }
 }
 
 void ReactRootControl::RemoveBackHandlers() noexcept {


### PR DESCRIPTION
Root control uses an RS4+ only API, causing crashes at startup on RS3 and below.

Followup fixes #5132 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/6980)