### PR TITLE
Update NuGetCommand@2 with workaround for microsoft ADO

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -31,7 +31,8 @@ steps:
       installVsComponents: ${{ parameters.installVsComponents }}
       debug: ${{ parameters.debug }}
 
-  - task: NuGetCommand@2
+  # NuGetCommand@2 workaround: https://developercommunity.visualstudio.com/content/problem/288534/vsts-yaml-build-failure-the-task-name-nugetcommand.html
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: NuGet restore
     inputs:
       command: restore

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -25,7 +25,8 @@ steps:
         inPathRoot: ${{parameters.nugetroot}}
         outPathRoot: ${{parameters.nugetroot}}
 
-  - task: NuGetCommand@2
+  # NuGetCommand@2 workaround: https://developercommunity.visualstudio.com/content/problem/288534/vsts-yaml-build-failure-the-task-name-nugetcommand.html
+  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: '${{ parameters.packageId }} - Nuget pack'
     inputs:
       command: pack


### PR DESCRIPTION
The microsoft ADO instance maintains two different tasks named NuGetCommand. This means pipelines running on that ADO instance need the unique GUID to identify it.

Part of #5540.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7238)