### PR TITLE
[0.64] Fix app template to use app.json's name for main component name (#7464)

### DIFF
--- a/change/@react-native-windows-cli-4be2d5ca-e277-4951-82bf-da53ce53d4de.json
+++ b/change/@react-native-windows-cli-4be2d5ca-e277-4951-82bf-da53ce53d4de.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Fix app template to use app.json's name for main component name (#7464)",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-49f20f25-562a-474d-a144-4ca4afc65f68.json
+++ b/change/react-native-windows-49f20f25-562a-474d-a144-4ca4afc65f68.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Fix app template to use app.json's name for main component name (#7464)",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -22,6 +22,7 @@
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",
+    "find-up": "^4.1.0",
     "glob": "^7.1.1",
     "inquirer": "^3.0.6",
     "mustache": "^4.0.1",

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as semver from 'semver';
 import * as _ from 'lodash';
+import * as findUp from 'find-up';
 import {readProjectFile, findPropertyValue} from '../config/configUtils';
 
 import {
@@ -163,6 +164,12 @@ export async function copyProjectTemplateAndReplace(
   const packageGuid = uuid.v4();
   const currentUser = username.sync()!; // Gets the current username depending on the platform.
 
+  let mainComponentName = newProjectName;
+  const appJsonPath = await findUp('app.json', {cwd: destPath});
+  if (appJsonPath) {
+    mainComponentName = JSON.parse(fs.readFileSync(appJsonPath, 'utf8')).name;
+  }
+
   const certificateThumbprint =
     projectType === 'app'
       ? await generateCertificate(
@@ -250,6 +257,8 @@ export async function copyProjectTemplateAndReplace(
     namespace: namespace,
     namespaceCpp: namespaceCpp,
     languageIsCpp: language === 'cpp',
+
+    mainComponentName: mainComponentName,
 
     // Visual Studio is very picky about the casing of the guids for projects, project references and the solution
     // https://www.bing.com/search?q=visual+studio+project+guid+casing&cvid=311a5ad7f9fc41089507b24600d23ee7&FORM=ANAB01&PC=U531

--- a/vnext/template/shared-app/src/MainPage.xaml
+++ b/vnext/template/shared-app/src/MainPage.xaml
@@ -15,7 +15,7 @@
 {{^languageIsCpp}}
         x:Name="reactRootView"
 {{/languageIsCpp}}
-        ComponentName="{{ name }}"
+        ComponentName="{{ mainComponentName }}"
         Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
         MinHeight="400"/>
 </Page>


### PR DESCRIPTION
[0.64] Fix app template to use app.json's name for main component name (#7464)

This PR backports #7464 to 0.64.

In react-native-community/cli#1370 the CLI was
changed in a way that can produce different values for the project name
(name in package.json) and the main component name (name in app.json).

Historically, sometimes older templates didn't set name in the
package.json at all, instead using app.json. So our CLI was written to
accomodate that logic (load name from package.json if possible, then
fallback to app.json). Either way, we use that single value everywhere
in our template, for file and varaible names.

This PR updates our template to use the value in app.json, if possible,
to set the component name to load. This matches the behavior on iOS and
and Android.

Closes #7451

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7471)