### PR TITLE
Update e2e doc with info about configuring WinAppDriver path

### DIFF
--- a/change/jest-environment-winappdriver-6f4a1d63-2951-4e4a-a78d-18f76018c64e.json
+++ b/change/jest-environment-winappdriver-6f4a1d63-2951-4e4a-a78d-18f76018c64e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update e2e doc",
+  "packageName": "jest-environment-winappdriver",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -14,6 +14,16 @@ A test app, test library and test cases are in [`/packages/e2e-test-app/`](../pa
 
 This will be automatically done for you if you use the [RNW dependency script](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies) with `rnwDev` as an argument.
 
+The E2E tests assume it is installed in the default location under `C:\Program Files (x86)\Windows Application Driver\WinAppDriver.exe`. If you choose a different path, you will need to specify it in [`/packages/e2e-test-app/jest.config.js`](../packages/e2e-test-app/jest.config.js).
+```js
+module.exports = {
+...
+  testEnvironmentOptions: {
+    ...
+    winAppDriverBin: 'D:\\Program Files (x86)\\Windows Application Driver\\WinAppDriver.exe',
+  },
+};
+```
 
 **Build the native test app**
 

--- a/packages/jest-environment-winappdriver/README.md
+++ b/packages/jest-environment-winappdriver/README.md
@@ -17,8 +17,11 @@ module.exports = {
       logLevel: 'error',
       ...
     },
+    winAppDriverBin: 'D:\\Program Files (x86)\\Windows Application Driver\\WinAppDriver.exe',
   },
 };
 ```
 
 WebDriverIO options for initializing a remote may be passed through `testEnvironmentOptions.webdriverOptions`.
+
+Custom installation paths of WinAppDriver can be specified through `testEnvironmentOptions.winAppDriverBin`.


### PR DESCRIPTION
Documenting the `testEnvironmentOptions.winAppDriverBin` property - used when WinAppDriver is not located under the path we hardcode.