### PR TITLE
Fixed typo in template which breaks C# autolinking

### DIFF
--- a/change/react-native-windows-7dad67fd-f462-4483-9c48-ce1cd160f497.json
+++ b/change/react-native-windows-7dad67fd-f462-4483-9c48-ce1cd160f497.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed typo in template which breaks C# autolinking",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/cs-app/src/AutolinkedNativeModules.g.cs
+++ b/vnext/template/cs-app/src/AutolinkedNativeModules.g.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ReactNative.Managed
     internal static class AutolinkedNativeModules
     {
         internal static void RegisterAutolinkedNativeModulePackages(IList<IReactPackageProvider> packageProviders)
-        { {{ &autolinkCsReactPacakgeProviders }}
+        { {{ &autolinkCsReactPackageProviders }}
         }
     }
 }


### PR DESCRIPTION
Closes #7097

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7102)