### PR TITLE
[0.63] Fixed typo in template which breaks C# autolinking

### DIFF
--- a/change/@react-native-windows-cli-2021-02-11-09-44-26-autolinktypo63.json
+++ b/change/@react-native-windows-cli-2021-02-11-09-44-26-autolinktypo63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed typo in template which breaks C# autolinking",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-02-11T17:44:26.191Z"
+}

--- a/packages/@react-native-windows/cli/templates/cs/src/AutolinkedNativeModules.g.cs
+++ b/packages/@react-native-windows/cli/templates/cs/src/AutolinkedNativeModules.g.cs
@@ -7,7 +7,7 @@ namespace Microsoft.ReactNative.Managed
     internal static class AutolinkedNativeModules
     {
         internal static void RegisterAutolinkedNativeModulePackages(IList<IReactPackageProvider> packageProviders)
-        { {{ &autolinkCsReactPacakgeProviders }}
+        { {{ &autolinkCsReactPackageProviders }}
         }
     }
 }


### PR DESCRIPTION
Backporting #7102 to 0.63.

Closes #7097

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7104)