### PR TITLE
Narrow fix for tintColor and repeat images

### DIFF
--- a/change/react-native-windows-529f30ae-e99b-41c4-8da5-fd63deb8c688.json
+++ b/change/react-native-windows-529f30ae-e99b-41c4-8da5-fd63deb8c688.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Narrow fix for tintColor and repeat images",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
There is a [bug](https://github.com/microsoft/Win2D/issues/809) in GaussianBlurEffect from Win2D that causes images to disappear when moving the app between screens. Since the ReactImageBrush always created the GaussianBlurEffect (even when `blurRadius` was 0) whenever `resizeMode=repeat` or `tintColor` was used on the Image, this meant that Images that only used `resizeMode` or `tintColor` suffered from the same bug.

This change ensures that GaussianBlurEffect is only used when the `blurRadius` prop is non-zero.

Fixes #7205

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7222)