### PR TITLE
[0.62] Fix app template to use app.json's name for main component name (#7464)

### DIFF
--- a/change/react-native-windows-2021-03-25-09-50-31-appjson62.json
+++ b/change/react-native-windows-2021-03-25-09-50-31-appjson62.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "[0.62] Fix app template to use app.json's name for main component name (#7464)",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-25T16:50:31.275Z"
+}

--- a/vnext/local-cli/config/dependencyConfig.js
+++ b/vnext/local-cli/config/dependencyConfig.js
@@ -7,7 +7,7 @@ function dependencyConfigWindows(folder, userConfig = {}) {
   if (userConfig === null) {
     return null;
   }
-  
+
   const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
 
   if (!sourceDir) {

--- a/vnext/local-cli/config/projectConfig.js
+++ b/vnext/local-cli/config/projectConfig.js
@@ -6,7 +6,7 @@ function projectConfigWindows(folder, userConfig = {}) {
   if (userConfig === null) {
     return null;
   }
-  
+
   const sourceDir = userConfig.sourceDir || findWindowsAppFolder(folder);
 
   if (!sourceDir) {

--- a/vnext/local-cli/generator-windows/index.js
+++ b/vnext/local-cli/generator-windows/index.js
@@ -81,11 +81,18 @@ function copyProjectTemplateAndReplace(
   const currentUser = username.sync(); // Gets the current username depending on the platform.
   const certificateThumbprint = generateCertificate(srcPath, destPath, newProjectName, currentUser);
 
+  let mainComponentName = newProjectName;
+  const appJsonPath = path.join(destPath, 'app.json');
+  if (fs.existsSync(appJsonPath)) {
+    mainComponentName = JSON.parse(fs.readFileSync(appJsonPath, 'utf8')).name;
+  }
+
   const templateVars = {
     '// clang-format off': '',
     '// clang-format on': '',
     '<%=ns%>': ns,
     '<%=name%>': newProjectName,
+    '<%=mainComponentName%>': mainComponentName,
     '<%=projectGuid%>': projectGuid,
     '<%=projectGuidUpper%>': projectGuid.toUpperCase(),
     '<%rnwVersion%>' : rnwVersion,

--- a/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
+++ b/vnext/local-cli/generator-windows/templates/cpp/src/App.cpp
@@ -16,7 +16,7 @@ using namespace winrt::<%=ns%>::implementation;
 /// </summary>
 App::App() noexcept
 {
-    MainComponentName(L"<%=name%>");
+    MainComponentName(L"<%=mainComponentName%>");
 
 #if BUNDLE
     JavaScriptBundleFile(L"index.windows");

--- a/vnext/local-cli/generator-windows/templates/cs/src/App.xaml.cs
+++ b/vnext/local-cli/generator-windows/templates/cs/src/App.xaml.cs
@@ -6,7 +6,7 @@ namespace <%=ns%>
     {
         public App()
         {
-            MainComponentName = "<%=name%>";
+            MainComponentName = "<%=mainComponentName%>";
 
 #if BUNDLE
             JavaScriptBundleFile = "index.windows";

--- a/vnext/src/IntegrationTests/websocket_integration_test_server_binary.js
+++ b/vnext/src/IntegrationTests/websocket_integration_test_server_binary.js
@@ -24,7 +24,7 @@ This will send each incoming message back, in binary form.
 
 const server = new WebSocket.Server({port: 5557});
 server.on('connection', ws => {
-  ws.binaryType = "arraybuffer";
+  ws.binaryType = 'arraybuffer';
   ws.on('message', message => {
     console.log(message);
 


### PR DESCRIPTION
This PR backports #7464 to 0.62.

In react-native-community/cli#1370 the CLI was
changed in a way that can produce different values for the project name
(name in package.json) and the main component name (name in app.json).

Historically, sometimes older templates didn't set name in the
package.json at all, instead using app.json. So our CLI was written to
accomodate that logic (load name from package.json if possible, then
fallback to app.json). Either way, we use that single value everywhere
in our template, for file and varaible names.

This PR updates our template to use the value in app.json, if possible,
to set the component name to load. This matches the behavior on iOS and
and Android.

Closes #7451

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7476)