### PR TITLE
Better dependency warning on run-windows build error

### DIFF
--- a/change/@react-native-windows-cli-577379f2-2f69-4382-ae0f-f986dd33a54d.json
+++ b/change/@react-native-windows-cli-577379f2-2f69-4382-ae0f-f986dd33a54d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Better dependency warning on run-windows build error",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -142,7 +142,7 @@ async function runWindows(
       );
 
       newError(
-        `It is possible your installation is missing depdencies. These can be automatically installed by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
+        `It is possible your installation is missing required software depdencies. Dependencies can be automatically installed by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
       );
     }
     return setExitProcessWithError(e, options.logging);

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -142,7 +142,7 @@ async function runWindows(
       );
 
       newError(
-        `It is possible your installation is missing required software depdencies. Dependencies can be automatically installed by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
+        `It is possible your installation is missing required software dependencies. Dependencies can be automatically installed by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
       );
     }
     return setExitProcessWithError(e, options.logging);

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -142,7 +142,7 @@ async function runWindows(
       );
 
       newError(
-        `Please install the necessary dependencies by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
+        `It is possible your installation is missing depdencies. These can be automatically installed by running ${rnwDependenciesPath} from an elevated PowerShell prompt.\nFor more information, go to http://aka.ms/rnw-deps`,
       );
     }
     return setExitProcessWithError(e, options.logging);


### PR DESCRIPTION
Partial fix for #6941

Mechanism testing for dependencies is unreliable, so this error message is often incorrect. Soften language to imply suggestion instead of root cause. New for 0.65, so no need to backport.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7079)