### PR TITLE
[0.64] Include RuntimeExecutor.h in nuget

### DIFF
--- a/change/react-native-windows-aee3f006-7675-42fc-932f-445f1f54a976.json
+++ b/change/react-native-windows-aee3f006-7675-42fc-932f-445f1f54a976.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Include RuntimeExecutor.h in nuget",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -28,6 +28,7 @@
     <file src="$nugetroot$\x64\Release\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"  target="lib\ship\x64"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
 
     <file src="$nugetroot$\inc\callinvoker\ReactCommon\CallInvoker.h" target="inc\ReactCommon"/>
+    <file src="$nugetroot$\inc\runtimeexecutor\ReactCommon\RuntimeExecutor.h" target="inc\ReactCommon"/>
     <file src="$nugetroot$\inc\cxxreact\*" target="inc\cxxreact"/>
     <file src="$nugetroot$\inc\jsi\**\*.*" target="inc\jsi"/>
     <file src="$nugetroot$\inc\Yoga\*.*" target="inc\Yoga"/>


### PR DESCRIPTION
Adding RuntimeExecutor.h to the office win32 nuget: required for internal consumption of react-native-win32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7174)