### PR TITLE
Integrate 9/2 RN nightly build

### DIFF
--- a/change/@office-iss-react-native-win32-64f7b541-c2dc-404b-af54-4fbe2cb74271.json
+++ b/change/@office-iss-react-native-win32-64f7b541-c2dc-404b-af54-4fbe2cb74271.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 2/9 nightly RN build.",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/node-rnw-rpc-0d79c73f-689f-41ef-a31b-796e6890bdb5.json
+++ b/change/node-rnw-rpc-0d79c73f-689f-41ef-a31b-796e6890bdb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate 2/9 nightly RN build.",
+  "packageName": "node-rnw-rpc",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-046b40f4-f03b-415e-9db9-3320af29acaf.json
+++ b/change/react-native-windows-046b40f4-f03b-415e-9db9-3320af29acaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 2/9 nightly RN build.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/overrides.json
+++ b/packages/@office-iss/react-native-win32-tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win32/**"
   ],
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "patch",
@@ -17,47 +17,47 @@
       "type": "patch",
       "file": "src/js/components/RNTesterEmptyBookmarksState.win32.js",
       "baseFile": "packages/rn-tester/js/components/RNTesterEmptyBookmarksState.js",
-      "baseHash": "312a8f4a51f942df975f865638570a5349c0cd3f",
+      "baseHash": "c211a725a3f935a4425f7af92bc7a4cba4f0655a",
       "issue": 6341
     },
     {
       "type": "patch",
       "file": "src/js/components/RNTesterExampleFilter.win32.js",
       "baseFile": "packages/rn-tester/js/components/RNTesterExampleFilter.js",
-      "baseHash": "20e35122c8529a5bf848f91d9ea9b85be3c23882"
+      "baseHash": "e0c08f622a9d7d12e2115ec16698c8612572a8e1"
     },
     {
       "type": "copy",
       "file": "src/js/RNTesterApp.win32.js",
       "baseFile": "packages/rn-tester/js/RNTesterApp.android.js",
-      "baseHash": "30f3ef9bdc0e2c337309079831664c4a596c404f",
+      "baseHash": "e4f79c1b0b3e8778ea28d5bce5c126664c47d253",
       "issue": 4586
     },
     {
       "type": "derived",
       "file": "src/js/utils/RNTesterList.win32.js",
       "baseFile": "packages/rn-tester/js/utils/RNTesterList.android.js",
-      "baseHash": "a51e3721933832a1e2e0c83c47b792184f6d45a8"
+      "baseHash": "4f71741892c963aeb64cdc41029aac614ce85ead"
     },
     {
       "type": "patch",
       "file": "src/js/utils/RNTesterStatePersister.win32.js",
       "baseFile": "packages/rn-tester/js/utils/RNTesterStatePersister.js",
-      "baseHash": "b12cac1795430a1ca851e4c88ccca0f6a3e599ce",
+      "baseHash": "a1b342000f67d104b850d3ce6f9be4d6b674a822",
       "issue": 6316
     },
     {
       "type": "patch",
       "file": "src/js/utils/testerStateUtils.win32.js",
       "baseFile": "packages/rn-tester/js/utils/testerStateUtils.js",
-      "baseHash": "d079e5493312ae176bfabf8e011df6bf7e7929c2",
+      "baseHash": "31ec7636d7440b1ae871afeb1a2471c126c76d61",
       "issue": 6316
     },
     {
       "type": "patch",
       "file": "src/js/utils/useAsyncStorageReducer.win32.js",
       "baseFile": "packages/rn-tester/js/utils/useAsyncStorageReducer.js",
-      "baseHash": "dd12805229a025d0c45f676d6c535f2f19386025",
+      "baseHash": "a2e3ecd63ca72af88e0bc11bc9f6ed1419c6e438",
       "issue": 6316
     }
   ]

--- a/packages/@office-iss/react-native-win32-tester/package.json
+++ b/packages/@office-iss/react-native-win32-tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@office-iss/react-native-win32": "^0.0.0-canary.81",
-    "react-native": "0.0.0-67699ba9f"
+    "react-native": "0.0.0-16efb8dd5"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "^0.0.0-canary.81",
@@ -24,7 +24,7 @@
     "@types/node": "^14.14.22",
     "eslint": "7.12.0",
     "just-scripts": "^1.3.3",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-platform-override": "^1.4.12",
     "typescript": "^3.8.3"
   }

--- a/packages/@office-iss/react-native-win32-tester/src/js/RNTesterApp.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/RNTesterApp.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {AppRegistry} from 'react-native';
 
 import RNTesterApp from './RNTesterAppShared';

--- a/packages/@office-iss/react-native-win32-tester/src/js/components/RNTesterEmptyBookmarksState.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/components/RNTesterEmptyBookmarksState.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {View, Image, Text, StyleSheet} from 'react-native';
 

--- a/packages/@office-iss/react-native-win32-tester/src/js/components/RNTesterExampleFilter.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/components/RNTesterExampleFilter.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 const RNTesterListFilters = require('./RNTesterListFilters');
 const {

--- a/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
@@ -58,6 +58,18 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('../examples/ScrollView/ScrollViewSimpleExample'),
   } /*
   {
+    key: 'SectionList_EndReached',
+    module: require('../examples/SectionList/SectionList_onEndReached'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
+    key: 'SectionList_onViewableItemsChanged',
+    module: require('../examples/SectionList/SectionList_onViewableItemsChanged'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
     key: 'SectionListExample',
     category: 'ListView',
     module: require('../examples/SectionList/SectionListExample'),

--- a/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterStatePersister.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterStatePersister.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 // import {AsyncStorage} from 'react-native'; [Win32] #6316
 

--- a/packages/@office-iss/react-native-win32-tester/src/js/utils/testerStateUtils.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/utils/testerStateUtils.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 // import {AsyncStorage} from 'react-native'; [Win32] #6316
 
 import RNTesterList from './RNTesterList';

--- a/packages/@office-iss/react-native-win32-tester/src/js/utils/useAsyncStorageReducer.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/utils/useAsyncStorageReducer.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 // import {AsyncStorage} from 'react-native'; [Win32] #6316
 

--- a/packages/@office-iss/react-native-win32/.flowconfig
+++ b/packages/@office-iss/react-native-win32/.flowconfig
@@ -111,4 +111,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.143.1
+^0.144.0

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -3,25 +3,25 @@
     ".flowconfig",
     "src/**"
   ],
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseHash": "1699b9d914d5f1941d5b87f72051a4190d5b0a6e"
+      "baseHash": "4830cc7767fcafb3ce15d7b884f2f6ad8c030366"
     },
     {
       "type": "derived",
       "file": "src/index.win32.js",
       "baseFile": "index.js",
-      "baseHash": "64001fe0d4f24d7219d2b6f3c4c1fa0c0c8a88ea"
+      "baseHash": "ca978f1d83fd841a2aa9f30f3bfabb620de21273"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.win32.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa"
+      "baseHash": "6ea428202edeea40370df390a6b8f7ab794270ac"
     },
     {
       "type": "patch",
@@ -34,14 +34,14 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseHash": "ada8044fad72483553c185750fc464c1b785342a",
+      "baseHash": "a1534c3bec8ef3537345310684e129e7819b769f",
       "issue": 4578
     },
     {
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.win32.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.android.js",
-      "baseHash": "ba167547a814d5be30acda847423f86cf2104b59",
+      "baseHash": "1255817acafffa2461805c76a10daafc233de377",
       "issue": 4578
     },
     {
@@ -158,7 +158,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.win32.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7"
+      "baseHash": "9b941d27fadc82ac74153cd52c08080b0b1c7c8f"
     },
     {
       "type": "copy",
@@ -201,7 +201,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseHash": "a4e696834cba3bfe5a5057f44f928e481109f2b8"
+      "baseHash": "ba99e0917fe2c518eb11e8b640f759f631621b40"
     },
     {
       "type": "platform",
@@ -211,7 +211,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseHash": "147459dc889f04f2405db051445833f791726895",
+      "baseHash": "008986be49bbb3166c1d9bccf3f25e577bbc9e04",
       "issue": 5843
     },
     {
@@ -226,14 +226,14 @@
       "type": "patch",
       "file": "src/Libraries/Core/ReactNativeVersionCheck.win32.js",
       "baseFile": "Libraries/Core/ReactNativeVersionCheck.js",
-      "baseHash": "1158beed7e691478c59af78c5a1097d76890cec8",
+      "baseHash": "dfed43df2bfebbf0fb3588cb827be451ee5286a3",
       "issue": 5170
     },
     {
       "type": "derived",
       "file": "src/Libraries/Image/Image.win32.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseHash": "8d053f7bcb66ea71fd361a5c882e4142b5977202",
+      "baseHash": "802ad09c9e8ae8ab0f51846ee4de4a96ac4bed1f",
       "issue": 4320
     },
     {
@@ -244,7 +244,7 @@
       "type": "derived",
       "file": "src/Libraries/Image/NativeImageLoaderWin32.js",
       "baseFile": "Libraries/Image/NativeImageLoaderIOS.js",
-      "baseHash": "50b70af2498caf216229426a1b74b1d3d3ee5334",
+      "baseHash": "fde33e1ab6ab396a91bf469da0aa4bbb4f639383",
       "issue": 4320
     },
     {
@@ -287,7 +287,7 @@
       "type": "patch",
       "file": "src/Libraries/Inspector/Inspector.win32.js",
       "baseFile": "Libraries/Inspector/Inspector.js",
-      "baseHash": "298fb992c56e404e68496a4542fd53334f876428"
+      "baseHash": "fb36e8419f4cb0b358505e991d59e1dc938432f9"
     },
     {
       "type": "patch",
@@ -299,21 +299,21 @@
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxInspectorStackFrame.js",
-      "baseHash": "a1f75145b083be2bc83ddc240cadbcdf93931e0d",
+      "baseHash": "d7a69edf4a2530a046a939d805707615fef1a7f4",
       "issue": 5885
     },
     {
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxStyle.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxStyle.js",
-      "baseHash": "118cad1437e07c7cb6c5c1fc3bb927b0c4dd1d52",
+      "baseHash": "044516da9d57212c7df6bc679efd7a271d7141e0",
       "issue": 5886
     },
     {
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworking.win32.js",
       "baseFile": "Libraries/Network/RCTNetworking.android.js",
-      "baseHash": "f37f4609ac267e701ba28bbe7af2d202e39c86ab",
+      "baseHash": "80f0e55a30b8ca1d89220deffc77a9c5a4c2cbe3",
       "issue": 4318
     },
     {
@@ -356,27 +356,27 @@
       "type": "derived",
       "file": "src/Libraries/Text/TextNativeComponent.win32.js",
       "baseFile": "Libraries/Text/TextNativeComponent.js",
-      "baseHash": "ecf4a89da45b7e81e1e6424e00bf292d389e3b9f",
+      "baseHash": "1a196691fb0e9b656c348b7d42427c1c6163c9bb",
       "issue": 7074
     },
     {
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.win32.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseHash": "972b0cbe23ba57207ee7c855975c0b3d4c28f0d2",
+      "baseHash": "dd36bd088f6aa9b5cf5ab3b4d9ba8de1439d8e14",
       "issue": 4629
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/DeviceInfo.win32.js",
       "baseFile": "Libraries/Utilities/DeviceInfo.js",
-      "baseHash": "19aa984db7404750d8b86ad1359057dfe8912b24"
+      "baseHash": "1fa221f86411cf85fb57207ee731049f792794ae"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Dimensions.win32.js",
       "baseFile": "Libraries/Utilities/Dimensions.js",
-      "baseHash": "a3cdcfacd5c32db430c3fbdd070e17c4aab007e0"
+      "baseHash": "33e55564b8716ff243e36de554cdcd90fccbe7e3"
     },
     {
       "type": "platform",
@@ -390,13 +390,13 @@
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00"
+      "baseHash": "4bbc29afd2148eb7a2348908976aa275c3e9353c"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.win32.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseHash": "5330352b660b0a0ab7dcea5117dddfadadbe2e78"
+      "baseHash": "fe62d1e6d0fb9e3ba8126104099fcd314faaa657"
     },
     {
       "type": "platform",

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -61,19 +61,19 @@
     "@types/react-native": "^0.63.46",
     "babel-eslint": "^10.1.0",
     "eslint": "7.12.0",
-    "flow-bin": "^0.143.1",
+    "flow-bin": "^0.144.0",
     "jscodeshift": "^0.11.0",
     "just-scripts": "^1.3.3",
     "prettier": "1.19.1",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-platform-override": "^1.4.12",
     "react-shallow-renderer": "16.14.1",
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f"
+    "react-native": "0.0.0-16efb8dd5"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/packages/@office-iss/react-native-win32/src/Libraries/Alert/Alert.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Alert/Alert.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 // [Windows
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 const PLYAlertManager = TurboModuleRegistry.getEnforcing('Alert');

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.win32.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import NativeAccessibilityInfo from './NativeAccessibilityInfo';
 import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.win32.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import UIManager from '../../ReactNative/UIManager';
 
 /**

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInputState.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInputState.win32.js
@@ -12,8 +12,6 @@
 // TextInputs. All calls relating to the keyboard should be funneled
 // through here.
 
-'use strict';
-
 const React = require('react');
 const Platform = require('../../Utilities/Platform');
 const {findNodeHandle} = require('../../Renderer/shims/ReactNative');

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import {type ViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import ReactNativeViewViewConfigAndroid from './ReactNativeViewViewConfigAndroid';
 import {Platform} from 'react-native';

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import type {ViewProps} from './ViewPropTypes';
 
 const React = require('react');

--- a/packages/@office-iss/react-native-win32/src/Libraries/Core/ReactNativeVersionCheck.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Core/ReactNativeVersionCheck.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import Platform from '../Utilities/Platform';
 const ReactNativeVersion = require('./ReactNativeVersion');
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/Image.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/Image.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const DeprecatedImagePropType = require('../DeprecatedPropTypes/DeprecatedImagePropType');
 const React = require('react');
 const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/NativeImageLoaderWin32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/NativeImageLoaderWin32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Inspector/Inspector.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Inspector/Inspector.win32.js
@@ -172,7 +172,10 @@ class Inspector extends React.Component<
   _onAgentShowNativeHighlight = node => {
     clearTimeout(this._hideTimeoutID);
 
-    node.measure((x, y, width, height, left, top) => {
+    // Shape of `node` is different in Fabric.
+    const component = node.canonical ?? node;
+
+    component.measure((x, y, width, height, left, top) => {
       this.setState({
         hierarchy: [],
         inspected: {

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import * as React from 'react';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxStyle.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxStyle.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 export function getBackgroundColor(opacity?: number): string {
   return `rgba(51, 51, 51, ${opacity == null ? 1 : opacity})`;
 }

--- a/packages/@office-iss/react-native-win32/src/Libraries/Network/RCTNetworking.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Network/RCTNetworking.win32.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 // Do not require the native RCTNetworking module directly! Use this wrapper module instead.
 // It will add the necessary requestId, so that you don't have to generate it yourself.
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import ReactNativeViewAttributes from '../Components/View/ReactNativeViewAttributes';
 import UIManager from '../ReactNative/UIManager';
 import {type HostComponent} from '../Renderer/shims/ReactNativeTypes';

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/BackHandler.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/BackHandler.win32.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import NativeDeviceEventManager from '../../Libraries/NativeModules/specs/NativeDeviceEventManager';
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/DeviceInfo.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/DeviceInfo.win32.js
@@ -10,8 +10,6 @@
  * @flow
  */
 
-'use strict';
-
 import type {Spec} from './NativeDeviceInfo';
 
 const DeviceInfo: Spec = {

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/Dimensions.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/Dimensions.win32.js
@@ -5,7 +5,6 @@
  * @format
  * @flow
  */
-'use strict';
 
 class Dimensions {
   static get(dim: string): Object {

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/NativePlatformConstantsWin.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/NativePlatformConstantsWin.js
@@ -6,8 +6,6 @@
  * @flow strict
  */
 
-'use strict';
-
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/Platform.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/Platform.win32.js
@@ -6,8 +6,6 @@
  * @flow strict
  */
 
-'use strict';
-
 import NativePlatformConstantsWin from './NativePlatformConstantsWin';
 
 export type PlatformSelectSpec<A, N, D> = {

--- a/packages/@office-iss/react-native-win32/src/index.win32.js
+++ b/packages/@office-iss/react-native-win32/src/index.win32.js
@@ -163,7 +163,7 @@ module.exports = {
       'maskedviewios-moved',
       'MaskedViewIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-masked-view/masked-view' instead of 'react-native'. " +
-        'See https://github.com/react-native-masked-view/react-native-masked-view',
+        'See https://github.com/react-native-masked-view/masked-view',
     );
     return require('./Libraries/Components/MaskedView/MaskedViewIOS');
   },
@@ -176,7 +176,7 @@ module.exports = {
       'picker-moved',
       'Picker has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/Picker');
   },
@@ -186,7 +186,7 @@ module.exports = {
       'pickerios-moved',
       'PickerIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/PickerIOS');
   },
@@ -230,7 +230,7 @@ module.exports = {
     warnOnce(
       'segmented-control-ios-moved',
       'SegmentedControlIOS has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/segmented-control' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-segmented-control/segmented-control' instead of 'react-native'. " +
         'See https://github.com/react-native-segmented-control/segmented-control',
     );
     return require('./Libraries/Components/SegmentedControlIOS/SegmentedControlIOS');
@@ -319,7 +319,7 @@ module.exports = {
     warnOnce(
       'clipboard-moved',
       'Clipboard has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/clipboard' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-clipboard/clipboard' instead of 'react-native'. " +
         'See https://github.com/react-native-clipboard/clipboard',
     );
     return require('./Libraries/Components/Clipboard/Clipboard');

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -5,20 +5,20 @@
   "excludePatterns": [
     "src/js/examples-win/**"
   ],
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "patch",
       "file": "src/js/components/RNTesterEmptyBookmarksState.windows.js",
       "baseFile": "packages/rn-tester/js/components/RNTesterEmptyBookmarksState.js",
-      "baseHash": "312a8f4a51f942df975f865638570a5349c0cd3f",
+      "baseHash": "c211a725a3f935a4425f7af92bc7a4cba4f0655a",
       "issue": 6341
     },
     {
       "type": "patch",
       "file": "src/js/examples/Pressable/PressableExample.windows.js",
       "baseFile": "packages/rn-tester/js/examples/Pressable/PressableExample.js",
-      "baseHash": "40d09402c5fba75ff77f5262393452cc92ad1b1d",
+      "baseHash": "cc2fb739dffedec67c3c8032e8f87d4edfd0aede",
       "issue": 6240
     },
     {
@@ -38,14 +38,14 @@
       "type": "copy",
       "file": "src/js/RNTesterApp.windows.js",
       "baseFile": "packages/rn-tester/js/RNTesterApp.android.js",
-      "baseHash": "30f3ef9bdc0e2c337309079831664c4a596c404f",
+      "baseHash": "e4f79c1b0b3e8778ea28d5bce5c126664c47d253",
       "issue": 4586
     },
     {
       "type": "derived",
       "file": "src/js/utils/RNTesterList.windows.js",
       "baseFile": "packages/rn-tester/js/utils/RNTesterList.android.js",
-      "baseHash": "a51e3721933832a1e2e0c83c47b792184f6d45a8"
+      "baseHash": "4f71741892c963aeb64cdc41029aac614ce85ead"
     }
   ]
 }

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -14,7 +14,7 @@
     "@react-native/tester": "0.0.1"
   },
   "peerDependencies": {
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "^0.0.0-canary.261"
   },
   "devDependencies": {
@@ -23,7 +23,7 @@
     "@types/node": "^14.14.22",
     "eslint": "7.12.0",
     "just-scripts": "^1.3.3",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-platform-override": "^1.4.12",
     "react-native-windows": "^0.0.0-canary.261",
     "typescript": "^3.8.3"

--- a/packages/@react-native-windows/tester/src/js/RNTesterApp.windows.js
+++ b/packages/@react-native-windows/tester/src/js/RNTesterApp.windows.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {AppRegistry} from 'react-native';
 
 import RNTesterApp from './RNTesterAppShared';

--- a/packages/@react-native-windows/tester/src/js/components/RNTesterEmptyBookmarksState.windows.js
+++ b/packages/@react-native-windows/tester/src/js/components/RNTesterEmptyBookmarksState.windows.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {View, Image, Text, StyleSheet} from 'react-native';
 

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import * as React from 'react';
 import {
   Animated,

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -95,6 +95,23 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('../examples/ScrollView/ScrollViewSimpleExample'),
   },
   {
+    key: 'ScrollViewAnimatedExample',
+    category: 'Basic',
+    module: require('../examples/ScrollView/ScrollViewAnimatedExample'),
+  },
+  {
+    key: 'SectionList_EndReached',
+    module: require('../examples/SectionList/SectionList_onEndReached'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
+    key: 'SectionList_onViewableItemsChanged',
+    module: require('../examples/SectionList/SectionList_onViewableItemsChanged'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
     key: 'SectionListExample',
     category: 'ListView',
     module: require('../examples/SectionList/SectionListExample'),

--- a/packages/@react-native/repo-config/overrides.json
+++ b/packages/@react-native/repo-config/overrides.json
@@ -1,11 +1,11 @@
 {
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "copy",
       "file": "package.json",
       "baseFile": "repo-config/package.json",
-      "baseHash": "15302785bc3c110c1700620a689fd09f56f8e7db"
+      "baseHash": "00daf5b8bf0913e208a988f1412621c7b60f96d9"
     }
   ]
 }

--- a/packages/@react-native/repo-config/package.json
+++ b/packages/@react-native/repo-config/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-react-hooks": "^4.0.7",
     "eslint-plugin-react-native": "3.10.0",
     "eslint-plugin-relay": "1.8.1",
-    "flow-bin": "^0.143.1",
+    "flow-bin": "^0.144.0",
     "jest": "^26.5.2",
     "jest-junit": "^10.0.0",
     "jscodeshift": "^0.11.0",

--- a/packages/@react-native/tester/js/RNTesterApp.android.js
+++ b/packages/@react-native/tester/js/RNTesterApp.android.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {AppRegistry} from 'react-native';
 
 import RNTesterApp from './RNTesterAppShared';

--- a/packages/@react-native/tester/js/RNTesterApp.ios.js
+++ b/packages/@react-native/tester/js/RNTesterApp.ios.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {AppRegistry} from 'react-native';
 import React from 'react';
 

--- a/packages/@react-native/tester/js/RNTesterAppShared.js
+++ b/packages/@react-native/tester/js/RNTesterAppShared.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {
   BackHandler,
   StyleSheet,

--- a/packages/@react-native/tester/js/components/ExamplePage.js
+++ b/packages/@react-native/tester/js/components/ExamplePage.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {StyleSheet, View, Text} from 'react-native';
 
@@ -22,41 +20,13 @@ type Props = $ReadOnly<{|
   android?: ?boolean,
 |}>;
 
-import {RNTesterThemeContext} from './RNTesterTheme';
-
 export default function ExamplePage(props: Props): React.Node {
-  const theme = React.useContext(RNTesterThemeContext);
-
   const description = props.description ?? '';
-  const onAndroid = props.android;
-  const onIos = props.ios;
-  const category = props.category;
-
   return (
     <>
       <View style={styles.titleView}>
+        <Text style={styles.title}>{props.title}</Text>
         <Text style={styles.description}>{description}</Text>
-        <View style={styles.rowStyle}>
-          <Text style={{color: theme.SecondaryLabelColor, width: 65}}>
-            {category || 'Other'}
-          </Text>
-          <View style={styles.platformLabelStyle}>
-            <Text
-              style={{
-                color: onIos ? '#787878' : theme.SeparatorColor,
-                fontWeight: onIos ? '500' : '300',
-              }}>
-              iOS
-            </Text>
-            <Text
-              style={{
-                color: onAndroid ? '#787878' : theme.SeparatorColor,
-                fontWeight: onAndroid ? '500' : '300',
-              }}>
-              Android
-            </Text>
-          </View>
-        </View>
       </View>
       <View style={styles.examplesContainer}>{props.children}</View>
     </>
@@ -67,8 +37,17 @@ const styles = StyleSheet.create({
   titleView: {
     backgroundColor: '#F3F8FF',
     paddingHorizontal: 25,
-    paddingTop: 8,
+    paddingTop: 4,
+    paddingBottom: 8,
     overflow: 'hidden',
+  },
+  title: {
+    alignSelf: 'center',
+    fontSize: 12,
+  },
+  description: {
+    fontSize: 16,
+    paddingTop: 4,
   },
   iconContainer: {
     flexDirection: 'row',
@@ -77,22 +56,5 @@ const styles = StyleSheet.create({
   examplesContainer: {
     flexGrow: 1,
     flex: 1,
-  },
-  description: {
-    marginVertical: 8,
-    fontSize: 16,
-  },
-  docsContainer: {
-    alignContent: 'center',
-    justifyContent: 'center',
-  },
-  rowStyle: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  platformLabelStyle: {
-    flexDirection: 'row',
-    width: 100,
-    justifyContent: 'space-between',
   },
 });

--- a/packages/@react-native/tester/js/components/RNTesterBlock.js
+++ b/packages/@react-native/tester/js/components/RNTesterBlock.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {RNTesterThemeContext} from './RNTesterTheme';
 import {StyleSheet, Text, View} from 'react-native';

--- a/packages/@react-native/tester/js/components/RNTesterBookmarkButton.js
+++ b/packages/@react-native/tester/js/components/RNTesterBookmarkButton.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 
 import {TouchableOpacity, Image, StyleSheet} from 'react-native';

--- a/packages/@react-native/tester/js/components/RNTesterDocumentationURL.js
+++ b/packages/@react-native/tester/js/components/RNTesterDocumentationURL.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {Image, StyleSheet, TouchableOpacity} from 'react-native';
 import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';

--- a/packages/@react-native/tester/js/components/RNTesterEmptyBookmarksState.js
+++ b/packages/@react-native/tester/js/components/RNTesterEmptyBookmarksState.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {View, Image, Text, StyleSheet} from 'react-native';
 

--- a/packages/@react-native/tester/js/components/RNTesterExampleContainer.js
+++ b/packages/@react-native/tester/js/components/RNTesterExampleContainer.js
@@ -7,8 +7,6 @@
  * @format
  */
 
-'use strict';
-
 const React = require('react');
 const {Platform} = require('react-native');
 const RNTesterBlock = require('./RNTesterBlock');
@@ -57,7 +55,7 @@ class RNTesterExampleContainer extends React.Component {
     if (module.examples.length === 1) {
       return (
         <ExamplePage
-          title={module.title}
+          title={module.testTitle || module.title}
           description={module.description}
           android={!module.platform || module.platform === 'android'}
           ios={!module.platform || module.platform === 'ios'}

--- a/packages/@react-native/tester/js/components/RNTesterExampleFilter.js
+++ b/packages/@react-native/tester/js/components/RNTesterExampleFilter.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 const RNTesterListFilters = require('./RNTesterListFilters');
 const {

--- a/packages/@react-native/tester/js/components/RNTesterExampleList.js
+++ b/packages/@react-native/tester/js/components/RNTesterExampleList.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const RNTesterExampleFilter = require('./RNTesterExampleFilter');
 const RNTesterComponentTitle = require('./RNTesterComponentTitle');
 const React = require('react');

--- a/packages/@react-native/tester/js/components/RNTesterHeader.js
+++ b/packages/@react-native/tester/js/components/RNTesterHeader.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {
   Text,
   View,

--- a/packages/@react-native/tester/js/components/RNTesterPage.js
+++ b/packages/@react-native/tester/js/components/RNTesterPage.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const RNTesterTitle = require('./RNTesterTitle');
 const React = require('react');
 const {ScrollView, StyleSheet, View} = require('react-native');

--- a/packages/@react-native/tester/js/components/RNTesterTheme.js
+++ b/packages/@react-native/tester/js/components/RNTesterTheme.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import * as React from 'react';
 import {Appearance} from 'react-native';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';

--- a/packages/@react-native/tester/js/components/RNTesterTitle.js
+++ b/packages/@react-native/tester/js/components/RNTesterTitle.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 const React = require('react');
 
 const {StyleSheet, Text, View} = require('react-native');

--- a/packages/@react-native/tester/js/components/TextLegend.js
+++ b/packages/@react-native/tester/js/components/TextLegend.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 
 const {Text, View} = require('react-native');

--- a/packages/@react-native/tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
+++ b/packages/@react-native/tester/js/examples/ActivityIndicator/ActivityIndicatorExample.js
@@ -8,7 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
 import type {Node} from 'React';
 import {ActivityIndicator, StyleSheet, View} from 'react-native';
 import React, {Component} from 'react';

--- a/packages/@react-native/tester/js/examples/Alert/AlertExample.js
+++ b/packages/@react-native/tester/js/examples/Alert/AlertExample.js
@@ -7,8 +7,6 @@
  * @format
  */
 
-'use strict';
-
 import React, {useState} from 'react';
 import {Alert, StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 

--- a/packages/@react-native/tester/js/examples/AppState/AppStateExample.js
+++ b/packages/@react-native/tester/js/examples/AppState/AppStateExample.js
@@ -12,6 +12,7 @@
 
 const React = require('react');
 
+import {type EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 const {AppState, Text, View, Platform} = require('react-native');
 
 class AppStateSubscription extends React.Component<
@@ -25,21 +26,26 @@ class AppStateSubscription extends React.Component<
     eventsDetected: [],
   };
 
+  _subscriptions: ?Array<EventSubscription>;
+
   componentDidMount() {
-    AppState.addEventListener('change', this._handleAppStateChange);
-    AppState.addEventListener('memoryWarning', this._handleMemoryWarning);
+    this._subscriptions = [
+      AppState.addEventListener('change', this._handleAppStateChange),
+      AppState.addEventListener('memoryWarning', this._handleMemoryWarning),
+    ];
     if (Platform.OS === 'android') {
-      AppState.addEventListener('focus', this._handleFocus);
-      AppState.addEventListener('blur', this._handleBlur);
+      this._subscriptions.push(
+        AppState.addEventListener('focus', this._handleFocus),
+        AppState.addEventListener('blur', this._handleBlur),
+      );
     }
   }
 
   componentWillUnmount() {
-    AppState.removeEventListener('change', this._handleAppStateChange);
-    AppState.removeEventListener('memoryWarning', this._handleMemoryWarning);
-    if (Platform.OS === 'android') {
-      AppState.removeEventListener('focus', this._handleFocus);
-      AppState.removeEventListener('blur', this._handleBlur);
+    if (this._subscriptions != null) {
+      for (const subscription of this._subscriptions) {
+        subscription.remove();
+      }
     }
   }
 

--- a/packages/@react-native/tester/js/examples/Appearance/AppearanceExample.js
+++ b/packages/@react-native/tester/js/examples/Appearance/AppearanceExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {Appearance, Text, useColorScheme, View} from 'react-native';
 import type {AppearancePreferences} from 'react-native/Libraries/Utilities/NativeAppearance';

--- a/packages/@react-native/tester/js/examples/Crash/CrashExample.js
+++ b/packages/@react-native/tester/js/examples/Crash/CrashExample.js
@@ -8,7 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
 import type {Node} from 'React';
 import {NativeModules, Button} from 'react-native';
 import React from 'react';

--- a/packages/@react-native/tester/js/examples/DevSettings/DevSettingsExample.js
+++ b/packages/@react-native/tester/js/examples/DevSettings/DevSettingsExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {Alert, Button, DevSettings} from 'react-native';
 

--- a/packages/@react-native/tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/@react-native/tester/js/examples/Dimensions/DimensionsExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {Dimensions, Text, useWindowDimensions} from 'react-native';
 import * as React from 'react';
 

--- a/packages/@react-native/tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
+++ b/packages/@react-native/tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 const React = require('react');
 
 const {Text, View, StyleSheet} = require('react-native');

--- a/packages/@react-native/tester/js/examples/OrientationChange/OrientationChangeExample.js
+++ b/packages/@react-native/tester/js/examples/OrientationChange/OrientationChangeExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 
 const {DeviceEventEmitter, Text, View} = require('react-native');

--- a/packages/@react-native/tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/@react-native/tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 const ReactNative = require('react-native');
 import Platform from 'react-native/Libraries/Utilities/Platform';

--- a/packages/@react-native/tester/js/examples/Pressable/PressableExample.js
+++ b/packages/@react-native/tester/js/examples/Pressable/PressableExample.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import * as React from 'react';
 import {
   Animated,

--- a/packages/@react-native/tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/@react-native/tester/js/examples/ScrollView/ScrollViewExample.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const React = require('react');
 
 const {
@@ -207,6 +205,7 @@ exports.examples = ([
     },
   },
   {
+    name: 'keyboardShouldPersistTaps',
     title: '<ScrollView> Keyboard Options\n',
     description:
       'Toggle the keyboard using the search bar and determine keyboard behavior in response to drag and tap.',
@@ -847,6 +846,7 @@ const KeyboardExample = () => {
   const [keyboardShouldPersistTaps, setKeyboardShouldPersistTaps] = useState(
     'never',
   );
+  const [textInputValue, setTextInputValue] = useState('Tap to open Keyboard');
   const dismissOptions =
     Platform.OS === 'ios'
       ? ['none', 'on-drag', 'interactive']
@@ -854,11 +854,20 @@ const KeyboardExample = () => {
   const persistOptions = ['never', 'always', 'handled'];
   return (
     <View>
+      <TextInput
+        style={styles.textInput}
+        value={textInputValue}
+        onChangeText={val => setTextInputValue(val)}
+      />
       <ScrollView
         style={[styles.scrollView, {height: 200}]}
         keyboardDismissMode={keyboardDismissMode}
         keyboardShouldPersistTaps={keyboardShouldPersistTaps}
         nestedScrollEnabled>
+        <Button
+          onPress={() => console.log('button pressed!')}
+          label={'Button'}
+        />
         {ITEMS.map(createItemRow)}
       </ScrollView>
       <Text style={styles.rowTitle}>Keyboard Dismiss Mode</Text>

--- a/packages/@react-native/tester/js/examples/SectionList/SectionListExamples.js
+++ b/packages/@react-native/tester/js/examples/SectionList/SectionListExamples.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {Button, SectionList, StyleSheet, Text, View} from 'react-native';
+import * as React from 'react';
+
+type Props = {
+  example?: ?string,
+};
+
+const DATA = [
+  {
+    title: 'Main dishes',
+    data: ['Pizza', 'Burger', 'Risotto'],
+  },
+  {
+    title: 'Sides',
+    data: ['French Fries', 'Onion Rings', 'Fried Shrimps'],
+  },
+  {
+    title: 'Drinks',
+    data: ['Water', 'Coke', 'Beer'],
+  },
+  {
+    title: 'Desserts',
+    data: ['Cheesecake', 'Ice Cream'],
+  },
+];
+
+const VIEWABILITY_CONFIG = {
+  minimumViewTime: 1000,
+  viewAreaCoveragePercentThreshold: 100,
+  waitForInteraction: true,
+};
+
+const Item = ({title}) => (
+  <View style={styles.item} testID={title}>
+    <Text style={styles.title}>{title}</Text>
+  </View>
+);
+
+function getExample(example, output, ref) {
+  switch (example) {
+    case 'onViewableItemsChanged':
+      return {
+        props: {
+          onViewableItemsChanged: info =>
+            output(
+              info.viewableItems
+                .filter(
+                  viewToken => viewToken.index != null && viewToken.isViewable,
+                )
+                .map(viewToken => viewToken.item)
+                .join(', '),
+            ),
+          viewabilityConfig: VIEWABILITY_CONFIG,
+        },
+        onTest: null,
+      };
+
+    case 'onEndReached':
+      return {
+        props: {
+          onEndReached: info => output('onEndReached'),
+          onEndReachedThreshold: 0,
+        },
+        onTest: () => {
+          const scrollResponder = ref?.current?.getScrollResponder();
+          if (scrollResponder != null) {
+            scrollResponder.scrollToEnd();
+          }
+        },
+      };
+    default:
+      return {};
+  }
+}
+
+function SectionListExamples(props: Props): React.Node {
+  const [output, setOutput] = React.useState('');
+  const ref = React.useRef<?React.ElementRef<typeof SectionList>>();
+  const {onTest, props: testProps} = getExample(props.example, setOutput, ref);
+  return (
+    <View>
+      <View testID="test_container" style={styles.testContainer}>
+        <Text testID="output">{output}</Text>
+        {onTest != null ? (
+          <Button testID="start_test" onPress={onTest} title="Test" />
+        ) : null}
+      </View>
+      <SectionList
+        ref={ref}
+        testID="section_list"
+        sections={DATA}
+        keyExtractor={(item, index) => item + index}
+        renderItem={({item}) => <Item title={item} />}
+        renderSectionHeader={({section: {title}}) => (
+          <Text style={styles.header}>{title}</Text>
+        )}
+        style={styles.sectionList}
+        {...testProps}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  item: {
+    backgroundColor: 'pink',
+    padding: 20,
+    marginVertical: 8,
+  },
+  header: {
+    fontSize: 32,
+    backgroundColor: 'white',
+  },
+  title: {
+    fontSize: 24,
+  },
+  sectionList: {height: '90%'},
+  testContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: '#f2f2f7ff',
+    padding: 10,
+  },
+  output: {
+    fontSize: 12,
+  },
+});
+
+export default SectionListExamples;

--- a/packages/@react-native/tester/js/examples/SectionList/SectionList_onEndReached.js
+++ b/packages/@react-native/tester/js/examples/SectionList/SectionList_onEndReached.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import SectionListExamples from './SectionListExamples';
+const React = require('react');
+
+exports.title = 'SectionList onEndReached';
+exports.testTitle = 'Test onEndReached callback';
+exports.category = 'ListView';
+exports.documentationURL = 'https://reactnative.dev/docs/sectionlist';
+exports.description =
+  'Scroll to end of list or tap Test button to see `onEndReached` triggered.';
+exports.examples = [
+  {
+    title: '',
+    render: function(): React.Element<typeof SectionListExamples> {
+      return <SectionListExamples example="onEndReached" />;
+    },
+  },
+];

--- a/packages/@react-native/tester/js/examples/SectionList/SectionList_onViewableItemsChanged.js
+++ b/packages/@react-native/tester/js/examples/SectionList/SectionList_onViewableItemsChanged.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import SectionListExamples from './SectionListExamples';
+const React = require('react');
+
+exports.title = 'SectionList onViewableItemsChanged';
+exports.testTitle = 'Test onViewableItemsChanged callback';
+exports.category = 'ListView';
+exports.documentationURL = 'https://reactnative.dev/docs/sectionlist';
+exports.description =
+  'Scroll list to see what items are returned in `onViewableItemsChanged` callback.';
+exports.examples = [
+  {
+    title: 'Simple scrollable list',
+    render: function(): React.Element<typeof SectionListExamples> {
+      return <SectionListExamples example="onViewableItemsChanged" />;
+    },
+  },
+];

--- a/packages/@react-native/tester/js/examples/Touchable/TouchableExample.js
+++ b/packages/@react-native/tester/js/examples/Touchable/TouchableExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 
 const {

--- a/packages/@react-native/tester/js/examples/Transform/TransformExample.js
+++ b/packages/@react-native/tester/js/examples/Transform/TransformExample.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import React, {useEffect, useState} from 'react';
 import {Animated, StyleSheet, Text, View} from 'react-native';
 

--- a/packages/@react-native/tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/@react-native/tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import {

--- a/packages/@react-native/tester/js/types/RNTesterTypes.js
+++ b/packages/@react-native/tester/js/types/RNTesterTypes.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 
 export type RNTesterExampleModuleItem = $ReadOnly<{|
@@ -22,6 +20,7 @@ export type RNTesterExampleModuleItem = $ReadOnly<{|
 
 export type RNTesterExampleModule = $ReadOnly<{|
   title: string,
+  testTitle?: ?string,
   description: string,
   displayName?: ?string,
   documentationURL?: ?string,

--- a/packages/@react-native/tester/js/utils/RNTesterList.android.js
+++ b/packages/@react-native/tester/js/utils/RNTesterList.android.js
@@ -80,6 +80,18 @@ const ComponentExamples: Array<RNTesterExample> = [
     module: require('../examples/ScrollView/ScrollViewAnimatedExample'),
   },
   {
+    key: 'SectionList_EndReached',
+    module: require('../examples/SectionList/SectionList_onEndReached'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
+    key: 'SectionList_onViewableItemsChanged',
+    module: require('../examples/SectionList/SectionList_onViewableItemsChanged'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
     key: 'SectionListExample',
     category: 'ListView',
     module: require('../examples/SectionList/SectionListExample'),

--- a/packages/@react-native/tester/js/utils/RNTesterList.ios.js
+++ b/packages/@react-native/tester/js/utils/RNTesterList.ios.js
@@ -104,6 +104,18 @@ const ComponentExamples: Array<RNTesterExample> = [
     supportsTVOS: true,
   },
   {
+    key: 'SectionList_EndReached',
+    module: require('../examples/SectionList/SectionList_onEndReached'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
+    key: 'SectionList_onViewableItemsChanged',
+    module: require('../examples/SectionList/SectionList_onViewableItemsChanged'),
+    category: 'ListView',
+    supportsTVOS: true,
+  },
+  {
     key: 'SectionListExample',
     module: require('../examples/SectionList/SectionListExample'),
     category: 'ListView',

--- a/packages/@react-native/tester/js/utils/RNTesterReducer.js
+++ b/packages/@react-native/tester/js/utils/RNTesterReducer.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import type {RNTesterState, ComponentList} from '../types/RNTesterTypes';
 
 export const RNTesterActionsType = {

--- a/packages/@react-native/tester/js/utils/RNTesterStatePersister.js
+++ b/packages/@react-native/tester/js/utils/RNTesterStatePersister.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const React = require('react');
 import {AsyncStorage} from 'react-native';
 

--- a/packages/@react-native/tester/js/utils/testerStateUtils.js
+++ b/packages/@react-native/tester/js/utils/testerStateUtils.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import {AsyncStorage} from 'react-native';
 
 import RNTesterList from './RNTesterList';

--- a/packages/@react-native/tester/js/utils/useAsyncStorageReducer.js
+++ b/packages/@react-native/tester/js/utils/useAsyncStorageReducer.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 import * as React from 'react';
 import {AsyncStorage} from 'react-native';
 

--- a/packages/@react-native/tester/overrides.json
+++ b/packages/@react-native/tester/overrides.json
@@ -1,11 +1,11 @@
 {
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "copy",
       "directory": "js",
       "baseDirectory": "packages/rn-tester/js",
-      "baseHash": "280977f936c214b0b5ff03d5b6723d4cc10e84a6",
+      "baseHash": "a662926a24c8c04b73e8a15c9d5ef42019df5501",
       "issue": 4054
     },
     {

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -14,7 +14,7 @@
     "@react-native-windows/tester": "0.0.1",
     "node-rnw-rpc": "^1.0.1-6",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "^0.0.0-canary.261"
   },
   "devDependencies": {

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.2.0",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "^0.0.0-canary.261",
     "node-rnw-rpc": "^1.0.1-6"
   },

--- a/packages/node-rnw-rpc/package.json
+++ b/packages/node-rnw-rpc/package.json
@@ -27,7 +27,7 @@
     "just-scripts": "^1.3.2",
     "prettier": "1.19.1",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "^0.0.0-canary.261",
     "typescript": "^3.8.3"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-native-windows/tester": "0.0.1",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "0.0.0-canary.261"
   },
   "devDependencies": {

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-windows": "0.0.0-canary.261"
   },
   "devDependencies": {

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -119,4 +119,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.143.1
+^0.144.0

--- a/vnext/ReactCopies/IntegrationTests/AccessibilityManagerTest.js
+++ b/vnext/ReactCopies/IntegrationTests/AccessibilityManagerTest.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import invariant from 'invariant';
 import NativeAccessibilityManager from 'react-native/Libraries/Components/AccessibilityInfo/NativeAccessibilityManager';
 import {DeviceEventEmitter, NativeModules, View} from 'react-native';

--- a/vnext/ReactCopies/IntegrationTests/ReactContentSizeUpdateTest.js
+++ b/vnext/ReactCopies/IntegrationTests/ReactContentSizeUpdateTest.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 const RCTNativeAppEventEmitter = require('react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter');
 const React = require('react');
 const ReactNative = require('react-native');

--- a/vnext/ReactCopies/IntegrationTests/SizeFlexibilityUpdateTest.js
+++ b/vnext/ReactCopies/IntegrationTests/SizeFlexibilityUpdateTest.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 const RCTNativeAppEventEmitter = require('react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter');
 const React = require('react');
 const ReactNative = require('react-native');

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -5,13 +5,13 @@
     "src/**"
   ],
   "excludePatterns": [],
-  "baseVersion": "0.0.0-67699ba9f",
+  "baseVersion": "0.0.0-16efb8dd5",
   "overrides": [
     {
       "type": "derived",
       "file": ".flowconfig",
       "baseFile": ".flowconfig",
-      "baseHash": "1699b9d914d5f1941d5b87f72051a4190d5b0a6e"
+      "baseHash": "4830cc7767fcafb3ce15d7b884f2f6ad8c030366"
     },
     {
       "type": "patch",
@@ -31,7 +31,7 @@
       "type": "copy",
       "directory": "ReactCopies/IntegrationTests",
       "baseDirectory": "IntegrationTests",
-      "baseHash": "1f4e966c3edbca9c5a388d31ccabcce6f9b767cd",
+      "baseHash": "bccaaa4429976117899ed61a39fda9971c7fee29",
       "issue": 4054
     },
     {
@@ -59,7 +59,7 @@
       "type": "derived",
       "file": "src/index.windows.js",
       "baseFile": "index.js",
-      "baseHash": "64001fe0d4f24d7219d2b6f3c4c1fa0c0c8a88ea"
+      "baseHash": "ca978f1d83fd841a2aa9f30f3bfabb620de21273"
     },
     {
       "type": "platform",
@@ -85,7 +85,7 @@
       "type": "patch",
       "file": "src/Libraries/Alert/Alert.windows.js",
       "baseFile": "Libraries/Alert/Alert.js",
-      "baseHash": "b4867752830f6953516c5898a7e2fc0dc796dcfa"
+      "baseHash": "6ea428202edeea40370df390a6b8f7ab794270ac"
     },
     {
       "type": "platform",
@@ -99,14 +99,14 @@
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/AccessibilityInfo.android.js",
-      "baseHash": "ada8044fad72483553c185750fc464c1b785342a",
+      "baseHash": "a1534c3bec8ef3537345310684e129e7819b769f",
       "issue": 4578
     },
     {
       "type": "copy",
       "file": "src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.windows.js",
       "baseFile": "Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.android.js",
-      "baseHash": "ba167547a814d5be30acda847423f86cf2104b59",
+      "baseHash": "1255817acafffa2461805c76a10daafc233de377",
       "issue": 4578
     },
     {
@@ -198,7 +198,7 @@
       "type": "derived",
       "file": "src/Libraries/Components/Picker/PickerWindows.tsx",
       "baseFile": "Libraries/Components/Picker/PickerIOS.ios.js",
-      "baseHash": "1e006e9676afafaaa6a6003a82548743018e84a1",
+      "baseHash": "b3988cd5371385622254319a5fc89aad91dc1805",
       "issue": 4611
     },
     {
@@ -213,7 +213,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/Pressable/Pressable.windows.js",
       "baseFile": "Libraries/Components/Pressable/Pressable.js",
-      "baseHash": "53bc7996e0fa83128b846a04d0bcec972a406133"
+      "baseHash": "1f1fb46e3ee28acbfeaaba6842b9f273171dd5c9"
     },
     {
       "type": "derived",
@@ -231,7 +231,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/RefreshControl/RefreshControl.windows.js",
       "baseFile": "Libraries/Components/RefreshControl/RefreshControl.js",
-      "baseHash": "51acc96ca8c6866da99471de8933a3c8c20fcca2"
+      "baseHash": "75d1508da1341e093768b8225de92d1e1eb7c444"
     },
     {
       "type": "derived",
@@ -255,7 +255,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/TextInput/TextInputState.windows.js",
       "baseFile": "Libraries/Components/TextInput/TextInputState.js",
-      "baseHash": "e982deb23d7ad5312ab0c09508a6d58c152b5be7"
+      "baseHash": "9b941d27fadc82ac74153cd52c08080b0b1c7c8f"
     },
     {
       "type": "platform",
@@ -271,31 +271,31 @@
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableHighlight.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableHighlight.js",
-      "baseHash": "780af3d9474bf5ecaf944545c197aee87806bbc0"
+      "baseHash": "ed75dadd09fb87a6421b2448d8858b3149ab3316"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableOpacity.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableOpacity.js",
-      "baseHash": "fb40e1ea51e0c0559b98528fb2010f1b35206f69"
+      "baseHash": "961640ecc2a5b15813d4986ade036ce4e3e43c41"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js",
       "baseFile": "Libraries/Components/Touchable/TouchableWithoutFeedback.js",
-      "baseHash": "12c738a636fa6736871d74aee6c7ff3be8fe2e50"
+      "baseHash": "27f66e316ea1c7b466e11703b1f2a75a5d8d409a"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js",
       "baseFile": "Libraries/Components/View/ReactNativeViewViewConfig.js",
-      "baseHash": "a4e696834cba3bfe5a5057f44f928e481109f2b8"
+      "baseHash": "ba99e0917fe2c518eb11e8b640f759f631621b40"
     },
     {
       "type": "patch",
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseHash": "147459dc889f04f2405db051445833f791726895",
+      "baseHash": "008986be49bbb3166c1d9bccf3f25e577bbc9e04",
       "issue": 5843
     },
     {
@@ -328,7 +328,7 @@
       "type": "patch",
       "file": "src/Libraries/Image/Image.windows.js",
       "baseFile": "Libraries/Image/Image.ios.js",
-      "baseHash": "8d053f7bcb66ea71fd361a5c882e4142b5977202",
+      "baseHash": "802ad09c9e8ae8ab0f51846ee4de4a96ac4bed1f",
       "issue": 4590
     },
     {
@@ -339,7 +339,7 @@
       "type": "derived",
       "file": "src/Libraries/Network/RCTNetworkingWinShared.js",
       "baseFile": "Libraries/Network/RCTNetworking.ios.js",
-      "baseHash": "6fa09eb85703489e276a86973adb09df3607435c"
+      "baseHash": "00581b3b2653a79be5d03610f41c1fc288b7370f"
     },
     {
       "type": "patch",
@@ -357,14 +357,14 @@
       "type": "patch",
       "file": "src/Libraries/Pressability/Pressability.windows.js",
       "baseFile": "Libraries/Pressability/Pressability.js",
-      "baseHash": "8ec1e8578c507df3e04f6e885822773388de008d",
+      "baseHash": "82f4338c74beba7c2321ab045bd00494b9669f61",
       "issue": 4379
     },
     {
       "type": "patch",
       "file": "src/Libraries/ReactNative/PaperUIManager.windows.js",
       "baseFile": "Libraries/ReactNative/PaperUIManager.js",
-      "baseHash": "2ec4b900f4db6306171fffd4c78eb64f59893e09"
+      "baseHash": "bf6e342f34dd6fea00ae7ea56938a5473db1912c"
     },
     {
       "type": "derived",
@@ -386,26 +386,26 @@
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",
-      "baseHash": "b1b07ee8ec52627ee47087032184fbd9e1254ba9"
+      "baseHash": "22c50d13820ca4db6c6cf5e6563f8437d55c24af"
     },
     {
       "type": "copy",
       "file": "src/Libraries/Utilities/BackHandler.windows.js",
       "baseFile": "Libraries/Utilities/BackHandler.android.js",
-      "baseHash": "972b0cbe23ba57207ee7c855975c0b3d4c28f0d2",
+      "baseHash": "dd36bd088f6aa9b5cf5ab3b4d9ba8de1439d8e14",
       "issue": 4629
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/NativePlatformConstantsWin.js",
       "baseFile": "Libraries/Utilities/NativePlatformConstantsIOS.js",
-      "baseHash": "71ec2fb1dbf35d65562538d2c63d099ec1392d00"
+      "baseHash": "4bbc29afd2148eb7a2348908976aa275c3e9353c"
     },
     {
       "type": "derived",
       "file": "src/Libraries/Utilities/Platform.windows.js",
       "baseFile": "Libraries/Utilities/Platform.android.js",
-      "baseHash": "5330352b660b0a0ab7dcea5117dddfadadbe2e78"
+      "baseHash": "fe62d1e6d0fb9e3ba8126104099fcd314faaa657"
     },
     {
       "type": "platform",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -62,12 +62,12 @@
     "@types/react-native": "^0.63.46",
     "eslint": "7.12.0",
     "eslint-plugin-prettier": "2.6.2",
-    "flow-bin": "^0.143.1",
+    "flow-bin": "^0.144.0",
     "jscodeshift": "^0.11.0",
     "just-scripts": "^1.3.3",
     "prettier": "1.19.1",
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f",
+    "react-native": "0.0.0-16efb8dd5",
     "react-native-platform-override": "^1.4.12",
     "react-refresh": "^0.4.0",
     "react-shallow-renderer": "16.14.1",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "17.0.1",
-    "react-native": "0.0.0-67699ba9f"
+    "react-native": "0.0.0-16efb8dd5"
   },
   "beachball": {
     "defaultNpmTag": "canary",

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -4,7 +4,6 @@
  * @flow
  * @format
  */
-'use strict';
 
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 const AlertNative = TurboModuleRegistry.getEnforcing('Alert');

--- a/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
+++ b/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import NativeAccessibilityInfo from './NativeAccessibilityInfo';
 import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';

--- a/vnext/src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.windows.js
+++ b/vnext/src/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.windows.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import UIManager from '../../ReactNative/UIManager';
 
 /**

--- a/vnext/src/Libraries/Components/Picker/PickerWindows.tsx
+++ b/vnext/src/Libraries/Components/Picker/PickerWindows.tsx
@@ -3,7 +3,6 @@
  * Licensed under the MIT License.
  * @format
  */
-'use strict';
 
 import * as React from 'react';
 import {

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import * as React from 'react';
 import {useMemo, useState, useRef, useImperativeHandle} from 'react';
 import useAndroidRippleForView, {
@@ -207,10 +205,16 @@ function Pressable(props: Props, forwardedRef): React.Node {
 
   const hitSlop = normalizeRect(props.hitSlop);
 
+  const accessibilityState =
+    disabled != null
+      ? {...props.accessibilityState, disabled}
+      : props.accessibilityState;
+
   const restPropsWithDefaults: React.ElementConfig<typeof View> = {
     ...restProps,
     ...android_rippleConfig?.viewProps,
     accessible: accessible !== false,
+    accessibilityState,
     focusable: focusable !== false,
     hitSlop,
   };

--- a/vnext/src/Libraries/Components/RefreshControl/RefreshControl.windows.js
+++ b/vnext/src/Libraries/Components/RefreshControl/RefreshControl.windows.js
@@ -8,8 +8,6 @@
  * @flow
  */
 
-'use strict';
-
 const Platform = require('../../Utilities/Platform');
 const React = require('react');
 

--- a/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
@@ -12,8 +12,6 @@
 // TextInputs. All calls relating to the keyboard should be funneled
 // through here.
 
-'use strict';
-
 const React = require('react');
 const Platform = require('../../Utilities/Platform');
 const {findNodeHandle} = require('../../Renderer/shims/ReactNative');

--- a/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableHighlight.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';

--- a/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableOpacity.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';

--- a/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
+++ b/vnext/src/Libraries/Components/Touchable/TouchableWithoutFeedback.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import Pressability, {
   type PressabilityConfig,
 } from '../../Pressability/Pressability';

--- a/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewViewConfig.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import {type ViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import ReactNativeViewViewConfigAndroid from './ReactNativeViewViewConfigAndroid';
 import {Platform} from 'react-native';

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 import type {ViewProps} from './ViewPropTypes';
 
 const React = require('react');

--- a/vnext/src/Libraries/Image/Image.windows.js
+++ b/vnext/src/Libraries/Image/Image.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const DeprecatedImagePropType = require('../DeprecatedPropTypes/DeprecatedImagePropType');
 const React = require('react');
 const ReactNative = require('../Renderer/shims/ReactNative'); // eslint-disable-line no-unused-vars

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import {isHoverEnabled} from './HoverState';
 import invariant from 'invariant';
 import SoundManager from '../Components/Sound/SoundManager';
@@ -566,8 +564,8 @@ export default class Pressability {
       },
 
       onClick: (event: PressEvent): void => {
-        const {onPress} = this._config;
-        if (onPress != null) {
+        const {onPress, disabled} = this._config;
+        if (onPress != null && disabled !== true) {
           onPress(event);
         }
       },

--- a/vnext/src/Libraries/ReactNative/PaperUIManager.windows.js
+++ b/vnext/src/Libraries/ReactNative/PaperUIManager.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const NativeModules = require('../BatchedBridge/NativeModules');
 const Platform = require('../Utilities/Platform');
 const UIManagerProperties = require('./UIManagerProperties');
@@ -41,7 +39,21 @@ function getViewManagerConfig(viewManagerName: string): any {
       viewManagerConfigs[
         viewManagerName
       ] = NativeUIManager.getConstantsForViewManager(viewManagerName);
+
+      if (viewManagerConfigs[viewManagerName] === undefined) {
+        console.warn(
+          'Error: Unable to find getConstantsForViewManager for viewManager: ' +
+            viewManagerName +
+            '.',
+        );
+      }
     } catch (e) {
+      console.error(
+        "NativeUIManager.getConstantsForViewManager('" +
+          viewManagerName +
+          "') threw an exception.",
+        e,
+      );
       viewManagerConfigs[viewManagerName] = null;
     }
   }
@@ -66,6 +78,12 @@ function getViewManagerConfig(viewManagerName: string): any {
     if (result != null && result.viewConfig != null) {
       getConstants()[viewManagerName] = result.viewConfig;
       lazifyViewManagerConfig(viewManagerName);
+    } else {
+      console.warn(
+        'Error: Unable to find viewManagerConfigs for viewManager: ' +
+          viewManagerName +
+          ' using lazyLoadView.',
+      );
     }
   }
 

--- a/vnext/src/Libraries/Types/CoreEventTypes.windows.js
+++ b/vnext/src/Libraries/Types/CoreEventTypes.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import * as React from 'react';
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 

--- a/vnext/src/Libraries/Utilities/BackHandler.windows.js
+++ b/vnext/src/Libraries/Utilities/BackHandler.windows.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import NativeDeviceEventManager from '../../Libraries/NativeModules/specs/NativeDeviceEventManager';
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 

--- a/vnext/src/Libraries/Utilities/NativePlatformConstantsWin.js
+++ b/vnext/src/Libraries/Utilities/NativePlatformConstantsWin.js
@@ -6,8 +6,6 @@
  * @flow strict
  */
 
-'use strict';
-
 import type {TurboModule} from '../TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../TurboModule/TurboModuleRegistry';
 

--- a/vnext/src/Libraries/Utilities/Platform.windows.js
+++ b/vnext/src/Libraries/Utilities/Platform.windows.js
@@ -6,8 +6,6 @@
  * @flow strict
  */
 
-'use strict';
-
 import NativePlatformConstantsWin from './NativePlatformConstantsWin';
 
 export type PlatformSelectSpec<A, N, D> = {

--- a/vnext/src/index.windows.js
+++ b/vnext/src/index.windows.js
@@ -159,7 +159,7 @@ module.exports = {
       'maskedviewios-moved',
       'MaskedViewIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-masked-view/masked-view' instead of 'react-native'. " +
-        'See https://github.com/react-native-masked-view/react-native-masked-view',
+        'See https://github.com/react-native-masked-view/masked-view',
     );
     return require('./Libraries/Components/MaskedView/MaskedViewIOS');
   },
@@ -171,7 +171,7 @@ module.exports = {
       'picker-moved',
       'Picker has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/Picker');
   },
@@ -181,7 +181,7 @@ module.exports = {
       'pickerios-moved',
       'PickerIOS has been extracted from react-native core and will be removed in a future release. ' +
         "It can now be installed and imported from '@react-native-picker/picker' instead of 'react-native'. " +
-        'See https://github.com/react-native-picker/react-native-picker',
+        'See https://github.com/react-native-picker/picker',
     );
     return require('./Libraries/Components/Picker/PickerIOS');
   },
@@ -225,7 +225,7 @@ module.exports = {
     warnOnce(
       'segmented-control-ios-moved',
       'SegmentedControlIOS has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/segmented-control' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-segmented-control/segmented-control' instead of 'react-native'. " +
         'See https://github.com/react-native-segmented-control/segmented-control',
     );
     return require('./Libraries/Components/SegmentedControlIOS/SegmentedControlIOS');
@@ -312,7 +312,7 @@ module.exports = {
     warnOnce(
       'clipboard-moved',
       'Clipboard has been extracted from react-native core and will be removed in a future release. ' +
-        "It can now be installed and imported from '@react-native-community/clipboard' instead of 'react-native'. " +
+        "It can now be installed and imported from '@react-native-clipboard/clipboard' instead of 'react-native'. " +
         'See https://github.com/react-native-clipboard/clipboard',
     );
     return require('./Libraries/Components/Clipboard/Clipboard');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5283,10 +5283,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@^0.143.1:
-  version "0.143.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.143.1.tgz#2ff825dfd85e84531b0ae780842cb1c2a9743cd2"
-  integrity sha512-6S6bgZ/pghBzEUELXkwFH/bsHT+GBMo8ftHDYs0SSJ+1e6NRdFfqxcYhaTvAK8zteSfQLZBIoec6G4WPPp4qQg==
+flow-bin@^0.144.0:
+  version "0.144.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.144.0.tgz#32fbeb94ef39cb8b9fa03d67b6f085042ce3a1bd"
+  integrity sha512-+TeTukkfRjimaNhOHt8iQ/M33Fg8Afrm+iBHS19XzAz2fH4GwgroKCrAxDHnZoAUnmRv6jm/XngFxADlcqwYkw==
 
 flow-parser@0.*:
   version "0.113.0"
@@ -8990,10 +8990,10 @@ react-native-tscodegen@0.66.1:
     nullthrows "1.1.1"
     typescript "^3.5.3"
 
-react-native@0.0.0-67699ba9f:
-  version "0.0.0-67699ba9f"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-67699ba9f.tgz#131b8d6e447e964b43e7541b7ce0f89302d54fd8"
-  integrity sha512-Xk3x1g2lg5NatZiDHm//NmOLtZOstZfY/J6Neokgyh8+jO1aKUhArltucP7BZ7c3gm/liSfMnVplFM3nr+XX9A==
+react-native@0.0.0-16efb8dd5:
+  version "0.0.0-16efb8dd5"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.0.0-16efb8dd5.tgz#3b56c4e57d5b7176d11ce19b29dd06bd617d8de0"
+  integrity sha512-lK4Qini3lqiC/LPC5wptNT6+nKO9uUkUiHnfjPHDlMLbQjBhETZ40rNiBT3r2FiI9IgAdwbHvjXFZkzHGW/ucA==
   dependencies:
     "@jest/create-cache-key-function" "^26.5.0"
     "@react-native-community/cli" "^5.0.1-alpha.0"


### PR DESCRIPTION
Commits: https://github.com/facebook/react-native/compare/67699ba9f...16efb8dd5

https://github.com/facebook/react-native/commit/690a29355e143588efb801e4796a6310716882aa introduces logging of exeptions thrown when calling a sync method in web debug mode. Specifically, this surfaces 3 error we have had in PaperUIManager.windows.js, when calling `getConstantsForViewManager` for Image, Text, and ForwardRef(textInput)

https://github.com/facebook/react-native/commit/a81b7d18fa65a727539c6c7ea17f787673d3c889 add some optimizations to RCTNetworking.ios.js, which we base our fork on. Needed to reconcile with our version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7213)