### PR TITLE
Fixes race conditions for ReactImage

### DIFF
--- a/change/react-native-windows-91ae018b-5e13-44ec-8d2a-0105ccd5303b.json
+++ b/change/react-native-windows-91ae018b-5e13-44ec-8d2a-0105ccd5303b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes race conditions for ReactImage",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -227,6 +227,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
   if (auto strong_this{weak_this.get()}) {
     // If the image source has been updated since this operation started, do not continue
+    // TODO: #7194 This "cancellation" will prevent onLoad / onLoadEnd events from firing for canceled source props
     if (currentImageSourceId != strong_this->m_imageSourceId) {
       co_return;
     }
@@ -330,6 +331,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         }
 
         svgImageSource.UriSource(uri);
+
       } else {
         winrt::BitmapImage bitmapImage{imageBrush.ImageSource().try_as<winrt::BitmapImage>()};
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -227,7 +227,6 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
   if (auto strong_this{weak_this.get()}) {
     // If the image source has been updated since this operation started, do not continue
-    // TODO: #7194 This "cancellation" will prevent onLoad / onLoadEnd events from firing for canceled source props
     if (currentImageSourceId != strong_this->m_imageSourceId) {
       co_return;
     }

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -196,6 +196,9 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   const ReactImageSource source{m_imageSource};
   winrt::Uri uri{react::uwp::UriTryCreate(Utf8ToUtf16(source.uri))};
 
+  // Increment the image source ID before any co_await calls
+  auto currentImageSourceId = ++m_imageSourceId;
+
   const bool fromStream{
       source.sourceType == ImageSourceType::Download || source.sourceType == ImageSourceType::InlineData};
 
@@ -219,9 +222,15 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
     if (strong_this && fireLoadEndEvent) {
       strong_this->m_onLoadEndEvent(*strong_this, false);
     }
+    co_return;
   }
 
   if (auto strong_this{weak_this.get()}) {
+    // If the image source has been updated since this operation started, do not continue
+    if (currentImageSourceId != strong_this->m_imageSourceId) {
+      co_return;
+    }
+
     if (strong_this->m_useCompositionBrush) {
       const auto compositionBrush{ReactImageBrush::Create()};
 
@@ -321,7 +330,6 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         }
 
         svgImageSource.UriSource(uri);
-
       } else {
         winrt::BitmapImage bitmapImage{imageBrush.ImageSource().try_as<winrt::BitmapImage>()};
 
@@ -363,9 +371,15 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         } else {
           bitmapImage.UriSource(uri);
 
-          // TODO: When we change the source of a BitmapImage, we're getting a flicker of the old image
-          // being resized to the size of the new image. This is a temporary workaround.
-          imageBrush.Opacity(0);
+          // It is possible that the same URI will be set twice if an intermediate update occurs that requires
+          // asynchronous behavior (e.g., when the ImageSourceType is ::Download or ::InlineData). In this case,
+          // do not set the opacity to zero as the ImageOpened event will not fire.
+          auto currentUri = bitmapImage.UriSource();
+          if (uri && currentUri && uri.AbsoluteUri() != currentUri.AbsoluteUri()) {
+            // TODO: When we change the source of a BitmapImage, we're getting a flicker of the old image
+            // being resized to the size of the new image. This is a temporary workaround.
+            imageBrush.Opacity(0);
+          }
         }
       }
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -71,6 +71,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
 
   bool m_useCompositionBrush{false};
   float m_blurRadius{0};
+  int m_imageSourceId{0};
   ReactImageSource m_imageSource;
   react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
   winrt::Windows::UI::Color m_tintColor{winrt::Colors::Transparent()};


### PR DESCRIPTION
This change adds a counter to ensure that only the latest prop value for
image source will be used in the ReactImage::SetBackground method and
also prevents a bug where the ImageBrush opacity gets stuck at zero by
checking that the URI has actually changed.

Fixes #7191
Fixes #7192

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7193)