### PR TITLE
Bump version of XamlTreeDump library

### DIFF
--- a/packages/e2e-test-app/windows/ReactUWPTestApp/MainPage.xaml.cs
+++ b/packages/e2e-test-app/windows/ReactUWPTestApp/MainPage.xaml.cs
@@ -46,7 +46,7 @@ namespace ReactUWPTestApp
                 }
             }
 
-            var rootDump = VisualTreeDumper.DumpTree(this, null, additionalProperties, DumpTreeMode.Json);
+            var rootDump = VisualTreeDumper.DumpTree(this, null, additionalProperties);
             var element = VisualTreeDumper.FindElementByAutomationId(JsonObject.Parse(rootDump), accessibilityId);
 
             return element;

--- a/packages/e2e-test-app/windows/ReactUWPTestApp/MainPage.xaml.cs
+++ b/packages/e2e-test-app/windows/ReactUWPTestApp/MainPage.xaml.cs
@@ -46,7 +46,7 @@ namespace ReactUWPTestApp
                 }
             }
 
-            var rootDump = VisualTreeDumper.DumpTree(this, null, additionalProperties);
+            var rootDump = VisualTreeDumper.DumpTree(this, null, additionalProperties, new AttachedProperty[] {});
             var element = VisualTreeDumper.FindElementByAutomationId(JsonObject.Parse(rootDump), accessibilityId);
 
             return element;

--- a/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -157,7 +157,7 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="XamlTreeDump">
-      <Version>1.0.6</Version>
+      <Version>1.0.7</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -157,7 +157,7 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="XamlTreeDump">
-      <Version>1.0.7</Version>
+      <Version>1.0.8</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The new version of the library includes support for dumping attached properties, which we need. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7265)