### PR TITLE
[0.63] Fix AppStateModule::GetCurrentAppState from returning undefined

### DIFF
--- a/change/react-native-windows-2021-03-25-11-59-48-appstatechangeFix.json
+++ b/change/react-native-windows-2021-03-25-11-59-48-appstatechangeFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix AppStateModule::GetCurrentAppState from returning undefined",
+  "packageName": "react-native-windows",
+  "email": "namrog84@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2021-03-25T18:59:48.170Z"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -47,7 +47,11 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
 void AppState::GetCurrentAppState(
     std::function<void(React::JSValue const &)> const &success,
     std::function<void(React::JSValue const &)> const &error) noexcept {
-  success(m_active ? "active" : "background");
+  auto writer = React::MakeJSValueTreeWriter();
+  writer.WriteObjectBegin();
+  React::WriteProperty(writer, "app_state", m_active ? "active" : "background");
+  writer.WriteObjectEnd();
+  success(React::TakeJSValue(writer));
 }
 
 void AppState::AddListener(std::string && /*eventName*/) noexcept {


### PR DESCRIPTION
This fix is in RNW64, but is not currently in RNW63.
https://github.com/microsoft/react-native-windows/pull/6500/

Fix AppStateModule::GetCurrentAppState from returning undefined





###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7477)

Also relevant:
https://github.com/microsoft/react-native-windows/issues/6482