### PR TITLE
Fixes missing image size in Image onLoad event

### DIFF
--- a/change/react-native-windows-c597c4ed-90a3-4cbe-81a9-2a9c993edcde.json
+++ b/change/react-native-windows-c597c4ed-90a3-4cbe-81a9-2a9c993edcde.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fixes missing image size in Image onLoad event",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -289,11 +289,6 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         strong_this->m_imageBrushOpenedRevoker =
             imageBrush.ImageOpened(winrt::auto_revoke, [weak_this, imageBrush](const auto &, const auto &) {
               if (auto strong_this{weak_this.get()}) {
-                if (auto bitmap{imageBrush.ImageSource().try_as<winrt::BitmapImage>()}) {
-                  strong_this->m_imageSource.height = bitmap.PixelHeight();
-                  strong_this->m_imageSource.width = bitmap.PixelWidth();
-                }
-
                 imageBrush.Stretch(strong_this->ResizeModeToStretch(strong_this->m_resizeMode));
               }
             });
@@ -339,6 +334,11 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
                 auto strong_this{weak_this.get()};
                 if (strong_this && fireLoadEndEvent) {
+                  if (auto bitmap{imageBrush.ImageSource().try_as<winrt::BitmapImage>()}) {
+                    strong_this->m_imageSource.height = bitmap.PixelHeight();
+                    strong_this->m_imageSource.width = bitmap.PixelWidth();
+                  }
+
                   strong_this->m_onLoadEndEvent(*strong_this, true);
                 }
               });


### PR DESCRIPTION
As reported in #7172, the native event payload does not contain the
pixel width and height of the image in standard cases (that use
BitmapImage). The issue was that the metadata for width and height sent
in the event was not updated until the XAML ImageSource.ImageOpened
event fired, and the onLoad event itself was triggered by the
BitmapImage.ImageOpened event. The BitmapImage.ImageOpened event will
always fire before it's parent ImageSource.ImageOpened event, thus the
event emitted to React Native would never have up-to-date information on
the image size.

This commit moves the logic to update the image size metadata from the
ImageSource.ImageOpened event to the BitmapImage.ImageOpened event.

Fixes #7172

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7173)