### PR TITLE
Avoid re-registering render callbacks when coalescing single element queue

### DIFF
--- a/change/react-native-windows-b4e6adb2-e454-4bfe-9455-8bc887380703.json
+++ b/change/react-native-windows-b4e6adb2-e454-4bfe-9455-8bc887380703.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid re-registering render callbacks when coalescing single element queue",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -75,6 +75,8 @@ void BatchingEventEmitter::EmitCoalescingJSEvent(
 }
 
 void BatchingEventEmitter::RegisterFrameCallback() noexcept {
+  VerifyElseCrash(!m_renderingRevoker);
+
   m_renderingRevoker = xaml::Media::CompositionTarget::Rendering(
       winrt::auto_revoke, [weakThis{weak_from_this()}](auto const &, auto const &) {
         if (auto strongThis = weakThis.lock()) {

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -25,27 +25,17 @@ void BatchingEventEmitter::EmitJSEvent(
   VerifyElseCrash(m_uiDispatcher.HasThreadAccess());
 
   implementation::BatchedEvent newEvent{std::move(emitterMethod), tag, std::move(eventName), std::move(eventObject)};
-
-  size_t queueSizeAfterInsert;
+  bool isFirstEventInBatch = false;
 
   {
     std::scoped_lock lock(m_eventQueueMutex);
 
+    isFirstEventInBatch = m_eventQueue.size() == 0;
     m_eventQueue.push_back(std::move(newEvent));
-    queueSizeAfterInsert = m_eventQueue.size();
   }
 
-  // Once a frame is presented, send a task to JS to emit all elements in the
-  // queue. We know the task is pending on the UI thread or JS thread if we
-  // have a non-zero size queue, so we want to only trigger pumping when the
-  // first element is added to an empty queue.
-  if (queueSizeAfterInsert == 1) {
-    m_renderingRevoker = xaml::Media::CompositionTarget::Rendering(
-        winrt::auto_revoke, [weakThis{weak_from_this()}](auto const &, auto const &) {
-          if (auto strongThis = weakThis.lock()) {
-            strongThis->OnFrameUI();
-          }
-        });
+  if (isFirstEventInBatch) {
+    RegisterFrameCallback();
   }
 }
 
@@ -63,16 +53,34 @@ void BatchingEventEmitter::EmitCoalescingJSEvent(
     JSValue &&eventObject) noexcept {
   VerifyElseCrash(m_uiDispatcher.HasThreadAccess());
 
+  implementation::BatchedEvent newEvent{std::move(emitterMethod), tag, std::move(eventName), std::move(eventObject)};
+  bool isFirstEventInBatch = false;
+
   {
     std::scoped_lock lock(m_eventQueueMutex);
+
+    isFirstEventInBatch = m_eventQueue.size() == 0;
+
     auto endIter = std::remove_if(m_eventQueue.begin(), m_eventQueue.end(), [&](const auto &evt) noexcept {
       return evt.eventName == eventName && evt.tag == tag;
     });
 
     m_eventQueue.erase(endIter, m_eventQueue.end());
+    m_eventQueue.push_back(std::move(newEvent));
   }
 
-  EmitJSEvent(std::move(emitterMethod), tag, std::move(eventName), std::move(eventObject));
+  if (isFirstEventInBatch) {
+    RegisterFrameCallback();
+  }
+}
+
+void BatchingEventEmitter::RegisterFrameCallback() noexcept {
+  m_renderingRevoker = xaml::Media::CompositionTarget::Rendering(
+      winrt::auto_revoke, [weakThis{weak_from_this()}](auto const &, auto const &) {
+        if (auto strongThis = weakThis.lock()) {
+          strongThis->OnFrameUI();
+        }
+      });
 }
 
 void BatchingEventEmitter::OnFrameUI() noexcept {

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -45,6 +45,7 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
       JSValue &&eventObject) noexcept;
 
  private:
+  void RegisterFrameCallback() noexcept;
   void OnFrameUI() noexcept;
   void OnFrameJS() noexcept;
 


### PR DESCRIPTION
Addresses a bug raised in https://github.com/microsoft/react-native-windows/pull/7260#discussion_r587943444

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7287)