### PR TITLE
[0.63] Avoid exporting data as that breaks delay loading

### DIFF
--- a/change/react-native-windows-2021-03-04-18-44-45-0.63-stable.json
+++ b/change/react-native-windows-2021-03-04-18-44-45-0.63-stable.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Avoid exporting data as that breaks delay loading",
+  "packageName": "react-native-windows",
+  "email": "ryknuth@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-05T02:44:45.505Z"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -42,12 +42,6 @@ EXPORTS
 ?loadScriptFromString@Instance@react@facebook@@QEAAXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PEBD@1@@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QEAA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@V?$vector@Udynamic@folly@@V?$allocator@Udynamic@folly@@@std@@@std@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@_J@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@_N@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@N@dynamic@folly@@2QEBDEB
 ?assertionFailure@detail@folly@@YAXPEBD00I0H@Z
 ?parseJson@folly@@YA?AUdynamic@1@V?$Range@PEBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QEAAXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -42,12 +42,6 @@ EXPORTS
 ?hash@dynamic@folly@@QBEIXZ
 ?loadScriptFromString@Instance@react@facebook@@QAEXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YG?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QBDB
-?name@?$TypeInfo@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@dynamic@folly@@2QBDB
-?name@?$TypeInfo@_J@dynamic@folly@@2QBDB
-?name@?$TypeInfo@_N@dynamic@folly@@2QBDB
-?name@?$TypeInfo@N@dynamic@folly@@2QBDB
-?name@?$TypeInfo@V?$vector@Udynamic@folly@@V?$allocator@Udynamic@folly@@@std@@@std@@@dynamic@folly@@2QBDB
 ?parseJson@folly@@YG?AUdynamic@1@V?$Range@PBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QAEXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z
 ?size@dynamic@folly@@QBEIXZ

--- a/vnext/Folly/TEMP_UntilFollyUpdate/dynamic-inl.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/dynamic-inl.h
@@ -1050,10 +1050,6 @@ struct dynamic::GetAddrImpl<dynamic::ObjectImpl> {
   }
 };
 
-// Workaround arm64 ship compiler/link bug:
-// https://developercommunity2.visualstudio.com/t/arm64-release-error-lnk2040-relocation-pageoffset/1338200
-#ifdef _M_ARM64
-
 template <class T>
 T &dynamic::get() {
   if (auto *p = get_nothrow<T>()) {
@@ -1087,18 +1083,6 @@ T &dynamic::get() {
       break;
   }
 }
-
-#else
-
-template <class T>
-T &dynamic::get() {
-  if (auto *p = get_nothrow<T>()) {
-    return *p;
-  }
-  throw_exception<TypeError>(TypeInfo<T>::name, type());
-}
-
-#endif
 
 template <class T>
 T const &dynamic::get() const {


### PR DESCRIPTION
The name export is being exported as CODE rather than DATA. This breaks CHPE/Arm64X linking. Any exports of DATA removes the ability to delayload the library.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7284)