### PR TITLE
Fix DevMenuControl.xbf copy conflict

### DIFF
--- a/change/react-native-windows-bac296d9-c8c9-452c-861e-6e9a1fa7872a.json
+++ b/change/react-native-windows-bac296d9-c8c9-452c-861e-6e9a1fa7872a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix DevMenuControl.xbf copy conflict",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
@@ -8,6 +8,14 @@
   Do not make any changes here unless it applies to ALL such projects.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!--
+      Define SkipAddPriPayloadFilesToCopyToOutputDirectoryItems=true and GenerateLibraryLayout=false to avoid
+      conflicts with copying Microsoft.ReactNative XBF files by the native module DLLs and by Microsoft.ReactNative.
+    -->
+    <SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>true</SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>
+    <GenerateLibraryLayout>false</GenerateLibraryLayout>
+  </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
 </Project>


### PR DESCRIPTION
When we work in the samples app solution and edit Microsoft.ReactNative files we see a build issue where the  DevMenuControl.xbf cannot be copied to the App package because there is a version conflict between the version produced by the  Microsoft.ReactNative project and the C++ native module project that tries to copy the old version of the same DevMenuControl.xbf file.

The issue exists only for the incremental builds and seems to be caused by a bug in XAML Build logic that does not update the XBF files in child projects correctly. The issue seems to be related only to C++ DLL projects. The C# DLL projects do not cause the same issue.
Because of this issue we must to do a full rebuild every time we change any Microsoft.ReactNative files.

In this PR we fix this issue by forcing the C++ native module project to stop copying Microsoft.ReactNative AppX files. They will be copied by application from the Microsoft.ReactNative project. This avoids any version conflict and make the incremental builds possible.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7153)