### PR TITLE
[0.64] Integrate react-native 0.64.0-rc.3

### DIFF
--- a/change/@office-iss-react-native-win32-2752f0fe-6159-4841-9de3-9ace95e0097b.json
+++ b/change/@office-iss-react-native-win32-2752f0fe-6159-4841-9de3-9ace95e0097b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate react-native 0.64.0-rc.3",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d2033839-e93f-48a0-81fc-c30b6a012c07.json
+++ b/change/react-native-windows-d2033839-e93f-48a0-81fc-c30b6a012c07.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate react-native 0.64.0-rc.3",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win/**"
   ],
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -14,7 +14,7 @@
     "@react-native/tester": "0.0.1"
   },
   "peerDependencies": {
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-windows": "0.64.0-preview.9"
   },
   "devDependencies": {
@@ -22,7 +22,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "eslint": "7.12.0",
     "just-scripts": "^0.44.7",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-platform-override": "^0.4.3",
     "react-native-windows": "0.64.0-preview.9",
     "typescript": "^3.8.3"

--- a/packages/@react-native/repo-config/overrides.json
+++ b/packages/@react-native/repo-config/overrides.json
@@ -1,5 +1,5 @@
 {
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@react-native/tester/overrides.json
+++ b/packages/@react-native/tester/overrides.json
@@ -1,5 +1,5 @@
 {
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "copy",

--- a/packages/E2ETest/package.json
+++ b/packages/E2ETest/package.json
@@ -22,7 +22,7 @@
     "@react-native-windows/tester": "0.0.1",
     "prompt-sync": "^4.2.0",
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-windows": "0.64.0-preview.9"
   },
   "devDependencies": {

--- a/packages/IntegrationTest/package.json
+++ b/packages/IntegrationTest/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-windows": "0.64.0-preview.9"
   },
   "devDependencies": {

--- a/packages/microsoft-reactnative-sampleapps/package.json
+++ b/packages/microsoft-reactnative-sampleapps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-windows": "0.64.0-preview.9"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-native-windows/tester": "0.0.1",
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-windows": "0.64.0-preview.9"
   },
   "devDependencies": {

--- a/packages/react-native-win32-tester/overrides.json
+++ b/packages/react-native-win32-tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win32/**"
   ],
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "patch",

--- a/packages/react-native-win32-tester/package.json
+++ b/packages/react-native-win32-tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "0.64.0-preview.6",
-    "react-native": "0.64.0-rc.1"
+    "react-native": "0.64.0-rc.3"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.64.0-preview.6",
@@ -23,7 +23,7 @@
     "@rnw-scripts/ts-config": "0.1.0",
     "eslint": "7.12.0",
     "just-scripts": "^0.44.7",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-platform-override": "^0.4.3",
     "typescript": "^3.8.3"
   }

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -3,7 +3,7 @@
     ".flowconfig",
     "src/**"
   ],
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "derived",

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -69,7 +69,7 @@
     "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-platform-override": "^0.4.3",
     "react-shallow-renderer": "16.14.1",
     "typescript": "^3.8.3"

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -7,7 +7,7 @@
   "excludePatterns": [
     "**/*.windesktop.js"
   ],
-  "baseVersion": "0.64.0-rc.1",
+  "baseVersion": "0.64.0-rc.3",
   "overrides": [
     {
       "type": "derived",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,7 +65,7 @@
     "just-scripts": "^0.44.7",
     "prettier": "1.19.1",
     "react": "17.0.1",
-    "react-native": "0.64.0-rc.1",
+    "react-native": "0.64.0-rc.3",
     "react-native-platform-override": "^0.4.3",
     "react-native-windows-codegen": "0.1.10",
     "react-refresh": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10205,10 +10205,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.64.0-rc.1:
-  version "0.64.0-rc.1"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.0-rc.1.tgz#63583fa57a0f20dda1ba95f50d972df8142d4396"
-  integrity sha512-EjQzqTWdX4FquZK+MQjJreqjBhJFznrihZ4h07NM+6sKDx1hEQ+Fzlsps6G6JwOHzSXRKbEFUF413JcfKrq8mw==
+react-native@0.64.0-rc.3:
+  version "0.64.0-rc.3"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.64.0-rc.3.tgz#31c27ea4baf935cc7340fb464e07352fac8864de"
+  integrity sha512-WjUvxO7yKOh3Jj0YWkInWR0UubstUFQSwOmWUnUb5ZrOfGpJc4gSYDfo5LQrqBO1Cd8+Me0zkEuFiIPeBxLMtQ==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.0"


### PR DESCRIPTION
Integrating the new RC bits into 0.64-stable. No file conflicts, but we do get some important JS platform updates.

Command: `yarn integrate-rn 0.64.0-rc.3`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7064)