### PR TITLE
[0.64] Raise Instance notifications in JSDispatcher thread (#7356)

### DIFF
--- a/change/react-native-windows-65cb61de-5d53-4917-8d6e-b50d3b506a93.json
+++ b/change/react-native-windows-65cb61de-5d53-4917-8d6e-b50d3b506a93.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Raise Instance notifications in JSDispatcher thread",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.cpp
@@ -43,7 +43,6 @@ facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) n
         ReactNotificationId<InstanceDestroyedEventArgs>{L"ReactNative.InstanceSettings", L"InstanceDestroyed"}};
     context.Notifications().Subscribe(
         destroyInstanceNotificationId,
-        jsDispatcher,
         [context, jsiRuntimeProperty](
             winrt::Windows::Foundation::IInspectable const & /*sender*/,
             ReactNotificationArgs<InstanceDestroyedEventArgs> const &args) noexcept {

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// See that we can safely reload react instance when we use C++ TurboModules.
+
+#include "pch.h"
+#include <ReactCommon/TurboModule.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <TurboModuleProvider.h> // It is RNW specific
+#include <limits>
+#include "TestEventService.h"
+#include "TestReactNativeHostHolder.h"
+
+using namespace facebook;
+using namespace winrt;
+using namespace Microsoft::ReactNative;
+
+namespace ReactNativeIntegrationTests {
+
+// Use anonymous namespace to avoid any linking conflicts
+namespace {
+
+// In this test we put spec definition that normally must be generated.
+// >>>> Start generated
+
+// The spec from .h file
+struct MyTrivialTurboModuleSpec : react::TurboModule {
+  virtual void startFromJS(jsi::Runtime &rt) = 0;
+
+ protected:
+  MyTrivialTurboModuleSpec(std::shared_ptr<react::CallInvoker> jsInvoker);
+};
+
+// The spec from .cpp file
+
+static jsi::Value MyTrivialTurboModuleSpec_startFromJS(
+    jsi::Runtime &rt,
+    react::TurboModule &turboModule,
+    [[maybe_unused]] const jsi::Value *args,
+    [[maybe_unused]] size_t count) {
+  assert(count >= 0);
+  static_cast<MyTrivialTurboModuleSpec *>(&turboModule)->startFromJS(rt);
+  return jsi::Value::undefined();
+}
+
+MyTrivialTurboModuleSpec::MyTrivialTurboModuleSpec(std::shared_ptr<react::CallInvoker> jsInvoker)
+    : react::TurboModule("MyTrivialTurboModuleSpec", std::move(jsInvoker)) {
+  methodMap_.try_emplace("startFromJS", MethodMetadata{0, MyTrivialTurboModuleSpec_startFromJS});
+}
+
+// <<<< End generated
+
+struct MyTrivialTurboModule : MyTrivialTurboModuleSpec {
+  MyTrivialTurboModule(std::shared_ptr<react::CallInvoker> jsInvoker);
+
+  void startFromJS(jsi::Runtime &rt) override;
+};
+
+MyTrivialTurboModule::MyTrivialTurboModule(std::shared_ptr<react::CallInvoker> jsInvoker)
+    : MyTrivialTurboModuleSpec(std::move(jsInvoker)) {}
+
+void MyTrivialTurboModule::startFromJS(jsi::Runtime & /*rt*/) {
+  TestEventService::LogEvent("startFromJS called", nullptr);
+}
+
+struct MyTrivialTurboModulePackageProvider
+    : winrt::implements<MyTrivialTurboModulePackageProvider, IReactPackageProvider> {
+  void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
+    AddTurboModuleProvider<MyTrivialTurboModule>(packageBuilder, L"MyTrivialTurboModule");
+  }
+};
+
+} // namespace
+
+TEST_CLASS (JsiSimpleTurboModuleTests) {
+  TEST_METHOD(TestInstanceReload) {
+    TestEventService::Initialize();
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"JsiSimpleTurboModuleTests", [&](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<MyTrivialTurboModulePackageProvider>());
+
+          // See that all events are raised in JSDispatcher thread.
+          host.InstanceSettings().InstanceCreated(
+              [](IInspectable const & /*sender*/, InstanceCreatedEventArgs const &args) {
+                TestEventService::LogEvent("Instance created event", nullptr);
+                TestCheck(ReactContext(args.Context()).JSDispatcher().HasThreadAccess());
+              });
+          host.InstanceSettings().InstanceLoaded(
+              [](IInspectable const & /*sender*/, InstanceLoadedEventArgs const &args) {
+                TestEventService::LogEvent("Instance loaded event", nullptr);
+                TestCheck(ReactContext(args.Context()).JSDispatcher().HasThreadAccess());
+              });
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const &args) {
+                TestEventService::LogEvent("Instance destroyed event", nullptr);
+                TestCheck(ReactContext(args.Context()).JSDispatcher().HasThreadAccess());
+              });
+        });
+
+    TestEventService::ObserveEvents({
+        TestEvent{"Instance created event", nullptr},
+        TestEvent{"startFromJS called", nullptr},
+        TestEvent{"Instance loaded event", nullptr},
+    });
+
+    reactNativeHost.Host().ReloadInstance();
+
+    TestEventService::ObserveEvents({
+        TestEvent{"Instance destroyed event", nullptr},
+        TestEvent{"Instance created event", nullptr},
+        TestEvent{"startFromJS called", nullptr},
+        TestEvent{"Instance loaded event", nullptr},
+    });
+
+    reactNativeHost.Host().UnloadInstance();
+
+    TestEventService::ObserveEvents({
+        TestEvent{"Instance destroyed event", nullptr},
+    });
+  }
+};
+
+} // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.js
@@ -1,0 +1,4 @@
+import * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegistry';
+const myTrivialTurboModule = TurboModuleRegistry.getEnforcing('MyTrivialTurboModule');
+
+myTrivialTurboModule.startFromJS();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.cpp
@@ -17,8 +17,8 @@
 // See the details for the MySimpleTurboModulePackageProvider below.
 
 #include "pch.h"
-#include <ReactCommon/TurboModule.h> // This comes from the react-native package.
-#include <ReactCommon/TurboModuleUtils.h> // This must come from the react-native package, but we use a local version to fix issues.
+#include <ReactCommon/TurboModule.h>
+#include <ReactCommon/TurboModuleUtils.h>
 #include <TurboModuleProvider.h> // It is RNW specific
 #include <limits>
 #include "TestEventService.h"

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -109,6 +109,7 @@
   <ItemGroup>
     <ClCompile Include="ExecuteJsiTests.cpp" />
     <ClCompile Include="JsiRuntimeTests.cpp" />
+    <ClCompile Include="JsiSimpleTurboModuleTests.cpp" />
     <ClCompile Include="JsiTurboModuleTests.cpp" />
     <ClCompile Include="ReactInstanceSettingsTests.cpp" />
     <ClCompile Include="ReactNonAbiValueTests.cpp" />
@@ -143,12 +144,14 @@
   <ItemGroup>
     <Manifest Include="Application.manifest" />
     <None Include="ExecuteJsiTests.js" />
+    <None Include="JsiSimpleTurboModuleTests.js" />
     <None Include="JsiTurboModuleTests.js" />
     <None Include="ReactNativeHostTests.js" />
     <None Include="ReactNotificationServiceTests.js" />
     <None Include="TurboModuleTests.js" />
     <None Include="packages.config" />
     <JsBundleEntry Include="ExecuteJsiTests.js" />
+    <JsBundleEntry Include="JsiSimpleTurboModuleTests.js" />
     <JsBundleEntry Include="JsiTurboModuleTests.js" />
     <JsBundleEntry Include="ReactNativeHostTests.js" />
     <JsBundleEntry Include="ReactNotificationServiceTests.js" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj.filters
@@ -23,6 +23,7 @@
       <Filter>Utilities</Filter>
     </ClCompile>
     <ClCompile Include="JsiTurboModuleTests.cpp" />
+    <ClCompile Include="JsiSimpleTurboModuleTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsi\jsi\test\testlib.h" />
@@ -47,6 +48,8 @@
     <None Include="packages.config">
       <Filter>Other Files</Filter>
     </None>
+    <None Include="JsiSimpleTurboModuleTests.js" />
+    <None Include="ReactNotificationServiceTests.js" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Utilities">

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
@@ -4,9 +4,7 @@
 #include "pch.h"
 #include "TestEventService.h"
 #include <motifCpp/testCheck.h>
-#include <chrono>
 #include <sstream>
-#include <thread>
 
 namespace ReactNativeIntegrationTests {
 
@@ -14,63 +12,51 @@ using namespace std::literals::chrono_literals;
 
 /*static*/ std::mutex TestEventService::s_mutex;
 /*static*/ std::condition_variable TestEventService::s_cv;
-/*static*/ TestEvent TestEventService::s_loggedEvent{};
-/*static*/ bool TestEventService::s_previousEventIsObserved{true}; // true to allow new event to be logged
-/*static*/ uint32_t TestEventService::s_observeEventIndex{0};
+/*static*/ std::queue<TestEvent> TestEventService::s_eventQueue;
+/*static*/ bool TestEventService::s_hasNewEvent{false};
 
 /*static*/ void TestEventService::Initialize() noexcept {
   auto lock = std::scoped_lock{s_mutex};
-  s_previousEventIsObserved = true;
-  s_observeEventIndex = 0;
+  s_eventQueue = {};
 }
 
 /*static*/ void TestEventService::LogEvent(std::string_view eventName, JSValue &&value) noexcept {
-  // Blocks the thread until the previous logged event is observed.
-  while (true) {
-    {
-      // Do not hold the lock while the thread sleeps.
-      auto lock = std::scoped_lock{s_mutex};
-      if (s_previousEventIsObserved) {
-        s_loggedEvent.EventName = eventName;
-        s_loggedEvent.Value = std::move(value);
-        s_previousEventIsObserved = false;
-        s_cv.notify_all();
-        break;
-      }
-    }
-
-    std::this_thread::sleep_for(1ms);
-  }
+  auto lock = std::scoped_lock{s_mutex};
+  s_eventQueue.push(TestEvent{eventName, std::move(value)});
+  s_hasNewEvent = true;
+  s_cv.notify_all();
 }
 
 /*static*/ void TestEventService::ObserveEvents(winrt::array_view<const TestEvent> expectedEvents) noexcept {
-  auto lock = std::unique_lock{s_mutex};
-  s_cv.wait(lock, [&]() {
-    if (!s_previousEventIsObserved) {
-      TestCheck(s_observeEventIndex < expectedEvents.size());
-      auto const &expectedEvent = expectedEvents[s_observeEventIndex];
+  uint32_t observeEventIndex{0};
+  while (observeEventIndex < expectedEvents.size()) {
+    auto lock = std::unique_lock{s_mutex};
+    if (!s_eventQueue.empty()) {
+      TestEvent loggedEvent{std::move(s_eventQueue.front())};
+      s_eventQueue.pop();
 
       // Check the event name and value
-      TestCheckEqual(expectedEvent.EventName, s_loggedEvent.EventName);
-      if (auto d1 = expectedEvent.Value.TryGetDouble(), d2 = s_loggedEvent.Value.TryGetDouble(); d1 && d2) {
+      auto const &expectedEvent = expectedEvents[observeEventIndex];
+      TestCheckEqual(expectedEvent.EventName, loggedEvent.EventName);
+      if (auto d1 = expectedEvent.Value.TryGetDouble(), d2 = loggedEvent.Value.TryGetDouble(); d1 && d2) {
         // Comparison of doubles has special logic because NaN != NaN.
         if (!isnan(*d1) && !isnan(*d2)) {
           TestCheckEqual(*d1, *d2);
         }
-      } else if (expectedEvent.Value != s_loggedEvent.Value) { // Use JSValue strict compare
+      } else if (expectedEvent.Value != loggedEvent.Value) { // Use JSValue strict compare
         std::stringstream os;
-        os << "Event index: " << s_observeEventIndex << '\n'
+        os << "Event index: " << observeEventIndex << '\n'
            << "Expected: " << expectedEvent.Value.ToString() << '\n'
-           << "Actual: " << s_loggedEvent.Value.ToString();
+           << "Actual: " << loggedEvent.Value.ToString();
         TestCheckFail("%s", os.str().c_str());
       }
-      s_previousEventIsObserved = true;
-      ++s_observeEventIndex;
-    }
 
-    // Finish observing after we observed the last event.
-    return s_observeEventIndex >= expectedEvents.size();
-  });
+      ++observeEventIndex;
+    } else {
+      s_cv.wait(lock, [&]() { return s_hasNewEvent; });
+      s_hasNewEvent = false;
+    }
+  }
 }
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
@@ -11,6 +11,7 @@
 #include <JSValue.h>
 #include <winrt/base.h>
 #include <mutex>
+#include <queue>
 #include <string_view>
 
 namespace ReactNativeIntegrationTests {
@@ -50,9 +51,8 @@ struct TestEventService {
  private:
   static std::mutex s_mutex; // to synchronize access to the fields below
   static std::condition_variable s_cv; // to notify about new event
-  static TestEvent s_loggedEvent; // last logged event
-  static bool s_previousEventIsObserved; // did we observe the last logged event?
-  static uint32_t s_observeEventIndex; // the event index to observe
+  static std::queue<TestEvent> s_eventQueue; // the event queue
+  static bool s_hasNewEvent;
 };
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
@@ -41,4 +41,8 @@ TestReactNativeHostHolder::~TestReactNativeHostHolder() noexcept {
   m_queueController.ShutdownQueueAsync().get();
 }
 
+winrt::Microsoft::ReactNative::ReactNativeHost const &TestReactNativeHostHolder::Host() const noexcept {
+  return m_host;
+}
+
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
@@ -16,6 +16,8 @@ struct TestReactNativeHostHolder {
       Mso::Functor<void(winrt::Microsoft::ReactNative::ReactNativeHost const &)> &&hostInitializer) noexcept;
   ~TestReactNativeHostHolder() noexcept;
 
+  winrt::Microsoft::ReactNative::ReactNativeHost const &Host() const noexcept;
+
  private:
   winrt::Microsoft::ReactNative::ReactNativeHost m_host{nullptr};
   winrt::Windows::System::DispatcherQueueController m_queueController{nullptr};

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -180,6 +180,7 @@
     <ClInclude Include="Base\CoreNativeModules.h" />
     <ClInclude Include="Base\CxxReactIncludes.h" />
     <ClInclude Include="Base\FollyIncludes.h" />
+    <ClInclude Include="ReactHost\JSCallInvokerScheduler.h" />
     <ClInclude Include="DevMenuControl.h">
       <DependentUpon>DevMenuControl.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -309,6 +309,9 @@
     <ClCompile Include="Modules\PaperUIManagerModule.cpp" />
     <ClCompile Include="Views\PaperShadowNode.cpp" />
     <ClCompile Include="Views\ShadowNodeRegistry.cpp" />
+    <ClCompile Include="ReactHost\JSCallInvokerScheduler.cpp">
+      <Filter>ReactHost</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
@@ -663,6 +666,9 @@
     <ClInclude Include="Views\PaperShadowNode.h" />
     <ClInclude Include="Views\ShadowNodeRegistry.h" />
     <ClInclude Include="DocString.h" />
+    </ClInclude>
+    <ClInclude Include="ReactHost\JSCallInvokerScheduler.h">
+      <Filter>ReactHost</Filter>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -179,7 +179,6 @@ ReactInstanceWin::ReactInstanceWin(
       m_weakReactHost{&reactHost},
       m_options{options},
       m_whenCreated{std::move(whenCreated)},
-      m_whenLoaded{std::move(whenLoaded)},
       m_isFastReloadEnabled(options.UseFastRefresh()),
       m_isLiveReloadEnabled(options.UseLiveReload()),
       m_updateUI{std::move(updateUI)},
@@ -190,6 +189,37 @@ ReactInstanceWin::ReactInstanceWin(
           this,
           options.Properties,
           winrt::make<implementation::ReactNotificationService>(options.Notifications))} {
+  // As soon as the bundle is loaded or failed to load, we set the m_whenLoaded promise value in JS queue.
+  // It then synchronously raises the OnInstanceLoaded event in the JS queue.
+  // Then, we notify the ReactHost about the load event in the internal queue.
+  m_whenLoaded.AsFuture()
+      .Then<Mso::Executors::Inline>(
+          [onLoaded = m_options.OnInstanceLoaded, reactContext = m_reactContext](Mso::Maybe<void> &&value) noexcept {
+            if (onLoaded) {
+              onLoaded.Get()->Invoke(reactContext, value.IsError() ? value.TakeError() : Mso::ErrorCode());
+            }
+          })
+      .Then(Queue(), [whenLoaded = std::move(whenLoaded)](Mso::Maybe<void> &&value) noexcept {
+        whenLoaded.SetValue(std::move(value));
+      });
+
+  // When the JS queue is shutdown, we set the m_whenDestroyed promise value as the last work item in the JS queue.
+  // No JS queue work can be done after that for the instance.
+  // The promise continuation synchronously calls the OnInstanceDestroyed event.
+  // Then, the Destroy() method returns the m_whenDestroyedResult future to ReactHost to handle instance destruction.
+  m_whenDestroyedResult =
+      m_whenDestroyed.AsFuture().Then<Mso::Executors::Inline>([whenLoaded = m_whenLoaded,
+                                                               onDestroyed = m_options.OnInstanceDestroyed,
+                                                               reactContext = m_reactContext]() noexcept {
+        whenLoaded.TryCancel(); // It only has an effect if whenLoaded was not set before
+        if (onDestroyed) {
+          onDestroyed.Get()->Invoke(reactContext);
+        }
+      });
+
+  // We notify the ReactHost immediately that the instance is created, but the
+  // OnInstanceCreated event is raised only after the internal react-native instance is ready and
+  // it starts handling JS queue work items.
   m_whenCreated.SetValue();
 }
 
@@ -398,10 +428,6 @@ void ReactInstanceWin::Initialize() noexcept {
 
         m_instanceWrapper.Exchange(std::move(instanceWrapper));
 
-        if (auto onCreated = m_options.OnInstanceCreated.Get()) {
-          onCreated->Invoke(Mso::CntPtr<Mso::React::IReactContext>(m_reactContext));
-        }
-
         LoadJSBundles();
 
         if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
@@ -468,46 +494,29 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
               return;
             }
 
-            auto &options = strongThis->m_options;
-
             try {
               instanceWrapper->loadBundleSync(Mso::Copy(strongThis->JavaScriptBundleFile()));
+              strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
             } catch (...) {
-              strongThis->m_state = ReactInstanceState::HasError;
-              strongThis->AbandonJSCallQueue();
               strongThis->OnReactInstanceLoaded(Mso::ExceptionErrorProvider().MakeErrorCode(std::current_exception()));
-              return;
             }
-
-            // All JS bundles successfully loaded.
-            strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
           }
         });
   }
 }
 
 void ReactInstanceWin::OnReactInstanceLoaded(const Mso::ErrorCode &errorCode) noexcept {
-  if (!m_isLoaded) {
-    Queue().InvokeElsePost([weakThis = Mso::WeakPtr{this}, errorCode]() noexcept {
-      if (auto strongThis = weakThis.GetStrongPtr()) {
-        if (!strongThis->m_isLoaded) {
-          strongThis->m_isLoaded = true;
-          if (!errorCode) {
-            strongThis->m_state = ReactInstanceState::Loaded;
-            strongThis->DrainJSCallQueue();
-          } else {
-            strongThis->m_state = ReactInstanceState::HasError;
-            strongThis->AbandonJSCallQueue();
-          }
-
-          if (auto onLoaded = strongThis->m_options.OnInstanceLoaded.Get()) {
-            onLoaded->Invoke(Mso::CntPtr<IReactContext>(strongThis->m_reactContext), errorCode);
-          }
-
-          strongThis->m_whenLoaded.SetValue();
-        }
-      }
-    });
+  bool isLoadedExpected = false;
+  if (m_isLoaded.compare_exchange_strong(isLoadedExpected, true)) {
+    if (!errorCode) {
+      m_state = ReactInstanceState::Loaded;
+      m_whenLoaded.SetValue();
+      DrainJSCallQueue();
+    } else {
+      m_state = ReactInstanceState::HasError;
+      m_whenLoaded.SetError(errorCode);
+      AbandonJSCallQueue();
+    }
   }
 }
 
@@ -516,20 +525,12 @@ Mso::Future<void> ReactInstanceWin::Destroy() noexcept {
   VerifyIsInQueueElseCrash();
 
   if (m_isDestroyed) {
-    return m_whenDestroyed.AsFuture();
+    return m_whenDestroyedResult;
   }
 
   m_isDestroyed = true;
   m_state = ReactInstanceState::Unloaded;
   AbandonJSCallQueue();
-
-  if (!m_isLoaded) {
-    OnReactInstanceLoaded(Mso::CancellationErrorProvider().MakeErrorCode(true));
-  }
-
-  if (auto onDestroyed = m_options.OnInstanceDestroyed.Get()) {
-    onDestroyed->Invoke(Mso::CntPtr<Mso::React::IReactContext>(m_reactContext));
-  }
 
   // Make sure that the instance is not destroyed yet
   if (auto instance = m_instance.Exchange(nullptr)) {
@@ -546,7 +547,7 @@ Mso::Future<void> ReactInstanceWin::Destroy() noexcept {
     m_jsDispatchQueue.Exchange(nullptr);
   }
 
-  return m_whenDestroyed.AsFuture();
+  return m_whenDestroyedResult;
 }
 
 const ReactOptions &ReactInstanceWin::Options() const noexcept {
@@ -560,37 +561,25 @@ ReactInstanceState ReactInstanceWin::State() const noexcept {
 void ReactInstanceWin::InitJSMessageThread() noexcept {
   m_instance.Exchange(std::make_shared<facebook::react::Instance>());
 
-  static bool old = false;
-  if (old) {
-    auto jsDispatchQueue = Mso::DispatchQueue::MakeLooperQueue();
+  auto scheduler = Mso::MakeJSCallInvokerScheduler(
+      m_instance.Load()->getJSCallInvoker(),
+      Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError),
+      Mso::Copy(m_whenDestroyed));
+  auto jsDispatchQueue = Mso::DispatchQueue::MakeCustomQueue(Mso::CntPtr(scheduler));
 
-    // Create MessageQueueThread for the DispatchQueue
-    VerifyElseCrashSz(jsDispatchQueue, "m_jsDispatchQueue must not be null");
+  // This work item will be processed as a first item in JS queue when the react instance is created.
+  jsDispatchQueue.Post([onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
+    if (onCreated) {
+      onCreated.Get()->Invoke(reactContext);
+    }
+  });
 
-    auto jsDispatcher =
-        winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));
-    m_options.Properties.Set(ReactDispatcherHelper::JSDispatcherProperty(), jsDispatcher);
+  auto jsDispatcher =
+      winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));
+  m_options.Properties.Set(ReactDispatcherHelper::JSDispatcherProperty(), jsDispatcher);
 
-    m_jsMessageThread.Exchange(std::make_shared<MessageDispatchQueue>(
-        jsDispatchQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError), Mso::Copy(m_whenDestroyed)));
-    m_jsDispatchQueue.Exchange(std::move(jsDispatchQueue));
-  } else {
-    auto scheduler = Mso::MakeJSCallInvokerScheduler(
-        m_instance.Load()->getJSCallInvoker(),
-        Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError),
-        Mso::Copy(m_whenDestroyed));
-    auto jsDispatchQueue = Mso::DispatchQueue::MakeCustomQueue(Mso::CntPtr(scheduler));
-
-    // Create MessageQueueThread for the DispatchQueue
-    VerifyElseCrashSz(jsDispatchQueue, "m_jsDispatchQueue must not be null");
-
-    auto jsDispatcher =
-        winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));
-    m_options.Properties.Set(ReactDispatcherHelper::JSDispatcherProperty(), jsDispatcher);
-
-    m_jsMessageThread.Exchange(qi_cast<Mso::IJSCallInvokerQueueScheduler>(scheduler.Get())->GetMessageQueue());
-    m_jsDispatchQueue.Exchange(std::move(jsDispatchQueue));
-  }
+  m_jsMessageThread.Exchange(qi_cast<Mso::IJSCallInvokerQueueScheduler>(scheduler.Get())->GetMessageQueue());
+  m_jsDispatchQueue.Exchange(std::move(jsDispatchQueue));
 }
 
 void ReactInstanceWin::InitNativeMessageThread() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -136,6 +136,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   const Mso::Promise<void> m_whenCreated;
   const Mso::Promise<void> m_whenLoaded;
   const Mso::Promise<void> m_whenDestroyed;
+  Mso::Future<void> m_whenDestroyedResult; // To be returned from the Destroy() method.
 
   const Mso::VoidFunctor m_updateUI;
   const bool m_debuggerBreakOnNextLine : 1;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -140,8 +140,44 @@ Subsequent runs of the application should be faster as the JavaScript will be lo
     UInt16 SourceBundlePort { get; set; };
 
     JSIEngine JSIEngineOverride { get; set; };
+    DOC_STRING(
+      "The @InstanceCreated event is triggered right after the React Native instance is created.\n"
+      "\n"
+      "It is triggered on the JSDispatcher thread before any other JSDispatcher work items.\n"
+      "No JavaScript code is loaded in the JavaScript engine yet.\n"
+      "The @InstanceCreatedEventArgs.Context property on the event arguments provides access to the instance context.\n"
+      "\n"
+      "Note that the @InstanceCreated event is triggered in response to the 'InstanceCreated' notification "
+      "raised in the 'ReactNative.InstanceSettings' namespace. "
+      "Consider using @Notifications to handle the notification in a dispatcher different from the JSDispatcher.")
     event Windows.Foundation.EventHandler<InstanceCreatedEventArgs> InstanceCreated;
+    DOC_STRING(
+      "The @InstanceLoaded event is triggered when React Native instance has finished loading the JavaScript bundle.\n"
+      "\n"
+      "It is triggered on the JSDispatcher thread.\n"
+      "If there were errors, then the @InstanceLoadedEventArgs.Failed property on the event arguments will be true.\n"
+      "The error types include:\n"
+      "\n"
+      "* JavaScript syntax errors.\n"
+      "* Global JavaScript exceptions thrown.\n"
+      "\n"
+      "The @InstanceLoadedEventArgs.Context property on the event arguments provides access to the instance context.\n"
+      "\n"
+      "Note that the @InstanceLoaded event is triggered in response to the 'InstanceLoaded' notification "
+      "raised in the 'ReactNative.InstanceSettings' namespace. "
+      "Consider using @Notifications to handle the notification in a dispatcher different from the JSDispatcher.")
     event Windows.Foundation.EventHandler<InstanceLoadedEventArgs> InstanceLoaded;
+
+    DOC_STRING(
+      "The @InstanceDestroyed event is triggered when React Native instance is destroyed.\n"
+      "\n"
+      "It is triggered on the JSDispatcher thread as the last work item before it shuts down.\n"
+      "No new JSDispatcher work can be executed after that.\n"
+      "The @InstanceDestroyedEventArgs.Context property on the event arguments provides access to the instance context.\n"
+      "\n"
+      "Note that the @InstanceDestroyed event is triggered in response to the 'InstanceDestroyed' notification "
+      "raised in the 'ReactNative.InstanceSettings' namespace. "
+      "Consider using @Notifications to handle the notification in a dispatcher different from the JSDispatcher.")
     event Windows.Foundation.EventHandler<InstanceDestroyedEventArgs> InstanceDestroyed;
   }
 }


### PR DESCRIPTION
Cherry pick PR #7356.
Original description:

The React instance notifications (`InstanceCreated`, `InstanceLoaded`, and `InstanceDestroyed`) introduced in 0.64 version are raised on a dispatcher thread that is used internally for synchronizing ReactHost and ReactInstanceWin components. While it works, it makes it difficult to use in the code because this dispatcher is not exposed to the public API and users must always redirect it to JS nor UI dispatchers. Such asynchronous redirection may cause unexpected issues in instance unload scenarios.
E.g. it is the the root cause of the issue #7305 where it is impossible to correctly destroy the JSI Runtime when a React instance is reloaded.

In this PR we change these notifications to be always raised in the JSDispatcher thread. This way the notifications are following the native module model where we also call methods in the JSDispatcher thread. It fixes the issue #7305 because we can now destroy the JSI Runtime at the same time when the JSDispatcher is destroyed. The `JsiSimpleTurboModuleTests` unit test is added to verify the threading model for the notifications.

Note that these instance events are new in 0.64 and if we change it in the upcoming 0.64 release, then there will be no breaking change.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7360)