### PR TITLE
Update API docs for 0.64

### DIFF
--- a/change/react-native-windows-20b023be-e576-4b57-bb19-7a86b3206683.json
+++ b/change/react-native-windows-20b023be-e576-4b57-bb19-7a86b3206683.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix up API documentation",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -36,8 +36,8 @@ namespace Microsoft.ReactNative {
     "- Use the Properties to share native module's data with other components. \n"
     "- Use the Notifications to exchange events with other components. \n"
     "- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events. \n"
-    "- Use @.UIDispatcher to schedule work in UI thread. \n"
-    "- Use @.JSDispatcher to schedule work in UI thread.")
+    "- Use @.UIDispatcher to schedule work in the UI thread. \n"
+    "- Use @.JSDispatcher to schedule work in the JS thread.")
   interface IReactContext {
 #ifndef CORE_ABI
     DOC_STRING("Get settings snapshot that were used to start the React instance.")

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -55,12 +55,12 @@ namespace Microsoft.ReactNative {
 
     DOC_STRING(
       "Get the UI thread dispatcher. \n"
-      "It is a shortcut for the `ReactDispatcherHelper::UIDispatcherProperty` from the @.Properties property bag.")
+      "It is a shortcut for the @ReactDispatcherHelper.UIDispatcherProperty from the @.Properties property bag.")
     IReactDispatcher UIDispatcher { get; };
 
     DOC_STRING(
       "Get the JS thread dispatcher. \n"
-      "It is a shortcut for the `ReactDispatcherHelper::JSDispatcherProperty` from the @.Properties property bag.")
+      "It is a shortcut for the @ReactDispatcherHelper.JSDispatcherProperty from the @.Properties property bag.")
     IReactDispatcher JSDispatcher { get; };
 
     DOC_STRING("Get the JavaScript runtime for the running React instance. It can be null if Web debugging is used.")


### PR DESCRIPTION
I've generated the API docs for 0.64, and there are some bugs. Using this PR to fix the doc source.
Generated docs PR: https://github.com/microsoft/react-native-windows-samples/pull/400

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7286)