### PR TITLE
Early change check in PR validation

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -26,6 +26,11 @@ stages:
 
           - template: templates/yarn-install.yml
 
+          - task: CmdLine@2
+            displayName: Check for change files
+            inputs:
+              script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+
           - template: templates/set-version-vars.yml
             parameters:
               buildEnvironment: Continuous


### PR DESCRIPTION
Since this is a common thing folks forget, let's perform the change file check earlier to save resources and fail early if someone forgot to run `yarn change`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7094)