### PR TITLE
[0.64] Allow git and npm publish to be skipped when manually publishing bits (#6705)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,6 +1,14 @@
 name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 
 parameters:
+- name: skipNpmPublish
+  displayName: Skip Npm Publish
+  type: boolean
+  default: false
+- name: skipGitPush
+  displayName: Skip Git Push
+  type: boolean
+  default: false
 - name: skipStableCodesign
   displayName: Skip Codesigning for Stable Branch
   type: boolean
@@ -10,6 +18,10 @@ variables:
   - template: variables/msbuild.yml
   - template: variables/vs2019.yml
   - group: RNW Secrets
+  - name: SkipNpmPublishArgs
+    value: ''
+  - name: SkipGitPushPublishArgs
+    value: ''
   - name: NugetSecurityAnalysisWarningLevel
     value: 'warn'
   - name: FailCGOnAlert
@@ -52,11 +64,24 @@ jobs:
       - script: yarn build
         displayName: yarn build
 
-      - script: npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public --no-git-tags
+      - script: |
+          echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish
+        displayName: Enable No-Publish
+        condition: ${{ parameters.skipNpmPublish }}
+
+      - script: |
+          echo ##vso[task.setvariable variable=SkipGitPushPublishArgs]--no-push
+        displayName: Enable No-Publish
+        condition: ${{ parameters.skipGitPush }}
+
+      - script: yarn build
+        displayName: yarn build
+
+      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public --no-git-tags
         displayName: Beachball Publish (Master Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
 
-      - script: npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
+      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
 
@@ -66,7 +91,7 @@ jobs:
 
       - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(GITHUB_API)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
-        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'master'))
+        condition: ${{ and(succeeded(), not(parameters.skipGitPush), ne(variables['Build.SourceBranchName'], 'master')) }}
 
       - template: templates/set-version-vars.yml
 


### PR DESCRIPTION
This PR backports #6705 into 0.64-stable.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7387)