### PR TITLE
Add IViewManagerCreateWithProperties to allow VMs to change behavior …

### DIFF
--- a/change/react-native-windows-146a8181-a6f2-4fe4-83bd-3938080c3b8f.json
+++ b/change/react-native-windows-146a8181-a6f2-4fe4-83bd-3938080c3b8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add IViewManagerCreateWithProperties to allow VMs to change behavior at create time",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -53,10 +53,12 @@ const wchar_t *ABIViewManager::GetName() const {
   return m_name.c_str();
 }
 
-xaml::DependencyObject ABIViewManager::CreateViewCore(int64_t, winrt::Microsoft::ReactNative::JSValueObject &props) {
+xaml::DependencyObject ABIViewManager::CreateViewCore(
+    int64_t,
+    const winrt::Microsoft::ReactNative::JSValueObject &props) {
   if (auto viewCreateProps = m_viewManager.try_as<IViewManagerCreateWithProperties>()) {
     auto view = viewCreateProps.CreateViewWithProperties(
-        MakeJSValueTreeReader(winrt::Microsoft::ReactNative::JSValue(std::move(props.Copy()))));
+        MakeJSValueTreeReader(winrt::Microsoft::ReactNative::JSValue(props.Copy())));
     return view.as<xaml::DependencyObject>();
   }
   return m_viewManager.CreateView();
@@ -111,7 +113,7 @@ void ABIViewManager::UpdateProperties(
 
     if (props.size() > 0) {
       m_viewManagerWithNativeProperties.UpdateProperties(
-          view, MakeJSValueTreeReader(winrt::Microsoft::ReactNative::JSValue(std::move(props.Copy()))));
+          view, MakeJSValueTreeReader(winrt::Microsoft::ReactNative::JSValue(props.Copy())));
     }
   }
 

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -53,9 +53,13 @@ const wchar_t *ABIViewManager::GetName() const {
   return m_name.c_str();
 }
 
-xaml::DependencyObject ABIViewManager::CreateViewCore(int64_t) {
-  auto view = m_viewManager.CreateView();
-  return view;
+xaml::DependencyObject ABIViewManager::CreateViewCore(int64_t, winrt::Microsoft::ReactNative::JSValueObject &props) {
+  if (auto viewCreateProps = m_viewManager.try_as<IViewManagerCreateWithProperties>()) {
+    auto view = viewCreateProps.CreateViewWithProperties(
+        MakeJSValueTreeReader(winrt::Microsoft::ReactNative::JSValue(std::move(props.Copy()))));
+    return view.as<xaml::DependencyObject>();
+  }
+  return m_viewManager.CreateView();
 }
 
 void ABIViewManager::GetExportedViewConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -62,7 +62,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   ::Microsoft::ReactNative::ShadowNode *createShadow() const override;
 
  protected:
-  xaml::DependencyObject CreateViewCore(int64_t) override;
+  xaml::DependencyObject CreateViewCore(int64_t, winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
   std::wstring m_name;
   ReactNative::IViewManager m_viewManager;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -62,7 +62,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   ::Microsoft::ReactNative::ShadowNode *createShadow() const override;
 
  protected:
-  xaml::DependencyObject CreateViewCore(int64_t, winrt::Microsoft::ReactNative::JSValueObject &props) override;
+  xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
   std::wstring m_name;
   ReactNative::IViewManager m_viewManager;

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
@@ -158,7 +158,7 @@ void GlyphViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVa
   writer.WriteString(L"boolean");
 }
 
-XamlView GlyphViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView GlyphViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   winrt::Glyphs glyphs = winrt::Glyphs();
   return glyphs;
 }

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
@@ -31,7 +31,7 @@ class GlyphShadowNode : public ShadowNodeBase {
  public:
   GlyphShadowNode() = default;
 
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -41,8 +41,8 @@ class GlyphShadowNode : public ShadowNodeBase {
   double m_height = 24;
 };
 
-void GlyphShadowNode::createView() {
-  Super::createView();
+void GlyphShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
   auto glyphs = GetView().as<winrt::Glyphs>();
 
   glyphs.FontRenderingEmSize(24);
@@ -158,7 +158,7 @@ void GlyphViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVa
   writer.WriteString(L"boolean");
 }
 
-XamlView GlyphViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView GlyphViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   winrt::Glyphs glyphs = winrt::Glyphs();
   return glyphs;
 }

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
@@ -31,7 +31,7 @@ class GlyphShadowNode : public ShadowNodeBase {
  public:
   GlyphShadowNode() = default;
 
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -41,7 +41,7 @@ class GlyphShadowNode : public ShadowNodeBase {
   double m_height = 24;
 };
 
-void GlyphShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void GlyphShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
   auto glyphs = GetView().as<winrt::Glyphs>();
 

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.h
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.h
@@ -18,7 +18,7 @@ class GlyphViewManager : public FrameworkElementViewManager {
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &props) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.h
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.h
@@ -18,7 +18,7 @@ class GlyphViewManager : public FrameworkElementViewManager {
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -54,7 +54,8 @@ namespace Microsoft.ReactNative
   }
 
   [webhosthidden]
-  DOC_STRING("Enables a view manager to dynamically decide what kind of view to create depending on the properties passed to it.")
+  DOC_STRING("Enables a view manager to create views whose behavior depend on the the property values passed to the view manager at creation time. \
+  For example, a view manager could choose to create different types of UI elements based on the properties passed in.")
   interface IViewManagerCreateWithProperties {
     Object CreateViewWithProperties(IJSValueReader propertyMapReader);
   };

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -47,9 +47,15 @@ namespace Microsoft.ReactNative
     void ReplaceChild(XAML_NAMESPACE.FrameworkElement parent, XAML_NAMESPACE.UIElement oldChild, XAML_NAMESPACE.UIElement newChild);
   }
 
-  [webhosthidden]
+  [webhosthidden] DOC_STRING("Enables a view manager to be responsible for its own layout and sizing.")
   interface IViewManagerRequiresNativeLayout
   {
     Boolean RequiresNativeLayout { get; };
   }
+
+  [webhosthidden]
+  DOC_STRING("Enables a view manager to dynamically decide what kind of view to create depending on the properties passed to it.")
+  interface IViewManagerCreateWithProperties {
+    Object CreateViewWithProperties(IJSValueReader propertyMapReader);
+  };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -156,7 +156,7 @@ struct RootShadowNode final : public ShadowNodeBase {
     m_view = reactRootView->GetXamlView();
   }
 
-  void createView() override {
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override {
     // ASSERT: The root view is created before react, so react should never tell
     // the root view to be created.
     assert(false);

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -156,7 +156,7 @@ struct RootShadowNode final : public ShadowNodeBase {
     m_view = reactRootView->GetXamlView();
   }
 
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override {
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override {
     // ASSERT: The root view is created before react, so react should never tell
     // the root view to be created.
     assert(false);

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -131,7 +131,7 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
     node->m_tag = reactTag;
     node->m_viewManager = viewManager;
 
-    node->createView();
+    node->createView(props);
 
     m_nativeUIManager->CreateView(*node, props);
 

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
@@ -25,7 +25,7 @@ void ActivityIndicatorViewManager::GetNativeProps(const winrt::Microsoft::ReactN
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"color", L"Color");
 }
 
-XamlView ActivityIndicatorViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView ActivityIndicatorViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto progressRing = xaml::Controls::ProgressRing();
   return progressRing;
 }

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
@@ -25,7 +25,9 @@ void ActivityIndicatorViewManager::GetNativeProps(const winrt::Microsoft::ReactN
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"color", L"Color");
 }
 
-XamlView ActivityIndicatorViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView ActivityIndicatorViewManager::CreateViewCore(
+    int64_t /*tag*/,
+    const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto progressRing = xaml::Controls::ProgressRing();
   return progressRing;
 }

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
@@ -22,7 +22,7 @@ class ActivityIndicatorViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
@@ -22,7 +22,7 @@ class ActivityIndicatorViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
@@ -23,7 +23,7 @@ class DatePickerShadowNode : public ShadowNodeBase {
 
  public:
   DatePickerShadowNode() = default;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -35,7 +35,7 @@ class DatePickerShadowNode : public ShadowNodeBase {
   xaml::Controls::CalendarDatePicker::DateChanged_revoker m_dataPickerDateChangedRevoker{};
 };
 
-void DatePickerShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void DatePickerShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
   auto datePicker = GetView().as<xaml::Controls::CalendarDatePicker>();

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
@@ -23,7 +23,7 @@ class DatePickerShadowNode : public ShadowNodeBase {
 
  public:
   DatePickerShadowNode() = default;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -35,8 +35,8 @@ class DatePickerShadowNode : public ShadowNodeBase {
   xaml::Controls::CalendarDatePicker::DateChanged_revoker m_dataPickerDateChangedRevoker{};
 };
 
-void DatePickerShadowNode::createView() {
-  Super::createView();
+void DatePickerShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 
   auto datePicker = GetView().as<xaml::Controls::CalendarDatePicker>();
 
@@ -164,7 +164,7 @@ ShadowNode *DatePickerViewManager::createShadow() const {
   return new DatePickerShadowNode();
 }
 
-XamlView DatePickerViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView DatePickerViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto datePicker = xaml::Controls::CalendarDatePicker();
   return datePicker;
 }

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
@@ -164,7 +164,7 @@ ShadowNode *DatePickerViewManager::createShadow() const {
   return new DatePickerShadowNode();
 }
 
-XamlView DatePickerViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView DatePickerViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto datePicker = xaml::Controls::CalendarDatePicker();
   return datePicker;
 }

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.h
@@ -20,7 +20,7 @@ class DatePickerViewManager : public ControlViewManager {
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class DatePickerShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.h
@@ -20,7 +20,7 @@ class DatePickerViewManager : public ControlViewManager {
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class DatePickerShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -434,7 +434,7 @@ const wchar_t *FlyoutViewManager::GetName() const {
   return L"RCTFlyout";
 }
 
-XamlView FlyoutViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView FlyoutViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   return winrt::make<winrt::react::uwp::implementation::ViewPanel>().as<XamlView>();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -86,7 +86,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   virtual ~FlyoutShadowNode();
 
   void AddView(ShadowNode &child, int64_t index) override;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   static void OnFlyoutClosed(const Mso::React::IReactContext &context, int64_t tag, bool newValue);
   void onDropViewInstance() override;
   void removeAllChildren() override;
@@ -149,7 +149,7 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t /*index*/) {
   }
 }
 
-void FlyoutShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void FlyoutShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
   m_flyout = winrt::Flyout();

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -86,7 +86,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   virtual ~FlyoutShadowNode();
 
   void AddView(ShadowNode &child, int64_t index) override;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   static void OnFlyoutClosed(const Mso::React::IReactContext &context, int64_t tag, bool newValue);
   void onDropViewInstance() override;
   void removeAllChildren() override;
@@ -149,8 +149,8 @@ void FlyoutShadowNode::AddView(ShadowNode &child, int64_t /*index*/) {
   }
 }
 
-void FlyoutShadowNode::createView() {
-  Super::createView();
+void FlyoutShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 
   m_flyout = winrt::Flyout();
   m_isFlyoutShowOptionsSupported = !!(winrt::Flyout().try_as<winrt::IFlyoutBase5>());
@@ -434,7 +434,7 @@ const wchar_t *FlyoutViewManager::GetName() const {
   return L"RCTFlyout";
 }
 
-XamlView FlyoutViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView FlyoutViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   return winrt::make<winrt::react::uwp::implementation::ViewPanel>().as<XamlView>();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.h
@@ -28,7 +28,7 @@ class FlyoutViewManager : public FrameworkElementViewManager {
       float height) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class FlyoutShadowNode;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.h
@@ -28,7 +28,7 @@ class FlyoutViewManager : public FrameworkElementViewManager {
       float height) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class FlyoutShadowNode;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -105,7 +105,7 @@ const wchar_t *ImageViewManager::GetName() const {
   return L"RCTImageView";
 }
 
-XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   return ReactImage::Create().as<winrt::Grid>();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -77,7 +77,7 @@ class ImageShadowNode : public ShadowNodeBase {
  public:
   ImageShadowNode() = default;
 
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &props) override {
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &props) override {
     ShadowNodeBase::createView(props);
     auto reactImage{m_view.as<ReactImage>()};
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -77,8 +77,8 @@ class ImageShadowNode : public ShadowNodeBase {
  public:
   ImageShadowNode() = default;
 
-  void createView() override {
-    ShadowNodeBase::createView();
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &props) override {
+    ShadowNodeBase::createView(props);
     auto reactImage{m_view.as<ReactImage>()};
 
     m_onLoadEndToken = reactImage->OnLoadEnd([imageViewManager{static_cast<ImageViewManager *>(GetViewManager())},
@@ -105,7 +105,7 @@ const wchar_t *ImageViewManager::GetName() const {
   return L"RCTImageView";
 }
 
-XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   return ReactImage::Create().as<winrt::Grid>();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
@@ -26,7 +26,7 @@ class ImageViewManager : public FrameworkElementViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   void setSource(xaml::Controls::Grid grid, const winrt::Microsoft::ReactNative::JSValue &sources);

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
@@ -26,7 +26,7 @@ class ImageViewManager : public FrameworkElementViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   void setSource(xaml::Controls::Grid grid, const winrt::Microsoft::ReactNative::JSValue &sources);

--- a/vnext/Microsoft.ReactNative/Views/PaperShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Views/PaperShadowNode.h
@@ -24,7 +24,7 @@ struct ShadowNode {
   virtual void removeAllChildren() = 0;
   virtual void AddView(ShadowNode &child, int64_t index) = 0;
   virtual void RemoveChildAt(int64_t indexToRemove) = 0;
-  virtual void createView(winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
+  virtual void createView(const winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
 
   int64_t m_tag{0};
   std::string m_className;

--- a/vnext/Microsoft.ReactNative/Views/PaperShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Views/PaperShadowNode.h
@@ -24,7 +24,7 @@ struct ShadowNode {
   virtual void removeAllChildren() = 0;
   virtual void AddView(ShadowNode &child, int64_t index) = 0;
   virtual void RemoveChildAt(int64_t indexToRemove) = 0;
-  virtual void createView() = 0;
+  virtual void createView(winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
 
   int64_t m_tag{0};
   std::string m_className;

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -24,7 +24,7 @@ class PickerShadowNode : public ShadowNodeBase {
 
  public:
   PickerShadowNode();
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
   bool NeedsForceLayout() override;
 
@@ -63,8 +63,8 @@ PickerShadowNode::PickerShadowNode() : Super() {
   }
 }
 
-void PickerShadowNode::createView() {
-  Super::createView();
+void PickerShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
   auto combobox = GetView().as<xaml::Controls::ComboBox>();
   combobox.AllowFocusOnInteraction(true);
 
@@ -200,7 +200,7 @@ ShadowNode *PickerViewManager::createShadow() const {
   return new PickerShadowNode();
 }
 
-XamlView PickerViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView PickerViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto combobox = xaml::Controls::ComboBox();
   return combobox;
 }

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -24,7 +24,7 @@ class PickerShadowNode : public ShadowNodeBase {
 
  public:
   PickerShadowNode();
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
   bool NeedsForceLayout() override;
 
@@ -63,7 +63,7 @@ PickerShadowNode::PickerShadowNode() : Super() {
   }
 }
 
-void PickerShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void PickerShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
   auto combobox = GetView().as<xaml::Controls::ComboBox>();
   combobox.AllowFocusOnInteraction(true);

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -200,7 +200,7 @@ ShadowNode *PickerViewManager::createShadow() const {
   return new PickerShadowNode();
 }
 
-XamlView PickerViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView PickerViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto combobox = xaml::Controls::ComboBox();
   return combobox;
 }

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.h
@@ -21,7 +21,7 @@ class PickerViewManager : public ControlViewManager {
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class PickerShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.h
@@ -21,7 +21,7 @@ class PickerViewManager : public ControlViewManager {
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class PickerShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -31,7 +31,7 @@ class PopupShadowNode : public ShadowNodeBase {
   PopupShadowNode() = default;
   virtual ~PopupShadowNode();
 
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void AddView(ShadowNode &child, int64_t index) override;
   virtual void removeAllChildren() override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
@@ -73,7 +73,7 @@ xaml::Controls::ContentControl PopupShadowNode::GetControl() {
   return control;
 }
 
-void PopupShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void PopupShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
   auto popup = GetView().as<winrt::Popup>();

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -314,7 +314,7 @@ ShadowNode *PopupViewManager::createShadow() const {
   return new PopupShadowNode();
 }
 
-XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto popup = winrt::Popup();
   auto control = xaml::Controls::ContentControl();
 

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -31,7 +31,7 @@ class PopupShadowNode : public ShadowNodeBase {
   PopupShadowNode() = default;
   virtual ~PopupShadowNode();
 
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void AddView(ShadowNode &child, int64_t index) override;
   virtual void removeAllChildren() override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
@@ -73,8 +73,8 @@ xaml::Controls::ContentControl PopupShadowNode::GetControl() {
   return control;
 }
 
-void PopupShadowNode::createView() {
-  Super::createView();
+void PopupShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 
   auto popup = GetView().as<winrt::Popup>();
   auto control = GetControl();
@@ -314,7 +314,7 @@ ShadowNode *PopupViewManager::createShadow() const {
   return new PopupShadowNode();
 }
 
-XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView PopupViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto popup = winrt::Popup();
   auto control = xaml::Controls::ContentControl();
 

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.h
@@ -29,7 +29,7 @@ class PopupViewManager : public FrameworkElementViewManager {
       float height) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class PopupShadowNode;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.h
@@ -29,7 +29,7 @@ class PopupViewManager : public FrameworkElementViewManager {
       float height) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class PopupShadowNode;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -34,7 +34,7 @@ const wchar_t *RawTextViewManager::GetName() const {
   return L"RCTRawText";
 }
 
-XamlView RawTextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView RawTextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   winrt::Run run;
   return run;
 }

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -34,7 +34,7 @@ const wchar_t *RawTextViewManager::GetName() const {
   return L"RCTRawText";
 }
 
-XamlView RawTextViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView RawTextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   winrt::Run run;
   return run;
 }

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
@@ -32,7 +32,7 @@ class RawTextViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   void NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate);

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
@@ -32,7 +32,7 @@ class RawTextViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   void NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate);

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -23,7 +23,7 @@ class RefreshControlShadowNode : public ShadowNodeBase {
 
  public:
   RefreshControlShadowNode(){};
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -31,7 +31,7 @@ class RefreshControlShadowNode : public ShadowNodeBase {
   winrt::Deferral m_refreshDeferral{nullptr};
 };
 
-void RefreshControlShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void RefreshControlShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
   if (auto refreshContainer = GetView().try_as<winrt::RefreshContainer>()) {
     m_refreshRequestedRevoker =

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -79,7 +79,9 @@ const wchar_t *RefreshControlViewManager::GetName() const {
   return L"RCTRefreshControl";
 }
 
-XamlView RefreshControlViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView RefreshControlViewManager::CreateViewCore(
+    int64_t /*tag*/,
+    const winrt::Microsoft::ReactNative::JSValueObject &) {
   if (react::uwp::IsRS4OrHigher()) {
     // refreshContainer is supported >= RS4
     return winrt::RefreshContainer();

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -23,7 +23,7 @@ class RefreshControlShadowNode : public ShadowNodeBase {
 
  public:
   RefreshControlShadowNode(){};
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -31,8 +31,8 @@ class RefreshControlShadowNode : public ShadowNodeBase {
   winrt::Deferral m_refreshDeferral{nullptr};
 };
 
-void RefreshControlShadowNode::createView() {
-  Super::createView();
+void RefreshControlShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
   if (auto refreshContainer = GetView().try_as<winrt::RefreshContainer>()) {
     m_refreshRequestedRevoker =
         refreshContainer.RefreshRequested(winrt::auto_revoke, [this](auto &&, winrt::RefreshRequestedEventArgs args) {
@@ -79,7 +79,7 @@ const wchar_t *RefreshControlViewManager::GetName() const {
   return L"RCTRefreshControl";
 }
 
-XamlView RefreshControlViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView RefreshControlViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   if (react::uwp::IsRS4OrHigher()) {
     // refreshContainer is supported >= RS4
     return winrt::RefreshContainer();

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.h
@@ -21,7 +21,7 @@ class RefreshControlViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.h
@@ -21,7 +21,7 @@ class RefreshControlViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
 };
 

--- a/vnext/Microsoft.ReactNative/Views/RootViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RootViewManager.cpp
@@ -22,7 +22,7 @@ const wchar_t *RootViewManager::GetName() const {
   return L"ROOT";
 }
 
-XamlView RootViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView RootViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   // ASSERT: Can't create a root view directly. Comes from host.
   assert(false);
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Views/RootViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RootViewManager.cpp
@@ -22,7 +22,7 @@ const wchar_t *RootViewManager::GetName() const {
   return L"ROOT";
 }
 
-XamlView RootViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView RootViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   // ASSERT: Can't create a root view directly. Comes from host.
   assert(false);
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Views/RootViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RootViewManager.h
@@ -30,7 +30,7 @@ class RootViewManager : public FrameworkElementViewManager {
   void destroyShadow(ShadowNode *node) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/RootViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RootViewManager.h
@@ -30,7 +30,7 @@ class RootViewManager : public FrameworkElementViewManager {
   void destroyShadow(ShadowNode *node) const override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -458,7 +458,7 @@ void ScrollViewManager::GetExportedCustomDirectEventTypeConstants(
   writer.WriteObjectEnd();
 }
 
-XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   const auto scrollViewer = winrt::ScrollViewer{};
 
   scrollViewer.HorizontalScrollBarVisibility(winrt::ScrollBarVisibility::Auto);

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -25,7 +25,7 @@ class ScrollViewShadowNode : public ShadowNodeBase {
   ~ScrollViewShadowNode();
   void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs)
       override;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -91,8 +91,8 @@ void ScrollViewShadowNode::dispatchCommand(
   }
 }
 
-void ScrollViewShadowNode::createView() {
-  Super::createView();
+void ScrollViewShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
   const auto scrollViewUWPImplementation = react::uwp::ScrollViewUWPImplementation(scrollViewer);
@@ -458,7 +458,7 @@ void ScrollViewManager::GetExportedCustomDirectEventTypeConstants(
   writer.WriteObjectEnd();
 }
 
-XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   const auto scrollViewer = winrt::ScrollViewer{};
 
   scrollViewer.HorizontalScrollBarVisibility(winrt::ScrollBarVisibility::Auto);

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -25,7 +25,7 @@ class ScrollViewShadowNode : public ShadowNodeBase {
   ~ScrollViewShadowNode();
   void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs)
       override;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
  private:
@@ -91,7 +91,7 @@ void ScrollViewShadowNode::dispatchCommand(
   }
 }
 
-void ScrollViewShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void ScrollViewShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
@@ -30,7 +30,7 @@ class ScrollViewManager : public ControlViewManager {
   void SnapToOffsets(const XamlView &parent, const winrt::IVectorView<float> &offsets);
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   friend class ScrollViewShadowNode;

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
@@ -30,7 +30,7 @@ class ScrollViewManager : public ControlViewManager {
   void SnapToOffsets(const XamlView &parent, const winrt::IVectorView<float> &offsets);
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
  private:
   friend class ScrollViewShadowNode;

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
@@ -31,8 +31,8 @@ void ShadowNodeBase::updateProperties(winrt::Microsoft::ReactNative::JSValueObje
   GetViewManager()->UpdateProperties(this, props);
 }
 
-void ShadowNodeBase::createView() {
-  m_view = GetViewManager()->CreateView(this->m_tag);
+void ShadowNodeBase::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  m_view = GetViewManager()->CreateView(this->m_tag, props);
 
   if (react::uwp::g_HasActualSizeProperty == react::uwp::TriBit::Undefined) {
     if (auto uielement = m_view.try_as<xaml::UIElement>()) {

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.cpp
@@ -31,7 +31,7 @@ void ShadowNodeBase::updateProperties(winrt::Microsoft::ReactNative::JSValueObje
   GetViewManager()->UpdateProperties(this, props);
 }
 
-void ShadowNodeBase::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void ShadowNodeBase::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   m_view = GetViewManager()->CreateView(this->m_tag, props);
 
   if (react::uwp::g_HasActualSizeProperty == react::uwp::TriBit::Undefined) {

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -69,7 +69,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   virtual void removeAllChildren() override;
   virtual void AddView(ShadowNode &child, int64_t index) override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
-  virtual void createView() override;
+  virtual void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   virtual bool NeedsForceLayout();
 
   virtual void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -69,7 +69,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   virtual void removeAllChildren() override;
   virtual void AddView(ShadowNode &child, int64_t index) override;
   virtual void RemoveChildAt(int64_t indexToRemove) override;
-  virtual void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  virtual void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   virtual bool NeedsForceLayout();
 
   virtual void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
@@ -25,11 +25,11 @@ class SliderShadowNode : public ShadowNodeBase {
 
  public:
   SliderShadowNode() = default;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 };
 
-void SliderShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void SliderShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 }
 

--- a/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
@@ -25,12 +25,12 @@ class SliderShadowNode : public ShadowNodeBase {
 
  public:
   SliderShadowNode() = default;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 };
 
-void SliderShadowNode::createView() {
-  Super::createView();
+void SliderShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 }
 
 void SliderShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) {
@@ -56,7 +56,7 @@ ShadowNode *SliderViewManager::createShadow() const {
   return new SliderShadowNode();
 }
 
-XamlView SliderViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView SliderViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto slider = xaml::Controls::Slider();
   return slider;
 }

--- a/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SliderViewManager.cpp
@@ -56,7 +56,7 @@ ShadowNode *SliderViewManager::createShadow() const {
   return new SliderShadowNode();
 }
 
-XamlView SliderViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView SliderViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto slider = xaml::Controls::Slider();
   return slider;
 }

--- a/vnext/Microsoft.ReactNative/Views/SliderViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/SliderViewManager.h
@@ -24,7 +24,7 @@ class SliderViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class SliderShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/SliderViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/SliderViewManager.h
@@ -24,7 +24,7 @@ class SliderViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class SliderShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -25,7 +25,7 @@ class SwitchShadowNode : public ShadowNodeBase {
 
  public:
   SwitchShadowNode() = default;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
   void UpdateThumbColor();
   void UpdateTrackColor();
@@ -42,8 +42,8 @@ class SwitchShadowNode : public ShadowNodeBase {
   winrt::Microsoft::ReactNative::JSValue m_onTrackColor;
 };
 
-void SwitchShadowNode::createView() {
-  Super::createView();
+void SwitchShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
 
   auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();
   m_toggleSwitchToggledRevoker = toggleSwitch.Toggled(winrt::auto_revoke, [=](auto &&, auto &&) {
@@ -145,7 +145,7 @@ ShadowNode *SwitchViewManager::createShadow() const {
   return new SwitchShadowNode();
 }
 
-XamlView SwitchViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView SwitchViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto toggleSwitch = winrt::ToggleSwitch();
   toggleSwitch.OnContent(nullptr);
   toggleSwitch.OffContent(nullptr);

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -145,7 +145,7 @@ ShadowNode *SwitchViewManager::createShadow() const {
   return new SwitchShadowNode();
 }
 
-XamlView SwitchViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView SwitchViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto toggleSwitch = winrt::ToggleSwitch();
   toggleSwitch.OnContent(nullptr);
   toggleSwitch.OffContent(nullptr);

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -25,7 +25,7 @@ class SwitchShadowNode : public ShadowNodeBase {
 
  public:
   SwitchShadowNode() = default;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
   void UpdateThumbColor();
   void UpdateTrackColor();
@@ -42,7 +42,7 @@ class SwitchShadowNode : public ShadowNodeBase {
   winrt::Microsoft::ReactNative::JSValue m_onTrackColor;
 };
 
-void SwitchShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void SwitchShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
   auto toggleSwitch = GetView().as<winrt::ToggleSwitch>();

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
@@ -23,7 +23,7 @@ class SwitchViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class SwitchShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.h
@@ -23,7 +23,7 @@ class SwitchViewManager : public ControlViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 
   friend class SwitchShadowNode;
 };

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -94,7 +94,7 @@ class TextInputShadowNode : public ShadowNodeBase {
 
  public:
   TextInputShadowNode() = default;
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
   void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs)
@@ -165,7 +165,7 @@ class TextInputShadowNode : public ShadowNodeBase {
   xaml::Controls::Control::Loaded_revoker m_controlLoadedRevoker{};
 };
 
-void TextInputShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+void TextInputShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
   registerEvents();
 }

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -94,7 +94,7 @@ class TextInputShadowNode : public ShadowNodeBase {
 
  public:
   TextInputShadowNode() = default;
-  void createView() override;
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &) override;
   void updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
   void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs)
@@ -165,8 +165,8 @@ class TextInputShadowNode : public ShadowNodeBase {
   xaml::Controls::Control::Loaded_revoker m_controlLoadedRevoker{};
 };
 
-void TextInputShadowNode::createView() {
-  Super::createView();
+void TextInputShadowNode::createView(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  Super::createView(props);
   registerEvents();
 }
 
@@ -730,7 +730,7 @@ ShadowNode *TextInputViewManager::createShadow() const {
   return new TextInputShadowNode();
 }
 
-XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   xaml::Controls::TextBox textBox;
   return textBox;
 }

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -730,7 +730,7 @@ ShadowNode *TextInputViewManager::createShadow() const {
   return new TextInputShadowNode();
 }
 
-XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   xaml::Controls::TextBox textBox;
   return textBox;
 }

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.h
@@ -23,7 +23,7 @@ class TextInputViewManager : public ControlViewManager {
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class TextInputShadowNode;
 
  private:

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.h
@@ -23,7 +23,7 @@ class TextInputViewManager : public ControlViewManager {
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView) override;
 
  protected:
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   friend class TextInputShadowNode;
 
  private:

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -137,7 +137,7 @@ const wchar_t *TextViewManager::GetName() const {
   return L"RCTText";
 }
 
-XamlView TextViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView TextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto textBlock = xaml::Controls::TextBlock();
   textBlock.TextWrapping(xaml::TextWrapping::Wrap); // Default behavior in React Native
   return textBlock;

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -137,7 +137,7 @@ const wchar_t *TextViewManager::GetName() const {
   return L"RCTText";
 }
 
-XamlView TextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView TextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto textBlock = xaml::Controls::TextBlock();
   textBlock.TextWrapping(xaml::TextWrapping::Wrap); // Default behavior in React Native
   return textBlock;

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -31,7 +31,7 @@ class TextViewManager : public FrameworkElementViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -31,7 +31,7 @@ class TextViewManager : public FrameworkElementViewManager {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -191,7 +191,7 @@ void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
   }
 }
 
-XamlView ViewManagerBase::CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject& props) {
+XamlView ViewManagerBase::CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) {
   XamlView view = CreateViewCore(tag, props);
 
   OnViewCreated(view);

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -191,7 +191,7 @@ void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
   }
 }
 
-XamlView ViewManagerBase::CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) {
+XamlView ViewManagerBase::CreateView(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &props) {
   XamlView view = CreateViewCore(tag, props);
 
   OnViewCreated(view);

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -191,8 +191,8 @@ void ViewManagerBase::GetExportedCustomDirectEventTypeConstants(
   }
 }
 
-XamlView ViewManagerBase::CreateView(int64_t tag) {
-  XamlView view = CreateViewCore(tag);
+XamlView ViewManagerBase::CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject& props) {
+  XamlView view = CreateViewCore(tag, props);
 
   OnViewCreated(view);
   // Set the tag if the element type supports it

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -38,7 +38,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   ViewManagerBase(const Mso::React::IReactContext &context);
   virtual ~ViewManagerBase() {}
 
-  virtual XamlView CreateView(int64_t tag);
+  virtual XamlView CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props);
 
   void GetExportedViewConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   void GetCommands(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
@@ -87,7 +87,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView);
 
  protected:
-  virtual XamlView CreateViewCore(int64_t tag) = 0;
+  virtual XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
   virtual void OnViewCreated(XamlView view) {}
   virtual bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -87,7 +87,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView);
 
  protected:
-  virtual XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
+  virtual XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
   virtual void OnViewCreated(XamlView view) {}
   virtual bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -38,7 +38,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   ViewManagerBase(const Mso::React::IReactContext &context);
   virtual ~ViewManagerBase() {}
 
-  virtual XamlView CreateView(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &props);
+  virtual XamlView CreateView(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &props);
 
   void GetExportedViewConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   void GetCommands(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -39,7 +39,7 @@ class ViewShadowNode : public ShadowNodeBase {
  public:
   ViewShadowNode() = default;
 
-  void createView(winrt::Microsoft::ReactNative::JSValueObject &props) override {
+  void createView(const winrt::Microsoft::ReactNative::JSValueObject &props) override {
     Super::createView(props);
 
     auto panel = GetViewPanel();

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -367,7 +367,7 @@ ShadowNode *ViewViewManager::createShadow() const {
   return new ViewShadowNode();
 }
 
-XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   auto panel = winrt::make<winrt::react::uwp::implementation::ViewPanel>();
   panel.VerticalAlignment(xaml::VerticalAlignment::Stretch);
   panel.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -39,8 +39,8 @@ class ViewShadowNode : public ShadowNodeBase {
  public:
   ViewShadowNode() = default;
 
-  void createView() override {
-    Super::createView();
+  void createView(winrt::Microsoft::ReactNative::JSValueObject &props) override {
+    Super::createView(props);
 
     auto panel = GetViewPanel();
 
@@ -367,7 +367,7 @@ ShadowNode *ViewViewManager::createShadow() const {
   return new ViewShadowNode();
 }
 
-XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   auto panel = winrt::make<winrt::react::uwp::implementation::ViewPanel>();
   panel.VerticalAlignment(xaml::VerticalAlignment::Stretch);
   panel.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -39,7 +39,7 @@ class ViewViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
   void OnPropertiesUpdated(ShadowNodeBase *node) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::react::uwp::ViewPanel &pPanel, bool useControl);
 
   xaml::Media::SolidColorBrush EnsureTransparentBrush();

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -39,7 +39,7 @@ class ViewViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
   void OnPropertiesUpdated(ShadowNodeBase *node) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
   void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::react::uwp::ViewPanel &pPanel, bool useControl);
 
   xaml::Media::SolidColorBrush EnsureTransparentBrush();

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -50,7 +50,7 @@ const wchar_t *VirtualTextViewManager::GetName() const {
   return L"RCTVirtualText";
 }
 
-XamlView VirtualTextViewManager::CreateViewCore(int64_t /*tag*/) {
+XamlView VirtualTextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
   return winrt::Span();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -50,7 +50,7 @@ const wchar_t *VirtualTextViewManager::GetName() const {
   return L"RCTVirtualText";
 }
 
-XamlView VirtualTextViewManager::CreateViewCore(int64_t /*tag*/, winrt::Microsoft::ReactNative::JSValueObject &) {
+XamlView VirtualTextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   return winrt::Span();
 }
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -49,7 +49,7 @@ class VirtualTextViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
+  XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -49,7 +49,7 @@ class VirtualTextViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  XamlView CreateViewCore(int64_t tag) override;
+  XamlView CreateViewCore(int64_t tag, winrt::Microsoft::ReactNative::JSValueObject &) override;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
…at create time

Fixes #7038 and enables a reduction of 50% in the number of xaml objects created (since the alternative is to return a panel or ContentControl from your view manager and create the actual element in `UpdateProperties`)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7137)