### PR TITLE
Fix ScrollToEnd for vertical <ScrollView>.

### DIFF
--- a/change/react-native-windows-00d11bb8-8263-4188-af57-f438d1ab587b.json
+++ b/change/react-native-windows-00d11bb8-8263-4188-af57-f438d1ab587b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fix] ScrollView.ScrollToEnd not working for vertical lists",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -466,6 +466,7 @@ XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/) {
   scrollViewer.VerticalSnapPointsAlignment(winrt::SnapPointsAlignment::Near);
   scrollViewer.VerticalSnapPointsType(winrt::SnapPointsType::Mandatory);
   scrollViewer.HorizontalSnapPointsType(winrt::SnapPointsType::Mandatory);
+  scrollViewer.HorizontalScrollMode(winrt::ScrollMode::Disabled);
 
   const auto snapPointManager = react::uwp::SnapPointManagingContentControl::Create();
   scrollViewer.Content(*snapPointManager);


### PR DESCRIPTION
By default, XAML enables both vertical and horizontal scrolling for the native `ScrollViewer`. 
The `scrollToEnd` method relies on checking whether horizontal scrolling is enabled to know if 'end' means 'bottom' or 'right'.
Setting horizontal scrolling to disabled by default - can be enabled with the 'horizontal` RN prop.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7072)