### PR TITLE
Update e2e docs for external link

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -238,7 +238,7 @@ No matter what JavaScript framework you choose for native app testing, you have 
 
  WinAppDriver provides rich API to help locate the UI element. If [testID](https://facebook.github.io/react-native/docs/picker-item#testid) is specified in React Native app for Windows, the locator strategy should choose `accessibility id`.
 
-A unique `accessiblity id`/`testID` per Window is recommended for React Native Windows E2E testing when authoring the test app and test cases. To ease the maintain effort, all testIDs are defined in [Consts.ts](https://github.com/microsoft/react-native-windows/blob/master/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/Consts.ts), then be imported by test app and test page objects or test cases.
+A unique `accessiblity id`/`testID` per Window is recommended for React Native Windows E2E testing when authoring the test app and test cases. To ease the maintain effort, all testIDs are defined in [VisitAllPages.test.ts](https://github.com/microsoft/react-native-windows/blob/master/packages/E2ETest/wdio/test/VisitAllPages.test.ts), then be imported by test app and test page objects or test cases.
 
 | **Client API** | **Locator Strategy** | **Matched Attribute in inspect.exe** | **Example** |
 | --- | --- | --- | --- |


### PR DESCRIPTION
#6947 removed consts.ts. This made the external link validation fail causing a constant warning on the JavaScript checks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/6989)