### PR TITLE
[0.64] Autolinking doesn't add a project marked as a non-direct dependency

### DIFF
--- a/change/@react-native-windows-cli-d0076a39-a34a-488b-990f-f2622a21750d.json
+++ b/change/@react-native-windows-cli-d0076a39-a34a-488b-990f-f2622a21750d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Autolinking doesn't add a project marked as a non-direct dependency",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -267,7 +267,7 @@ async function updateAutoLink(
               dependencyIsValid = !!(
                 dependencyIsValid &&
                 item in project &&
-                project[item] &&
+                project[item] != '' &&
                 !project[item]!.toString().startsWith('Error: ')
               );
             });


### PR DESCRIPTION
Port #7437 to 0.64

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7447)