### PR TITLE
Disable warning 4103 in MemoryMappedBufferTests.cpp

### DIFF
--- a/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
+++ b/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable warning 4103 in MemoryMappedBufferTests.cpp",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/MemoryMappedBufferTests.cpp
+++ b/vnext/Desktop.UnitTests/MemoryMappedBufferTests.cpp
@@ -1,7 +1,10 @@
 #include "MemoryMappedBuffer.h"
 #include "Utilities.h"
 
+#pragma pack(push)
+#pragma warning(disable : 4103)
 #include <CppUnitTest.h>
+#pragma pack(pop)
 
 #include <shlwapi.h>
 #include <windows.h>


### PR DESCRIPTION
Desktop solution fails to build on Visual Studio `16.9.0` with the current master as follows:

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29910\include\system_error(18,1): error C2220: the following warning is treated as an error [vnext\Desktop.UnitTests\React.Windows.Desktop.UnitTests.vcxproj]
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.28.29910\include\system_error(18,1): warning C4103: alignment changed after including header, may be due to missing #pragma pack(pop) [vnext\Desktop.UnitTests\React.Windows.Desktop.UnitTests.vcxproj]
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7319)