### PR TITLE
Workaround to make nuget restore more robust.

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -31,6 +31,14 @@ steps:
       installVsComponents: ${{ parameters.installVsComponents }}
       debug: ${{ parameters.debug }}
 
+   # Workaround to get NuGet more reliable per https://github.com/microsoft/artifacts-credprovider/issues/91#issuecomment-530907753
+   # It should behave been fixed from 5.5.x where we use 5.9.0.7134
+   # But maybe ADO's cred provider is not updated yet...
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS]20
+      Write-Host "##vso[task.setvariable variable=NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS]20
+    displayName: Workaround NuGet Auth Issues
+
   # NuGetCommand@2 workaround: https://developercommunity.visualstudio.com/content/problem/288534/vsts-yaml-build-failure-the-task-name-nugetcommand.html
   - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
     displayName: NuGet restore


### PR DESCRIPTION
Later nuget version should have fixed this issue per the links from https://stackoverflow.microsoft.com/questions/223717 but adding just in case it makes it more robust. Perhaps the ADO cred provider is not the latest and greatest.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7450)