### PR TITLE
[FIX] Switch component not working.

### DIFF
--- a/change/react-native-windows-d1742e8e-85f4-4dc4-a93c-5d9f3948f50e.json
+++ b/change/react-native-windows-d1742e8e-85f4-4dc4-a93c-5d9f3948f50e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Switch.onChange",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -165,7 +165,7 @@ void ViewManagerBase::GetExportedCustomBubblingEventTypeConstants(
     writer.WritePropertyName(L"phasedRegistrationNames");
     writer.WriteObjectBegin();
     React::WriteProperty(writer, L"captured", bubbleName + L"Capture");
-    React::WriteProperty(writer, L"capbubbledtured", std::move(bubbleName));
+    React::WriteProperty(writer, L"bubbled", std::move(bubbleName));
     writer.WriteObjectEnd();
     writer.WriteObjectEnd();
   }


### PR DESCRIPTION
**tl; dr;** We have a typo that breaks the Switch component, and here's a fix.

Currently, the Switch component doesn't work - toggling it doesn't result in the `onChange` callback being invoked.
I debugged it and found out that deep in the `ReactNativeRenderer` the event listener for the `topChange` event in the `bubbled` phase of capture was not getting located. Tracing it all the way up through the construction of the `ViewConfig`, and then across the bridge to `OInstance` and the `remoteModuleConfig` object, I noticed that we corrupt the `customBubblingEventTypes` object that gets passed on to the `ReactNativeViewConfigRegistry` - the `phasedRegistrationNames` field contained ['captured', 'cap**bubbled**tured'], which produced a cascading error and the onChange callback was not working.

(This also affect the Picker and DatePicker, but since the core implementations are deprecated no-one has noticed.)

Fixes #7057 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7061)