### PR TITLE
Avoid exception when trying to create Uri from empty strings

### DIFF
--- a/change/react-native-windows-09aa6466-41c0-4718-801b-510db2c25e37.json
+++ b/change/react-native-windows-09aa6466-41c0-4718-801b-510db2c25e37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid exception when trying to create Uri from empty strings",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -251,11 +251,14 @@ REACTWINDOWS_API_(winrt::TimeSpan) TimeSpanFromMs(double ms) {
 
 // C# provides System.Uri.TryCreate, but no native equivalent seems to exist
 winrt::Uri UriTryCreate(winrt::param::hstring const &uri) {
-  try {
-    return winrt::Uri(uri);
-  } catch (...) {
-    return winrt::Uri(nullptr);
+  winrt::Uri ret{nullptr};
+  if (uri != winrt::hstring{L""}) {
+    try {
+      ret = winrt::Uri(uri);
+    } catch (...) {
+    }
   }
+  return ret;
 }
 
 } // namespace react::uwp


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7296)