### PR TITLE
Fix build for codegen test on new agents

### DIFF
--- a/change/react-native-windows-03e0841c-eea4-4548-912a-5ca9abe8284d.json
+++ b/change/react-native-windows-03e0841c-eea4-4548-912a-5ca9abe8284d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "AzDO image now installs uwp package 6.2.11, not 6.2.10; Update Codegen UnitTest",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
@@ -60,9 +60,15 @@ public class TestClass
 
             var references = new List<string>();
 
-            var microsoftNetCoreUwpPkgVersion = "6.2.10";
             var uapVersion = "uap10.0.15138";
-            var microsoftNetCoreUwpPkgFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft SDKs", "UWPNuGetPackages", "microsoft.netcore.universalwindowsplatform", microsoftNetCoreUwpPkgVersion, "ref", uapVersion);
+            var uwpPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), 
+                "Microsoft SDKs", "UWPNuGetPackages", "microsoft.netcore.universalwindowsplatform");
+
+            var versions = Directory.GetDirectories(uwpPath).Select(x => new Version(Path.GetFileName(x)));
+            Assert.IsTrue(versions.Count() > 0);
+            var microsoftNetCoreUwpPkgVersion = versions.Max();
+            Assert.IsTrue(microsoftNetCoreUwpPkgVersion >= "6.2.10");
+            var microsoftNetCoreUwpPkgFolder = Path.Combine(uwpPath, microsoftNetCoreUwpPkgVersion, "ref", uapVersion);
             if (!Directory.Exists(microsoftNetCoreUwpPkgFolder))
             {
                 Assert.Fail($"Could not find path {microsoftNetCoreUwpPkgFolder}. This should have been installed as part of the UWP workload for Microsoft Visual Studio 2019 version 16.6");

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
@@ -68,7 +68,7 @@ public class TestClass
             Assert.IsTrue(versions.Count() > 0);
             var microsoftNetCoreUwpPkgVersion = versions.Max();
             Assert.IsTrue(microsoftNetCoreUwpPkgVersion >= new Version("6.2.10"));
-            var microsoftNetCoreUwpPkgFolder = Path.Combine(uwpPath, microsoftNetCoreUwpPkgVersion, "ref", uapVersion);
+            var microsoftNetCoreUwpPkgFolder = Path.Combine(uwpPath, microsoftNetCoreUwpPkgVersion.ToString(), "ref", uapVersion);
             if (!Directory.Exists(microsoftNetCoreUwpPkgFolder))
             {
                 Assert.Fail($"Could not find path {microsoftNetCoreUwpPkgFolder}. This should have been installed as part of the UWP workload for Microsoft Visual Studio 2019 version 16.6");

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/AnalysisTestBase.cs
@@ -67,7 +67,7 @@ public class TestClass
             var versions = Directory.GetDirectories(uwpPath).Select(x => new Version(Path.GetFileName(x)));
             Assert.IsTrue(versions.Count() > 0);
             var microsoftNetCoreUwpPkgVersion = versions.Max();
-            Assert.IsTrue(microsoftNetCoreUwpPkgVersion >= "6.2.10");
+            Assert.IsTrue(microsoftNetCoreUwpPkgVersion >= new Version("6.2.10"));
             var microsoftNetCoreUwpPkgFolder = Path.Combine(uwpPath, microsoftNetCoreUwpPkgVersion, "ref", uapVersion);
             if (!Directory.Exists(microsoftNetCoreUwpPkgFolder))
             {


### PR DESCRIPTION
The AzDO agents now include VS with uwp 6.2.11, not 6.2.10; the codegen integration tests had a strict version dependency, relaxing it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7398)