### PR TITLE
Fix documentation for running a single E2ETest Test

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -35,9 +35,16 @@ module.exports = {
 
 > C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest`
 
+or
+
+> C:\repo\react-native-windows\packages\e2e-test-app\test> `yarn e2etest`
+
+
 **Running a specific test**
 
-> C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest -t visitAllPages`
+> C:\repo\react-native-windows\packages\e2e-test-app\test> `yarn e2etest .\visitAllPages.test.ts`
+
+⚠ This command will only work from the `test` directory ([#7272](https://github.com/microsoft/react-native-windows/issues/7272))
 
 ## Debugging E2E Tests in CI
 ### Increasing verbosity


### PR DESCRIPTION
Fixes #7266
Fixes #7240

This documents how you can run a single test from E2ETest, with restriction. Fixing the restriction is tracked by https://github.com/microsoft/react-native-windows/issues/7272

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7273)