### PR TITLE
[0.64] Fix publish pipeline due to ADO not recognizing `succeeded()` from template expression (#6774)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -91,7 +91,7 @@ jobs:
 
       - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(GITHUB_API)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
-        condition: ${{ and(succeeded(), not(parameters.skipGitPush), ne(variables['Build.SourceBranchName'], 'master')) }}
+        condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'master') }} )
 
       - template: templates/set-version-vars.yml
 


### PR DESCRIPTION
This PR backports #6774 to 0.64.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7389)