### PR TITLE
Add Functionality to announceForAccessibility to Support Xaml Islands

### DIFF
--- a/change/react-native-windows-2fe5aef3-7497-4418-8cf6-038834f023b1.json
+++ b/change/react-native-windows-2fe5aef3-7497-4418-8cf6-038834f023b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add method support for Xaml Islands",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -35,7 +35,7 @@ void AccessibilityInfo::isTouchExplorationEnabled(
   onSuccess(UiaClientsAreListening());
 }
 
-void AccessibilityInfo::setAccessibilityFocus(double reactTag) noexcept {
+void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
   // no-op - This appears to be unused in RN
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -47,11 +47,13 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
 
     if (react::uwp::Is19H1OrHigher()) {
       // XamlRoot added in 19H1
-      if (auto xamlRoot =
-              winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleXamlRoot(context.Properties().Handle())) {
-        element = xamlRoot.Content();
-      } else {
-        return;
+      if (winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(context.Properties().Handle())) {
+        if (auto xamlroot =
+                winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleXamlRoot(context.Properties().Handle())) {
+          element = xamlroot.Content();
+        } else {
+          return;
+        }
       }
     }
 
@@ -60,10 +62,6 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
         element = window.Content();
         element.SetValue(xaml::Automation::AutomationProperties::LandmarkTypeProperty(), winrt::box_value(80002));
       }
-    }
-
-    if (!element) {
-      return;
     }
 
     auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element);

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -45,23 +45,22 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
     // So we need to find something to raise the notification event from.
     xaml::UIElement element{nullptr};
 
-    if (react::uwp::Is19H1OrHigher()) {
-      // XamlRoot added in 19H1
-      if (winrt::Microsoft::ReactNative::XamlUIService::GetXamlRoot(context.Properties().Handle())) {
-        if (auto xamlroot =
-                winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleXamlRoot(context.Properties().Handle())) {
-          element = xamlroot.Content();
-        } else {
-          return;
+    if (react::uwp::IsXamlIsland()) {
+      if (auto xamlroot =
+              winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleRoot(context.Properties().Handle())) {
+        element = xamlroot.Content();
+      }
+      if (!element) {
+        if (auto window = xaml::Window::Current()) {
+          if (element = window.Content()) {
+            element.SetValue(xaml::Automation::AutomationProperties::LandmarkTypeProperty(), winrt::box_value(80002));
+          } else {
+            return;
+          }
         }
       }
-    }
-
-    if (!element) {
-      if (auto window = xaml::Window::Current()) {
-        element = window.Content();
-        element.SetValue(xaml::Automation::AutomationProperties::LandmarkTypeProperty(), winrt::box_value(80002));
-      }
+    } else {
+      element = xaml::Controls::TextBlock();
     }
 
     auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element);

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -5,11 +5,13 @@
 #include "AccessibilityInfoModule.h"
 #include <UI.Xaml.Automation.Peers.h>
 #include <UI.Xaml.Controls.h>
+#include <UI.Xaml.Input.h>
 #include <XamlUtils.h>
 #include <uiautomationcore.h>
 #include <uiautomationcoreapi.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include <winrt/Windows.UI.ViewManagement.h>
+#include "XamlUIService.h"
 #include "Unicode.h"
 #include "Utils/Helpers.h"
 
@@ -35,8 +37,25 @@ void AccessibilityInfo::isTouchExplorationEnabled(
   onSuccess(UiaClientsAreListening());
 }
 
-void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
-  // no-op - This appears to be unused in RN
+void AccessibilityInfo::setAccessibilityFocus(double reactTag) noexcept {
+  m_context.UIDispatcher().Post([context = m_context, reactTag = std::move(reactTag)] {
+    auto service = winrt::Microsoft::ReactNative::XamlUIService::FromContext(context.Handle());
+    auto element = service.ElementFromReactTag(int64_t(reactTag));
+
+    if (!element) {
+      return;
+    }
+
+    auto frameworkElement = element.try_as<xaml::FrameworkElement>();
+    xaml::Input::FocusManager::TryFocusAsync(frameworkElement, xaml::FocusState::Programmatic);
+    auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(frameworkElement);
+
+    if (!peer) {
+      return;
+    }
+
+    peer.RaiseAutomationEvent(xaml::Automation::Peers::AutomationEvents::AutomationFocusChanged);
+  });
 }
 
 void AccessibilityInfo::announceForAccessibility(std::string announcement) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -46,18 +46,11 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
     xaml::UIElement element{nullptr};
 
     if (react::uwp::IsXamlIsland()) {
-      if (auto xamlroot =
+      if (auto accessibleRoot =
               winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleRoot(context.Properties().Handle())) {
-        element = xamlroot.Content();
-      }
-      if (!element) {
-        if (auto window = xaml::Window::Current()) {
-          if (element = window.Content()) {
-            element.SetValue(xaml::Automation::AutomationProperties::LandmarkTypeProperty(), winrt::box_value(80002));
-          } else {
-            return;
-          }
-        }
+        element = accessibleRoot;
+      } else {
+        return;
       }
     } else {
       element = xaml::Controls::TextBlock();

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -6,11 +6,9 @@
 #include "XamlUIService.g.cpp"
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
-#include <UI.Xaml.Automation.Peers.h>
 #include "DynamicWriter.h"
 #include "ShadowNodeBase.h"
 #include "Views/ShadowNodeBase.h"
-
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -56,8 +56,8 @@ ReactPropertyId<xaml::XamlRoot> XamlRootProperty() noexcept {
   return propId;
 }
 
-ReactPropertyId<xaml::XamlRoot> AccessibleRootProperty() noexcept {
-  static ReactPropertyId<xaml::XamlRoot> propId{L"ReactNative.UIManager", L"AccessibleXamlRoot"};
+ReactPropertyId<xaml::FrameworkElement> AccessibleRootProperty() noexcept {
+  static ReactPropertyId<xaml::FrameworkElement> propId{L"ReactNative.UIManager", L"AccessibleRoot"};
   return propId;
 }
 
@@ -69,15 +69,15 @@ ReactPropertyId<xaml::XamlRoot> AccessibleRootProperty() noexcept {
 
 /*static*/ void XamlUIService::SetAccessibleRoot(
     IReactPropertyBag const &properties,
-    xaml::XamlRoot const &xamlRoot) noexcept {
-  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleRootProperty(), xamlRoot);
+    xaml::FrameworkElement const &accessibleRoot) noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleRootProperty(), accessibleRoot);
 }
 
 /*static*/ xaml::XamlRoot XamlUIService::GetXamlRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(XamlRootProperty());
 }
 
-/*static*/ xaml::XamlRoot XamlUIService::GetAccessibleRoot(IReactPropertyBag const &properties) noexcept {
+/*static*/ xaml::FrameworkElement XamlUIService::GetAccessibleRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(AccessibleRootProperty());
 }
 

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -56,7 +56,7 @@ ReactPropertyId<xaml::XamlRoot> XamlRootProperty() noexcept {
   return propId;
 }
 
-ReactPropertyId<xaml::XamlRoot> AccessibleXamlRootProperty() noexcept {
+ReactPropertyId<xaml::XamlRoot> AccessibleRootProperty() noexcept {
   static ReactPropertyId<xaml::XamlRoot> propId{L"ReactNative.UIManager", L"AccessibleXamlRoot"};
   return propId;
 }
@@ -67,18 +67,18 @@ ReactPropertyId<xaml::XamlRoot> AccessibleXamlRootProperty() noexcept {
   winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(XamlRootProperty(), xamlRoot);
 }
 
-/*static*/ void XamlUIService::SetAccessibleXamlRoot(
+/*static*/ void XamlUIService::SetAccessibleRoot(
     IReactPropertyBag const &properties,
     xaml::XamlRoot const &xamlRoot) noexcept {
-  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleXamlRootProperty(), xamlRoot);
+  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleRootProperty(), xamlRoot);
 }
 
 /*static*/ xaml::XamlRoot XamlUIService::GetXamlRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(XamlRootProperty());
 }
 
-/*static*/ xaml::XamlRoot XamlUIService::GetAccessibleXamlRoot(IReactPropertyBag const &properties) noexcept {
-  return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(AccessibleXamlRootProperty());
+/*static*/ xaml::XamlRoot XamlUIService::GetAccessibleRoot(IReactPropertyBag const &properties) noexcept {
+  return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(AccessibleRootProperty());
 }
 
 ReactPropertyId<uint64_t> XamlIslandProperty() noexcept {

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -6,9 +6,11 @@
 #include "XamlUIService.g.cpp"
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#include <UI.Xaml.Automation.Peers.h>
 #include "DynamicWriter.h"
 #include "ShadowNodeBase.h"
 #include "Views/ShadowNodeBase.h"
+
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -56,14 +58,29 @@ ReactPropertyId<xaml::XamlRoot> XamlRootProperty() noexcept {
   return propId;
 }
 
+ReactPropertyId<xaml::XamlRoot> AccessibleXamlRootProperty() noexcept {
+  static ReactPropertyId<xaml::XamlRoot> propId{L"ReactNative.UIManager", L"AccessibleXamlRoot"};
+  return propId;
+}
+
 /*static*/ void XamlUIService::SetXamlRoot(
     IReactPropertyBag const &properties,
     xaml::XamlRoot const &xamlRoot) noexcept {
   winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(XamlRootProperty(), xamlRoot);
 }
 
+/*static*/ void XamlUIService::SetAccessibleXamlRoot(
+    IReactPropertyBag const &properties,
+    xaml::XamlRoot const &xamlRoot) noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleXamlRootProperty(), xamlRoot);
+}
+
 /*static*/ xaml::XamlRoot XamlUIService::GetXamlRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(XamlRootProperty());
+}
+
+/*static*/ xaml::XamlRoot XamlUIService::GetAccessibleXamlRoot(IReactPropertyBag const &properties) noexcept {
+  return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(AccessibleXamlRootProperty());
 }
 
 ReactPropertyId<uint64_t> XamlIslandProperty() noexcept {

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -23,7 +23,9 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
-  static void SetAccessibleRoot(IReactPropertyBag const &properties, xaml::FrameworkElement const &accessibleRoot) noexcept;
+  static void SetAccessibleRoot(
+      IReactPropertyBag const &properties,
+      xaml::FrameworkElement const &accessibleRoot) noexcept;
   static xaml::XamlRoot GetXamlRoot(IReactPropertyBag const &properties) noexcept;
   static xaml::FrameworkElement GetAccessibleRoot(IReactPropertyBag const &properties) noexcept;
 

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -23,7 +23,9 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
+  static void SetAccessibleXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static xaml::XamlRoot GetXamlRoot(IReactPropertyBag const &properties) noexcept;
+  static xaml::XamlRoot GetAccessibleXamlRoot(IReactPropertyBag const &properties) noexcept;
 
   static void SetIslandWindowHandle(IReactPropertyBag const &properties, uint64_t hwnd) noexcept;
   static uint64_t GetIslandWindowHandle(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -23,9 +23,9 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
-  static void SetAccessibleXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
+  static void SetAccessibleRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static xaml::XamlRoot GetXamlRoot(IReactPropertyBag const &properties) noexcept;
-  static xaml::XamlRoot GetAccessibleXamlRoot(IReactPropertyBag const &properties) noexcept;
+  static xaml::XamlRoot GetAccessibleRoot(IReactPropertyBag const &properties) noexcept;
 
   static void SetIslandWindowHandle(IReactPropertyBag const &properties, uint64_t hwnd) noexcept;
   static uint64_t GetIslandWindowHandle(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -23,9 +23,9 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
-  static void SetAccessibleRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
+  static void SetAccessibleRoot(IReactPropertyBag const &properties, xaml::FrameworkElement const &accessibleRoot) noexcept;
   static xaml::XamlRoot GetXamlRoot(IReactPropertyBag const &properties) noexcept;
-  static xaml::XamlRoot GetAccessibleRoot(IReactPropertyBag const &properties) noexcept;
+  static xaml::FrameworkElement GetAccessibleRoot(IReactPropertyBag const &properties) noexcept;
 
   static void SetIslandWindowHandle(IReactPropertyBag const &properties, uint64_t hwnd) noexcept;
   static uint64_t GetIslandWindowHandle(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -26,11 +26,11 @@ namespace Microsoft.ReactNative {
     DOC_STRING("Set XamlRoot for app. This must be manually provided to the ReactInstanceSettings when using XamlIslands.")
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
-    DOC_STRING("Set accessible XamlRoot for app. This XamlRoot should be able to create an automation peer. This must be manually provided to the ReactInstanceSettings when using XamlIslands to have access to accessibility methods.")
+    DOC_STRING("Set accessible FrameworkElement for app. Make sure the element is able to create an automation peer. This must be manually provided to the ReactInstanceSettings when using XamlIslands to have access to accessibility methods.")
     static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement accessibleRoot);
     DOC_STRING("Retrieve XamlRoot for app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
-    DOC_STRING("Retrieve accessible XamlRoot for app.")
+    DOC_STRING("Retrieve accessible FrameworkElement for app.")
     static XAML_NAMESPACE.FrameworkElement GetAccessibleRoot(IReactPropertyBag properties);
 
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -24,7 +24,10 @@ namespace Microsoft.ReactNative {
 
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
+    // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
+    static void SetAccessibleXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
+    static XAML_NAMESPACE.XamlRoot GetAccessibleXamlRoot(IReactPropertyBag properties);
 
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);
     DOC_STRING("Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -27,11 +27,11 @@ namespace Microsoft.ReactNative {
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
     DOC_STRING("Set accessible XamlRoot for app. This XamlRoot should be able to create an automation peer. This must be manually provided to the ReactInstanceSettings when using XamlIslands to have access to accessibility methods.")
-    static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
+    static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement accessibleRoot);
     DOC_STRING("Retrieve XamlRoot for app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
     DOC_STRING("Retrieve accessible XamlRoot for app.")
-    static XAML_NAMESPACE.XamlRoot GetAccessibleRoot(IReactPropertyBag properties);
+    static XAML_NAMESPACE.FrameworkElement GetAccessibleRoot(IReactPropertyBag properties);
 
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);
     DOC_STRING("Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -23,11 +23,15 @@ namespace Microsoft.ReactNative {
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
+    DOC_STRING("Set XamlRoot for app. This must be manually provided to the ReactInstanceSettings when using XamlIslands.")
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
-    static void SetAccessibleXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
+    DOC_STRING("Set accessible XamlRoot for app. This XamlRoot should be able to create an automation peer. This must be manually provided to the ReactInstanceSettings when using XamlIslands to have access to accessibility methods.")
+    static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
+    DOC_STRING("Retrieve XamlRoot for app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
-    static XAML_NAMESPACE.XamlRoot GetAccessibleXamlRoot(IReactPropertyBag properties);
+    DOC_STRING("Retrieve accessible XamlRoot for app.")
+    static XAML_NAMESPACE.XamlRoot GetAccessibleRoot(IReactPropertyBag properties);
 
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);
     DOC_STRING("Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")

--- a/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
+++ b/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
@@ -151,7 +151,9 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#setaccessibilityfocus
    */
   setAccessibilityFocus: function(reactTag: number): void {
-    legacySendAccessibilityEvent(reactTag, 'focus');
+    if (NativeAccessibilityInfo) {
+      NativeAccessibilityInfo.setAccessibilityFocus(reactTag);
+    }
   },
 
   /**

--- a/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
+++ b/vnext/src/Libraries/Components/AccessibilityInfo/AccessibilityInfo.windows.js
@@ -151,9 +151,7 @@ const AccessibilityInfo = {
    * See https://reactnative.dev/docs/accessibilityinfo.html#setaccessibilityfocus
    */
   setAccessibilityFocus: function(reactTag: number): void {
-    if (NativeAccessibilityInfo) {
-      NativeAccessibilityInfo.setAccessibilityFocus(reactTag);
-    }
+    legacySendAccessibilityEvent(reactTag, 'focus');
   },
 
   /**


### PR DESCRIPTION
#7220 added functionality to announceForAccessibility which worked for UWP apps. New changes allow for method to work for apps using XAML Islands. Note: apps using XAML Islands must now set/specify an AccessibleXamlRoot in order for announceForAccessibility to work. AccessibleXamlRoots must be able to create an automation peer or need to set AutomationProperties::LandmarkTypeProperty() to 80002.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7290)