### PR TITLE
[FIX] Cursor resetting in TextInput

### DIFF
--- a/change/react-native-windows-2dead2dd-8acc-4a17-a3f2-7e3091cde5ad.json
+++ b/change/react-native-windows-2dead2dd-8acc-4a17-a3f2-7e3091cde5ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix cursor resetting in TextInput.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -623,7 +623,6 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
           } else {
             textBox.SelectionStart(newValue.size());
           }
-          textBox.SelectionLength(oldSelectionLength);
         }
       } else if (text.IsNull())
         textBox.ClearValue(xaml::Controls::TextBox::TextProperty());

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -612,10 +612,18 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
   if (m_mostRecentEventCount == m_nativeEventCount) {
     if (textBox) {
       if (text.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+        auto oldCursor = textBox.SelectionStart();
+        auto oldSelectionLength = textBox.SelectionLength();
         auto oldValue = textBox.Text();
         auto newValue = react::uwp::asHstring(text);
         if (oldValue != newValue) {
           textBox.Text(newValue);
+          if (static_cast<uint32_t>(oldCursor) <= newValue.size()) {
+            textBox.SelectionStart(oldCursor);
+          } else {
+            textBox.SelectionStart(newValue.size());
+          }
+          textBox.SelectionLength(oldSelectionLength);
         }
       } else if (text.IsNull())
         textBox.ClearValue(xaml::Controls::TextBox::TextProperty());


### PR DESCRIPTION
When modifying the contents of a `TextInput` programmatically, the cursor position gets moved to the front, which is the default behavior of XAML. Overriding it to enable dynamic re-write scenarios - eg. auto-capitalize, removing forbidden characters etc..

Fixes #6786 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7056)