### PR TITLE
Get constants for view manager throws

### DIFF
--- a/change/react-native-windows-2a59f263-f757-4309-93ae-257a58fa468a.json
+++ b/change/react-native-windows-2a59f263-f757-4309-93ae-257a58fa468a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix redbox on boot when using web debugging",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/ReactNative/PaperUIManager.windows.js
+++ b/vnext/src/Libraries/ReactNative/PaperUIManager.windows.js
@@ -33,6 +33,7 @@ function getConstants(): Object {
 function getViewManagerConfig(viewManagerName: string): any {
   if (
     viewManagerConfigs[viewManagerName] === undefined &&
+    global.nativeCallSyncHook && // [Windows] getConstantsForViewManager doesn't work while web debugging. So skip calling it since all constants will have been provided ahead of time.
     NativeUIManager.getConstantsForViewManager
   ) {
     try {


### PR DESCRIPTION
Fixes #7295.

There is some debug code used to detect deprecated properties - https://github.com/facebook/react-native/blob/e68cf7cee9d36271a1d3899fecff817304bb8bdc/Libraries/Utilities/deprecatedPropType.js#L26

Part of that code will call `UIManager.hasViewManagerConfig` for View/Image (since they have the deprecatedPropType set).  This function should return false, but in the process it calls into `UIManager.getViewManagerConfig`.  This is protected by a null check of `UIManager.getViewManagerConfig`.  

Ideally we'd be able to have the web debugging version of UIManager not provide that method, but without manually implementing the module instead of using the macros, I dont see a good way to have the module provide difference methods in webdebugging vs non-webdebugging.  Instead, I've added an if check for web debugging on the JS side to avoid the call.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7397)