### PR TITLE
Disable C4824 warning

### DIFF
--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -21,9 +21,10 @@
           C4290 - C++ exception specification ignored except to indicate a function is not __declspec(nothrow)
           C4309 - truncation of constant value
           C4324 - structure was padded due to __declspec(align())
+          C4824 - discarding return value of function with 'nodiscard' attribute
           C5205 - delete of an abstract class that has a non-virtual destructor results in undefined behavior
       -->
-    <ExtraWarningsToDisable>4068;4100;4101;4127;4189;4290;4309;4324;5205;$(DisableSpecificWarnings)</ExtraWarningsToDisable>
+    <ExtraWarningsToDisable>4068;4100;4101;4127;4189;4290;4309;4324;4824;5205;$(DisableSpecificWarnings)</ExtraWarningsToDisable>
   </PropertyGroup>
 
   <ItemDefinitionGroup>


### PR DESCRIPTION
While building react-native-windows projects in our internal repo, we're hitting this compile warning:

```
##[error]Build\react_native\node_modules\react-native\ReactCommon\runtimeexecutor\ReactCommon\RuntimeExecutor.h(42,14): Error C2220: the following warning is treated as an error (compiling source file D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\cxxreact\Instance.cpp)
     8>D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\runtimeexecutor\ReactCommon\RuntimeExecutor.h(42,14): error C2220: the following warning is treated as an error (compiling source file D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\cxxreact\Instance.cpp) [D:\a\1\s\Build\react_native\node_modules\react-native-windows\ReactCommon\ReactCommon.vcxproj]
##[warning]Build\react_native\node_modules\react-native\ReactCommon\runtimeexecutor\ReactCommon\RuntimeExecutor.h(42,14): Warning C4834: discarding return value of function with 'nodiscard' attribute (compiling source file D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\cxxreact\Instance.cpp)
     8>D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\runtimeexecutor\ReactCommon\RuntimeExecutor.h(42,14): warning C4834: discarding return value of function with 'nodiscard' attribute (compiling source file D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\cxxreact\Instance.cpp) [D:\a\1\s\Build\react_native\node_modules\react-native-windows\ReactCommon\ReactCommon.vcxproj]
       D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\runtimeexecutor\ReactCommon\RuntimeExecutor.h(42,14): message : to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings (compiling source file D:\a\1\s\Build\react_native\node_modules\react-native\ReactCommon\cxxreact\Instance.cpp) [D:\a\1\s\Build\react_native\node_modules\react-native-windows\ReactCommon\ReactCommon.vcxproj]
```

The root cause is from this function in `RuntimeExecutor.h` from core React Native due to not assigning the `std::thread` object to a named variable:

```cpp
inline static void executeAsynchronously(
    RuntimeExecutor const &runtimeExecutor,
    std::function<void(jsi::Runtime &runtime)> &&callback) noexcept {
  std::thread{[callback = std::move(callback), runtimeExecutor]() mutable {
    runtimeExecutor(std::move(callback));
  }};
}
```

The MSVC STL implementation tags `std::thread`'s constructor with `[[nodiscard]]` causing the warning. This PR adds C4834 to the set of warnings that are ignored while building react-native-windows components.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7435)