### PR TITLE
[0.64] Add NugetSecurityAnalysisWarningLevel=warn for publish.yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -4,6 +4,8 @@ variables:
   - template: variables/msbuild.yml
   - template: variables/vs2019.yml
   - group: RNW Secrets
+  - name: NugetSecurityAnalysisWarningLevel
+    value: 'warn'
 
 schedules:
 - cron: "0 5 * * *" # 5AM Daily UTC (10PM Daily PST)


### PR DESCRIPTION
This should prevent publish from failing due to our nuget multifeed
issues.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7315)