### PR TITLE
Make most autolink FS operations async

### DIFF
--- a/change/@react-native-windows-cli-8b43c495-33e7-4911-a6ee-aa9451b43017.json
+++ b/change/@react-native-windows-cli-8b43c495-33e7-4911-a6ee-aa9451b43017.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "move autolink FS operations to async",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -34,7 +34,7 @@ test('autolink with no windows project', () => {
     protected getExperimentalFeaturesPropsXml(){
         return {path: 'ExperimentalFeatures.props', content: new DOMParser().parseFromString(this.experimentalFeaturesProps, 'application/xml')};
     }
-    protected updateFile(filepath: string, content: string) {
+    protected async updateFile(filepath: string, content: string) {
         if (filepath === 'packages.config') {
             this.packagesConfig = content;
         } else if (filepath === 'ExperimentalFeatures.props') {
@@ -259,7 +259,8 @@ test('autolink with no windows project', () => {
     al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
     al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
   
-    expect(al.ensureXAMLDialect()).toBeTruthy();
+    const exd = await al.ensureXAMLDialect();
+    expect(exd).toBeTruthy();
   
     const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
     expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
@@ -294,7 +295,8 @@ test('autolink with no windows project', () => {
     al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
     al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
   
-    expect(al.ensureXAMLDialect()).toBeTruthy();
+    const exd = await al.ensureXAMLDialect();
+    expect(exd).toBeTruthy();
   
     const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
     expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
@@ -329,7 +331,8 @@ test('autolink with no windows project', () => {
     al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
     al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
   
-    expect(al.ensureXAMLDialect()).toBeTruthy();
+    const exd = await al.ensureXAMLDialect();
+    expect(exd).toBeTruthy();
   
     const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
     expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
@@ -364,7 +367,8 @@ test('autolink with no windows project', () => {
     al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
     al.packagesConfig = `<packages><package id="SuperPkg" version="42"/><package id="Microsoft.WinUI"/></packages>`;
   
-    expect(al.ensureXAMLDialect()).toBeTruthy();
+    const exd = await al.ensureXAMLDialect();
+    expect(exd).toBeTruthy();
   
     const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
     expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);

--- a/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
@@ -180,7 +180,8 @@ test('useWinUI3=true in react-native.config.js, useWinUI3=false in ExperimentalF
     },
   );
 
-  expect(al.ensureXAMLDialect()).toBeTruthy();
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
 
   const packagesConfig = (
     await fs.promises.readFile(


### PR DESCRIPTION
Fixes #7081 by moving most file operations to be async

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7095)