### PR TITLE
Integrate rnw-dependencies into react-native doctor

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -194,6 +194,13 @@ steps:
       script: npx react-native info
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
+  # Verify react-native doctor command works
+  - task: CmdLine@2
+    displayName: React Native Doctor
+    inputs:
+      script: npx react-native doctor
+      workingDirectory: $(Agent.BuildDirectory)\testcli
+
   - task: CmdLine@2
     displayName: Build project (Release)
     inputs:

--- a/change/@react-native-windows-cli-a9518dc5-9d31-4eae-931e-055d46bedb85.json
+++ b/change/@react-native-windows-cli-a9518dc5-9d31-4eae-931e-055d46bedb85.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate rnw-dependencies into react-native doctor",
+  "packageName": "@react-native-windows/cli",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-249bff49-d0fc-49e3-a4fb-fec202c395ae.json
+++ b/change/react-native-windows-249bff49-d0fc-49e3-a4fb-fec202c395ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate rnw-dependencies into react-native doctor",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/healthChecks.ts
+++ b/packages/@react-native-windows/cli/src/healthChecks.ts
@@ -1,0 +1,68 @@
+import * as path from 'path';
+
+import { execSync} from 'child_process';
+
+const cliDir = path.dirname(require.resolve('@react-native-community/cli/package.json', {paths: [process.cwd()]}));
+const execaPath = require.resolve('execa', { paths: [cliDir] });
+const execa = require(execaPath);
+
+import type {HealthCheckCategory} from '@react-native-community/cli-types';
+
+export function getHealthChecks(): HealthCheckCategory[] | undefined {
+// All our health checks are windows only...
+    if (process.platform !== 'win32') {
+        return undefined;
+    }
+
+    const rnwDepScriptPath = path.join(path.dirname(require.resolve(
+        'react-native-windows/package.json',
+        {paths: [process.cwd()]})), 'Scripts/rnw-dependencies.ps1');
+    
+    const rnwDeps = execSync(`powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -NoPrompt -ListChecks`);
+    const deps = rnwDeps.toString().trim().split('\n');
+    return [
+      {
+        label: 'Windows',
+        healthchecks:
+          deps.map(dep => {
+            const match = /([^:]+): ([^:]+): (.*)/.exec(dep);
+            if (!match) {
+              throw new Error(`Unexpected output from ${rnwDepScriptPath}`);
+            }
+            const [, /*optional*/, id, name] = match;
+            return {
+              label: name,
+              // The schema check of react-native doctor requires this to be a string, although it should be a boolean
+              // Enable this once we pick up a new version of the CLI that includes https://github.com/react-native-community/cli/pull/1367
+              // isRequired: (optional.trim() === 'Required') ? true : false, 
+              isRequired: false,
+              getDiagnostics: async () => {
+                let needsToBeFixed = true;
+                try {
+                  await execa(`powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -NoPrompt -Check ${id}`);
+                  needsToBeFixed = false;
+                } catch {
+                }
+                return {
+                  needsToBeFixed,
+                }
+              },
+              runAutomaticFix: async ({ loader, logManualInstallation }) => {
+                const command = `powershell ${rnwDepScriptPath} -Check ${id}`;
+                try {
+                  const { exitCode } = await execa(command, { stdio: 'inherit' });
+                  if (exitCode) {
+                    logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
+                    loader.fail();
+                  } else {
+                    loader.succeed();
+                  }
+                } catch {
+                  logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
+                  loader.fail();
+                }
+              }
+            }
+          })
+      }];
+  }

--- a/packages/@react-native-windows/cli/src/healthChecks.ts
+++ b/packages/@react-native-windows/cli/src/healthChecks.ts
@@ -35,7 +35,6 @@ export function getHealthChecks(): HealthCheckCategory[] | undefined {
               // The schema check of react-native doctor requires this to be a string, although it should be a boolean
               // Enable this once we pick up a new version of the CLI that includes https://github.com/react-native-community/cli/pull/1367
               // isRequired: (optional.trim() === 'Required') ? true : false, 
-              isRequired: false,
               getDiagnostics: async () => {
                 let needsToBeFixed = true;
                 try {

--- a/packages/@react-native-windows/cli/src/healthChecks.ts
+++ b/packages/@react-native-windows/cli/src/healthChecks.ts
@@ -47,7 +47,7 @@ export function getHealthChecks(): HealthCheckCategory[] | undefined {
                 }
               },
               runAutomaticFix: async ({ loader, logManualInstallation }) => {
-                const command = `powershell ${rnwDepScriptPath} -Check ${id}`;
+                const command = `powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -Check ${id}`;
                 try {
                   const { exitCode } = await execa(command, { stdio: 'inherit' });
                   if (exitCode) {

--- a/packages/@react-native-windows/cli/src/index.ts
+++ b/packages/@react-native-windows/cli/src/index.ts
@@ -151,3 +151,4 @@ assertStableInterface;
 export const commands = [autoLinkCommand, runWindowsCommand];
 export const dependencyConfig = dependencyConfigWindows;
 export const projectConfig = projectConfigWindows;
+export * from './healthChecks';

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -2,12 +2,6 @@
 require('source-map-support').install();
 
 const cli = require('@react-native-windows/cli');
-const { execSync } = require('child_process');
-const path = require('path');
-
-const cliDir = path.dirname(require.resolve('@react-native-community/cli/package.json'));
-const execaPath = require.resolve('execa', { paths: [cliDir] });
-const execa = require(execaPath);
 
 module.exports = {
   // **** This section defined commands and options on how to provide the Windows platform to external applications
@@ -19,60 +13,6 @@ module.exports = {
       dependencyConfig: cli.dependencyConfig,
       npmPackageName: 'react-native-windows',
     },
-  }
+  },
+  healthChecks: cli.getHealthChecks()
 };
-
-// All our health checks are windows only...
-if (process.platform === 'win32') {
-  const rnwDepScriptPath = path.resolve(__dirname, 'Scripts/rnw-dependencies.ps1');
-  try {
-    const rnwDeps = execSync(`powershell ${rnwDepScriptPath} -NoPrompt -ListChecks`);
-    const deps = rnwDeps.toString().trim().split('\n');
-    module.exports.healthChecks = [
-      {
-        label: 'react-native-windows',
-        healthchecks:
-          deps.map(dep => {
-            const match = /([^:]+): ([^:]+): (.*)/.exec(dep);
-            if (!match) {
-              throw new Error(`Unexpected output from ${rnwDepScriptPath}`);
-            }
-            const [other, optional, id, name] = match;
-            return {
-              label: name,
-              // The schema check of react-native doctor requires this to be a string, although it should be a boolean 
-              // It also doesn't seem to do much with the value currently
-              // isRequired: (optional.trim() === 'Required') ? true : false, 
-              getDiagnostics: async () => {
-                let needsToBeFixed = true;
-                try {
-                  await execa(`powershell ${rnwDepScriptPath} -NoPrompt -Check ${id}`);
-                  needsToBeFixed = false;
-                } catch {
-                }
-                return {
-                  needsToBeFixed,
-                }
-              },
-              runAutomaticFix: async ({ loader, logManualInstallation }) => {
-                const command = `powershell ${rnwDepScriptPath} -Check ${id}`;
-                try {
-                  const { exitCode } = await execa(command, { stdio: 'inherit' });
-                  if (exitCode) {
-                    logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
-                    loader.fail();
-                  } else {
-                    loader.succeed();
-                  }
-                } catch {
-                  logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
-                  loader.fail();
-                }
-              }
-            }
-          })
-      }]
-  }
-  catch {
-  }
-}

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -2,16 +2,77 @@
 require('source-map-support').install();
 
 const cli = require('@react-native-windows/cli');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const cliDir = path.dirname(require.resolve('@react-native-community/cli/package.json'));
+const execaPath = require.resolve('execa', { paths: [cliDir] });
+const execa = require(execaPath);
 
 module.exports = {
-    // **** This section defined commands and options on how to provide the Windows platform to external applications
-    commands: cli.commands,
-    platforms: {
-      windows: {
-        linkConfig: () => null,
-        projectConfig: cli.projectConfig,
-        dependencyConfig: cli.dependencyConfig,
-        npmPackageName: 'react-native-windows',
-      },
+  // **** This section defined commands and options on how to provide the Windows platform to external applications
+  commands: cli.commands,
+  platforms: {
+    windows: {
+      linkConfig: () => null,
+      projectConfig: cli.projectConfig,
+      dependencyConfig: cli.dependencyConfig,
+      npmPackageName: 'react-native-windows',
     },
-  };
+  }
+};
+
+// All our health checks are windows only...
+if (process.platform === 'win32') {
+  const rnwDepScriptPath = path.resolve(__dirname, 'Scripts/rnw-dependencies.ps1');
+  try {
+    const rnwDeps = execSync(`powershell ${rnwDepScriptPath} -NoPrompt -ListChecks`);
+    const deps = rnwDeps.toString().trim().split('\n');
+    module.exports.healthChecks = [
+      {
+        label: 'react-native-windows',
+        healthchecks:
+          deps.map(dep => {
+            const match = /([^:]+): ([^:]+): (.*)/.exec(dep);
+            if (!match) {
+              throw new Error(`Unexpected output from ${rnwDepScriptPath}`);
+            }
+            const [other, optional, id, name] = match;
+            return {
+              label: name,
+              // The schema check of react-native doctor requires this to be a string, although it should be a boolean 
+              // It also doesn't seem to do much with the value currently
+              // isRequired: (optional.trim() === 'Required') ? true : false, 
+              getDiagnostics: async () => {
+                let needsToBeFixed = true;
+                try {
+                  await execa(`powershell ${rnwDepScriptPath} -NoPrompt -Check ${id}`);
+                  needsToBeFixed = false;
+                } catch {
+                }
+                return {
+                  needsToBeFixed,
+                }
+              },
+              runAutomaticFix: async ({ loader, logManualInstallation }) => {
+                const command = `powershell ${rnwDepScriptPath} -Check ${id}`;
+                try {
+                  const { exitCode } = await execa(command, { stdio: 'inherit' });
+                  if (exitCode) {
+                    logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
+                    loader.fail();
+                  } else {
+                    loader.succeed();
+                  }
+                } catch {
+                  logManualInstallation({ command, healthcheck: `react-native-windows dependency "${id}"` });
+                  loader.fail();
+                }
+              }
+            }
+          })
+      }]
+  }
+  catch {
+  }
+}


### PR DESCRIPTION
Running `react-native doctor` installs the dependencies for react-native android, and when on a mac for react-native iOS.

This PR makes it so that running `react-native doctor` in a project that is using `react-native-windows` on a windows machine will help users install the dependencies needed for `react-native-windows`.

The output of running `react-native doctor` will looks something like this:  (The react-native-windows section is added by this PR)

```
E:\Repos\react-native-windows2\packages\playground>npx react-native doctor
Windows
 ✓ Free space on E: > 15 GB
 ✓ Installed memory >= 16 GB
 ✓ Windows version > 10.0.16299.0
 ✓ Developer mode is on
 ✓ Long path support is enabled
 ✓ Choco
 ✓ git
 ✓ Visual Studio >= 16.5 with UWP and Desktop/C++
 ✓ NodeJS 12, 13 or 14 installed
 ✓ Chrome
 ✓ Yarn
 ✓ .net core 3.1

Common
 ✓ Node.js
 ✓ yarn
 ✓ npm

Android
 ✖ JDK
   - Version found: N/A
   - Version supported: >= 8
 ✓ Android Studio - Required for building and installing your app on Android
 ✖ Android SDK - Required for building and installing your app on Android
   - Versions found: N/A
   - Version supported: Not Found
 ✓ ANDROID_HOME

Errors:   2
Warnings: 0

Usage
 › Press f to try to fix issues.
 › Press e to try to fix errors.
 › Press w to try to fix warnings.
 › Press Enter to exit.
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7090)