### PR TITLE
Enable RNW_FASTBUILD for PR validation

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -10,41 +10,60 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
-            - Name: X64Release
+            - Name: X64ReleaseFast
               BuildConfiguration: Release
               BuildPlatform: X64
-            - Name: X86Debug
+              FastBuild: true
+            - Name: X86DebugFast
               BuildConfiguration: Debug
               BuildPlatform: X86
               LayoutHeaders: true
+              FastBuild: true
         - BuildEnvironment: Continuous
           Matrix:
             - Name: ArmDebug
               BuildConfiguration: Debug
               BuildPlatform: ARM
+              FastBuild: false
             - Name: ArmRelease
               BuildConfiguration: Release
               BuildPlatform: ARM
+              FastBuild: false
             - Name: Arm64RDebug
               BuildConfiguration: Debug
               BuildPlatform: ARM64
+              FastBuild: false
             - Name: Arm64Release
               BuildConfiguration: Release
               BuildPlatform: ARM64
+              FastBuild: false
             - Name: X64Debug
               BuildConfiguration: Debug
               BuildPlatform: X64
+              FastBuild: false
             - Name: X64Release
               BuildConfiguration: Release
               BuildPlatform: X64
+              FastBuild: false
             - Name: X86Debug
               BuildConfiguration: Debug
               BuildPlatform: X86
               LayoutHeaders: true
+              FastBuild: false
             - Name: X86Release
               BuildConfiguration: Release
               BuildPlatform: X86
-      
+              FastBuild: false
+            - Name: X64ReleaseFast
+              BuildConfiguration: Release
+              BuildPlatform: X64
+              FastBuild: true
+            - Name: X86DebugFast
+              BuildConfiguration: Debug
+              BuildPlatform: X86
+              LayoutHeaders: true
+              FastBuild: true
+
   jobs:
     - ${{ each config in parameters.buildMatrix }}:
       - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
@@ -70,6 +89,7 @@
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
                     multicoreBuild: true
+                    msbuildArguments: /p:RNW_FASTBUILD=${{ matrix.FastBuild }}
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Publish binaries for testing"


### PR DESCRIPTION
Leverage the fatter PCH file to improve compile times.
For the Universal build this saves 3 minutes. 
I only enabled it for Universl for now since that is on the critical path.

CI validation will still build without the flag.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7384)