### PR TITLE
Fixes case where focus commands may be ignored

### DIFF
--- a/change/react-native-windows-58079bd4-79e5-455a-a510-7b6beb15e66b.json
+++ b/change/react-native-windows-58079bd4-79e5-455a-a510-7b6beb15e66b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes case where focus commands may be ignored",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInputState.windows.js
@@ -88,7 +88,16 @@ function focusTextInput(textField: ?ComponentRef) {
     return;
   }
 
-  if (currentlyFocusedInputRef !== textField && textField != null) {
+  // [Windows
+  if (Platform.OS === 'windows' && textField != null) {
+    // On Windows, we cannot test if the currentlyFocusedInputRef equals the
+    // target ref because the call to focus on the target ref may occur before
+    // an onBlur event for the target ref has been dispatched to JS but after
+    // the target ref has lost native focus.
+    focusInput(textField);
+    WindowsTextInputCommands.focus(textField);
+    // Windows]
+  } else if (currentlyFocusedInputRef !== textField && textField != null) {
     focusInput(textField);
     if (Platform.OS === 'ios') {
       // This isn't necessarily a single line text input
@@ -100,11 +109,6 @@ function focusTextInput(textField: ?ComponentRef) {
     } else if (Platform.OS === 'android') {
       AndroidTextInputCommands.focus(textField);
     }
-    // [Windows
-    else if (Platform.OS === 'windows') {
-      WindowsTextInputCommands.focus(textField);
-    }
-    // Windows]
   }
 }
 


### PR DESCRIPTION
Given JS state is async from native state, it is possible that a control
may lose native focus, but the TextInputState module that manages focus
for TextInput components may not yet have received the event, and as a
result may ignore commands to focus the TextInput. This change removes a
check from TextInputState that would prevent focus commands from
executing.

Fixes #7303

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7304)