### PR TITLE
Remove stale Appium comment

### DIFF
--- a/change/react-native-windows-66a7a026-2973-48ac-ad29-9153ea483a8b.json
+++ b/change/react-native-windows-66a7a026-2973-48ac-ad29-9153ea483a8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove stale appium comment",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -258,8 +258,6 @@ $requirements = @(
         Tags = @('rnwDev');
         Valid = CheckWinAppDriver;
         Install = {
-            # don't install from choco as we need an exact version match. appium-windows-driver checks the checksum of WAD.
-            # See \node_modules\appium-windows-driver\build\lib\installer.js
             $ProgressPreference = 'Ignore';
             $url = "https://github.com/microsoft/WinAppDriver/releases/download/v1.2.1/WindowsApplicationDriver_1.2.1.msi";
             Invoke-WebRequest -UseBasicParsing $url -OutFile $env:TEMP\WindowsApplicationDriver.msi


### PR DESCRIPTION
Removing outdated comment about Appium from the dependency script. We're already not installing Appium, WinAppDriver is properly included there.

Closes #6676 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7280)