### PR TITLE
Add onKeyDown/onKeyUp to Pressable.

### DIFF
--- a/change/react-native-windows-c7f8bf18-e09f-40e2-b3a6-6c1b1c388391.json
+++ b/change/react-native-windows-c7f8bf18-e09f-40e2-b3a6-6c1b1c388391.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add onKeyDown/onKeyUp to Pressable.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -17,6 +17,7 @@ import {
   TouchableHighlight,
   Platform,
   View,
+  Switch,
 } from 'react-native';
 
 const {useEffect, useRef, useState} = React;
@@ -294,6 +295,59 @@ function PressableFocusCallbacks() {
   );
 }
 
+function PressWithOnKeyDown() {
+  const [timesPressed, setTimesPressed] = useState(0);
+  const [text, setText] = useState('defaultText');
+
+  let textLog = '';
+  if (timesPressed > 1) {
+    textLog = timesPressed + 'x onPress';
+  } else if (timesPressed > 0) {
+    textLog = 'onPress';
+  }
+
+  const [shouldPreventDefault, setShouldPreventDefault] = useState(false);
+  const toggleSwitch = () =>
+    setShouldPreventDefault(previousState => !previousState);
+
+  function myKeyDown(event) {
+    console.log('keyDown - ' + event.nativeEvent.code);
+    setText(event.nativeEvent.code);
+    if (shouldPreventDefault) {
+      event.preventDefault();
+    }
+  }
+  function myKeyUp(event) {
+    console.log('keyUp - ' + event.nativeEvent.code);
+    setText(event.nativeEvent.code);
+    if (shouldPreventDefault) {
+      event.preventDefault();
+    }
+  }
+
+  return (
+    <>
+      <View style={styles.row}>
+        <Pressable
+          onKeyDown={event => myKeyDown(event)}
+          onKeyUp={event => myKeyUp(event)}
+          onPress={() => {
+            setTimesPressed(current => current + 1);
+          }}>
+          {({pressed}) => (
+            <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
+          )}
+        </Pressable>
+        <Switch onValueChange={toggleSwitch} value={shouldPreventDefault} />
+      </View>
+      <View style={styles.logBox}>
+        <Text testID="pressable_press_console">{textLog}</Text>
+        <Text>{text}</Text>
+      </View>
+    </>
+  );
+}
+
 const styles = StyleSheet.create({
   row: {
     justifyContent: 'center',
@@ -528,6 +582,15 @@ exports.examples = [
       'They also expose onFocus and onBlur callbacks to hadle incoming native events.': string),
     render: function(): React.Node {
       return <PressableFocusCallbacks />;
+    },
+  },
+  {
+    title: 'OnKeyDown/OnKeyUp callbacks on Pressable',
+    description: ('<Pressable> components can be respond to keyDown/keyUp native events.' + 
+    ' Additionally, they can be activated by pressing Space or Enter as if they were clicked with the mouse, triggering onPress' + 
+      ' - this behavior can be suppressed by calling e.preventDefault() on the event (can be toggled with the switch).': string),
+    render: function(): React.Node {
+      return <PressWithOnKeyDown />;
     },
   },
 ];

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -586,8 +586,8 @@ exports.examples = [
   },
   {
     title: 'OnKeyDown/OnKeyUp callbacks on Pressable',
-    description: ('<Pressable> components can be respond to keyDown/keyUp native events.' + 
-    ' Additionally, they can be activated by pressing Space or Enter as if they were clicked with the mouse, triggering onPress' + 
+    description: ('<Pressable> components can be respond to keyDown/keyUp native events.' +
+      ' Additionally, they can be activated by pressing Space or Enter as if they were clicked with the mouse, triggering onPress' +
       ' - this behavior can be suppressed by calling e.preventDefault() on the event (can be toggled with the switch).': string),
     render: function(): React.Node {
       return <PressWithOnKeyDown />;

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -126,6 +126,16 @@ type Props = $ReadOnly<{|
    */
   onFocus?: ?(event: FocusEvent) => mixed,
 
+  /*
+   * Called after a key down event is detected.
+   */
+  onKeyDown?: ?(event: KeyEvent) => mixed,
+
+  /*
+   * Called after a key up event is detected.
+   */
+  onKeyUp?: ?(event: KeyEvent) => mixed,
+
   /**
    * Either view styles or a function that receives a boolean reflecting whether
    * the component is currently pressed and returns view styles.
@@ -179,6 +189,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
     // [Windows
     onBlur,
     onFocus,
+    onKeyDown,
+    onKeyUp,
     // Windows]
     pressRetentionOffset,
     style,
@@ -259,6 +271,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
       // [Windows
       onBlur,
       onFocus,
+      onKeyDown,
+      onKeyUp,
       // Windows]
     }),
     [
@@ -275,6 +289,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
       // [Windows
       onBlur,
       onFocus,
+      onKeyDown,
+      onKeyUp,
       // Windows]
       pressRetentionOffset,
       setPressed,

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -28,7 +28,8 @@ import type {
   PressEvent,
   // [Windows
   BlurEvent,
-  FocusEvent, // Windows]
+  FocusEvent,
+  KeyEvent, // Windows]
 } from '../../Types/CoreEventTypes';
 import View from '../View/View';
 import TextInputState from '../TextInput/TextInputState';

--- a/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
+++ b/vnext/src/Libraries/Components/View/ViewPropTypes.windows.js
@@ -379,7 +379,7 @@ type IOSViewProps = $ReadOnly<{|
 
 // [Windows
 
-type HandledKeyboardEvent = $ReadOnly<{|
+export type HandledKeyboardEvent = $ReadOnly<{|
   altKey?: ?boolean,
   ctrlKey?: ?boolean,
   metaKey?: ?boolean,

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -657,6 +657,7 @@ export default class Pressability {
           event.nativeEvent.code === 'Enter' ||
           event.nativeEvent.code === 'GamepadA'
         ) {
+          // flowlint sketchy-null:warn, sketchy-null-bool:off
           if (!event.defaultPrevented) {
             const {onPressOut, onPress} = this._config;
             // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
@@ -675,6 +676,7 @@ export default class Pressability {
           event.nativeEvent.code === 'Enter' ||
           event.nativeEvent.code === 'GamepadA'
         ) {
+          // flowlint sketchy-null:warn, sketchy-null-bool:off
           if (!event.defaultPrevented) {
             const {onPressIn} = this._config;
             // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -653,18 +653,16 @@ export default class Pressability {
         onKeyUp && onKeyUp(event);
 
         if (
-          event.nativeEvent.code === 'Space' ||
-          event.nativeEvent.code === 'Enter' ||
-          event.nativeEvent.code === 'GamepadA'
+          (event.nativeEvent.code === 'Space' ||
+            event.nativeEvent.code === 'Enter' ||
+            event.nativeEvent.code === 'GamepadA') &&
+          event.defaultPrevented != true
         ) {
-          // flowlint sketchy-null:warn, sketchy-null-bool:off
-          if (!event.defaultPrevented) {
-            const {onPressOut, onPress} = this._config;
-            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-            onPressOut && onPressOut(event);
-            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-            onPress && onPress(event);
-          }
+          const {onPressOut, onPress} = this._config;
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPressOut && onPressOut(event);
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPress && onPress(event);
         }
       },
       onKeyDown: (event: KeyEvent): void => {
@@ -672,16 +670,14 @@ export default class Pressability {
         onKeyDown && onKeyDown(event);
 
         if (
-          event.nativeEvent.code === 'Space' ||
-          event.nativeEvent.code === 'Enter' ||
-          event.nativeEvent.code === 'GamepadA'
+          (event.nativeEvent.code === 'Space' ||
+            event.nativeEvent.code === 'Enter' ||
+            event.nativeEvent.code === 'GamepadA') &&
+          event.defaultPrevented != true
         ) {
-          // flowlint sketchy-null:warn, sketchy-null-bool:off
-          if (!event.defaultPrevented) {
-            const {onPressIn} = this._config;
-            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-            onPressIn && onPressIn(event);
-          }
+          const {onPressIn} = this._config;
+          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+          onPressIn && onPressIn(event);
         }
       },
     };

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -92,6 +92,16 @@ export type PressabilityConfig = $ReadOnly<{|
    */
   onFocus?: ?(event: FocusEvent) => mixed,
 
+  /*
+   * Called after a key down event is detected.
+   */
+  onKeyDown?: ?(event: KeyEvent) => mixed,
+
+  /*
+   * Called after a key up event is detected.
+   */
+  onKeyUp?: ?(event: KeyEvent) => mixed,
+
   /**
    * Called when the hover is activated to provide visual feedback.
    */
@@ -639,29 +649,37 @@ export default class Pressability {
     // [Windows
     const keyboardEventHandlers = {
       onKeyUp: (event: KeyEvent): void => {
+        const {onKeyUp} = this._config;
+        onKeyUp && onKeyUp(event);
+
         if (
           event.nativeEvent.code === 'Space' ||
           event.nativeEvent.code === 'Enter' ||
           event.nativeEvent.code === 'GamepadA'
         ) {
-          const {onPressOut, onPress} = this._config;
-
-          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-          onPressOut && onPressOut(event);
-          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-          onPress && onPress(event);
+          if (!event.defaultPrevented) {
+            const {onPressOut, onPress} = this._config;
+            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+            onPressOut && onPressOut(event);
+            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+            onPress && onPress(event);
+          }
         }
       },
       onKeyDown: (event: KeyEvent): void => {
+        const {onKeyDown} = this._config;
+        onKeyDown && onKeyDown(event);
+
         if (
           event.nativeEvent.code === 'Space' ||
           event.nativeEvent.code === 'Enter' ||
           event.nativeEvent.code === 'GamepadA'
         ) {
-          const {onPressIn} = this._config;
-
-          // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
-          onPressIn && onPressIn(event);
+          if (!event.defaultPrevented) {
+            const {onPressIn} = this._config;
+            // $FlowFixMe: PressEvents don't mesh with keyboarding APIs. Keep legacy behavior of passing KeyEvents instead
+            onPressIn && onPressIn(event);
+          }
         }
       },
     };


### PR DESCRIPTION
Currently, the `onKeyDown|Up` properties only respond to pressing `Space/Enter/GamepadA`, and do so by firing `onPress|(in|out)` events. 

Adding support for invoking the `onKeyDown|Up` callbacks, if provided. Preserving the current behavior by executing it conditionally, if `preventDefault()` wasn't called on the event. 


https://user-images.githubusercontent.com/12816515/111390420-ef58d400-866f-11eb-816b-fe7e69c1390f.mp4



Fixes #7185 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7406)