### PR TITLE
Avoid Full Yarn Install During Setup

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -24,12 +24,10 @@ stages:
               targetType: filePath
               filePath: .ado/scripts/shouldSkipPRBuild.ps1
 
-          - template: templates/yarn-install.yml
-
           - task: CmdLine@2
             displayName: Check for change files
             inputs:
-              script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+              script: npx --ignore-existing beachball@^1.50.1 check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
 
           - template: templates/set-version-vars.yml
             parameters:


### PR DESCRIPTION
Testing time improvements for downloding beachball + deps individually. Needs pinned beachball outside of lockfile, but old versions should probably be okay with checking.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7120)