### PR TITLE
[0.64] Bump xmldom to 0.5.0.

### DIFF
--- a/change/@react-native-windows-cli-8bc4d332-33c7-4e49-860e-3d7dab8011a3.json
+++ b/change/@react-native-windows-cli-8bc4d332-33c7-4e49-860e-3d7dab8011a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump xmldom to 0.5.0.",
+  "packageName": "@react-native-windows/cli",
+  "email": "yicyao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -31,7 +31,7 @@
     "username": "^5.1.0",
     "uuid": "^3.3.2",
     "xml-parser": "^1.2.1",
-    "xmldom": "^0.3.0",
+    "xmldom": "^0.5.0",
     "xpath": "^0.0.27"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12585,10 +12585,10 @@ xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27:
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
   integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
 
-xmldom@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.3.0.tgz#e625457f4300b5df9c2e1ecb776147ece47f3e5a"
-  integrity sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xpath@0.0.27, xpath@^0.0.27:
   version "0.0.27"


### PR DESCRIPTION
Bumping the xmldom dependency in react-native-windows\cli to mitigate security vulnerability CVE-2021-21366. master has already been updated. See #7412 for corresponding PR for 0.63.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7413)