### PR TITLE
Make hermes and WinUI3 checks required again now that we have better agents.

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -155,6 +155,21 @@ jobs:
             additionalInitArguments:
             additionalRunArguments: --no-autolink --no-deploy
 
+          X86DebugCppWinUI3:
+            language: cpp
+            configuration: Debug
+            platform: x86
+            projectType: app
+            additionalInitArguments: --useWinUI3 true
+            additionalRunArguments:
+          X86DebugCsWinUI3:
+            language: cs
+            configuration: Debug
+            platform: x86
+            projectType: app
+            additionalInitArguments: --useWinUI3 true
+            additionalRunArguments:
+
           X64DebugCppHermes:
             language: cpp
             configuration: Debug
@@ -169,14 +184,11 @@ jobs:
             projectType: app
             additionalInitArguments:
             additionalRunArguments:
-            continueOnBuildFailure: true # See issue #6129
       pool: $(AgentPool.Medium)
       timeoutInMinutes: 60
       cancelTimeoutInMinutes: 5
 
       steps:
-        # We unfortunately can't inline the template here because WinUI needs continueOnBuildFailure and ADO does not allow that variable to be an expression
-        # We can take out that part when we have better agents.
         - template: ../templates/react-native-init.yml
           parameters:
             language: $(language)
@@ -185,46 +197,6 @@ jobs:
             projectType: $(projectType)    
             additionalInitArguments: $(additionalInitArguments)
             additionalRunArguments: $(additionalRunArguments)
-            continueOnBuildFailure: ${{ eq('$(continueOnBuildFailure)', 'true')}}
-
-  # We unfortunately can't add the winUI3 ones to the existing matrix above because Auzre DevOps has problems with expressions for continueOnError.
-  # We have to place this as a value
-  - ${{ if not(parameters.buildNuGetOnly) }}:
-    - job: CliInitWinUI3
-      variables:
-        - template: ../variables/vs2019.yml
-      displayName: Verify Cli
-      strategy:
-        matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
-          X86DebugCppWinUI3:
-            language: cpp
-            configuration: Debug
-            platform: x86
-            projectType: app
-            additionalInitArguments: --useWinUI3 true
-            additionalRunArguments:
-            
-          X86DebugCsWinUI3:
-            language: cs
-            configuration: Debug
-            platform: x86
-            projectType: app
-            additionalInitArguments: --useWinUI3 true
-            additionalRunArguments:
-      pool: $(AgentPool.Medium)
-      timeoutInMinutes: 60
-      cancelTimeoutInMinutes: 5
-
-      steps:          
-        - template: ../templates/react-native-init.yml
-          parameters:
-            language: $(language)
-            configuration: $(configuration)
-            platform: $(platform)
-            projectType: $(projectType)    
-            additionalInitArguments: $(additionalInitArguments)
-            additionalRunArguments: $(additionalRunArguments)
-            continueOnBuildFailure: true # See issue #6129
 
 
   # We unfortunately can't add the nuget ones to the existing matrix above because Azure DevOps does not allow the dependsOn to be dynamic based on matrix expansion


### PR DESCRIPTION
We should not run out of memory for these builds anymore, so make then required to avoid accidentally sneaking in breaks.

Fixes #6129

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7012)