### PR TITLE
Integration Test App Not Running in CI

### DIFF
--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -111,7 +111,7 @@ jobs:
       - script: yarn integration-test
         displayName: yarn integration-test
         workingDirectory: packages/integration-test-app
-        condition: eq($(NoDeployOption), "")
+        condition: eq(variables.NoDeployOption, '')
 
       - script: yarn take-screenshot --filename $(Build.StagingDirectory)/Screenshots/after-test.png
         displayName: Screenshot desktop after tests

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -111,7 +111,7 @@ jobs:
       - script: yarn integration-test
         displayName: yarn integration-test
         workingDirectory: packages/integration-test-app
-        condition: eq('$(NoDeployOption)', '')
+        condition: eq($(NoDeployOption), "")
 
       - script: yarn take-screenshot --filename $(Build.StagingDirectory)/Screenshots/after-test.png
         displayName: Screenshot desktop after tests


### PR DESCRIPTION
Tests running are conditioned on  `$(NoDeployOption)` being an empty string. String interpolation into above commands shows it is an empty string. Was not correctly accessing runtime variables it looks like.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7076)