### PR TITLE
Fixes autolink check error to include command to fix it

### DIFF
--- a/change/@react-native-windows-cli-280a57c0-befb-4056-8cbf-0e2417f689a9.json
+++ b/change/@react-native-windows-cli-280a57c0-befb-4056-8cbf-0e2417f689a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes autolink check error to incude command to fix it",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -808,6 +808,18 @@ export class AutolinkWindows {
     });
     return changed;
   }
+
+  /** @return The CLI command to invoke autolink-windows independently */
+  public getAutolinkWindowsCommand() {
+    const folder = this.windowsAppConfig.folder;
+
+    const autolinkCommand = 'npx react-native autolink-windows';
+    const autolinkArgs = `--sln "${path.relative(
+      folder,
+      this.getSolutionFile(),
+    )}" --proj "${path.relative(folder, this.getProjectFile())}"`;
+    return `${autolinkCommand} ${autolinkArgs}`;
+  }
 }
 
 /**
@@ -876,18 +888,19 @@ async function updateAutoLink(
         )}ms)`,
       );
     } else if (options.check) {
+      const autolinkCommand = autolink.getAutolinkWindowsCommand();
       console.log(
         `${chalk.yellow(
           'Warning:',
         )} Auto-linking changes were necessary but ${chalk.bold(
           '--check',
-        )} specified. Run ${chalk.bold(
-          "'npx react-native autolink-windows'",
-        )} to apply the changes. (${Math.round(endTime - startTime)}ms)`,
+        )} specified. Run '${chalk.bold(
+          `${autolinkCommand}`,
+        )}' to apply the changes. (${Math.round(endTime - startTime)}ms)`,
       );
       throw new CodedError(
         'NeedAutolinking',
-        'Auto-linking changes were necessary but --check was specified',
+        `Auto-linking changes were necessary but --check was specified. Run '${autolinkCommand}' to apply the changes`,
       );
     } else {
       console.log(


### PR DESCRIPTION
If the autolinking check fails, the error should include the proper command to fix it.

Closes #6761

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7146)