### PR TITLE
Remove 20 sec from critical path to not clone repo in 'synchronization' job.

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -222,6 +222,8 @@
       cancelTimeoutInMinutes: 5
 
       steps:
+        - checkout: none
+          clean: false
         - powershell: |
             Write-Host "Waited for all Universal Build steps"
           displayName: Waiting for all Universal Build steps


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7053)