### PR TITLE
Fix deep linking activation

### DIFF
--- a/change/react-native-windows-93385742-18a3-4c29-b83b-1b87733bb4ce.json
+++ b/change/react-native-windows-93385742-18a3-4c29-b83b-1b87733bb4ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix deep linking activation",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.cpp
@@ -65,4 +65,16 @@ void App::OnLaunched(LaunchActivatedEventArgs const &e) {
   rootFrame.Navigate(xaml_typename<MainPage>(), box_value(e.Arguments()));
 }
 
+/// <summary>
+/// Invoked when the application is activated by some means other than normal launching.
+/// </summary>
+void App::OnActivated(IActivatedEventArgs const &e) {
+  auto preActivationContent = Window::Current().Content();
+  super::OnActivated(e);
+  if (!preActivationContent && Window::Current()) {
+    Frame rootFrame = Window::Current().Content().as<Frame>();
+    rootFrame.Navigate(xaml_typename<MainPage>(), nullptr);
+  }
+}
+
 } // namespace winrt::SampleAppCpp::implementation

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.h
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCPP/App.h
@@ -8,7 +8,8 @@ namespace winrt::SampleAppCpp::implementation {
 
 struct App : AppT<App> {
   App() noexcept;
-  void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &);
+  void OnLaunched(Windows::ApplicationModel::Activation::LaunchActivatedEventArgs const &e);
+  void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
 
  private:
   using super = AppT<App>;

--- a/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
+++ b/packages/microsoft-reactnative-sampleapps/windows/SampleAppCS/App.xaml.cs
@@ -42,7 +42,8 @@ namespace SampleAppCS
             InstanceSettings.Properties.Set(ReactPropertyBagHelper.GetName(null, "Prop1"), 43);
             InstanceSettings.Properties.Set(ReactPropertyBagHelper.GetName(null, "Prop2"), "Hello RNW!");
 
-            Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders); // Includes any autolinked modules
+            // Includes any autolinked modules
+            Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders);
 
             PackageProviders.Add(new Microsoft.ReactNative.Managed.ReactPackageProvider());
             PackageProviders.Add(new SampleAppCS.ReactPackageProvider());
@@ -52,11 +53,31 @@ namespace SampleAppCS
             InitializeComponent();
         }
 
+        /// <summary>
+        /// Invoked when the application is launched normally by the end user.  Other entry points
+        /// will be used such as when the application is launched to open a specific file.
+        /// </summary>
+        /// <param name="e">Details about the launch request and process.</param>
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
             base.OnLaunched(e);
             var frame = (Frame)Window.Current.Content;
             frame.Navigate(typeof(MainPage), e.Arguments);
+        }
+
+        /// <summary>
+        /// Invoked when the application is activated by some means other than normal launching.
+        /// </summary>
+        protected override void OnActivated(IActivatedEventArgs e)
+        {
+            var preActivationContent = Window.Current.Content;
+            base.OnActivated(e);
+            if (preActivationContent == null && Window.Current != null)
+            {
+                // Display the initial content
+                var frame = (Frame)Window.Current.Content;
+                frame.Navigate(typeof(MainPage), null);
+            }
         }
     }
 }

--- a/vnext/template/cpp-app/src/App.cpp
+++ b/vnext/template/cpp-app/src/App.cpp
@@ -5,14 +5,13 @@
 #include "AutolinkedNativeModules.g.h"
 #include "ReactPackageProvider.h"
 
-using namespace winrt::{{ namespaceCpp }};
-using namespace winrt::{{ namespaceCpp }}::implementation;
 using namespace winrt;
 using namespace {{ xamlNamespaceCpp }};
 using namespace {{ xamlNamespaceCpp }}::Controls;
 using namespace {{ xamlNamespaceCpp }}::Navigation;
 using namespace Windows::ApplicationModel;
-
+namespace winrt::{{ namespaceCpp }}::implementation
+{
 /// <summary>
 /// Initializes the singleton application object.  This is the first line of
 /// authored code executed, and as such is the logical equivalent of main() or
@@ -53,7 +52,19 @@ void App::OnLaunched(activation::LaunchActivatedEventArgs const& e)
     super::OnLaunched(e);
 
     Frame rootFrame = Window::Current().Content().as<Frame>();
-    rootFrame.Navigate(xaml_typename<{{ namespaceCpp }}::MainPage>(), box_value(e.Arguments()));
+    rootFrame.Navigate(xaml_typename<MainPage>(), box_value(e.Arguments()));
+}
+
+/// <summary>
+/// Invoked when the application is activated by some means other than normal launching.
+/// </summary>
+void App::OnActivated(Activation::IActivatedEventArgs const &e) {
+  auto preActivationContent = Window::Current().Content();
+  super::OnActivated(e);
+  if (!preActivationContent && Window::Current()) {
+    Frame rootFrame = Window::Current().Content().as<Frame>();
+    rootFrame.Navigate(xaml_typename<MainPage>(), nullptr);
+  }
 }
 
 /// <summary>
@@ -77,3 +88,5 @@ void App::OnNavigationFailed(IInspectable const&, NavigationFailedEventArgs cons
 {
     throw hresult_error(E_FAIL, hstring(L"Failed to load Page ") + e.SourcePageType().Name);
 }
+
+} // namespace winrt::{{ namespaceCpp }}::implementation

--- a/vnext/template/cpp-app/src/App.h
+++ b/vnext/template/cpp-app/src/App.h
@@ -15,6 +15,7 @@ namespace winrt::{{ namespaceCpp }}::implementation
     {
         App() noexcept;
         void OnLaunched(activation::LaunchActivatedEventArgs const&);
+        void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
         void OnSuspending(IInspectable const&, Windows::ApplicationModel::SuspendingEventArgs const&);
         void OnNavigationFailed(IInspectable const&, {{ xamlNamespaceCpp }}::Navigation::NavigationFailedEventArgs const&);
       private:

--- a/vnext/template/cs-app/src/App.xaml.cs
+++ b/vnext/template/cs-app/src/App.xaml.cs
@@ -43,9 +43,23 @@ namespace {{ namespace }}
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {
             base.OnLaunched(e);
-            var frame = Window.Current.Content as Frame;
-            frame.Navigate(typeof(MainPage));
-            Window.Current.Activate();
+            var frame = (Frame)Window.Current.Content;
+            frame.Navigate(typeof(MainPage), e.Arguments);
+        }
+
+        /// <summary>
+        /// Invoked when the application is activated by some means other than normal launching.
+        /// </summary>
+        protected override void OnActivated(IActivatedEventArgs e)
+        {
+            var preActivationContent = Window.Current.Content;
+            base.OnActivated(e);
+            if (preActivationContent == null && Window.Current != null)
+            {
+                // Display the initial content
+                var frame = (Frame)Window.Current.Content;
+                frame.Navigate(typeof(MainPage), null);
+            }
         }
     }
 }


### PR DESCRIPTION
This PR contains only changes to samples and new project templates. No core code changes.

When an application is activated using a link we currently see a dark screen because the app does not navigate to the `MainWindow`. We have all the required wiring inside of the `ReactApplication`, but it is not clear what needs to be done in the application to make it work.

In this PR we update our sample apps and new project templates to have the `OnActivated` method overwritten that navigates to the `MainWindow` when the activation is done against a newly launched app.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7011)