### PR TITLE
Adds declarative props to clear/submit TextInput

### DIFF
--- a/change/react-native-windows-049db1de-5833-4cb0-a208-fec0fa53e060.json
+++ b/change/react-native-windows-049db1de-5833-4cb0-a208-fec0fa53e060.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds declarative props to clear/submit TextInput",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -455,4 +455,37 @@ exports.examples = ([
       return <PressInOutEvents />;
     },
   },
+  // [Windows
+  {
+    title: 'Clear text on submit',
+    render: function(): React.Node {
+      return (
+        <View>
+          <Text>Default submit key (Enter):</Text>
+          <TextInput clearTextOnSubmit style={styles.singleLine} />
+          <Text>Custom submit key event (Shift + Enter), single-line:</Text>
+          <TextInput
+            clearTextOnSubmit
+            style={styles.singleLine}
+            submitKeyEvents={[{code: 'Enter', shiftKey: true}]}
+          />
+          <Text>Custom submit key event (Shift + Enter), multi-line:</Text>
+          <TextInput
+            multiline
+            clearTextOnSubmit
+            style={styles.multiline}
+            submitKeyEvents={[{code: 'Enter', shiftKey: true}]}
+          />
+          <Text>Submit with Enter key, return key with Shift + Enter</Text>
+          <TextInput
+            multiline
+            clearTextOnSubmit
+            style={styles.multiline}
+            submitKeyEvents={[{code: 'Enter'}]}
+          />
+        </View>
+      );
+    },
+  },
+  // Windows]
 ]: Array<RNTesterExampleModuleItem>);

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -185,7 +185,6 @@ void HandledKeyboardEventHandler::KeyboardEventHandledHandler(
     args.Handled(true);
 }
 
-
 /* static */ bool KeyboardHelper::ShouldMarkKeyboardHandled(
     std::vector<HandledKeyboardEvent> const &handledEvents,
     HandledKeyboardEvent currentEvent) {

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -177,15 +177,16 @@ void HandledKeyboardEventHandler::KeyboardEventHandledHandler(
 
   bool shouldMarkHandled = false;
   if (phase == KeyboardEventPhase::PreviewKeyDown || phase == KeyboardEventPhase::KeyDown)
-    shouldMarkHandled = ShouldMarkKeyboardHandled(m_handledKeyDownKeyboardEvents, event);
+    shouldMarkHandled = KeyboardHelper::ShouldMarkKeyboardHandled(m_handledKeyDownKeyboardEvents, event);
   else
-    shouldMarkHandled = ShouldMarkKeyboardHandled(m_handledKeyUpKeyboardEvents, event);
+    shouldMarkHandled = KeyboardHelper::ShouldMarkKeyboardHandled(m_handledKeyUpKeyboardEvents, event);
 
   if (shouldMarkHandled)
     args.Handled(true);
 }
 
-bool HandledKeyboardEventHandler::ShouldMarkKeyboardHandled(
+
+/* static */ bool KeyboardHelper::ShouldMarkKeyboardHandled(
     std::vector<HandledKeyboardEvent> const &handledEvents,
     HandledKeyboardEvent currentEvent) {
   for (auto const &event : handledEvents) {

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.h
@@ -113,9 +113,6 @@ class HandledKeyboardEventHandler {
       KeyboardEventPhase phase,
       winrt::IInspectable const &sender,
       xaml::Input::KeyRoutedEventArgs const &args);
-  bool ShouldMarkKeyboardHandled(
-      std::vector<HandledKeyboardEvent> const &handledEvents,
-      HandledKeyboardEvent currentEvent);
 
   std::vector<HandledKeyboardEvent> m_handledKeyUpKeyboardEvents;
   std::vector<HandledKeyboardEvent> m_handledKeyDownKeyboardEvents;
@@ -131,5 +128,8 @@ struct KeyboardHelper {
   static std::string CodeFromVirtualKey(winrt::Windows::System::VirtualKey key);
   static bool IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey);
   static bool IsModifiedKeyLocked(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey);
+  static bool ShouldMarkKeyboardHandled(
+      std::vector<HandledKeyboardEvent> const &handledEvents,
+      HandledKeyboardEvent currentEvent);
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -161,7 +161,7 @@ class TextInputShadowNode : public ShadowNodeBase {
 
   xaml::Controls::Control::GotFocus_revoker m_controlGotFocusRevoker{};
   xaml::Controls::Control::LostFocus_revoker m_controlLostFocusRevoker{};
-  xaml::Controls::Control::PreviewKeyDown_revoker m_controlKeyDownRevoker{};
+  xaml::Controls::Control::PreviewKeyDown_revoker m_controlPreviewKeyDownRevoker{};
   xaml::Controls::Control::SizeChanged_revoker m_controlSizeChangedRevoker{};
   xaml::Controls::Control::CharacterReceived_revoker m_controlCharacterReceivedRevoker{};
   xaml::Controls::ScrollViewer::ViewChanging_revoker m_scrollViewerViewChangingRevoker{};
@@ -365,7 +365,7 @@ void TextInputShadowNode::registerEvents() {
 void TextInputShadowNode::registerPreviewKeyDown() {
   auto control = GetView().as<xaml::Controls::Control>();
   auto tag = m_tag;
-  m_controlKeyDownRevoker =
+  m_controlPreviewKeyDownRevoker =
       control.PreviewKeyDown(winrt::auto_revoke, [=](auto &&, xaml::Input::KeyRoutedEventArgs const &args) {
         auto isMultiline = m_isTextBox && control.as<xaml::Controls::TextBox>().AcceptsReturn();
         auto shouldSubmit = !args.Handled();
@@ -660,7 +660,7 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
 
   // We need to re-register the PreviewKeyDown handler so it is invoked after the ShadowNodeBase handler
   if (hasKeyDownEvents) {
-    m_controlKeyDownRevoker.revoke();
+    m_controlPreviewKeyDownRevoker.revoke();
     registerPreviewKeyDown();
   }
 

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -421,10 +421,37 @@ type AndroidProps = $ReadOnly<{|
   underlineColorAndroid?: ?ColorValue,
 |}>;
 
+// [Windows
+
+type SubmitKeyEvent = $ReadOnly<{|
+  altKey?: ?boolean,
+  ctrlKey?: ?boolean,
+  metaKey?: ?boolean,
+  shiftKey?: ?boolean,
+  code: string,
+|}>;
+
+type WindowsProps = $ReadOnly<{|
+  /**
+   * If `true`, clears the text field synchronously before `onSubmitEditing` is emitted.
+   * @platform windows
+   */
+  clearTextOnSubmit?: ?boolean,
+
+  /**
+   * Configures keys that can be used to submit editing for the TextInput.
+   * @platform windows
+   */
+  submitKeyEvents?: ?$ReadOnlyArray<SubmitKeyEvent>,
+|}>;
+
+// Windows]
+
 export type Props = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
   ...IOSProps,
   ...AndroidProps,
+  ...WindowsProps, // [Windows]
 
   /**
    * Can tell `TextInput` to automatically capitalize certain characters.


### PR DESCRIPTION
This change adds two new props and a new behavior for multiline TextInput.

New props:
1. `clearTextOnSubmit`: similar to `clearTextOnFocus`, except that it clears out the TextInput whenever the `onSubmitEditing` event would be dispatched.
2. `submitKeyEvents`: registers a set of key down events that will trigger `onSubmitEditing` for multiline TextInput.

New behavior:
Previously, `onSubmitEditing` would never fire when `multiline={true}` for a TextInput. Now, `onSubmitEditing` may fire for a multiline TextInput if a key down event matching the configuration in `submitKeyEvents` is observed.

Fixes #7330

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7333)