### PR TITLE
Add retries to Folly download

### DIFF
--- a/change/react-native-windows-e8fc0ecf-f569-432a-a940-79548093f13f.json
+++ b/change/react-native-windows-e8fc0ecf-f569-432a-a940-79548093f13f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add retries to Folly download since it sometimes fails in CI",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -275,7 +275,11 @@
   </Target>
   <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
     <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" />
-    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" SourceUrl="https://github.com/facebook/folly/archive/v$(FollyVersion).zip" DestinationFileName="folly-$(FollyVersion).zip" DestinationFolder="$(FollyDir)..\.follyzip" />
+    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" 
+      SourceUrl="https://github.com/facebook/folly/archive/v$(FollyVersion).zip" 
+      DestinationFileName="folly-$(FollyVersion).zip" 
+      DestinationFolder="$(FollyDir)..\.follyzip" 
+      Retries="10"/>
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
     <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />


### PR DESCRIPTION
Sometimes downloading Folly in CI is failing due to network flakiness, add some retry logic

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7421)