### PR TITLE
Enable apps to override WinUI and SDK version for RNW framework projects

### DIFF
--- a/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
+++ b/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable overriding WinUI and SDK versions via ExperimentalFeatures.props",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -35,7 +35,6 @@
    <!-- Ensure the Win10 SDK binaries loaded by the unittest match our apps SDK versions -->
   <PropertyGroup>
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersionEncoded>$(WindowsTargetPlatformVersion.Replace('.', '_'))</WindowsTargetPlatformVersionEncoded>
     <DefineConstants>$(p:DefineConstants);win10SdkVersion$(WindowsTargetPlatformVersionEncoded)</DefineConstants>
   </PropertyGroup>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -6,7 +6,7 @@
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <!-- Use 19H1 SDK (10.0.18362.0)  Support running on RS3+ (10.0.16299.0) -->
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' Or '$(WindowsTargetPlatformVersion)'=='10.0.0.0'">10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'=='' Or '$(WindowsTargetPlatformVersion)'=='10.0.0.0'">10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'=='' Or '$(WindowsTargetPlatformMinVersion)'=='10.0.0.0'">10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -5,8 +5,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <!-- Use 19H1 SDK (10.0.18362.0)  Support running on RS3+ (10.0.16299.0) -->
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'==''">10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' Or '$(WindowsTargetPlatformVersion)'=='10.0.0.0'">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'=='' Or '$(WindowsTargetPlatformVersion)'=='10.0.0.0'">10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -5,8 +5,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <!-- Use 19H1 SDK (10.0.18362.0)  Support running on RS3+ (10.0.16299.0) -->
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'==''">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'==''">10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup Label="WinUI2x versioning">
 		<!--This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI2xVersion Condition="'$(WinUI2xVersion)'=''">2.5.0</WinUI2xVersion>
+    <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.5.0</WinUI2xVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseWinUI3)'=='true'">

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -2,12 +2,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="WinUI3 versioning">
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI3Version>3.0.0-preview4.210210.4</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">3.0.0-preview4.210210.4</WinUI3Version>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">
 		<!--This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI2xVersion>2.5.0</WinUI2xVersion>
+    <WinUI2xVersion Condition="'$(WinUI2xVersion)'=''">2.5.0</WinUI2xVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseWinUI3)'=='true'">


### PR DESCRIPTION
Fixes #7414 

This change enables an app to use ExperimentalFeatures.props (or another props file that gets loaded early enough) to override WindowsTargetPlatformVersion and WinUI2xVersion/WinUI3Version

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7416)