### PR TITLE
Do not try to execute snapshots in Jest debug config

### DIFF
--- a/change/@rnw-scripts-jest-debug-config-8b535a05-86da-456e-aaf3-598af0fe44e8.json
+++ b/change/@rnw-scripts-jest-debug-config-8b535a05-86da-456e-aaf3-598af0fe44e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Do not try to execute snapshots in Jest debug config",
+  "packageName": "@rnw-scripts/jest-debug-config",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/jest-debug-config/jest.debug.config.js
+++ b/packages/@rnw-scripts/jest-debug-config/jest.debug.config.js
@@ -20,7 +20,7 @@ module.exports = {
   testEnvironment: 'node',
 
   // The pattern or patterns Jest uses to detect test files
-  testRegex: '/(test|e2etest)/.*\\.test',
+  testRegex: '/(test|e2etest)/.*\\.test\.ts$',
 
   // Default timeout of a test in milliseconds
   testTimeout: 600000,


### PR DESCRIPTION
Fixes #7096

Updated in e2e config and unittest config, but not debug config used by VSCode.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7100)