### PR TITLE
Added 0.64+ to projectType flag for react-native-windows-init cli

### DIFF
--- a/change/react-native-windows-init-ff672186-e7d4-4afc-a426-920010c7da26.json
+++ b/change/react-native-windows-init-ff672186-e7d4-4afc-a426-920010c7da26.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added 0.64+ to projectType flag for react-native-windows-init cli",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -77,7 +77,7 @@ const argv = yargs
     },
     projectType: {
       type: 'string',
-      describe: 'The type of project to initialize.',
+      describe: 'The type of project to initialize (supported on 0.64+)',
       choices: ['app', 'lib'],
       default: 'app',
     },


### PR DESCRIPTION
Closes #6829

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7306)