### PR TITLE
Improve error message for forgetting to run `Yarn change`

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -33,7 +33,7 @@ stages:
           - task: CmdLine@2
             displayName: Check for change files
             inputs:
-              script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+              script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
 
           - template: templates/set-version-vars.yml
             parameters:


### PR DESCRIPTION
I've noticed that frequently contributers that don't primary work in our repo miss running `yarn change` and we have to explain it.
This hopefully will put the error more front and center and make it more self-serve for our contributors.

## ADO shows
![image](https://user-images.githubusercontent.com/11037542/111384774-1c54b900-8667-11eb-8b9f-a6a63560bcf7.png)
and
![image](https://user-images.githubusercontent.com/11037542/111384865-3bebe180-8667-11eb-8f0a-b32cf8ffa616.png)


## GitHub now shows:
![image](https://user-images.githubusercontent.com/11037542/111384696-0f37ca00-8667-11eb-8c0a-d45b3deda54d.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7405)