### PR TITLE
Added change files so publish re-runs

### DIFF
--- a/change/@office-iss-react-native-win32-302430a4-2c5a-411f-808c-52c62d47a0bf.json
+++ b/change/@office-iss-react-native-win32-302430a4-2c5a-411f-808c-52c62d47a0bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 6/3 RN nigtly build. (#7318)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/node-rnw-rpc-c69cb7e8-753f-497e-b3ac-376b724d41a2.json
+++ b/change/node-rnw-rpc-c69cb7e8-753f-497e-b3ac-376b724d41a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate 6/3 RN nigtly build. (#7318)",
+  "packageName": "node-rnw-rpc",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-d874ef92-15e6-40de-b10a-d6dfabc15f49.json
+++ b/change/react-native-windows-init-d874ef92-15e6-40de-b10a-d6dfabc15f49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added 0.64+ to projectType flag for react-native-windows-init cli (#7306)",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Re-added change files to make sure these packages get published:

* react-native-windows-init
* @office-iss/react-native-win32
* node-rnw-rpc