### PR TITLE
[0.64] Fix CI due to breaking change in create-react-native-module

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -94,7 +94,7 @@ steps:
   - task: CmdLine@2
     displayName: Init new lib project
     inputs:
-      script: npx create-react-native-module --module-name "testcli" testcli
+      script: npx create-react-native-module@^0.19.0 --module-name "testcli" testcli
       workingDirectory: $(Agent.BuildDirectory)
     condition: and(succeeded(), eq(variables['localProjectType'], 'lib'))
   


### PR DESCRIPTION
Fixes #7419 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7422)