### PR TITLE
Fix branch name problem with beachball

### DIFF
--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -24,6 +24,8 @@ jobs:
 
       - template: ../templates/yarn-install.yml
 
+      - template: ../templates/compute-beachball-branch-name.yml
+
       - task: CmdLine@2
         displayName: Check for change files
         inputs:

--- a/.ado/templates/compute-beachball-branch-name.yml
+++ b/.ado/templates/compute-beachball-branch-name.yml
@@ -1,0 +1,16 @@
+steps:
+  - task: CmdLine@2
+    displayName: Set BeachBallBranchName for Pull Request
+    inputs:
+      script: |
+        echo Setting BeachBallBranchName to $(System.PullRequest.TargetBranch)
+        echo "##vso[task.setvariable variable=BeachBallBranchName]$(System.PullRequest.TargetBranch)
+    condition: ${{ eq(variables['Build.Reason'], 'PullRequest') }}
+
+  - task: CmdLine@2
+    displayName: Set BeachBallBranchName for CI
+    inputs:
+      script: |
+        echo Setting BeachBallBranchName to $(Build.SourceBranchName)
+        echo "##vso[task.setvariable variable=BeachBallBranchName]$(Build.SourceBranchName)
+    condition: ${{ ne(variables['Build.Reason'], 'PullRequest') }}

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -67,6 +67,8 @@ steps:
       node .ado/scripts/npmAddUser.js user pass mail@nomail.com http://localhost:4873
     displayName: Add npm user to verdaccio
 
+  - template: ../templates/compute-beachball-branch-name.yml
+
   - script: |
       npx --no-install beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -8,4 +8,4 @@ variables:
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60
-  BeachBallBranchName: ${{ coalesce(variables['Build.SourceBranch'], variables['System.PullRequest.SourceBranchName']) }}
+  

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -16,6 +16,8 @@ stages:
       - job: Setup
         variables:
           - template: variables/vs2019.yml
+        pool:
+          vmImage: windows-2019
         steps:
           - task: powershell@2
             name: checkPayload
@@ -25,6 +27,8 @@ stages:
               filePath: .ado/scripts/shouldSkipPRBuild.ps1
 
           - template: templates/yarn-install.yml
+
+          - template: templates/compute-beachball-branch-name.yml
 
           - task: CmdLine@2
             displayName: Check for change files


### PR DESCRIPTION
It turns out that during the variable expansion the PR branch variables are not properly populated yet...
This change updates the yaml to extract the branch name to just before we need it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7154)