### PR TITLE
Allow custom view managers to be able to trigger our logic to run native layout

### DIFF
--- a/change/react-native-windows-083f1165-a2b7-4be3-8e8b-522983f37163.json
+++ b/change/react-native-windows-083f1165-a2b7-4be3-8e8b-522983f37163.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow custom view managers to be able to trigger our logic to run native layout",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -10,9 +10,23 @@
 
 #include <JSValueWriter.h>
 #include <Utils/ValueUtils.h>
+#include <Views/ShadowNodeBase.h>
 #include "ReactHost/MsoUtils.h"
 
 namespace winrt::Microsoft::ReactNative {
+
+class ABIShadowNode : public ::Microsoft::ReactNative::ShadowNodeBase {
+  using Super = ShadowNodeBase;
+
+ public:
+  ABIShadowNode(bool needsForceLayout) : m_needsForceLayout(needsForceLayout) {}
+  bool NeedsForceLayout() override {
+    return m_needsForceLayout;
+  }
+
+ private:
+  bool m_needsForceLayout;
+};
 
 ABIViewManager::ABIViewManager(
     Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
@@ -25,6 +39,7 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithNativeProperties{viewManager.try_as<IViewManagerWithNativeProperties>()},
       m_viewManagerWithCommands{viewManager.try_as<IViewManagerWithCommands>()},
       m_viewManagerWithExportedEventTypeConstants{viewManager.try_as<IViewManagerWithExportedEventTypeConstants>()},
+      m_viewManagerRequiresNativeLayout{viewManager.try_as<IViewManagerRequiresNativeLayout>()},
       m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()} {
   if (m_viewManagerWithReactContext) {
     m_viewManagerWithReactContext.ReactContext(winrt::make<implementation::ReactContext>(Mso::Copy(reactContext)));
@@ -181,6 +196,21 @@ void ABIViewManager::ReplaceChild(
   } else {
     Super::ReplaceChild(parent, oldChild, newChild);
   }
+}
+
+YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
+  if (m_viewManagerRequiresNativeLayout &&
+      m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
+    return ::Microsoft::ReactNative::DefaultYogaSelfMeasureFunc;
+  } else {
+    return nullptr;
+  }
+}
+
+::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {
+  return new ABIShadowNode(
+      m_viewManagerRequiresNativeLayout &&
+      m_viewManagerRequiresNativeLayout.RequiresNativeLayout());
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -199,8 +199,7 @@ void ABIViewManager::ReplaceChild(
 }
 
 YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
-  if (m_viewManagerRequiresNativeLayout &&
-      m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
+  if (m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
     return ::Microsoft::ReactNative::DefaultYogaSelfMeasureFunc;
   } else {
     return nullptr;
@@ -209,8 +208,7 @@ YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
 
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {
   return new ABIShadowNode(
-      m_viewManagerRequiresNativeLayout &&
-      m_viewManagerRequiresNativeLayout.RequiresNativeLayout());
+      m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout());
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -58,6 +58,9 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
       const xaml::DependencyObject &oldChild,
       const xaml::DependencyObject &newChild) override;
 
+  YGMeasureFunc GetYogaCustomMeasureFunc() const override;
+  ::Microsoft::ReactNative::ShadowNode *createShadow() const override;
+
  protected:
   xaml::DependencyObject CreateViewCore(int64_t) override;
 
@@ -69,6 +72,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithCommands m_viewManagerWithCommands;
   IViewManagerWithExportedEventTypeConstants m_viewManagerWithExportedEventTypeConstants;
   IViewManagerWithChildren m_viewManagerWithChildren;
+  IViewManagerRequiresNativeLayout m_viewManagerRequiresNativeLayout;
 
   winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, ViewManagerPropertyType> m_nativeProps;
 };

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -46,4 +46,10 @@ namespace Microsoft.ReactNative
 
     void ReplaceChild(XAML_NAMESPACE.FrameworkElement parent, XAML_NAMESPACE.UIElement oldChild, XAML_NAMESPACE.UIElement newChild);
   }
+
+  [webhosthidden]
+  interface IViewManagerRequiresNativeLayout
+  {
+    Boolean RequiresNativeLayout { get; };
+  }
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
Currently custom view manager have to have their size specified directly on them.  Internally we have some logic to ensure that native layout is run on native controls, but community/custom view manger have no way to opt into that logic.

This adds a new interface that custom viewmanagers can implement, `IViewManagerRequiresNativeLayout`.  This interface contains a single boolean property `RequiresNativeLayout`.  If the viewmanager returns true for this property, then we will do what we do internally to ensure native layout gets run.

Fixes #6411.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/6987)