### PR TITLE
Updates to documentation in IDL files

### DIFF
--- a/change/react-native-windows-e0a73f29-3f67-499f-953d-3427552c2bad.json
+++ b/change/react-native-windows-e0a73f29-3f67-499f-953d-3427552c2bad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add doc comments to IDL files",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IJSValueReader.idl
+++ b/vnext/Microsoft.ReactNative/IJSValueReader.idl
@@ -22,7 +22,8 @@ namespace Microsoft.ReactNative
     "Forward-only reader for JSON-like streams.\n"
     "It is used to read data sent between native modules and the Microsoft.ReactNative library.\n"
     "\n"
-    "The JSON-like streams are data structures that satisfy the [JSON specification](https://tools.ietf.org/html/rfc8259). "
+    "The JSON-like streams are data structures that satisfy the "
+    "[JSON specification](https://tools.ietf.org/html/rfc8259). "
     "The data structure may have objects with name-value pairs and arrays of items. "
     "Property values or array items can be of type `Null`, `Object`, `Array`, `String`, `Boolean`, or `Number`. "
     "The `IJSValueReader` treats the `Number` type as `Int64` or `Double`. See @JSValueType.\n"
@@ -31,7 +32,8 @@ namespace Microsoft.ReactNative
     "For example, if the current value type is `Object`, one must call @.GetNextObjectProperty "
     "to start reading the current object's properties, and if the current type is `Array`, "
     "@.GetNextArrayItem must be called to start reading the elements in the array. "
-    "These functions must be called in a loop until they return false, which signifies that there are no more items within the object or array being traversed.\n"
+    "These functions must be called in a loop until they return false, which signifies that there are "
+    "no more items within the object or array being traversed.\n"
     "\n"
     "See the @IJSValueWriter for the corresponding writer interface.\n"
     "\n"
@@ -49,7 +51,8 @@ namespace Microsoft.ReactNative
     JSValueType ValueType { get; };
 
     DOC_STRING(
-      "Advances the iterator within the current object to fetch the next object property. The property value can then be obtained by calling one of the Get functions.\n"
+      "Advances the iterator within the current object to fetch the next object property. "
+      "The property value can then be obtained by calling one of the Get functions.\n"
       "\n"
       "Returns **`true`** if the next property is acquired successfully. "
       "In that case the `propertyName` is set to the name of the property. "
@@ -62,7 +65,8 @@ namespace Microsoft.ReactNative
     Boolean GetNextObjectProperty(out String propertyName);
 
     DOC_STRING(
-      "Advances the iterator within the current array to fetch the next array element. The element can then be obtained by calling one of the Get functions.\n"
+      "Advances the iterator within the current array to fetch the next array element. "
+      "The element can then be obtained by calling one of the Get functions.\n"
       "\n"
       "Returns **`true`** if the next array item is acquired successfully. "
       "Otherwise, it returns **`false`**, meaning that reading of the JSON-like array is completed.\n"

--- a/vnext/Microsoft.ReactNative/IJSValueWriter.idl
+++ b/vnext/Microsoft.ReactNative/IJSValueWriter.idl
@@ -10,7 +10,8 @@ namespace Microsoft.ReactNative
     "JSON-like stream writer.\n"
     "It is used to write data that is sent between native modules and the Microsoft.ReactNative library.\n"
     "\n"
-    "The JSON-like streams are data structures that satisfy the [JSON specification](https://tools.ietf.org/html/rfc8259). "
+    "The JSON-like streams are data structures that satisfy the "
+    "[JSON specification](https://tools.ietf.org/html/rfc8259). "
     "The data structure may have objects with name-value pairs and arrays of items. "
     "Property values or array items can be of type `Null`, `Object`, `Array`, `String`, `Boolean`, or `Number`. "
     "The `IJSValueWriter` treats the `Number` type as `Int64` or `Double`. See @JSValueType.\n"
@@ -61,7 +62,7 @@ namespace Microsoft.ReactNative
   }
 
   DOC_STRING(
-    "The `JSValueArgWriter` delegate is used to pass arbitrary value to ABI API. \n"
-    "In a function that implements the delegate use the provided writer to stream custom values.")
+    "The `JSValueArgWriter` delegate is used to pass values to ABI API. \n"
+    "In a function that implements the delegate use the provided `writer` to stream custom values.")
   delegate void JSValueArgWriter(IJSValueWriter writer);
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -11,12 +11,13 @@ import "IReactPropertyBag.idl";
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
 #ifndef CORE_ABI
   [webhosthidden]
   DOC_STRING("An immutable snapshot of @ReactInstanceSettings used to create the current React instance.")
-  interface IReactSettingsSnapshot {
+  interface IReactSettingsSnapshot
+  {
     DOC_STRING(
       "A read-only snapshot of @ReactInstanceSettings.UseWebDebugger property value "
       "at the time when the React instance is created.\n"
@@ -106,7 +107,8 @@ namespace Microsoft.ReactNative {
     "- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events.\n"
     "- Use @.UIDispatcher to post asynchronous work in the UI thread.\n"
     "- Use @.JSDispatcher to post asynchronous work in the JavaScript engine thread.")
-  interface IReactContext {
+  interface IReactContext
+  {
 #ifndef CORE_ABI
     DOC_STRING("Gets the settings snapshot that was used to start the React instance.")
     IReactSettingsSnapshot SettingsSnapshot { get; };

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -15,20 +15,20 @@ namespace Microsoft.ReactNative
 {
 #ifndef CORE_ABI
   [webhosthidden]
-  DOC_STRING("An immutable snapshot of @ReactInstanceSettings used to create the current React instance.")
+  DOC_STRING("An immutable snapshot of the @ReactInstanceSettings used to create the current React instance.")
   interface IReactSettingsSnapshot
   {
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.UseWebDebugger property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.UseWebDebugger property value "
+      "at the time when the React instance was created.\n"
       "Controls whether the instance JavaScript runs in a remote environment such as within a browser.\n"
       "By default, this is using a browser navigated to http://localhost:8081/debugger-ui served by Metro/Haul.\n"
       "Debugging will start as soon as the react native instance is loaded.")
     Boolean UseWebDebugger { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.UseFastRefresh property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.UseFastRefresh property value "
+      "at the time when the React instance was created.\n"
       "Controls whether the instance triggers the hot module reload logic when it first loads the instance.\n"
       "Most edits should be visible within a second or two without the instance having to reload.\n"
       "Non-compatible changes still cause full reloads.\n"
@@ -36,16 +36,16 @@ namespace Microsoft.ReactNative
     Boolean UseFastRefresh { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.UseDirectDebugger property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.UseDirectDebugger property value "
+      "at the time when the React instance was created.\n"
       "Enables debugging in the JavaScript engine (if supported).\n"
       "For Chakra this enables debugging of the JS runtime directly within the app using "
       "Visual Studio -> Attach to process (Script)")
     Boolean UseDirectDebugger { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.DebuggerBreakOnNextLine property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.DebuggerBreakOnNextLine property value "
+      "at the time when the React instance was created.\n"
       "For direct debugging, controls whether to break on the next line of JavaScript that is executed.\n"
       "This can help debug issues hit early in the JavaScript bundle load.\n"
       "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine. "
@@ -53,41 +53,41 @@ namespace Microsoft.ReactNative
     Boolean DebuggerBreakOnNextLine { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.DebuggerPort property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.DebuggerPort property value "
+      "at the time when the React instance was created.\n"
       "When @.UseDirectDebugger is enabled, this controls the port that the JavaScript engine debugger will run on.")
     UInt16 DebuggerPort { get; };
 
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.DebugBundlePath property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.DebugBundlePath property value "
+      "at the time when the React instance was created.\n"
       "When loading from a bundle server (such as metro), this is the path that will be requested from the server.")
     String DebugBundlePath { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.BundleRootPath property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.BundleRootPath property value "
+      "at the time when the React instance was created.\n"
       "Base path used for the location of the bundle.")
     String BundleRootPath { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.SourceBundleHost property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.SourceBundleHost property value "
+      "at the time when the React instance was created.\n"
       "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server hostname "
       "that will be used to load the bundle from.")
     String SourceBundleHost { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.SourceBundlePort property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.SourceBundlePort property value "
+      "at the time when the React instance was created.\n"
       "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server port "
       "that will be used to load the bundle from.")
     UInt16 SourceBundlePort { get; };
 
     DOC_STRING(
-      "A read-only snapshot of @ReactInstanceSettings.JavaScriptBundleFile property value "
-      "at the time when the React instance is created.\n"
+      "A read-only snapshot of the @ReactInstanceSettings.JavaScriptBundleFile property value "
+      "at the time when the React instance was created.\n"
       "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "
       "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
     String JavaScriptBundleFile { get; };
@@ -97,7 +97,7 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   DOC_STRING(
     "The `IReactContext` object is a weak pointer to the React instance. "
-    "It allows native modules and view manages communicate with the application, and with other "
+    "It allows native modules and view managers to communicate with the application, and with other "
     "native modules and view managers.\n"
     "Since the @IReactContext is a weak pointer to the React instance, some of its functionality becomes unavailable "
     "after the React instance is unloaded. When a React instance is reloaded inside of the @ReactNativeHost, the "
@@ -142,8 +142,7 @@ namespace Microsoft.ReactNative
       "Gets the JavaScript runtime for the running React instance.\n"
       "It can be null if Web debugging is used.\n"
       "**Node: do not use this property directly. "
-      "It is an experimental property that can be removed or changed in version 0.65.")
-    [experiemental]
+      "It is an experimental property that may be removed or changed in version 0.65.")
     Object JSRuntime { get; };
 
 #ifndef CORE_ABI
@@ -160,7 +159,7 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "Emits JavaScript module event `eventName` for the `eventEmitterName` with the `paramsArgWriter`.\n"
-      "It is a specialized `CallJSFunction` call where method name is always `emit` and the "
+      "It is a specialized @.CallJSFunction` call where the method name is always `emit` and the "
       "`eventName` is added to parameters.\n"
       "The `paramsArgWriter` is a @JSValueArgWriter delegate that receives @IJSValueWriter to serialize "
       "the event parameters.")

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -15,66 +15,153 @@ namespace Microsoft.ReactNative {
 
 #ifndef CORE_ABI
   [webhosthidden]
+  DOC_STRING("An immutable snapshot of @ReactInstanceSettings used to create the current React instance.")
   interface IReactSettingsSnapshot {
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.UseWebDebugger property value "
+      "at the time when the React instance is created.\n"
+      "Controls whether the instance JavaScript runs in a remote environment such as within a browser.\n"
+      "By default, this is using a browser navigated to http://localhost:8081/debugger-ui served by Metro/Haul.\n"
+      "Debugging will start as soon as the react native instance is loaded.")
     Boolean UseWebDebugger { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.UseFastRefresh property value "
+      "at the time when the React instance is created.\n"
+      "Controls whether the instance triggers the hot module reload logic when it first loads the instance.\n"
+      "Most edits should be visible within a second or two without the instance having to reload.\n"
+      "Non-compatible changes still cause full reloads.\n"
+      "See [Fast Refresh](https://reactnative.dev/docs/fast-refresh) for more information on Fast Refresh.")
     Boolean UseFastRefresh { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.UseDirectDebugger property value "
+      "at the time when the React instance is created.\n"
+      "Enables debugging in the JavaScript engine (if supported).\n"
+      "For Chakra this enables debugging of the JS runtime directly within the app using "
+      "Visual Studio -> Attach to process (Script)")
     Boolean UseDirectDebugger { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.DebuggerBreakOnNextLine property value "
+      "at the time when the React instance is created.\n"
+      "For direct debugging, controls whether to break on the next line of JavaScript that is executed.\n"
+      "This can help debug issues hit early in the JavaScript bundle load.\n"
+      "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine. "
+      "As a workaround you could add the `debugger` keyword in the beginning of the bundle.***")
     Boolean DebuggerBreakOnNextLine { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.DebuggerPort property value "
+      "at the time when the React instance is created.\n"
+      "When @.UseDirectDebugger is enabled, this controls the port that the JavaScript engine debugger will run on.")
     UInt16 DebuggerPort { get; };
+
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.DebugBundlePath property value "
+      "at the time when the React instance is created.\n"
+      "When loading from a bundle server (such as metro), this is the path that will be requested from the server.")
     String DebugBundlePath { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.BundleRootPath property value "
+      "at the time when the React instance is created.\n"
+      "Base path used for the location of the bundle.")
     String BundleRootPath { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.SourceBundleHost property value "
+      "at the time when the React instance is created.\n"
+      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server hostname "
+      "that will be used to load the bundle from.")
     String SourceBundleHost { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.SourceBundlePort property value "
+      "at the time when the React instance is created.\n"
+      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server port "
+      "that will be used to load the bundle from.")
     UInt16 SourceBundlePort { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of @ReactInstanceSettings.JavaScriptBundleFile property value "
+      "at the time when the React instance is created.\n"
+      "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "
+      "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
     String JavaScriptBundleFile { get; };
   }
 #endif
 
   [webhosthidden]
   DOC_STRING(
-    "The `IReactContext` object is given to native modules to communicate with other native modules, views, application, and the React Native instance. \n"
-    "It has the same lifetime as the React instance. When the React instance is reloaded or unloaded, the `IReactContext` is destroyed. \n"
-    "- Use the Properties to share native module's data with other components. \n"
-    "- Use the Notifications to exchange events with other components. \n"
-    "- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events. \n"
-    "- Use @.UIDispatcher to schedule work in the UI thread. \n"
-    "- Use @.JSDispatcher to schedule work in the JavaScript thread.")
+    "The `IReactContext` object is a weak pointer to the React instance. "
+    "It allows native modules and view manages communicate with the application, and with other "
+    "native modules and view managers.\n"
+    "Since the @IReactContext is a weak pointer to the React instance, some of its functionality becomes unavailable "
+    "after the React instance is unloaded. When a React instance is reloaded inside of the @ReactNativeHost, the "
+    "previous React instance is unloaded and then a new React instance is created with a new @IReactContext.\n"
+    "- Use the @.Properties to share native module's data with other components.\n"
+    "- Use the @.Notifications to exchange events with other components.\n"
+    "- Use @.CallJSFunction to call JavaScript functions, and @.EmitJSEvent to raise JavaScript events.\n"
+    "- Use @.UIDispatcher to post asynchronous work in the UI thread.\n"
+    "- Use @.JSDispatcher to post asynchronous work in the JavaScript engine thread.")
   interface IReactContext {
 #ifndef CORE_ABI
-    DOC_STRING("Get settings snapshot that were used to start the React instance.")
+    DOC_STRING("Gets the settings snapshot that was used to start the React instance.")
     IReactSettingsSnapshot SettingsSnapshot { get; };
 #endif
 
-    DOC_STRING("Properties shared with the @ReactInstanceSettings.Properties. It can be used to share values and state between components.")
+    DOC_STRING(
+      "Gets @IReactPropertyBag shared with the @ReactInstanceSettings.Properties.\n"
+      "It can be used to share values and state between components and the applications.")
     IReactPropertyBag Properties { get; };
 
     DOC_STRING(
-      "Notifications shared with the @ReactInstanceSettings.Notifications. They can be used to exchange events between components. \n"
-      "All subscriptions added to the `IReactContext.Notifications` are automatically removed after the `IReactContext` is destroyed. \n"
-      "The subscriptions added to the `ReactInstanceSettings.Notifications` are kept as long as `ReactInstanceSettings` is alive.")
+      "Gets @IReactNotificationService shared with the @ReactInstanceSettings.Notifications.\n"
+      "It can be used to send notifications events between components and the application.\n"
+      "All notification subscriptions added to the @IReactContext.Notifications are automatically removed "
+      "after the @IReactContext is destroyed.\n"
+      "The notification subscriptions added to the @ReactInstanceSettings.Notifications are kept "
+      "as long as the @ReactInstanceSettings is alive.")
     IReactNotificationService Notifications { get; };
 
     DOC_STRING(
-      "Get the UI thread dispatcher. \n"
+      "Gets the UI thread dispatcher.\n"
       "It is a shortcut for the @ReactDispatcherHelper.UIDispatcherProperty from the @.Properties property bag.")
     IReactDispatcher UIDispatcher { get; };
 
     DOC_STRING(
-      "Get the JS thread dispatcher. \n"
+      "Gets the JavaScript engine thread dispatcher.\n"
       "It is a shortcut for the @ReactDispatcherHelper.JSDispatcherProperty from the @.Properties property bag.")
     IReactDispatcher JSDispatcher { get; };
 
-    DOC_STRING("Get the JavaScript runtime for the running React instance. It can be null if Web debugging is used.")
+    DOC_STRING(
+      "Gets the JavaScript runtime for the running React instance.\n"
+      "It can be null if Web debugging is used.\n"
+      "**Node: do not use this property directly. "
+      "It is an experimental property that can be removed or changed in version 0.65.")
+    [experiemental]
     Object JSRuntime { get; };
 
 #ifndef CORE_ABI
     [deprecated("Use @XamlUIService.DispatchEvent instead", deprecate, 1)]
+    DOC_STRING("Deprecated property. Use @XamlUIService.DispatchEvent instead. It will be removed in version 0.65.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 #endif
 
-    DOC_STRING("Call the JavaScript function named `methodName` of `moduleName`.")
+    DOC_STRING(
+      "Calls the JavaScript function named `methodName` of `moduleName` with the `paramsArgWriter`.\n"
+      "The `paramsArgWriter` is a @JSValueArgWriter delegate that receives @IJSValueWriter to serialize "
+      "the method parameters.")
     void CallJSFunction(String moduleName, String methodName, JSValueArgWriter paramsArgWriter);
 
-    DOC_STRING("Call JavaScript module event. It is a specialized `CallJSFunction` call where method name is always 'emit'.")
+    DOC_STRING(
+      "Emits JavaScript module event `eventName` for the `eventEmitterName` with the `paramsArgWriter`.\n"
+      "It is a specialized `CallJSFunction` call where method name is always `emit` and the "
+      "`eventName` is added to parameters.\n"
+      "The `paramsArgWriter` is a @JSValueArgWriter delegate that receives @IJSValueWriter to serialize "
+      "the event parameters.")
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -16,7 +16,7 @@ namespace Microsoft.ReactNative
     "`IReactDispatcher` provides the core threading/task management interface for ensuring that the code execution "
     "happens in the right order on the right thread.\n"
     "One primary dispatcher that applications may require is the @IReactContext.UIDispatcher which provides native "
-    "modules access to the UI thread associated with this react instance. "
+    "modules access to the UI thread associated with this React instance. "
     "Another one is the @IReactContext.JSDispatcher which allows apps to post tasks to the JS engine thread.")
   interface IReactDispatcher
   {

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.idl
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.idl
@@ -4,41 +4,54 @@
 import "IReactPropertyBag.idl";
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
+namespace Microsoft.ReactNative
+{
 
-  // The delegate is used to create property value on-demand.
   [webhosthidden]
   DOC_STRING("The delegate is used to create property value on-demand.")
   delegate void ReactDispatcherCallback();
 
   [webhosthidden]
-  DOC_STRING("`IReactDispatcher` provides the core threading/task management interface for ensuring code happens in the right order on the right thread. \
-One primary dispatcher that applications may require is the @IReactContext.UIDispatcher which provides native modules access to the UI thread associated with this react instance.   Another one is the @IReactContext.JSDispatcher which allows apps to post tasks to the JS engine thread.")
+  DOC_STRING(
+    "`IReactDispatcher` provides the core threading/task management interface for ensuring that the code execution "
+    "happens in the right order on the right thread.\n"
+    "One primary dispatcher that applications may require is the @IReactContext.UIDispatcher which provides native "
+    "modules access to the UI thread associated with this react instance. "
+    "Another one is the @IReactContext.JSDispatcher which allows apps to post tasks to the JS engine thread.")
   interface IReactDispatcher
   {
-    // True if dispatcher uses current thread.
     DOC_STRING("`true` if the dispatcher uses current thread.")
     Boolean HasThreadAccess { get; };
 
-    // Post task for the asynchronous execution.
-    DOC_STRING("Post a task to the dispatcher.  This callback will be called asynchronously on the thread/queue associated with this dispatcher.")
+    DOC_STRING(
+      "Posts a task to the dispatcher.\n"
+      "The `callback` will be called asynchronously on the thread/queue associated with this dispatcher.")
     void Post(ReactDispatcherCallback callback);
   }
 
-  // Helper methods for the property bag implementation.
   [webhosthidden]
+  DOC_STRING("Helper methods for the @IReactDispatcher implementation.")
   static runtimeclass ReactDispatcherHelper
   {
     DOC_STRING("Creates a new serial dispatcher that uses thread pool to run tasks.")
     static IReactDispatcher CreateSerialDispatcher();
 
-    DOC_STRING("Get or creates a @IReactDispatcher for the current UI thread. This can be used with @ReactInstanceSettings.UIDispatcher to launch a React instance from a non-UI thread.  This API must be called from a UI thread.  It will return null if called from a non-UI thread.")
+    DOC_STRING(
+      "Gets or creates a @IReactDispatcher for the current UI thread.\n"
+      "This can be used with @ReactInstanceSettings.UIDispatcher to launch a React instance from a non-UI thread. "
+      "This API must be called from a UI thread. It will return null if called from a non-UI thread.")
     static IReactDispatcher UIThreadDispatcher{ get; };
 
-    DOC_STRING("Get name of the UIDispatcher property for the @IReactPropertyBag. Generally you can use @ReactContext.UIDispatcher to get the value of this property for a specific React instance.")
+    DOC_STRING(
+      "Gets name of the `UIDispatcher` property for the @IReactPropertyBag.\n"
+      "Generally you can use @IReactContext.UIDispatcher to get the value of this property for "
+      "a specific React instance.")
     static IReactPropertyName UIDispatcherProperty { get; };
 
-    DOC_STRING("Get name of the JSDispatcher property for the @IReactPropertyBag. Generally you can use @ReactContext.JSDispatcher to get the value of this property for a specific React instance.")
+    DOC_STRING(
+      "Gets name of the `JSDispatcher` property for the @IReactPropertyBag.\n"
+      "Generally you can use @ReactContext.JSDispatcher to get the value of this property for "
+      "a specific React instance.")
     static IReactPropertyName JSDispatcherProperty { get; };
   }
 } // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.idl
@@ -15,7 +15,7 @@ namespace Microsoft.ReactNative
     "Experimental code uses it to initialize TurboModule `CallInvoker`.")
   delegate void InitializerDelegate(IReactContext reactContext);
 
-  // Native method return type.
+  DOC_STRING("Native method return type.")
   enum MethodReturnType
   {
     Void,
@@ -48,17 +48,19 @@ namespace Microsoft.ReactNative
   {
     DOC_STRING(
       "Adds an initializer method called on the native module initialization.\n"
-      "It provides the native module with the @IReactContext for the running ReactNative instance.  See @InitializerDelegate.\n"
+      "It provides the native module with the @IReactContext for the running ReactNative instance. "
+      "See @InitializerDelegate.\n"
       "There can be multiple initializer methods which are called in the order they were registered.")
     void AddInitializer(InitializerDelegate initializer);
 
-    DOC_STRING("Adds a constant provider method to define constants for the native module.  See @ConstantProviderDelegate.")
+    DOC_STRING(
+      "Adds a constant provider method to define constants for the native module. See @ConstantProviderDelegate.")
     void AddConstantProvider(ConstantProviderDelegate constantProvider);
 
-    DOC_STRING("Adds an asynchronous method to the native module.  See @MethodDelegate.")
+    DOC_STRING("Adds an asynchronous method to the native module. See @MethodDelegate.")
     void AddMethod(String name, MethodReturnType returnType, MethodDelegate method);
 
-    DOC_STRING("Adds a synchronous method to the native module.  See @SyncMethodDelegate.")
+    DOC_STRING("Adds a synchronous method to the native module. See @SyncMethodDelegate.")
     void AddSyncMethod(String name, SyncMethodDelegate method);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactNonAbiValue.idl
+++ b/vnext/Microsoft.ReactNative/IReactNonAbiValue.idl
@@ -3,19 +3,17 @@
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
-  // IReactNonAbiValue helps to wrap up a non-ABI safe C++ values into an
-  // IInspectable object. We use it to handle native module lifetime.
-  // It also can be used to store values in the IReactPropertyBag that do not
-  // need to go through the EXE/DLL boundary.
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
-  DOC_STRING("`IReactNonAbiValue` helps wrap a non-ABI-safe C++ value into an `IInspectable` object. Use it to handle native module lifetime. \
-It also can be used to store values in the @IReactPropertyBag that do not need to go through the EXE/DLL boundary.")
+  DOC_STRING(
+    "The `IReactNonAbiValue` helps wrapping a non-ABI-safe C++ value into an "
+    "`IInspectable` object. Use it to handle native module lifetime.\n"
+    "It also can be used to store values in the @IReactPropertyBag that do not "
+    "need to go through the EXE/DLL boundary.")
   interface IReactNonAbiValue
   {
-    // Get a pointer to the stored value.
-    DOC_STRING("Get a pointer to the stored value.")
+    DOC_STRING("Gets a pointer to the stored value.")
     Int64 GetPtr();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.idl
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.idl
@@ -19,7 +19,7 @@ namespace Microsoft.ReactNative {
   {
     DOC_STRING(
       "The notification service for the subscription.\n"
-      "It can be null if the @.IsSubscribed is true and the notification service is already deleted.")
+      "It can be null if @.IsSubscribed is true and the notification service was already deleted.")
     IReactNotificationService NotificationService { get; };
 
     DOC_STRING("Name of the notification.")

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.idl
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.idl
@@ -13,33 +13,33 @@ namespace Microsoft.ReactNative {
 
   [webhosthidden]
   DOC_STRING(
-    "A subscription to a notification.\n"
+    "A subscription to a @IReactNotificationService notification.\n"
     "The subscription is removed when this object is deleted or the @.Unsubscribe method is called.")
   interface IReactNotificationSubscription
   {
     DOC_STRING(
       "The notification service for the subscription.\n"
-      "It can be null if @.IsSubscribed is true and the service is already deleted.")
+      "It can be null if the @.IsSubscribed is true and the notification service is already deleted.")
     IReactNotificationService NotificationService { get; };
 
     DOC_STRING("Name of the notification.")
     IReactPropertyName NotificationName { get; };
 
     DOC_STRING(
-      "The @IReactDispatcher provided when the notification subscription created.\n"
-      "All notifications will be handled using this dispatcher.\n"
-      "If the dispatcher is null, the events are handled synchronously.")
+      "The @IReactDispatcher that was provided when the notification subscription was created.\n"
+      "All notifications for this subscription will be handled using this dispatcher.\n"
+      "If the dispatcher is null, then the events are handled synchronously.")
     IReactDispatcher Dispatcher { get; };
 
     DOC_STRING(
       "True if the subscription is still active.\n"
-      "This property is checked before notification handler is invoked.")
+      "This property is checked internally before the notification handler is invoked.")
     Boolean IsSubscribed { get; };
 
     DOC_STRING(
       "Removes the subscription.\n"
       "Because of the multi-threaded nature of the notifications, the handler can be still called "
-      "after the @.Unsubscribe method called if the @.IsSubscribed property is already checked. "
+      "after the @.Unsubscribe method has been called if the @.IsSubscribed property has already been checked. "
       "Consider calling the @.Unsubscribe method and the handler in the same @IReactDispatcher "
       "to ensure that no handler is invoked after the @.Unsubscribe method call.")
     void Unsubscribe();
@@ -56,27 +56,30 @@ namespace Microsoft.ReactNative {
 
     DOC_STRING(
       "The data sent with the notification. It can be any WinRT type. "
-      "Consider using @IReactPropertyBag for semi-structured data. "
-      "It can be null if notification has no data. ")
+      "Consider using @IReactPropertyBag for sending semi-structured data. "
+      "It can be null if the notification has no data associated with it.")
     Object Data { get; };
   }
 
   [webhosthidden]
   DOC_STRING(
     "Delegate to handle notifications.\n"
-    "The `sender` parameter is the object that sent the notification. It can be null. "
-    "The `args` contain the notification-specific data and the notification subscription.")
+    "- The `sender` parameter is the object that sent the notification. It can be null.\n"
+    "- The `args` contain the notification-specific data and the notification subscription.")
   delegate void ReactNotificationHandler(Object sender, IReactNotificationArgs args);
 
   [webhosthidden]
-  DOC_STRING("The notification service is used to subscribe to notifications and to send notifications.")
+  DOC_STRING(
+    "The notification service that can be used to send notifications between different components in an app.\n"
+    "Use the @.Subscribe method to subscribe to notifications and the @.SendNotification method to send notifications.")
   interface IReactNotificationService
   {
     DOC_STRING(
       "Subscribes to a notification.\n"
-      "The `notificationName` is a non-null property name and can belong to a specific namespace.\n"
-      "The `dispatcher` is used to call notification handlers. If it is null, then the handler is called synchronously.\n"
-      "The `handler` is a delegate that can be implemented as a lambda to handle notifications.\n"
+      "- `notificationName` is a non-null notification name that can belong to a specific namespace"
+      "  like any @IReactPropertyName.\n"
+      "- `dispatcher` is used to call notification handlers. If it is null, then the handler is called synchronously.\n"
+      "- `handler` is a delegate that can be implemented as a lambda to handle notifications.\n"
       "The method returns a @IReactNotificationSubscription that must be kept alive while the subscription "
       "is active. The subscription is removed when the @IReactNotificationSubscription is destroyed.")
     IReactNotificationSubscription Subscribe(
@@ -84,19 +87,19 @@ namespace Microsoft.ReactNative {
 
     DOC_STRING(
       "Sends the notification with `notificationName`.\n"
-      "The `notificationName` must not be null.\n"
-      "The `sender` is the object that sends notification. It can be null.\n"
-      "The `data` is the data associated with the notification. It can be null.\n"
+      "- `notificationName` is the name of the notification to send. It must not be null.\n"
+      "- `sender` is the object that sends notification. It can be null.\n"
+      "- `data` is the data associated with the notification. It can be null.\n"
       "Consider using @IReactPropertyBag for sending semi-structured data. It can be created "
       "using the @ReactPropertyBagHelper.CreatePropertyBag method.")
     void SendNotification(IReactPropertyName notificationName, Object sender, Object data);
   }
 
   [webhosthidden]
-  DOC_STRING("Helper methods for the notification service implementation.")
+  DOC_STRING("Helper methods for the @IReactNotificationService implementation.")
   static runtimeclass ReactNotificationServiceHelper
   {
-    DOC_STRING("Creates a new instance of IReactNotificationService")
+    DOC_STRING("Creates a new instance of @IReactNotificationService")
     static IReactNotificationService CreateNotificationService();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -11,11 +11,11 @@ import "IViewManager.idl";
 
 namespace Microsoft.ReactNative
 {
-  DOC_STRING("Provides information about a custom native module.  See @IReactModuleBuilder.")
+  DOC_STRING("Provides information about a custom native module. See @IReactModuleBuilder.")
   delegate Object ReactModuleProvider(IReactModuleBuilder moduleBuilder);
 
 #ifndef CORE_ABI
-  DOC_STRING("Provides information about a custom view manager.  See @IViewManager.")
+  DOC_STRING("Provides information about a custom view manager. See @IViewManager.")
   delegate IViewManager ReactViewManagerProvider();
 #endif
 
@@ -37,7 +37,7 @@ namespace Microsoft.ReactNative
   DOC_STRING("Experimental extensions to the @IReactPackageBuilder.")
   interface IReactPackageBuilderExperimental requires IReactPackageBuilder
   {
-    DOC_STRING("Adds a custom TurboModule that directly uses the JS Engine API.")
+    DOC_STRING("Adds a custom TurboModule that directly uses the JS Engine API (JSI).")
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactPackageProvider.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageProvider.idl
@@ -5,13 +5,15 @@ import "IReactPackageBuilder.idl";
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
-  // This interface is to be implemented by package creators.
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
-  DOC_STRING("This interface is to be implemented by package creators.")
-  interface IReactPackageProvider {
-    DOC_STRING("Provides a @IReactPackageBuilder which the app or package will use to register custom native modules and view managers.")
+  DOC_STRING("Implement this interface to provide custom native modules and view managers.")
+  interface IReactPackageProvider
+  {
+    DOC_STRING(
+      "Creates a new package with help of the @IReactPackageBuilder.\n"
+      "Use the @IReactPackageBuilder to register custom native modules and view managers.")
     void CreatePackage(IReactPackageBuilder packageBuilder);
   };
 

--- a/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
+++ b/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
@@ -12,7 +12,7 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   DOC_STRING(
     "A namespace for a @IReactPropertyBag property name.\n"
-    "Use @ReactPropertyBagHelper.GetNamespace to get atomic property namespace for a string.");
+    "Use @ReactPropertyBagHelper.GetNamespace to get atomic property namespace for a string.")
   interface IReactPropertyNamespace
   {
     DOC_STRING("Gets String representation of the @IReactPropertyNamespace.")
@@ -29,7 +29,7 @@ namespace Microsoft.ReactNative
     DOC_STRING("Gets String representation of the @IReactPropertyName.")
     String LocalName { get; };
 
-    DOC_STRING("Gets the @IReactPropertyNamespace where the property name is defined.");
+    DOC_STRING("Gets the @IReactPropertyNamespace where the property name is defined.")
     IReactPropertyNamespace Namespace { get; };
   }
 

--- a/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
+++ b/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
@@ -3,85 +3,87 @@
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
-  // The delegate is used to create property value on-demand.
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
-  DOC_STRING("This delegate is used to create a property value on-demand.")
+  DOC_STRING("This delegate is used to create a @IReactPropertyBag property value on-demand.")
   delegate Object ReactCreatePropertyValue();
 
-  // Namespace for the property name.
-  // Use ReactPropertyBagHelper.GetNamespace to get atomic property namespace for a string.
   [webhosthidden]
+  DOC_STRING(
+    "A namespace for a @IReactPropertyBag property name.\n"
+    "Use @ReactPropertyBagHelper.GetNamespace to get atomic property namespace for a string.");
   interface IReactPropertyNamespace
   {
-    // Get String name representation of the property namespace.
+    DOC_STRING("Gets String representation of the @IReactPropertyNamespace.")
     String NamespaceName { get; };
   }
 
-  // Name of a property.
-  // Use ReactPropertyBagHelper.GetName to get atomic property name for a string.
   [webhosthidden]
+  DOC_STRING(
+    "A name for a @IReactPropertyBag property.\n"
+    "Use @ReactPropertyBagHelper.GetName to get atomic property name for a string in a @IReactPropertyNamespace.\n"
+    "Each @IReactPropertyName object has a unique @.LocalName in context of the @IReactPropertyNamespace")
   interface IReactPropertyName
   {
-    // The local property name String in context of the property namespace.
+    DOC_STRING("Gets String representation of the @IReactPropertyName.")
     String LocalName { get; };
 
-    // The namespace the property name is defined in.
+    DOC_STRING("Gets the @IReactPropertyNamespace where the property name is defined.");
     IReactPropertyNamespace Namespace { get; };
   }
 
-  // The IReactPropertyBag provides a thread-safe property storage.
-  // Properties are identified by IReactPropertyName instance.
-  // It is expected that there will be no direct use of this interface.
-  // Ideally, all usage should happen through a strongly typed accessors.
   [webhosthidden]
-  DOC_STRING("`IReactPropertyBag` provides a thread-safe property storage. Properties are identified by an instance of `IReactPropertyName`. It is expected that there will be no direct use of this interface. Ideally, all usage should happen through strongly-typed accessors.")
+  DOC_STRING(
+    "`IReactPropertyBag` provides a thread-safe property storage.\n"
+    "Properties are identified by an instance of @IReactPropertyName. "
+    "It is expected that there will be no direct use of this interface. "
+    "Ideally, all usage should happen through strongly-typed accessors.")
   interface IReactPropertyBag
   {
-    // Get a property's value. It returns null if the property does not exist.
-    DOC_STRING("Get a property's value. It returns null if the property does not exist.")
+    DOC_STRING(
+      "Gets value of the `name` property.\n"
+      "It returns null if the property does not exist.")
     Object Get(IReactPropertyName name);
 
-    // Get property value for the property name.
-    // If the property does not exist, then create it by calling createValue delegate.
-    // The function may return null if the createValue returns null when called.
-    // The createValue is called outside of lock. It is possible that its
-    // result is not used in case if other thread sets the property value before
-    // the created value is applied.
-    DOC_STRING("Get a property's value. If the property does not exist, this method creates it by calling the `createValue` delegate. \
-The function may return null if the `createValue` returns null when called.\
-The `createValue` is called outside of any locks. \
-It is possible that its result is not used in case another thread sets the property value before the created value is applied.")
+    DOC_STRING(
+      "Gets or creates value of the `name` property.\n"
+      "If the property exists, then the method returns its value. "
+      "If the property does not exist, then this method creates it by calling the `createValue` delegate.\n"
+      "The function may return null if the `createValue` returns null when called. "
+      "The `createValue` is called outside of any locks. "
+      "It is possible that `createValue` result is not used when another thread sets the property value before "
+      "the created value is stored.")
     Object GetOrCreate(IReactPropertyName name, ReactCreatePropertyValue createValue);
 
-    // Set property value for the property name.
-    // It returns previously stored property value.
-    // It returns null if property did not exist.
-    // If the new value is null, then the property is removed.
-    DOC_STRING("Set a property's value. \
-It returns the previously-stored property value. \
-It returns null if the property did not exist. \
-If the new value is null, then the property is removed.")
+    DOC_STRING(
+      "Sets property `name` to `value`.\n"
+      "It returns the previously-stored property value. "
+      "It returns null if the property did not exist.\n"
+      "If the new value is null, then the property is removed.")
     Object Set(IReactPropertyName name, Object value);
   }
 
-  // Helper methods for the property bag implementation.
   [webhosthidden]
+  DOC_STRING("Helper methods for the property bag implementation.")
   static runtimeclass ReactPropertyBagHelper
   {
-    // Return a global namespace that corresponds to an empty string.
+    [deprecated("Do not use. It will be removed in version 0.65.", deprecate, 1)]
+    DOC_STRING("Deprecated. Do not use. It will be removed in version 0.65.")
     static IReactPropertyNamespace GlobalNamespace { get; };
 
-    // Get an atomic IReactPropertyNamespace for a provided namespaceName.
-    // Consider to use module name as a namespace for module-specific properties.
+    DOC_STRING(
+      "Gets an atomic @IReactPropertyNamespace for a provided `namespaceName`.\n"
+      "Consider using module name as the namespace for module-specific properties.")
     static IReactPropertyNamespace GetNamespace(String namespaceName);
 
-    // Get atomic IReactPropertyName for the namespace and local name.
-    // If ns is null, then it uses IReactPropertyNamespace.GlobalNamespace.
+    DOC_STRING(
+      "Gets atomic @IReactPropertyName for the namespace `ns` and the `localName`.\n"
+      "**Note that passing `null` as `ns` is reserved for local values in version 0.65. "
+      "In previous versions is was the same as passing @.GlobalNamespace.**")
     static IReactPropertyName GetName(IReactPropertyNamespace ns, String localName);
 
-    // Create new instance of IReactPropertyBag
+    DOC_STRING("Creates new instance of @IReactPropertyBag")
     static IReactPropertyBag CreatePropertyBag();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/JsiApi.idl
+++ b/vnext/Microsoft.ReactNative/JsiApi.idl
@@ -15,9 +15,13 @@ namespace Microsoft.ReactNative
   // copy data if it wants to store it for the later use. Otherwise it may cause issues due to the memory
   // being overwritten after the call is completed. It may happen if the provided byte array was stored
   // on the call stack or it was a managed memory pinned for the use and then unpinned after that.
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   delegate void JsiByteArrayUser(UInt8[] bytes);
 
   // IJsiByteBuffer encapsulates a byte array buffer.
@@ -30,10 +34,13 @@ namespace Microsoft.ReactNative
   // JsiByteArrayUser delegate. For example, .Net implementation must pin the memory before the JsiByteArrayUser
   // delegate call and unpin it after that. It means that the provided data is only valid while the
   // JsiByteArrayUser delegate is being called.
-  [webhosthidden]
+  [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   interface IJsiByteBuffer
   {
     // Size of the byte buffer data.
@@ -44,9 +51,13 @@ namespace Microsoft.ReactNative
   };
 
   // Type of the JavaScript value. It is currently matching the full JavaScript set of types except for the BigInt type.
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   enum JsiValueKind
   {
     Undefined,
@@ -58,68 +69,98 @@ namespace Microsoft.ReactNative
     Object,
   };
 
-  [webhosthidden]
+  [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiValueRef
   {
     JsiValueKind Kind;
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiSymbolRef
   {
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiStringRef
   {
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiObjectRef
   {
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiWeakObjectRef
   {
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiPropertyIdRef
   {
     UInt64 Data;
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   struct JsiScopeState
   {
     UInt64 Data;
   };
 
-  [default_interface]
+  [experimental, default_interface]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   runtimeclass JsiPreparedJavaScript
   {
   };
@@ -127,14 +168,19 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   delegate JsiValueRef JsiHostFunction(JsiRuntime runtime, JsiValueRef thisArg, JsiValueRef[] args);
 
-  [webhosthidden]
-  [experimental]
+  [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   interface IJsiHostObject
   {
     JsiValueRef GetProperty(JsiRuntime runtime, JsiPropertyIdRef propertyId);
@@ -142,19 +188,26 @@ namespace Microsoft.ReactNative
     IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime runtime);
   };
 
+  [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   enum JsiErrorType
   {
     JSError,         // JavaScript error
     NativeException, // JSI native code exception
   };
 
-  [webhosthidden, default_interface]
+  [experimental, webhosthidden, default_interface]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API.")
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   runtimeclass JsiError
   {
     JsiErrorType ErrorType { get; };
@@ -164,12 +217,13 @@ namespace Microsoft.ReactNative
     JsiValueRef Value { get; };
   };
 
-  [webhosthidden, default_interface]
-  [experimental]
+  [experimental, webhosthidden, default_interface]
   DOC_STRING(
-    "It is an experimental API to implement ABI-safe JSI.\n"
-    "**Do not use this interface directly. We plan to change or remove it in version 0.65. "
-    "Instead use the JSI API through the ExecuteJsi function or in a JSI-based Turbo Module**")
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
+    "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
+    "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
   runtimeclass JsiRuntime
   {
     // TODO : replace with a registered factory method

--- a/vnext/Microsoft.ReactNative/JsiApi.idl
+++ b/vnext/Microsoft.ReactNative/JsiApi.idl
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "DocString.h"
+
 namespace Microsoft.ReactNative
 {
   // JsiByteArrayUser delegate receives a range of bytes as a byte array.
@@ -13,6 +15,9 @@ namespace Microsoft.ReactNative
   // copy data if it wants to store it for the later use. Otherwise it may cause issues due to the memory
   // being overwritten after the call is completed. It may happen if the provided byte array was stored
   // on the call stack or it was a managed memory pinned for the use and then unpinned after that.
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   delegate void JsiByteArrayUser(UInt8[] bytes);
 
   // IJsiByteBuffer encapsulates a byte array buffer.
@@ -26,6 +31,9 @@ namespace Microsoft.ReactNative
   // delegate call and unpin it after that. It means that the provided data is only valid while the
   // JsiByteArrayUser delegate is being called.
   [webhosthidden]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   interface IJsiByteBuffer
   {
     // Size of the byte buffer data.
@@ -36,6 +44,9 @@ namespace Microsoft.ReactNative
   };
 
   // Type of the JavaScript value. It is currently matching the full JavaScript set of types except for the BigInt type.
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   enum JsiValueKind
   {
     Undefined,
@@ -48,52 +59,82 @@ namespace Microsoft.ReactNative
   };
 
   [webhosthidden]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiValueRef
   {
     JsiValueKind Kind;
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiSymbolRef
   {
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiStringRef
   {
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiObjectRef
   {
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiWeakObjectRef
   {
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiPropertyIdRef
   {
     UInt64 Data;
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   struct JsiScopeState
   {
     UInt64 Data;
   };
 
   [default_interface]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   runtimeclass JsiPreparedJavaScript
   {
   };
 
   [experimental]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   delegate JsiValueRef JsiHostFunction(JsiRuntime runtime, JsiValueRef thisArg, JsiValueRef[] args);
 
   [webhosthidden]
   [experimental]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   interface IJsiHostObject
   {
     JsiValueRef GetProperty(JsiRuntime runtime, JsiPropertyIdRef propertyId);
@@ -101,6 +142,9 @@ namespace Microsoft.ReactNative
     IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime runtime);
   };
 
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   enum JsiErrorType
   {
     JSError,         // JavaScript error
@@ -108,6 +152,9 @@ namespace Microsoft.ReactNative
   };
 
   [webhosthidden, default_interface]
+  DOC_STRING(
+    "An experimental API. Do not use it directly. "
+    "It may be removed or changed in 0.65. Instead, use the JSI API.")
   runtimeclass JsiError
   {
     JsiErrorType ErrorType { get; };
@@ -119,6 +166,10 @@ namespace Microsoft.ReactNative
 
   [webhosthidden, default_interface]
   [experimental]
+  DOC_STRING(
+    "It is an experimental API to implement ABI-safe JSI.\n"
+    "**Do not use this interface directly. We plan to change or remove it in version 0.65. "
+    "Instead use the JSI API through the ExecuteJsi function or in a JSI-based Turbo Module**")
   runtimeclass JsiRuntime
   {
     // TODO : replace with a registered factory method

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -11,18 +11,19 @@ namespace Microsoft.ReactNative
   [default_interface]
   DOC_STRING(
     "This can be used to add settings that allow react-native-windows behavior to be maintained across version updates "
-    "to facilitate upgrades. Settings in here are likely to be removed in future releases, so apps should try "
-    "to update their code to not rely on settings from here.")
+    "to facilitate upgrades. Settings in this class are likely to be removed in future releases, so apps should try "
+    "to update their code to not rely on these settings.")
   static runtimeclass QuirkSettings
   {
     DOC_STRING(
-      "Older versions of react-native-windows did not use yoga's legacy stretch behavior. This meant that "
-      "react-native-windows would layout views slightly differently that in iOS and Android. "
+      "Older versions of react-native-windows did not use [Yoga](https://github.com/facebook/yoga)'s legacy "
+      "stretch behavior. This meant that react-native-windows would layout views "
+      "slightly differently that in iOS and Android.\n"
       "Set this setting to false to maintain the behavior from react-native-windows <= 0.62.")
     DOC_DEFAULT("true")
     static void SetMatchAndroidAndIOSStretchBehavior(ReactInstanceSettings settings, Boolean value);
 
-    DOC_STRING("Transitional setting allowing to use the to be retired LegacyWebSocketModule.")
+    DOC_STRING("Transitional setting allowing to use the deprecated `LegacyWebSocketModule`.")
     static void SetUseLegacyWebSocketModule(ReactInstanceSettings settings, Boolean value);
 
     DOC_STRING("Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.")

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -3,27 +3,29 @@
 
 import "ReactInstanceSettings.idl";
 
-namespace Microsoft.ReactNative {
+#include "DocString.h"
 
-  // This can be used to add settings that allow react-native-windows behavior to be maintained across version updates
-  // to facilitate upgrades.  Settings in here are likely to be removed in future releases, so apps should try to update
-  // their code to not rely on settings from here.
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
   [default_interface]
-  runtimeclass QuirkSettings {
-    QuirkSettings();
-
-    // Older versions of react-native-windows did not use yoga's legacy stretch behavior.  This meant that 
-    // react-native-windows would layout views slightly differently that in iOS and Android.
-    // Set this setting to false to maintain the behavior from react-native-windows <= 0.62
-    // The default value is true.
+  DOC_STRING(
+    "This can be used to add settings that allow react-native-windows behavior to be maintained across version updates "
+    "to facilitate upgrades. Settings in here are likely to be removed in future releases, so apps should try "
+    "to update their code to not rely on settings from here.")
+  static runtimeclass QuirkSettings
+  {
+    DOC_STRING(
+      "Older versions of react-native-windows did not use yoga's legacy stretch behavior. This meant that "
+      "react-native-windows would layout views slightly differently that in iOS and Android. "
+      "Set this setting to false to maintain the behavior from react-native-windows <= 0.62.")
+    DOC_DEFAULT("true")
     static void SetMatchAndroidAndIOSStretchBehavior(ReactInstanceSettings settings, Boolean value);
 
-    // Transitional setting allowing to use the to be retired LegacyWebSocketModule.
+    DOC_STRING("Transitional setting allowing to use the to be retired LegacyWebSocketModule.")
     static void SetUseLegacyWebSocketModule(ReactInstanceSettings settings, Boolean value);
 
-    // Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.
+    DOC_STRING("Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.")
     static void SetAcceptSelfSigned(ReactInstanceSettings settings, Boolean value);
   }
-
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -10,9 +10,10 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   [default_interface]
   DOC_STRING(
-    "`ReactApplication` provides a base application class for use in applications that are entirely written "
-    "in React Native. `ReactApplication` will load the React instance on launch of your app for you and provide "
-    "accessors to your application's @ReactInstanceSettings and @ReactNativeHost to customize your React instance.")
+    "The `ReactApplication` is a base application class for use in applications that are entirely written "
+    "in React Native. When the app launches, the `ReactApplication` will load the React instance. "
+    "Use @ReactInstanceSettings and @ReactNativeHost properties to customize React instance in "
+    "your application's constructor.")
   unsealed runtimeclass ReactApplication : XAML_NAMESPACE.Application
   {
     DOC_STRING("Creates a new instance of @ReactApplication")
@@ -21,7 +22,7 @@ namespace Microsoft.ReactNative
     DOC_STRING(
       "Provides access to your application's @ReactInstanceSettings.\n"
       "Generally, changes to these settings will not take effect if the React instance is already loaded, "
-      "unless the React instance is reloaded, so most settings should be set in your applications constructor.")
+      "unless the React instance is reloaded, so most settings should be set in your application's constructor.")
     ReactInstanceSettings InstanceSettings { get; set; };
 
     DOC_STRING(
@@ -34,7 +35,7 @@ namespace Microsoft.ReactNative
     ReactNativeHost Host { get; };
 
     DOC_STRING(
-      "Should the developer experience features such as the developer menu and `RedBox` be enabled.\n"
+      "Controls whether the developer experience features such as the developer menu and `RedBox` are enabled.\n"
       "See @ReactInstanceSettings.UseDeveloperSupport.")
     Boolean UseDeveloperSupport { get; set; };
 

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -5,29 +5,42 @@ import "ReactNativeHost.idl";
 #include "NamespaceRedirect.h"
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
   [default_interface]
-  DOC_STRING("`ReactApplication` provides a base application class for use in applications that are entirely written in React Native. `ReactApplication` will load the React instance on launch of your app for you and provide accessors to your application's @ReactInstanceSettings and @ReactNativeHost to customize your React instance.")
-  unsealed runtimeclass ReactApplication : XAML_NAMESPACE.Application {
+  DOC_STRING(
+    "`ReactApplication` provides a base application class for use in applications that are entirely written "
+    "in React Native. `ReactApplication` will load the React instance on launch of your app for you and provide "
+    "accessors to your application's @ReactInstanceSettings and @ReactNativeHost to customize your React instance.")
+  unsealed runtimeclass ReactApplication : XAML_NAMESPACE.Application
+  {
+    DOC_STRING("Creates a new instance of @ReactApplication")
     ReactApplication();
 
-    DOC_STRING("Provides access to your application's @ReactInstanceSettings.  Generally, changes to these settings will not take effect if the React instance is already loaded, unless the React instance is reloaded, so most settings should be set in your applications constructor.")
+    DOC_STRING(
+      "Provides access to your application's @ReactInstanceSettings.\n"
+      "Generally, changes to these settings will not take effect if the React instance is already loaded, "
+      "unless the React instance is reloaded, so most settings should be set in your applications constructor.")
     ReactInstanceSettings InstanceSettings { get; set; };
 
-    DOC_STRING("Provides access to the list of `IReactPackageProvider`'s that the instance will use to provide native modules to the application. This can be used to register additional package providers, such as package providers from community modules. See @ReactNativeHost for more information.")
+    DOC_STRING(
+      "Provides access to the list of `IReactPackageProvider`'s that the instance will use to provide native modules "
+      "to the application. This can be used to register additional package providers, such as package providers from "
+      "community modules. See @ReactNativeHost for more information.")
     IVector<IReactPackageProvider> PackageProviders { get; };
 
     DOC_STRING("Access to the @ReactNativeHost of your application.")
     ReactNativeHost Host { get; };
 
-    DOC_STRING("Should the developer experience features such as the developer menu and `RedBox` be enabled.  See @ReactInstanceSettings.UseDeveloperSupport.")
+    DOC_STRING(
+      "Should the developer experience features such as the developer menu and `RedBox` be enabled.\n"
+      "See @ReactInstanceSettings.UseDeveloperSupport.")
     Boolean UseDeveloperSupport { get; set; };
 
     // Deprecated - Use JavaScriptBundleFile instead
-    DOC_STRING("See @ReactInstanceSettings.JavaScriptMainModuleName.")
     [deprecated("Use @.JavaScriptBundleFile instead", deprecate, 1)]
+    DOC_STRING("See @ReactInstanceSettings.JavaScriptMainModuleName.")
     String JavaScriptMainModuleName { get; set; };
 
     DOC_STRING("See @ReactInstanceSettings.JavaScriptBundleFile.")

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -55,7 +55,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
 
   Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
 
-  //! This controls the availiablility of various developer support functionality including
+  //! This controls the availability of various developer support functionality including
   //! RedBox, and the Developer Menu
   bool UseDeveloperSupport() noexcept;
   void UseDeveloperSupport(bool value) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -27,7 +27,7 @@ namespace Microsoft.ReactNative {
   DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceCreated event.")
   runtimeclass InstanceCreatedEventArgs
   {
-    DOC_STRING("Gets @IReactContext for the React instance that was just created.")
+    DOC_STRING("Gets the @IReactContext for the React instance that was just created.")
     IReactContext Context { get; };
   }
 
@@ -36,10 +36,10 @@ namespace Microsoft.ReactNative {
   DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceLoaded event.")
   runtimeclass InstanceLoadedEventArgs
   {
-    DOC_STRING("Gets @IReactContext for the React instance that finished loading the bundle.")
+    DOC_STRING("Gets the @IReactContext for the React instance that finished loading the bundle.")
     IReactContext Context { get; };
 
-    DOC_STRING("Gets `true` if JavaScript bundle failed to load.")
+    DOC_STRING("Returns `true` if the JavaScript bundle failed to load.")
     Boolean Failed { get; };
   }
 
@@ -48,24 +48,24 @@ namespace Microsoft.ReactNative {
   DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceDestroyed event.")
   runtimeclass InstanceDestroyedEventArgs
   {
-    DOC_STRING("Gets @IReactContext for the React instance that just destroyed.")
+    DOC_STRING("Gets the @IReactContext for the React instance that just destroyed.")
     IReactContext Context { get; };
   }
 
   [webhosthidden]
-  DOC_STRING("Provides settings to create React instance.")
+  DOC_STRING("Provides settings to create a React instance.")
   runtimeclass ReactInstanceSettings
   {
     DOC_STRING("Creates new instance of @ReactInstanceSettings")
     ReactInstanceSettings();
 
     DOC_STRING(
-      "Gets @IReactPropertyBag to share values between components and the application."
+      "Gets a @IReactPropertyBag to share values between components and the application.\n"
       "Use @IReactContext.Properties to access this @IReactPropertyBag from native components and view managers.")
     IReactPropertyBag Properties { get; };
 
     DOC_STRING(
-      "Gets @IReactNotificationService to send notifications between components and the application.\n"
+      "Gets a @IReactNotificationService to send notifications between components and the application.\n"
       "Use @IReactContext.Notifications to access this @IReactNotificationService "
       "from native components or view managers.")
     IReactNotificationService Notifications { get; };
@@ -79,8 +79,7 @@ namespace Microsoft.ReactNative {
 
     DOC_STRING(
       "This controls whether various developer experience features are available for this instance. "
-      "In particular, it enables the developer menu, the default `RedBox` and `LogBox` experience, "
-      "and loading UI during the JavaScript bundle load.")
+      "In particular, it enables the developer menu, the default `RedBox` and `LogBox` experience.")
     Boolean UseDeveloperSupport { get; set; };
 
     // Deprecated - use JavaScriptBundleFile instead
@@ -101,7 +100,7 @@ namespace Microsoft.ReactNative {
     Boolean UseWebDebugger { get; set; };
 
     DOC_STRING(
-      "Should the instance trigger the hot module reload logic when it first loads the instance.\n"
+      "Controls whether the instance triggers the hot module reload logic when it first loads the instance.\n"
       "Most edits should be visible within a second or two without the instance having to reload.\n"
       "Non-compatible changes still cause full reloads.\n"
       "See [Fast Refresh](https://reactnative.dev/docs/fast-refresh) for more information on Fast Refresh.")
@@ -120,7 +119,7 @@ namespace Microsoft.ReactNative {
     Boolean UseDirectDebugger { get; set; };
 
     DOC_STRING(
-      "For direct debugging, whether to break on the next line of JavaScript that is executed.\n"
+      "For direct debugging, controls whether to break on the next line of JavaScript that is executed.\n"
       "This can help debug issues hit early in the JavaScript bundle load.\n"
       "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine***")
     Boolean DebuggerBreakOnNextLine { get; set; };
@@ -135,7 +134,8 @@ namespace Microsoft.ReactNative {
       "Subsequent runs of the application should be faster as the JavaScript will be loaded from bytecode "
       "instead of the raw JavaScript.\n"
       "@.ByteCodeFileUri must be set to a location the application has write access to in order for "
-      "the bytecode to be successfully cached.")
+      "the bytecode to be successfully cached.\n"
+      "**Note that currently the byte code generation is not implemented for UWP applications.**")
     DOC_DEFAULT("false")
     Boolean EnableByteCodeCaching { get; set; };
 
@@ -145,12 +145,13 @@ namespace Microsoft.ReactNative {
       "In version 0.63 both properties will do the same thing. It will be removed in version 0.65.", deprecate, 1)]
     DOC_STRING(
       "This controls whether various developer experience features are available for this instance. "
-      "In particular the developer menu, the default `RedBox` experience and the loading UI during bundle load.")
+      "In particular the developer menu, and the default `RedBox` experience.")
     Boolean EnableDeveloperMenu { get; set; };
 
     DOC_STRING(
       "Set this to a location the application has write access to in order for bytecode to be successfully cached. "
-      "See @.EnableByteCodeCaching.")
+      "See @.EnableByteCodeCaching.\n"
+      "**Note that currently the byte code generation is not implemented for UWP applications.**")
     String ByteCodeFileUri { get; set; };
 
     // Deprecated
@@ -204,7 +205,7 @@ namespace Microsoft.ReactNative {
     DOC_STRING(
       "The @JSIEngine override to be used with the React instance.\n"
       "In order the override to work the Microsoft.ReactNative must be compiled with support of that engine.")
-    DOC_DEFAULT("8081")
+    DOC_DEFAULT("JSIEngine.Chakra")
     JSIEngine JSIEngineOverride { get; set; };
 
     DOC_STRING(

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -94,7 +94,7 @@ namespace Microsoft.ReactNative {
     String JavaScriptBundleFile { get; set; };
 
     DOC_STRING(
-      "Should the instance run in a remote environment such as within a browser.\n"
+      "Controls whether the instance JavaScript runs in a remote environment such as within a browser.\n"
       "By default, this is using a browser navigated to http://localhost:8081/debugger-ui served by Metro/Haul.\n"
       "Debugging will start as soon as the react native instance is loaded.")
     Boolean UseWebDebugger { get; set; };
@@ -107,21 +107,22 @@ namespace Microsoft.ReactNative {
     Boolean UseFastRefresh { get; set; };
 
     DOC_STRING(
-      "Enable live reload to load the source bundle from the React Native packager.\n"
+      "Enables live reload to load the source bundle from the React Native packager.\n"
       "When the file is saved, the packager will trigger reloading.\n"
       "**For general use this has been replaced by @.UseFastRefresh.**")
     Boolean UseLiveReload { get; set; };
 
     DOC_STRING(
       "Enables debugging in the JavaScript engine (if supported).\n"
-      "For Chakra this enables you to debug the JS runtime directly within your app using "
+      "For Chakra this enables debugging of the JS runtime directly within the app using "
       "Visual Studio -> Attach to process (Script)")
     Boolean UseDirectDebugger { get; set; };
 
     DOC_STRING(
       "For direct debugging, controls whether to break on the next line of JavaScript that is executed.\n"
       "This can help debug issues hit early in the JavaScript bundle load.\n"
-      "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine***")
+      "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine. "
+      "As a workaround you could add the `debugger` keyword in the beginning of the bundle.***")
     Boolean DebuggerBreakOnNextLine { get; set; };
 
     DOC_STRING("Flag controlling whether the JavaScript engine uses JIT compilation.")
@@ -191,13 +192,13 @@ namespace Microsoft.ReactNative {
     IReactDispatcher UIDispatcher { get; set; };
 
     DOC_STRING(
-      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server hostname "
+      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server hostname "
       "that will be used to load the bundle from.")
     DOC_DEFAULT("localhost")
     String SourceBundleHost { get; set; };
 
     DOC_STRING(
-      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server port "
+      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server port "
       "that will be used to load the bundle from.")
     DOC_DEFAULT("8081")
     UInt16 SourceBundlePort { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -12,8 +12,11 @@ import "RedBoxHandler.idl";
 
 namespace Microsoft.ReactNative {
 
+  DOC_STRING(
+    "A JavaScript engine type that can be set for a React instance in @ReactInstanceSettings.JSIEngineOverride")
   // Keep in sync with enum in IReactInstance.h
-  enum JSIEngine {
+  enum JSIEngine
+  {
     Chakra = 0,
     Hermes = 1,
     V8 = 2
@@ -21,120 +24,187 @@ namespace Microsoft.ReactNative {
 
   [webhosthidden]
   [default_interface]
-  runtimeclass InstanceCreatedEventArgs {
+  DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceCreated event.")
+  runtimeclass InstanceCreatedEventArgs
+  {
+    DOC_STRING("Gets @IReactContext for the React instance that was just created.")
     IReactContext Context { get; };
   }
 
   [webhosthidden]
   [default_interface]
-  runtimeclass InstanceLoadedEventArgs {
+  DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceLoaded event.")
+  runtimeclass InstanceLoadedEventArgs
+  {
+    DOC_STRING("Gets @IReactContext for the React instance that finished loading the bundle.")
     IReactContext Context { get; };
+
+    DOC_STRING("Gets `true` if JavaScript bundle failed to load.")
     Boolean Failed { get; };
   }
 
   [webhosthidden]
-  [default_interface] runtimeclass InstanceDestroyedEventArgs {
+  [default_interface]
+  DOC_STRING("The arguments for the @ReactInstanceSettings.InstanceDestroyed event.")
+  runtimeclass InstanceDestroyedEventArgs
+  {
+    DOC_STRING("Gets @IReactContext for the React instance that just destroyed.")
     IReactContext Context { get; };
   }
 
   [webhosthidden]
-  DOC_STRING("Provides configuration of the react instance.")
-  runtimeclass ReactInstanceSettings 
+  DOC_STRING("Provides settings to create React instance.")
+  runtimeclass ReactInstanceSettings
   {
+    DOC_STRING("Creates new instance of @ReactInstanceSettings")
     ReactInstanceSettings();
 
-    DOC_STRING("Properties are shared with @IReactContext.Properties. It can be used to configure and share values and state between components.")
+    DOC_STRING(
+      "Gets @IReactPropertyBag to share values between components and the application."
+      "Use @IReactContext.Properties to access this @IReactPropertyBag from native components and view managers.")
     IReactPropertyBag Properties { get; };
 
-    DOC_STRING("Provides access to the `IReactNotificationService`, which allows easy communication between custom native modules or view managers.")
+    DOC_STRING(
+      "Gets @IReactNotificationService to send notifications between components and the application.\n"
+      "Use @IReactContext.Notifications to access this @IReactNotificationService "
+      "from native components or view managers.")
     IReactNotificationService Notifications { get; };
 
-    DOC_STRING("Provides a list of additional native modules and custom view managers that should be included in the instance.")
+    DOC_STRING(
+      "Gets a list of @IReactPackageProvider.\n"
+      "Add an implementation of @IReactPackageProvider to this list to define additional "
+      "native modules and custom view managers to be included in the React instance.\n"
+      "Auto-linking automatically adds @IReactPackageProvider to the application's @.PackageProviders.")
     IVector<IReactPackageProvider> PackageProviders { get; };
 
-    DOC_STRING("This controls whether various developer experience features are available for this instance.  In particular the developer menu, the default `RedBox` and `LogBox` experience and loading UI during bundle load.")
+    DOC_STRING(
+      "This controls whether various developer experience features are available for this instance. "
+      "In particular, it enables the developer menu, the default `RedBox` and `LogBox` experience, "
+      "and loading UI during the JavaScript bundle load.")
     Boolean UseDeveloperSupport { get; set; };
 
     // Deprecated - use JavaScriptBundleFile instead
-    DOC_STRING("Name of the JavaScript bundle file.  If @.JavaScriptBundleFile is specified it is used instead.")
-    [deprecated("use JavaScriptBundleFile instead", deprecate, 1)]
+    [deprecated("Use JavaScriptBundleFile instead. It will be removed in version 0.65.", deprecate, 1)]
+    DOC_STRING("Name of the JavaScript bundle file. If @.JavaScriptBundleFile is specified it is used instead.")
     String JavaScriptMainModuleName { get; set; };
 
-    DOC_STRING("The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath.  `.bundle` will be appended to the end, when looking for the bundle file.")
+    DOC_STRING(
+      "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "
+      "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
     DOC_DEFAULT("index.windows")
     String JavaScriptBundleFile { get; set; };
 
-    DOC_STRING("Should the instance run in a remote environment such as within a browser.\n\
-By default, this is using a browser navigated to  http://localhost:8081/debugger-ui served by Metro/Haul.\n\
-Debugging will start as soon as the react native instance is loaded.")
+    DOC_STRING(
+      "Should the instance run in a remote environment such as within a browser.\n"
+      "By default, this is using a browser navigated to http://localhost:8081/debugger-ui served by Metro/Haul.\n"
+      "Debugging will start as soon as the react native instance is loaded.")
     Boolean UseWebDebugger { get; set; };
 
-    DOC_STRING("Should the instance trigger the hot module reload logic when it first loads the instance.\n\
-Most edits should be visible within a second or two without the instance having to reload.\n\
-Non-compatible changes still cause full reloads.\n\
-See [Fast Refresh](https://reactnative.dev/docs/fast-refresh) for more information on Fast Refresh.")
+    DOC_STRING(
+      "Should the instance trigger the hot module reload logic when it first loads the instance.\n"
+      "Most edits should be visible within a second or two without the instance having to reload.\n"
+      "Non-compatible changes still cause full reloads.\n"
+      "See [Fast Refresh](https://reactnative.dev/docs/fast-refresh) for more information on Fast Refresh.")
     Boolean UseFastRefresh { get; set; };
 
-    DOC_STRING("Enable live reload to load the source bundle from the React Native packager.\n\
-When the file is saved, the packager will trigger reloading.\n\
-**For general use this has been replaced by @.UseFastRefresh.**")
+    DOC_STRING(
+      "Enable live reload to load the source bundle from the React Native packager.\n"
+      "When the file is saved, the packager will trigger reloading.\n"
+      "**For general use this has been replaced by @.UseFastRefresh.**")
     Boolean UseLiveReload { get; set; };
 
-    DOC_STRING("Enables debugging in the JavaScript engine (if supported).  \n\
-For Chakra this enables you to debug the JS runtime directly within your app using Visual Studio -> Attach to process (Script)")
+    DOC_STRING(
+      "Enables debugging in the JavaScript engine (if supported).\n"
+      "For Chakra this enables you to debug the JS runtime directly within your app using "
+      "Visual Studio -> Attach to process (Script)")
     Boolean UseDirectDebugger { get; set; };
 
-    DOC_STRING("For direct debugging, whether to break on the next line of JavaScript that is executed.  This can help debug issues hit early in the JavaScript bundle load.\n\
-***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine***")
+    DOC_STRING(
+      "For direct debugging, whether to break on the next line of JavaScript that is executed.\n"
+      "This can help debug issues hit early in the JavaScript bundle load.\n"
+      "***Note: this is not supported with the Chakra JS engine which is the currently used JavaScript engine***")
     Boolean DebuggerBreakOnNextLine { get; set; };
 
     DOC_STRING("Flag controlling whether the JavaScript engine uses JIT compilation.")
     DOC_DEFAULT("true")
     Boolean EnableJITCompilation { get; set; };
 
-    DOC_STRING("For JS engines that support bytecode generation, this controls if bytecode should be generated when a JavaScript bundle is first loaded.\n\
-Subsequent runs of the application should be faster as the JavaScript will be loaded from bytecode instead of the raw JavaScript.  \n\
-@.ByteCodeFileUri must be set to a location the application has write access to in order for the bytecode to be successfully cached.")
+    DOC_STRING(
+      "For JS engines that support bytecode generation, this controls if bytecode should be generated when "
+      "a JavaScript bundle is first loaded.\n"
+      "Subsequent runs of the application should be faster as the JavaScript will be loaded from bytecode "
+      "instead of the raw JavaScript.\n"
+      "@.ByteCodeFileUri must be set to a location the application has write access to in order for "
+      "the bytecode to be successfully cached.")
     DOC_DEFAULT("false")
     Boolean EnableByteCodeCaching { get; set; };
 
-    DOC_STRING("This controls whether various developer experience features are available for this instance.  In particular the developer menu, the default `RedBox` experience and the loading UI during bundle load.")
-    [deprecated("This property has been replaced by @.UseDeveloperSupport. In version 0.63 both properties will do the same thing.", deprecate, 1)]
+    // Deprecated
+    [deprecated(
+      "This property has been replaced by @.UseDeveloperSupport. "
+      "In version 0.63 both properties will do the same thing. It will be removed in version 0.65.", deprecate, 1)]
+    DOC_STRING(
+      "This controls whether various developer experience features are available for this instance. "
+      "In particular the developer menu, the default `RedBox` experience and the loading UI during bundle load.")
     Boolean EnableDeveloperMenu { get; set; };
 
-    DOC_STRING("Set this to a location the application has write access to in order for bytecode to be successfully cached. See @.EnableByteCodeCaching.")
+    DOC_STRING(
+      "Set this to a location the application has write access to in order for bytecode to be successfully cached. "
+      "See @.EnableByteCodeCaching.")
     String ByteCodeFileUri { get; set; };
 
-    DOC_STRING("When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server that will be used to load the bundle from.")
-    [deprecated("This has been replaced with @.SourceBundleHost and @.SourceBundlePort and will be removed in a future version.", deprecate, 1)]
+    // Deprecated
+    [deprecated(
+      "This has been replaced with @.SourceBundleHost and @.SourceBundlePort and will be removed in a version 0.65.",
+      deprecate, 1)]
+    DOC_STRING(
+      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server that will be "
+      "used to load the bundle from.")
     DOC_DEFAULT("localhost:8081")
     String DebugHost { get; set; };
 
-    DOC_STRING("When loading from a bundle server (such as metro), this is the path that will be requested from the server.  If this is not provided the value of @.JavaScriptBundleFile or @.JavaScriptMainModuleName is used.")
+    DOC_STRING(
+      "When loading from a bundle server (such as metro), this is the path that will be requested from the server. "
+      "If this is not provided the value of @.JavaScriptBundleFile or @.JavaScriptMainModuleName is used.")
     String DebugBundlePath { get; set; };
 
     DOC_STRING("Base path used for the location of the bundle.")
     DOC_DEFAULT("ms-appx:///Bundle/")
     String BundleRootPath { get; set; };
 
-    DOC_STRING("When @.UseDirectDebugger is enabled, this controls the port that the JavaScript engine debugger will run on.")
+    DOC_STRING(
+      "When @.UseDirectDebugger is enabled, this controls the port that the JavaScript engine debugger will run on.")
     DOC_DEFAULT("9229")
     UInt16 DebuggerPort { get; set; };
 
-    DOC_STRING("Provides an extension point to allow custom error handling within the react instance. See @IRedBoxHandler for more information.")
+    DOC_STRING(
+      "Provides an extension point to allow custom error handling within the react instance. "
+      "See @IRedBoxHandler for more information.")
     IRedBoxHandler RedBoxHandler { get; set; };
 
-    DOC_STRING("Control the main UI dispatcher to be used by the React instance.  If the @ReactInstanceSettings object is initially created on a UI thread, then this will default to that thread.  The value provided here will be available to native modules and view managers using @IReactContext.UIDispatcher")
+    DOC_STRING(
+      "Control the main UI dispatcher to be used by the React instance. "
+      "If the @ReactInstanceSettings object is initially created on a UI thread, then this will "
+      "default to that thread. The value provided here will be available to native modules and view managers "
+      "using @IReactContext.UIDispatcher")
     IReactDispatcher UIDispatcher { get; set; };
 
-    DOC_STRING("When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server hostname that will be used to load the bundle from.")
+    DOC_STRING(
+      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server hostname "
+      "that will be used to load the bundle from.")
     DOC_DEFAULT("localhost")
     String SourceBundleHost { get; set; };
 
-    DOC_STRING("When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server port that will be used to load the bundle from.")
+    DOC_STRING(
+      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server port "
+      "that will be used to load the bundle from.")
     DOC_DEFAULT("8081")
     UInt16 SourceBundlePort { get; set; };
 
+    DOC_STRING(
+      "The @JSIEngine override to be used with the React instance.\n"
+      "In order the override to work the Microsoft.ReactNative must be compiled with support of that engine.")
+    DOC_DEFAULT("8081")
     JSIEngine JSIEngineOverride { get; set; };
 
     DOC_STRING(

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -10,8 +10,8 @@ import "RedBoxHandler.idl";
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   DOC_STRING(
     "A JavaScript engine type that can be set for a React instance in @ReactInstanceSettings.JSIEngineOverride")
   // Keep in sync with enum in IReactInstance.h
@@ -83,7 +83,7 @@ namespace Microsoft.ReactNative {
     Boolean UseDeveloperSupport { get; set; };
 
     // Deprecated - use JavaScriptBundleFile instead
-    [deprecated("Use JavaScriptBundleFile instead. It will be removed in version 0.65.", deprecate, 1)]
+    [deprecated("Use @.JavaScriptBundleFile instead. It will be removed in version 0.65.", deprecate, 1)]
     DOC_STRING("Name of the JavaScript bundle file. If @.JavaScriptBundleFile is specified it is used instead.")
     String JavaScriptMainModuleName { get; set; };
 

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.idl
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.idl
@@ -11,7 +11,7 @@ namespace Microsoft.ReactNative
   [webhosthidden]
   [default_interface]
   DOC_STRING(
-    "This is the main entry-point to create a react-native instance.\n"
+    "This is the main entry-point to create a React instance.\n"
     "The `ReactNativeHost` object exists to configure the instance using @ReactInstanceSettings before it is loaded, "
     "as well as enabling control of when to load the instance.\n"
     "Use @ReactInstanceSettings events to observe instance creation, loading, and destruction.")
@@ -28,13 +28,14 @@ namespace Microsoft.ReactNative
     DOC_STRING("Provides access to this host's @ReactInstanceSettings to configure the react instance.")
     ReactInstanceSettings InstanceSettings { get; set; };
 
-    DOC_STRING("Loads new React instance. It is an alias for @.ReloadInstance method.")
+    DOC_STRING("Loads a new React instance. It is an alias for @.ReloadInstance method.")
     Windows.Foundation.IAsyncAction LoadInstance();
 
     DOC_STRING(
-      "Unloads current React instance and loads the new one.\n"
-      "The React instance loading creates an instance of the JS engine and launches provided JavaScript code bundle. "
-      "If a React instance of this host is already running, then the @.ReloadInstance shuts down the already "
+      "Unloads the current React instance and loads a new one.\n"
+      "The React instance loading creates an instance of the JavaScript engine, "
+      "and launches the provided JavaScript code bundle.\n"
+      "If a React instance is already running in this host, then @.ReloadInstance shuts down the already "
       "the running React instance, and loads a new React instance.\n"
       "The React instance lifecycle can be observed with the following events:"
       "- The @ReactInstanceSettings.InstanceCreated event is raised when the React instance is just created.\n"
@@ -45,12 +46,12 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "Unloads current React instance.\n"
-      "After the ReactInsatnce is unloaded, all the React resources including the JaavScript engine environment "
+      "After the React instance is unloaded, all the React resources including the JavaScript engine environment "
       "are cleaned up.\n"
       "The React instance destruction can be observed with the @ReactInstanceSettings.InstanceDestroyed event.")
     Windows.Foundation.IAsyncAction UnloadInstance();
 
-    DOC_STRING("Returns @ReactNativeHost instance from the @IReactContext.")
+    DOC_STRING("Returns the @ReactNativeHost instance associated with the given @IReactContext.")
     static ReactNativeHost FromContext(IReactContext reactContext);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.idl
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.idl
@@ -6,27 +6,51 @@ import "ReactInstanceSettings.idl";
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
   [default_interface]
-  DOC_STRING("This is the main entry-point to create a react-native instance.  The `ReactNativeHost` object exists to configure the instance using @ReactInstanceSettings before its loaded, as well as enabling control of when to load the instance. \n\
-_In the future more lifecycle events will be added to this object to provide better information on when an instance is loaded and unloaded._")
+  DOC_STRING(
+    "This is the main entry-point to create a react-native instance.\n"
+    "The `ReactNativeHost` object exists to configure the instance using @ReactInstanceSettings before it is loaded, "
+    "as well as enabling control of when to load the instance.\n"
+    "Use @ReactInstanceSettings events to observe instance creation, loading, and destruction.")
   runtimeclass ReactNativeHost {
+    DOC_STRING("Creates a new instance of @ReactNativeHost")
     ReactNativeHost();
 
-    DOC_STRING("Provides access to the list of `IReactPackageProvider`'s that the react instance will use to provide native modules to the application.  This can be used to register additional package providers, such as package providers from community modules or other shared libraries")
+    DOC_STRING(
+      "Provides access to the list of @IReactPackageProvider's that the React instance will use to provide "
+      "native modules to the application. This can be used to register additional package providers, such as "
+      "package providers from community modules or other shared libraries.")
     IVector<IReactPackageProvider> PackageProviders { get; };
 
-    DOC_STRING("Provides access to your this host's @ReactInstanceSettings to configure the react instance.")
+    DOC_STRING("Provides access to this host's @ReactInstanceSettings to configure the react instance.")
     ReactInstanceSettings InstanceSettings { get; set; };
 
+    DOC_STRING("Loads new React instance. It is an alias for @.ReloadInstance method.")
     Windows.Foundation.IAsyncAction LoadInstance();
 
-    DOC_STRING("This is used to load the instance, which will create an instance of the JS engine and launch your JavaScript code.  If an instance of this host is already running, this will shutdown the already running instance, and load a new instance.")
+    DOC_STRING(
+      "Unloads current React instance and loads the new one.\n"
+      "The React instance loading creates an instance of the JS engine and launches provided JavaScript code bundle. "
+      "If a React instance of this host is already running, then the @.ReloadInstance shuts down the already "
+      "the running React instance, and loads a new React instance.\n"
+      "The React instance lifecycle can be observed with the following events:"
+      "- The @ReactInstanceSettings.InstanceCreated event is raised when the React instance is just created.\n"
+      "- The @ReactInstanceSettings.InstanceLoaded event is raised when the React instance completed"
+      "  loading the JavaScript bundle.\n"
+      "- The @ReactInstanceSettings.InstanceDestroyed event is raised when the React instance is destroyed.")
     Windows.Foundation.IAsyncAction ReloadInstance();
+
+    DOC_STRING(
+      "Unloads current React instance.\n"
+      "After the ReactInsatnce is unloaded, all the React resources including the JaavScript engine environment "
+      "are cleaned up.\n"
+      "The React instance destruction can be observed with the @ReactInstanceSettings.InstanceDestroyed event.")
     Windows.Foundation.IAsyncAction UnloadInstance();
 
+    DOC_STRING("Returns @ReactNativeHost instance from the @IReactContext.")
     static ReactNativeHost FromContext(IReactContext reactContext);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -21,10 +21,10 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "The name of the root UI component registered in JavaScript with help of the "
-      "`AppRegistry.registerComponent` method.")
+      "[`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent) method.")
     String ComponentName { get; set; };
 
-    DOC_STRING("The @JSValueArgWriter that is used to serialze the main component initial properties.")
+    DOC_STRING("The @JSValueArgWriter that is used to serialize the main component initial properties.")
     JSValueArgWriter InitialProps { get; set; };
 
     DOC_STRING(

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -4,19 +4,37 @@
 import "IJSValueWriter.idl";
 import "ReactNativeHost.idl";
 #include "NamespaceRedirect.h"
+#include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   [default_interface]
   [webhosthidden]
-  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid {
+  DOC_STRING("A XAML component that hosts React Native UI elements.")
+  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid
+  {
+    DOC_STRING("Creates a new instance of @ReactRootView.")
     ReactRootView();
 
+    DOC_STRING("The @ReactNativeHost associated with the @ReactRootView. It must be set to show any React UI elements.")
     ReactNativeHost ReactNativeHost { get; set; };
+
+    DOC_STRING(
+      "The name of the root UI component registered in JavaScript with help of the "
+      "`AppRegistry.registerComponent` method.")
     String ComponentName { get; set; };
+
+    DOC_STRING("The @JSValueArgWriter that is used to serialze the main component initial properties.")
     JSValueArgWriter InitialProps { get; set; };
+
+    DOC_STRING(
+      "XAML's default projection in 3D is orthographic (all lines are parallel) "
+      "However React Native's default projection is a one-point perspective. "
+      "This property enables setting a default perspective projection on the main control to mimic this.")
+    DOC_DEFAULT("true")
     Boolean IsPerspectiveEnabled { get; set; };
 
+    DOC_STRING("Reloads the current @ReactRootView UI components.")
     void ReloadView();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.idl
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.idl
@@ -84,8 +84,6 @@ This can be useful if you have an existing error reporting system that you want 
 The default implementation of `RedBoxHandler` shows an error messages in a error screen
 that covers the whole application window.
 
--- Insert Screenshot here --
-
 If you want to maintain the existing `RedBox` behaviors, and also report errors to your own reporting system,
 your implementation can call into the default `RedBoxHandler`, which can be obtained by calling :
 

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.idl
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.idl
@@ -5,77 +5,96 @@ import "ReactNativeHost.idl";
 
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
+namespace Microsoft.ReactNative
+{
+  DOC_STRING("The error type shown in the RedBox.")
+  enum RedBoxErrorType
+  {
+    DOC_STRING("A JS Exception was thrown and not caught, or otherwise fatal error.")
+    JavaScriptFatal,
 
-  enum RedBoxErrorType {
-    DOC_STRING("A JS Exception was thrown and not caught or otherwise fatal error")
-    JavaScriptFatal, // A JS Exception was thrown or otherwise fatal error
+    DOC_STRING("An error coming from JS that isn't fatal, such as `console.error`.")
+    JavaScriptSoft,
 
-    DOC_STRING("An error coming from JS that isn't fatal, such as `console.error`")
-    JavaScriptSoft, // An error coming from JS that isn't fatal, such as console.error
-
-    DOC_STRING("An error happened in native code")
+    DOC_STRING("An error happened in native code.")
     Native,
   };
 
   [webhosthidden]
   DOC_STRING("This object represents a single frame within the call stack of an error.")
-  interface IRedBoxErrorFrameInfo {
-    DOC_STRING("The file location of this frame")
+  interface IRedBoxErrorFrameInfo
+  {
+    DOC_STRING("The file location of this frame.")
     String File { get; };
 
-    DOC_STRING("The method name of this frame")
+    DOC_STRING("The method name of this frame.")
     String Method { get; };
 
-    DOC_STRING("The line number within the file")
+    DOC_STRING("The line number within the file.")
     UInt32 Line { get; };
 
-    DOC_STRING("The column within the line")
+    DOC_STRING("The column within the line.")
     UInt32 Column { get; };
 
-    DOC_STRING("True if this frame is part of the internals of `react-native`, that is likely not useful for the developer to see.")
+    DOC_STRING(
+      "True if this frame is part of the internals of `react-native`, "
+      "that is likely not useful for the developer to see.")
     Boolean Collapse { get; };
   }
 
   [webhosthidden]
-  DOC_STRING("This object provides information about the error.  For JavaScript errors, a call stack is also provided.")
-  interface IRedBoxErrorInfo {
+  DOC_STRING("This object provides information about the error. For JavaScript errors, a call stack is also provided.")
+  interface IRedBoxErrorInfo
+  {
     DOC_STRING("The error message.")
     String Message { get; };
 
-    DOC_STRING("If the message was adjusted for formatting, or otherwise processed, this contains the message before those modifications")
+    DOC_STRING(
+      "If the message was adjusted for formatting, or otherwise processed, "
+      "this contains the message before those modifications.")
     String OriginalMessage { get; };
 
     DOC_STRING("An identifier for this error.")
     String Name { get; };
 
-    DOC_STRING("This will contain the component stack where the error occurred, which can help identify the component that is producing the error")
+    DOC_STRING(
+      "This will contain the component stack where the error occurred, "
+      "which can help identify the component that is producing the error.")
     String ComponentStack { get; };
 
-    DOC_STRING("This Id can be used in @IRedBoxHandler.UpdateError to identify which error is being updated.  For native errors, this is currently always `0`, and @IRedBoxHandler.UpdateError will never be called.")
+    DOC_STRING(
+      "This Id can be used in @IRedBoxHandler.UpdateError to identify which error is being updated. "
+      "For native errors, this is currently always `0`, and @IRedBoxHandler.UpdateError will never be called.")
     UInt32 Id { get; };
 
     DOC_STRING("For JavaScript errors, this will contain the call stack of where the error occurred.")
     IVectorView<IRedBoxErrorFrameInfo> Callstack { get; };
 
-    DOC_STRING("Provides access to extra data attached to the error.  Adding additional data to the errors is not yet part of the stable API.")
+    DOC_STRING(
+      "Provides access to extra data attached to the error. "
+      "Adding additional data to the errors is not yet part of the stable API.")
     IJSValueReader ExtraData { get; };
   }
 
   [webhosthidden]
 #ifdef USE_DOCSTRING
   [doc_string(
-    "`IRedBoxHandler` provides an extension point to allow custom error handling within the React instance.  This can be useful if you have an existing error reporting system that you want React errors to be reported to.  The default implementation of `RedBoxHandler` shows an error messages in a error screen that covers the whole application window.
+    "`IRedBoxHandler` provides an extension point to allow custom error handling within the React instance.
+This can be useful if you have an existing error reporting system that you want React errors to be reported to.
+The default implementation of `RedBoxHandler` shows an error messages in a error screen
+that covers the whole application window.
 
 -- Insert Screenshot here --
 
-If you want to maintain the existing `RedBox` behaviors, and also report errors to your own reporting system, your implementation can call into the default `RedBoxHandler`, which can be obtained by calling :
+If you want to maintain the existing `RedBox` behaviors, and also report errors to your own reporting system,
+your implementation can call into the default `RedBoxHandler`, which can be obtained by calling :
 
 ```csharp
 RedBoxHelper::CreateDefaultHandler(Host);
 ```
 
-Sample settings up a `RedBoxHandler` that reports errors to an external system, and displays the default `RedBox` experience within the application:
+Sample settings up a `RedBoxHandler` that reports errors to an external system, and displays the default `RedBox`
+experience within the application:
 
 ```csharp
 
@@ -131,20 +150,27 @@ RegisterMyRedBoxHandler()
     DOC_STRING("This method is called when an error is initially hit.")
     void ShowNewError(IRedBoxErrorInfo info, RedBoxErrorType type);
 
-    DOC_STRING("This property will control if errors should be reported to the handler.  If this returns false, @.ShowNewError and @.UpdateError will not be called.")
+    DOC_STRING(
+      "This property will control if errors should be reported to the handler. "
+      "If this returns false, @.ShowNewError and @.UpdateError will not be called.")
     Boolean IsDevSupportEnabled { get; };
 
-    DOC_STRING("This method is called when updated information about an error has been resolved.  For JavaScript errors, this is called if source map information was able to be resolved to provide a more useful call stack.")
+    DOC_STRING(
+      "This method is called when updated information about an error has been resolved. "
+      "For JavaScript errors, this is called if source map information was able to be resolved "
+      "to provide a more useful call stack.")
     void UpdateError(IRedBoxErrorInfo info);
     void DismissRedBox();
   }
 
   [webhosthidden]
   [default_interface]
-  runtimeclass RedBoxHelper {
-    RedBoxHelper();
-
-    DOC_STRING("This provides access to the default @IRedBoxHandler. This can be used to display the default `RedBox` as part of a custom `RedBoxHandler` implementation.")
+  DOC_STRING("A helper static class for @IRedBoxHandler.")
+  static runtimeclass RedBoxHelper
+  {
+    DOC_STRING(
+      "This provides access to the default @IRedBoxHandler. "
+      "This can be used to display the default `RedBox` as part of a custom `RedBoxHandler` implementation.")
     static IRedBoxHandler CreateDefaultHandler(Microsoft.ReactNative.ReactNativeHost host);
   }
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.idl
+++ b/vnext/Microsoft.ReactNative/XamlHelper.idl
@@ -3,15 +3,19 @@
 
 import "IJSValueWriter.idl";
 #include "NamespaceRedirect.h"
+#include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   [webhosthidden]
   [default_interface]
-  runtimeclass XamlHelper {
-    XamlHelper();
+  DOC_STRING("XAML helper methods to implement custom view managers.")
+  static runtimeclass XamlHelper
+  {
+    DOC_STRING("Returns a Brush from @JSValueArgWriter.")
     static XAML_NAMESPACE.Media.Brush BrushFrom(JSValueArgWriter valueProvider);
+
+    DOC_STRING("Returns a Color from @JSValueArgWriter.")
     static Windows.UI.Color ColorFrom(JSValueArgWriter valueProvider);
   };
-
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -15,38 +15,44 @@ namespace Microsoft.ReactNative
     "It provides access to APIs to get a XAML element from a react tag, and to dispatch events to JS components.")
   runtimeclass XamlUIService
   {
-    DOC_STRING("Use this method to gain access to the `XamlUIService` from a `ReactContext`.")
+    DOC_STRING("Use this method to get access to the @XamlUIService associated with the @IReactContext.")
     static XamlUIService FromContext(IReactContext context);
 
-    DOC_STRING("Get the backing XAML element from a react tag.")
+    DOC_STRING("Gets the backing XAML element from a react tag.")
     XAML_NAMESPACE.DependencyObject ElementFromReactTag(Int64 reactTag);
 
-    DOC_STRING("Dispatch an event to a JS component.")
-    // Dispatch UI event. This method is to be moved to IReactViewContext.
+    DOC_STRING("Dispatches an event to a JS component.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 
-    // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
     DOC_STRING(
-      "Set XamlRoot for app. This must be manually provided to the ReactInstanceSettings when using XamlIslands.")
+      "Sets the @Windows.UI.Xaml.XamlRoot element for the app. "
+      "This must be manually provided to the @ReactInstanceSettings object when using XAML Islands "
+      "so that certain APIs work correctly.\n"
+      "For more information, see [Host WinRT XAML Controls in desktop apps (XAML Islands)]"
+      "(https://docs.microsoft.com/windows/apps/desktop/modernize/xaml-islands).")
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
 
-    // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
     DOC_STRING(
-      "Sets accessible FrameworkElement for app. Make sure the element is able to create an automation peer. "
-      "This must be manually provided to the ReactInstanceSettings when using XamlIslands "
-      "to have access to accessibility methods.")
+      "Sets the @Windows.UI.Xaml.FrameworkElement that will act as the default accessible element for the app. "
+      "The element must be able to create an automation peer "
+      "(see @Windows.UI.Xaml.Automation.Peers.FrameworkElementAutomationPeer), or have a Landmark property set "
+      "(see @Windows.UI.Xaml.Automation.AutomationProperties.LandmarkTypeProperty Property).\n"
+      "This must be manually provided to the @ReactInstanceSettings when using XAML Islands "
+      "to have access to functionality related to accessibility.")
     static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement accessibleRoot);
 
-    DOC_STRING("Retrieve XamlRoot for app.")
+    DOC_STRING("Retrieves XamlRoot for app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
 
-    DOC_STRING("Retrieve accessible FrameworkElement for app.")
+    DOC_STRING("Retrieves accessible FrameworkElement for app.")
     static XAML_NAMESPACE.FrameworkElement GetAccessibleRoot(IReactPropertyBag properties);
 
+    DOC_STRING(
+      "Gets the window handle HWND (as an UInt64) used as the XAML Island window for the current React instance.")
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);
 
     DOC_STRING(
-      "Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. "
+      "Sets the windowHandle HWND (as an UInt64) to be the XAML Island window for the current React instance.\n"
       "Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")
     static void SetIslandWindowHandle(IReactPropertyBag properties, UInt64 windowHandle);
   }

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -6,12 +6,15 @@ import "IReactContext.idl";
 #include "NamespaceRedirect.h"
 #include "DocString.h"
 
-namespace Microsoft.ReactNative {
-
+namespace Microsoft.ReactNative
+{
   [default_interface]
   [webhosthidden]
-  DOC_STRING("Provides access to XAML UI-specific functionality. It provides access to APIs to get a XAML element from a react tag, and to dispatch events to JS components.")
-  runtimeclass XamlUIService {
+  DOC_STRING(
+    "Provides access to XAML UI-specific functionality. "
+    "It provides access to APIs to get a XAML element from a react tag, and to dispatch events to JS components.")
+  runtimeclass XamlUIService
+  {
     DOC_STRING("Use this method to gain access to the `XamlUIService` from a `ReactContext`.")
     static XamlUIService FromContext(IReactContext context);
 
@@ -23,18 +26,28 @@ namespace Microsoft.ReactNative {
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
-    DOC_STRING("Set XamlRoot for app. This must be manually provided to the ReactInstanceSettings when using XamlIslands.")
+    DOC_STRING(
+      "Set XamlRoot for app. This must be manually provided to the ReactInstanceSettings when using XamlIslands.")
     static void SetXamlRoot(IReactPropertyBag properties, XAML_NAMESPACE.XamlRoot xamlRoot);
+
     // This needs to be manually provided to the ReactInstanceSettings when using XamlIslands
-    DOC_STRING("Set accessible FrameworkElement for app. Make sure the element is able to create an automation peer. This must be manually provided to the ReactInstanceSettings when using XamlIslands to have access to accessibility methods.")
+    DOC_STRING(
+      "Sets accessible FrameworkElement for app. Make sure the element is able to create an automation peer. "
+      "This must be manually provided to the ReactInstanceSettings when using XamlIslands "
+      "to have access to accessibility methods.")
     static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement accessibleRoot);
+
     DOC_STRING("Retrieve XamlRoot for app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
+
     DOC_STRING("Retrieve accessible FrameworkElement for app.")
     static XAML_NAMESPACE.FrameworkElement GetAccessibleRoot(IReactPropertyBag properties);
 
     static UInt64 GetIslandWindowHandle(IReactPropertyBag properties);
-    DOC_STRING("Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")
+
+    DOC_STRING(
+      "Sets the windowHandle HWND (as an uint64) to be the XAML Island window for the current React instance. "
+      "Pass the value returned by IDesktopWindowXamlSourceNative get_WindowHandle.")
     static void SetIslandWindowHandle(IReactPropertyBag properties, UInt64 windowHandle);
   }
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
In this PR we update contents and formatting of the DOC_STRINGs in IDL files.
They are used to generate docs for the ABI-safe API docs.
The PR covers changes to the following files:
- IReactContext.idl
- IReactDispatcher.idl
- IReactModuleBuilder.idl
- IReactNonAbiValue.idl
- IReactNotificationService.idl
- IReactPackageBuilder.idl
- IReactPackageProvbider.idl
- IReactPropertyBag.idl
- JsiApi.idl
- QuirkSettings.idl
- ReactApplication.idl
- ReactInstanceSettings.idl
- ReactNativeHost.idl
- ReactRootView.idl
- RedBoxHandler.idl
- XamlHelper.idl
- XamlUIService.idl


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7393)