### PR TITLE
Update option name due to breaking change in create-react-native-module

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -108,7 +108,7 @@ steps:
   - task: CmdLine@2
     displayName: Init new lib project
     inputs:
-      script: npx create-react-native-module --module-name "testcli" testcli
+      script: npx create-react-native-module --package-name "testcli" testcli
       workingDirectory: $(Agent.BuildDirectory)
     condition: and(succeeded(), eq(variables['localProjectType'], 'lib'))
   


### PR DESCRIPTION
Fixes #7419 
The 0.20.0 version of create-react-native-module which was just published contains breaking changes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7420)