### PR TITLE
Change TextInput cursor behavior

### DIFF
--- a/change/react-native-windows-b3c2f4a8-d704-4a38-b837-993459d15495.json
+++ b/change/react-native-windows-b3c2f4a8-d704-4a38-b837-993459d15495.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change TextInput cursor behavior",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -618,7 +618,7 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
         auto newValue = react::uwp::asHstring(text);
         if (oldValue != newValue) {
           textBox.Text(newValue);
-          if (static_cast<uint32_t>(oldCursor) <= newValue.size()) {
+          if (oldValue.size() == newValue.size()) {
             textBox.SelectionStart(oldCursor);
           } else {
             textBox.SelectionStart(newValue.size());


### PR DESCRIPTION
As stated in issue #7283, the cursor position changes seem to be somewhat different on each platform. Since we're already adding code in react-native-windows to change the Windows default cursor positioning behavior, we might as well make it a bit more consistent with other platforms. The change here matches the behavior on iOS, macOS and Web (so it's only different from Android, which seems to keep cursor position relative to the TextInput value length constant).

Fixes #7283

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7285)