### PR TITLE
[0.63] Remove 'use strict' from PlatformColorValueTypesWin32.d.ts

### DIFF
--- a/packages/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.d.ts
+++ b/packages/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.d.ts
@@ -8,8 +8,6 @@
  * @flow strict-local
  */
 
-'use strict';
-
 // Use ColorValue typings when available in 0.63
 // import {ColorValue} from 'react-native';
 


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7463)