### PR TITLE
Fix announceForAccessibility

### DIFF
--- a/change/react-native-windows-29f65fa8-43ca-4485-9da4-0168ac84cd17.json
+++ b/change/react-native-windows-29f65fa8-43ca-4485-9da4-0168ac84cd17.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix announceForAccessibility",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -41,7 +41,6 @@ void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
 
 void AccessibilityInfo::announceForAccessibility(std::string announcement) noexcept {
   m_context.UIDispatcher().Post([context = m_context, announcement = std::move(announcement)] {
-
     // Windows requires a specific element to announce from. Unfortunately the react-native API does not provide a tag
     // So we need to add a temporary control to raise the notification event from.
 

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -41,27 +41,17 @@ void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
 
 void AccessibilityInfo::announceForAccessibility(std::string announcement) noexcept {
   m_context.UIDispatcher().Post([context = m_context, announcement = std::move(announcement)] {
-    xaml::UIElement element{nullptr};
 
-    // Windows requires a specific element to announce from.  Unfortunately the react-native API does not provide a tag
-    // So we need to find something to try to raise the notification event from
+    // Windows requires a specific element to announce from. Unfortunately the react-native API does not provide a tag
+    // So we need to add a temporary control to raise the notification event from.
 
-    if (auto window = xaml::Window::Current()) {
-      element = window.Content();
-    }
+    auto textBlock = xaml::Controls::TextBlock();
 
-    if (!element && react::uwp::Is19H1OrHigher()) {
-      // XamlRoot added in 19H1
-      if (auto xamlRoot = React::XamlUIService::GetXamlRoot(context.Properties().Handle())) {
-        element = xamlRoot.Content();
-      }
-    }
-
-    if (!element) {
+    if (!textBlock) {
       return;
     }
 
-    auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element);
+    auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(textBlock);
 
     if (!peer) {
       return;


### PR DESCRIPTION
Resolve #5908 

**_Why_**
announceForAccessibility method in the AccessibilityInfo module failed to announce messages.

**_What_**
The API for the method does not include a reference to a RN component as a parameter but Windows requires an element to announce from. The previous implementation tried to pass in Xaml::Window::Content into FrameworkElementAutomationPeer::FromElement to create an automation peer, but this approach always resulted in the peer being null and no announcement could be made. 

Altered the code such that a Xaml Control (TextBlock) is passed into FrameworkElementAutomationPeer::FromElement instead. This caused the peer returned to be non-null and the announcement could be fired.

**_Testing_**
Created an RNW app and altered Microsoft.ReactNative inside of tester app with the changes to AccessibilityInfo. Was able to hear announcement when announceForAccessibility was called.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7220)