### PR TITLE
Fix app template to use app.json's name for main component name

### DIFF
--- a/change/@react-native-windows-cli-0feca964-7b3e-404c-8e51-364f88390786.json
+++ b/change/@react-native-windows-cli-0feca964-7b3e-404c-8e51-364f88390786.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix app template to use app.json's name for main component name",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-c082b40c-f14b-48a1-b788-08264f8c0382.json
+++ b/change/react-native-windows-c082b40c-f14b-48a1-b788-08264f8c0382.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix app template to use app.json's name for main component name",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -22,6 +22,7 @@
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",
+    "find-up": "^4.1.0",
     "glob": "^7.1.1",
     "inquirer": "^3.0.6",
     "mustache": "^4.0.1",

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as semver from 'semver';
 import * as _ from 'lodash';
+import * as findUp from 'find-up';
 import {readProjectFile, findPropertyValue} from '../config/configUtils';
 
 import {
@@ -179,6 +180,12 @@ export async function copyProjectTemplateAndReplace(
   const packageGuid = uuid.v4();
   const currentUser = username.sync()!; // Gets the current username depending on the platform.
 
+  let mainComponentName = newProjectName;
+  const appJsonPath = findUp.sync('app.json', {cwd: destPath});
+  if (appJsonPath) {
+    mainComponentName = JSON.parse(fs.readFileSync(appJsonPath, 'utf8')).name;
+  }
+
   const certificateThumbprint =
     projectType === 'app'
       ? await generateCertificate(
@@ -281,6 +288,8 @@ export async function copyProjectTemplateAndReplace(
     namespace: namespace,
     namespaceCpp: namespaceCpp,
     languageIsCpp: language === 'cpp',
+
+    mainComponentName: mainComponentName,
 
     // Visual Studio is very picky about the casing of the guids for projects, project references and the solution
     // https://www.bing.com/search?q=visual+studio+project+guid+casing&cvid=311a5ad7f9fc41089507b24600d23ee7&FORM=ANAB01&PC=U531

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -181,7 +181,7 @@ export async function copyProjectTemplateAndReplace(
   const currentUser = username.sync()!; // Gets the current username depending on the platform.
 
   let mainComponentName = newProjectName;
-  const appJsonPath = findUp.sync('app.json', {cwd: destPath});
+  const appJsonPath = await findUp('app.json', {cwd: destPath});
   if (appJsonPath) {
     mainComponentName = JSON.parse(fs.readFileSync(appJsonPath, 'utf8')).name;
   }

--- a/vnext/template/shared-app/src/MainPage.xaml
+++ b/vnext/template/shared-app/src/MainPage.xaml
@@ -15,7 +15,7 @@
 {{^languageIsCpp}}
         x:Name="reactRootView"
 {{/languageIsCpp}}
-        ComponentName="{{ name }}"
+        ComponentName="{{ mainComponentName }}"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         MinHeight="400"/>
 </Page>


### PR DESCRIPTION
In react-native-community/cli#1370 the CLI was
changed in a way that can produce different values for the project name
(name in package.json) and the main component name (name in app.json).

Historically, sometimes older templates didn't set name in the
package.json at all, instead using app.json. So our CLI was written to
accomodate that logic (load name from package.json if possible, then
fallback to app.json). Either way, we use that single value everywhere
in our template, for file and varaible names.

This PR updates our template to use the value in app.json, if possible,
to set the component name to load. This matches the behavior on iOS and
and Android.

Closes #7451

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7464)