### PR TITLE
Fixing FocusManager export and adding FocusManager testpage

### DIFF
--- a/packages/react-native-win32-tester/src/js/examples-win32/APIs/FocusManagerAPI.tsx
+++ b/packages/react-native-win32-tester/src/js/examples-win32/APIs/FocusManagerAPI.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { FocusManager } from '../../../../../react-native-win32/Libraries/Utilities/FocusManager.win32';
+import { View, StyleSheet, TouchableHighlight, Text } from 'react-native';
+
+const styles = StyleSheet.create({
+    blackbox: { height: 30, width: 30, borderColor: 'black', borderWidth: 3 },
+  });
+
+export const PoliteFocusTest: React.FunctionComponent<{}> = () => {
+    const [isPoliteFocus, changePoliteFocus] = React.useState('Not focused');
+    const [isAggressiveFocus, changeAggressiveFocus] = React.useState('Not focused');
+
+    const buttonRef = React.useRef();
+    const buttonRef2 = React.useRef();
+
+    const politeFocusOnPress = () => {
+      FocusManager.focus(buttonRef.current, false);
+      changePoliteFocus('Polite Focus Set');
+    }
+
+    const aggresiveFocusOnPress = () => {
+      FocusManager.focus(buttonRef.current, true);
+      changeAggressiveFocus('Aggressive Focus Set');
+    }
+
+    return (
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginVertical: 5 }}>
+          <View style={{ flexDirection: 'column', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
+            <Text>Polite Focus Test</Text>
+            <TouchableHighlight onPress={politeFocusOnPress}>
+              <View ref={buttonRef} style={styles.blackbox} />
+            </TouchableHighlight>
+            <Text>{isPoliteFocus}</Text>
+          </View>
+          <View style={{ flexDirection: 'column', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5, marginLeft: 10 }}>
+            <Text>Aggressive Focus Test</Text>
+            <TouchableHighlight onPress={aggresiveFocusOnPress}>
+              <View ref={buttonRef2} style={styles.blackbox} />  
+            </TouchableHighlight>
+            <Text>{isAggressiveFocus}</Text>
+          </View>        
+        </View>
+    );
+  };
+
+  export const title = 'FocusManager API';
+  export const displayName =  'FocusManager API Example';
+  export const description = 'Change between polite and aggressive focus';
+  export const examples = [
+    {
+      title: 'FocusManager Example',
+      description: 'Use FocusManager API to change between polite and aggressive focus',
+      render: () => <PoliteFocusTest />
+    }
+  ]; 

--- a/packages/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
+++ b/packages/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
@@ -213,6 +213,11 @@ const APIExamples: Array<RNTesterExample> = [
     key: 'TransformExample',
     category: 'UI',
     module: require('../examples/Transform/TransformExample'),
+  },
+  {
+    key: 'FocusManagerExample',
+    category: 'UI',
+    module: require('../examples-win32/APIs/FocusManagerAPI'),
   } /*
   {
     key: 'WebSocketExample',

--- a/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.js
+++ b/packages/react-native-win32/src/Libraries/Utilities/FocusManager.win32.js
@@ -39,4 +39,4 @@ class FocusManager {
   }
 }
 
-module.exports = FocusManager;
+module.exports = { FocusManager };


### PR DESCRIPTION
The FocusManager export was exporting the class itself rather than an object with the FocusManager property. This PR fixes the export and adds a test file for the FocusManager API.

This will be backported to 62, 63, and 64

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7020)