### PR TITLE
[0.63] Autolinking doesn't add a project marked as a non-direct dependency

### DIFF
--- a/change/@react-native-windows-cli-7995510b-9839-4382-b2f4-2e6ebe444f00.json
+++ b/change/@react-native-windows-cli-7995510b-9839-4382-b2f4-2e6ebe444f00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.63] Autolinking doesn't add a project marked as a non-direct dependency",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -252,7 +252,7 @@ async function updateAutoLink(
               dependencyIsValid = !!(
                 dependencyIsValid &&
                 item in project &&
-                project[item] &&
+                project[item] != '' &&
                 !project[item]!.toString().startsWith('Error: ')
               );
             });


### PR DESCRIPTION
Port #7437 to 0.63

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7452)