### PR TITLE
Speed up react-native init in CLI tests

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -84,10 +84,14 @@ steps:
       Write-Host "##vso[task.setvariable variable=localProjectType]${{ parameters.projectType}}"
 
   # We force the usage of npm instead of yarn because yarn has fragility issues when redirected to a different server (such as verdaccio)
+  # We use --no-install and symlink the node_modules from the source tree to avoid having npx download react-native and all it dependencies
+  # which takes over a minute on the CI machines.
   - task: CmdLine@2
     displayName: Init new app project
     inputs:
-      script: npx react-native init testcli --npm --template react-native@$(reactNativeDevDependency)
+      script: |
+        mklink /D node_modules $(System.DefaultWorkingDirectory)\node_modules
+        npx --no-install react-native init testcli --npm --template react-native@$(reactNativeDevDependency)
       workingDirectory: $(Agent.BuildDirectory)
     condition: and(succeeded(), eq(variables['localProjectType'], 'app'))
   


### PR DESCRIPTION
This saves several 1-2 minutes of the critical path our our CLI tests by skipping npx installing react-native again and makes it use the version already downloaded by midgard-yarn and installed locally.

I tried to find npx equivalent in yarn, there are a few but they wouldn't work out of the box with midgard-yarn...



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/6983)