### PR TITLE
Avoid MaxPath issue with telemetry in UnitTest project

### DIFF
--- a/change/@react-native-windows-cli-4dcf4d3c-2602-4173-a389-5f1f0392e66a.json
+++ b/change/@react-native-windows-cli-4dcf4d3c-2602-4173-a389-5f1f0392e66a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid MaxPath issue with telemetry in UnitTest project",
+  "packageName": "@react-native-windows/cli",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/powershell/Add-AppDevPackage.ps1
+++ b/packages/@react-native-windows/cli/powershell/Add-AppDevPackage.ps1
@@ -107,10 +107,10 @@ function PrintMessageAndExit($ErrorMessage, $ReturnCode)
     {
         # Log telemetry data regarding the use of the script if possible.
         # There are three ways that this can be disabled:
-        #   1. If the "TelemetryDependencies" folder isn't present.  This can be excluded at build time by setting the MSBuild property AppxLogTelemetryFromSideloadingScript to false
+        #   1. If the "TelDeps" folder isn't present.  This can be excluded at build time by setting the MSBuild property AppxLogTelemetryFromSideloadingScript to false
         #   2. If the SkipLoggingTelemetry switch is passed to this script.
         #   3. If Visual Studio telemetry is disabled via the registry.
-        $TelemetryAssembliesFolder = (Join-Path $PSScriptRoot "TelemetryDependencies")
+        $TelemetryAssembliesFolder = (Join-Path $PSScriptRoot "TelDeps")
         if (!$SkipLoggingTelemetry -And (Test-Path $TelemetryAssembliesFolder))
         {
             $job = Start-Job -FilePath (Join-Path $TelemetryAssembliesFolder "LogSideloadingTelemetry.ps1") -ArgumentList $TelemetryAssembliesFolder, "VS/DesignTools/SideLoadingScript/AddAppDevPackage", $ReturnCode, $ProcessorArchitecture


### PR DESCRIPTION
The Hosted agents add _work to the agent path i.e `d:\a\_work\1\s` vs `d:\a\1\s` caused max path issue for the unittest project when switching. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7155)