### PR TITLE
Fixes registration name for TextInput onScroll

### DIFF
--- a/change/react-native-windows-c5698690-4198-40b4-8676-9fc490f8f49d.json
+++ b/change/react-native-windows-c5698690-4198-40b4-8676-9fc490f8f49d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes registration name for TextInput onScroll",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -328,7 +328,7 @@ void TextInputShadowNode::registerEvents() {
               folly::dynamic offsetData = folly::dynamic::object("x", args.FinalView().HorizontalOffset())(
                   "y", args.FinalView().VerticalOffset());
               folly::dynamic eventData = folly::dynamic::object("target", tag)("contentOffset", std::move(offsetData));
-              GetViewManager()->GetReactContext().DispatchEvent(tag, "topTextInputOnScroll", std::move(eventData));
+              GetViewManager()->GetReactContext().DispatchEvent(tag, "topTextInputScroll", std::move(eventData));
             }
           });
     }
@@ -713,7 +713,7 @@ void TextInputViewManager::GetExportedCustomDirectEventTypeConstants(
                                L"KeyPress",
                                L"PressIn",
                                L"PressOut",
-                               L"OnScroll",
+                               L"Scroll",
                                L"SubmitEditing"};
 
   for (auto &eventBaseName : eventNames) {


### PR DESCRIPTION
Previously, scroll events on TextInput mapped to `onOnScroll`. The
correct event name is `onScroll`. This fixes that.

Fixes #7258

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7259)