### PR TITLE
[0.64] Fix cursor warning when right clicking (#7278)

### DIFF
--- a/change/react-native-windows-97d7ac05-284f-40fe-9829-493043e1988b.json
+++ b/change/react-native-windows-97d7ac05-284f-40fe-9829-493043e1988b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix right click warning.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -171,7 +171,9 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
   if (TagFromOriginalSource(args, &tag, &sourceElement))
     UpdateReactPointer(m_pointers[*optPointerIndex], args, sourceElement);
 
-  DispatchTouchEvent(eventType, *optPointerIndex);
+  if (m_pointers[*optPointerIndex].isLeftButton) {
+    DispatchTouchEvent(eventType, *optPointerIndex);
+  }
 
   m_pointers.erase(cbegin(m_pointers) + *optPointerIndex);
   if (m_pointers.size() == 0)


### PR DESCRIPTION
Backporting the warning fix to 0.64.

* Fix right click warning.

* Change files

Co-authored-by: Igor Klemenski <igklemen@microsoft.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7307)