### PR TITLE
Remove Root Level Perspective Transform

### DIFF
--- a/change/react-native-windows-5536d7c1-ee48-4e33-8072-fa4f519fef6d.json
+++ b/change/react-native-windows-5536d7c1-ee48-4e33-8072-fa4f519fef6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Perspective Transform",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.7.2-microsoft.5" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
+  <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.7.2-microsoft.5" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
-  <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
+  <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.7.2-microsoft.5" targetFramework="native"/>
 </packages>

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -11,7 +11,6 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactRootView::ReactRootView() noexcept {
   m_rootControl = std::make_shared<react::uwp::ReactRootControl>(*this);
-  UpdatePerspective();
   Loaded([this](auto &&, auto &&) {
     ::Microsoft::ReactNative::SetCompositor(::Microsoft::ReactNative::GetCompositor(*this));
   });
@@ -69,19 +68,4 @@ void ReactRootView::ReloadView() noexcept {
   }
 }
 
-void ReactRootView::UpdatePerspective() {
-  // Xaml's default projection in 3D is orthographic (all lines are parallel)
-  // However React Native's default projection is a one-point perspective.
-  // Set a default perspective projection on the main control to mimic this.
-  auto grid = m_rootControl->GetXamlView().as<xaml::Controls::Grid>();
-
-  if (m_isPerspectiveEnabled) {
-    auto perspectiveTransform3D = xaml::Media::Media3D::PerspectiveTransform3D();
-    perspectiveTransform3D.Depth(850);
-    xaml::Media::Media3D::Transform3D t3d(perspectiveTransform3D);
-    grid.Transform3D(t3d);
-  } else {
-    grid.ClearValue(xaml::UIElement::Transform3DProperty());
-  }
-}
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -30,7 +30,6 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   }
   void IsPerspectiveEnabled(bool value) noexcept {
     m_isPerspectiveEnabled = value;
-    UpdatePerspective();
   }
 
   void ReloadView() noexcept;
@@ -46,8 +45,6 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   folly::dynamic m_initialProps;
   bool m_isPerspectiveEnabled{true};
   std::shared_ptr<react::uwp::ReactRootControl> m_rootControl;
-
-  void UpdatePerspective();
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
**_Why_**
PopupViewManager and FlyoutViewManager attempt to work around a z-index shadowing issue by forcing a translation along the Z axis. This interacts poorly with the PerspectiveTransform3D set on the React root view (ReactControl), causing Popups and Flyouts to scale and text to become blurry as their Z position increases.

Perspective Transform is putting a transform into the DWM visual tree that is unsupported by DManip causing the WebView community module to be unable to scroll via Touch.

React Native's "transform" property supports a perspective setting, its not required. Transforms should be orthographic by default, and only change to perspective when a {perspective: value} entry is added to the transform array. Root-level transform should be removed in favor of components independently setting perspective if needed. Remove of transform also brings us into alignment with the other platforms.

Resolves #4466 

Resolves #6287

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7432)