### PR TITLE
Fix projectName issue with C# projects and deploy tool version check

### DIFF
--- a/change/@react-native-windows-cli-574dfc33-3d0e-4e33-9f03-16ee0384aead.json
+++ b/change/@react-native-windows-cli-574dfc33-3d0e-4e33-9f03-16ee0384aead.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix projectName issue with C# projects and deploy tool version check",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -29,7 +29,6 @@ export function findFiles(folder: string, filenamePattern: string): string[] {
       'node_modules/**',
       '**/Debug/**',
       '**/Release/**',
-      '**/WinUI3/**',
       '**/Generated Files/**',
       '**/packages/**',
     ],
@@ -290,10 +289,13 @@ export function importProjectExists(
  * @param projectContents The XML project contents.
  * @return The project name.
  */
-export function getProjectName(projectContents: Node): string {
+export function getProjectName(
+  projectPath: string,
+  projectContents: Node,
+): string {
   const name =
     tryFindPropertyValue(projectContents, 'ProjectName') ||
-    tryFindPropertyValue(projectContents, 'AssemblyName') ||
+    path.parse(projectPath).name ||
     '';
 
   return name;

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -227,7 +227,10 @@ export function dependencyConfigWindows(
       const projectContents = configUtils.readProjectFile(projectFile);
 
       // Calculating (auto) items
-      project.projectName = configUtils.getProjectName(projectContents);
+      project.projectName = configUtils.getProjectName(
+        projectFile,
+        projectContents,
+      );
       project.projectLang = configUtils.getProjectLanguage(projectFile);
       project.projectGuid = configUtils.getProjectGuid(projectContents);
 
@@ -265,7 +268,10 @@ export function dependencyConfigWindows(
 
       const projectContents = configUtils.readProjectFile(projectFile);
 
-      const projectName = configUtils.getProjectName(projectContents);
+      const projectName = configUtils.getProjectName(
+        projectFile,
+        projectContents,
+      );
 
       const projectGuid = configUtils.getProjectGuid(projectContents);
 

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -187,7 +187,10 @@ export function projectConfigWindows(
     const projectContents = configUtils.readProjectFile(projectFile);
 
     // Add missing (auto) items
-    result.project.projectName = configUtils.getProjectName(projectContents);
+    result.project.projectName = configUtils.getProjectName(
+      projectFile,
+      projectContents,
+    );
     result.project.projectLang = configUtils.getProjectLanguage(projectFile);
     result.project.projectGuid = configUtils.getProjectGuid(projectContents);
   }

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -227,20 +227,31 @@ async function runWindowsInternal(
   }
 
   // Get the solution file
-  const slnFile = build.getAppSolutionFile(options, config);
+  let slnFile;
+  try {
+    slnFile = build.getAppSolutionFile(options, config);
+  } catch (e) {
+    newError(`Couldn't get app solution information. ${e.message}`);
+    throw e;
+  }
 
-  if (options.autolink) {
-    const autolinkArgs: string[] = [];
-    const autolinkConfig = config;
-    const autoLinkOptions = {
-      logging: options.logging,
-      proj: options.proj,
-      sln: options.sln,
-    };
-    runWindowsPhase = 'AutoLink';
-    await autoLinkCommand.func(autolinkArgs, autolinkConfig, autoLinkOptions);
-  } else {
-    newInfo('Autolink step is skipped');
+  try {
+    if (options.autolink) {
+      const autolinkArgs: string[] = [];
+      const autolinkConfig = config;
+      const autoLinkOptions = {
+        logging: options.logging,
+        proj: options.proj,
+        sln: options.sln,
+      };
+      runWindowsPhase = 'AutoLink';
+      await autoLinkCommand.func(autolinkArgs, autolinkConfig, autoLinkOptions);
+    } else {
+      newInfo('Autolink step is skipped');
+    }
+  } catch (e) {
+    newError(`Autolinking failed. ${e.message}`);
+    throw e;
   }
 
   let buildTools: MSBuildTools;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -176,7 +176,7 @@ export class AutolinkWindows {
           ),
           projFile,
         ),
-        projectName: configUtils.getProjectName(projectContents),
+        projectName: configUtils.getProjectName(projFile, projectContents),
         projectLang: configUtils.getProjectLanguage(projFile),
         projectGuid: configUtils.getProjectGuid(projectContents),
       };

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -240,7 +240,7 @@ export async function deployToDesktop(
   const projectName =
     windowsConfig && windowsConfig.project && windowsConfig.project.projectName
       ? windowsConfig.project.projectName
-      : options.proj!;
+      : path.parse(options.proj!).name;
   const windowsStoreAppUtils = getWindowsStoreAppUtils(options);
   const appxManifestPath = getAppxManifestPath(options, projectName);
   const appxManifest = parseAppxManifest(appxManifestPath);
@@ -291,7 +291,7 @@ export async function deployToDesktop(
       'InstallAppFailure',
     );
   } else {
-    // If we have DeployAppRecipe.exe, use it (start in 16.9 Preview 2, don't use 16.8 even if it's there as that version has bugs)
+    // If we have DeployAppRecipe.exe, use it (start in 16.8.4, earlier 16.8 versions have bugs)
     const appxRecipe = path.join(
       path.dirname(appxManifestPath),
       `${projectName}.build.appxrecipe`,
@@ -299,7 +299,7 @@ export async function deployToDesktop(
     const ideFolder = `${buildTools.installationPath}\\Common7\\IDE`;
     const deployAppxRecipeExePath = `${ideFolder}\\DeployAppRecipe.exe`;
     if (
-      vsVersion.gte(Version.fromString('16.9.30801.93')) &&
+      vsVersion.gte(Version.fromString('16.8.30906.45')) &&
       fs.existsSync(deployAppxRecipeExePath)
     ) {
       await commandWithProgress(


### PR DESCRIPTION
Fixes #7164

We were erroneously using the assembly name as a project name, which will be different for C# projects that get --namespace passed to init. Also updating the deploy code to use the earlier version of VS that supports the VS deploy tool

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7165)