### PR TITLE
Ensure root views are properly unloaded

### DIFF
--- a/change/react-native-windows-2021-03-01-10-44-41-fix-unloading.json
+++ b/change/react-native-windows-2021-03-01-10-44-41-fix-unloading.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure root views are properly unloaded (#7221)",
+  "packageName": "react-native-windows",
+  "email": "skyle@fb.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-01T18:44:41.417Z"
+}


### PR DESCRIPTION
This adds `ReactViewHost::PostInQueue` method that *safely* calls the callback as long as the `ReactViewHost` is still alive. It was unsafe before as it would capture the raw `this` pointer, which could result in a crash (I was able to observe this).

However, for *unloading* the view, we actually want to capture the `ReactViewHost` strongly to ensure that it gets fully detached from the `ReactHost` and that `AppRegistry.unmountApplicationComponentAtRootTag()` is called.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7221)