### PR TITLE
Fix deployment of x64 apps when they've also been already built for x86

### DIFF
--- a/change/@react-native-windows-cli-e8a45edf-cfc4-4a35-9121-5f3088d8799b.json
+++ b/change/@react-native-windows-cli-e8a45edf-cfc4-4a35-9121-5f3088d8799b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix deploy of x64 when x86 has already been built",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #7440 
The globbing we had for finding appxmanifest/recipes would find and favor the wrong architecture if more than one has been built

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7441)