### PR TITLE
Revert "Fix DispatchEvent for events that don't have a sender"

### DIFF
--- a/change/react-native-windows-923d9c58-108f-4eb0-9f78-dfa4daabec03.json
+++ b/change/react-native-windows-923d9c58-108f-4eb0-9f78-dfa4daabec03.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Some XAML events do not have a sender (e.g. Loaded)",
-  "packageName": "react-native-windows",
-  "email": "asklar@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-a032e591-3908-4bf5-90a6-4b8972478e89.json
+++ b/change/react-native-windows-a032e591-3908-4bf5-90a6-4b8972478e89.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert \"Fix DispatchEvent for events that don't have a sender (#7207)\"",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -42,8 +42,7 @@ void XamlUIService::DispatchEvent(
     eventData = eventDataWriter->TakeValue();
   }
 
-  auto tag = view ? unbox_value<int64_t>(view.Tag()) : 0;
-  m_context->DispatchEvent(tag, to_string(eventName), std::move(eventData));
+  m_context->DispatchEvent(unbox_value<int64_t>(view.Tag()), to_string(eventName), std::move(eventData));
 }
 
 /*static*/ ReactPropertyId<XamlUIService> XamlUIService::XamlUIServiceProperty() noexcept {


### PR DESCRIPTION
Reverts microsoft/react-native-windows#7207

Going to try a different approach for now

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7218)