### PR TITLE
[0.64] Disable warning 4103 in MemoryMappedBufferTests.cpp

### DIFF
--- a/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
+++ b/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Disable warning 4103 in MemoryMappedBufferTests.cpp",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
+++ b/change/react-native-windows-00b73d31-195e-4e20-97d3-444d09a770eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable warning 4103 in MemoryMappedBufferTests.cpp",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-7fe6b7ea-630a-4f0e-bf79-394a1ddb0f0a.json
+++ b/change/react-native-windows-7fe6b7ea-630a-4f0e-bf79-394a1ddb0f0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable warning 4103 in MemoryMappedBufferTests.cpp (#7319)",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/MemoryMappedBufferTests.cpp
+++ b/vnext/Desktop.UnitTests/MemoryMappedBufferTests.cpp
@@ -1,7 +1,10 @@
 #include "MemoryMappedBuffer.h"
 #include "Utilities.h"
 
+#pragma pack(push)
+#pragma warning(disable : 4103)
 #include <CppUnitTest.h>
+#pragma pack(pop)
 
 #include <shlwapi.h>
 #include <windows.h>


### PR DESCRIPTION
Backport of #7319 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7355)