### PR TITLE
Make BaseWebSocketResource destructor noexcept

### DIFF
--- a/change/react-native-windows-885d112a-fe20-474d-8ac2-06adf41cdf0d.json
+++ b/change/react-native-windows-885d112a-fe20-474d-8ac2-06adf41cdf0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make BaseWebSocketResource destructor noexcept",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -38,7 +38,7 @@ template <typename SocketLayer, typename Stream>
 BaseWebSocketResource<SocketLayer, Stream>::BaseWebSocketResource(Url &&url) : m_url{std::move(url)} {}
 
 template <typename SocketLayer, typename Stream>
-BaseWebSocketResource<SocketLayer, Stream>::~BaseWebSocketResource() {
+BaseWebSocketResource<SocketLayer, Stream>::~BaseWebSocketResource() noexcept {
   if (!m_context.stopped()) {
     if (!m_closeRequested)
       Close(CloseCode::GoingAway, "Terminating instance");


### PR DESCRIPTION
Prevents a compilation error after the upgrade to VS 16.9.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7415)