### PR TITLE
Enable modules to consume NuGet package

### DIFF
--- a/change/react-native-windows-04fae67d-8f70-40ea-a1f6-119f6f7134ff.json
+++ b/change/react-native-windows-04fae67d-8f70-40ea-a1f6-119f6f7134ff.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Enable libraries to use NuGet to (avoid mdmerge MDM2009 error)",
+  "comment": "Enable libraries to use NuGet too (avoid mdmerge MDM2009 error)",
   "packageName": "react-native-windows",
   "email": "asklar@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-04fae67d-8f70-40ea-a1f6-119f6f7134ff.json
+++ b/change/react-native-windows-04fae67d-8f70-40ea-a1f6-119f6f7134ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable libraries to use NuGet to (avoid mdmerge MDM2009 error)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -9,7 +9,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'UAP'">
-    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ReactNative.winmd">
+    <Reference Include="$(MSBuildThisFileDirectory)..\..\lib\uap10.0\Microsoft.ReactNative.winmd" Private="false">
       <Implementation>Microsoft.ReactNative.dll</Implementation>
     </Reference>
     


### PR DESCRIPTION
This change is necessary to work around a bug in mdmerge.
The scenario is as follows:
- native module/view manager references nuget
- app references nuget and also references native module project
You get an mdmerge error because there are two instantiations of the M.RN types (MDM2009). Same bug as microsoft/cppwinrt#452

The fix is to ensure that copy local is false which is achieved via the `Private` attribute.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7473)