### PR TITLE
Update WinAppDriver version requirement

### DIFF
--- a/change/react-native-windows-96f79fad-22cc-49c2-a3a1-7727f3903e48.json
+++ b/change/react-native-windows-96f79fad-22cc-49c2-a3a1-7727f3903e48.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update WinAppDriver version requirement",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -126,6 +126,15 @@ function CheckNode {
     }
 }
 
+function CheckWinAppDriver {
+    $WADPath = "${env:ProgramFiles(x86)}\Windows Application Driver\WinAppDriver.exe";
+    if (Test-Path $WADPath) {
+        $version = [Version]([System.Diagnostics.FileVersionInfo]::GetVersionInfo($WADPath).FileVersion);
+        return $version.CompareTo([Version]"1.2.1") -ge 0;
+    }
+    return $false;
+}
+
 function EnableDevmode {
     $RegistryKeyPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock"
 
@@ -247,12 +256,13 @@ $requirements = @(
         Id=[CheckId]::WinAppDriver;
         Name = 'WinAppDriver';
         Tags = @('rnwDev');
-        Valid = (Test-Path "${env:ProgramFiles(x86)}\Windows Application Driver\WinAppDriver.exe");
+        Valid = CheckWinAppDriver;
         Install = {
             # don't install from choco as we need an exact version match. appium-windows-driver checks the checksum of WAD.
             # See \node_modules\appium-windows-driver\build\lib\installer.js
             $ProgressPreference = 'Ignore';
-            Invoke-WebRequest -UseBasicParsing https://github.com/microsoft/WinAppDriver/releases/download/v1.1/WindowsApplicationDriver.msi -OutFile $env:TEMP\WindowsApplicationDriver.msi
+            $url = "https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi";
+            Invoke-WebRequest -UseBasicParsing $url -OutFile $env:TEMP\WindowsApplicationDriver.msi
             & $env:TEMP\WindowsApplicationDriver.msi /q
         };
         Optional = $true;


### PR DESCRIPTION
The recent changes to our test infrastructure require WinAppDriver version >= 1.2.1, but this new requirement was not added to the requirements script

Fixes #7223 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7228)