### PR TITLE
[0.64] Bump peer dependency to require non-rc version of react-native

### DIFF
--- a/change/@office-iss-react-native-win32-b242d66c-aec8-416c-9627-bfbad81339b1.json
+++ b/change/@office-iss-react-native-win32-b242d66c-aec8-416c-9627-bfbad81339b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump peer dependency to require non-rc version of react-native",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1e08502b-2b0f-460c-8875-7512862d716b.json
+++ b/change/react-native-windows-1e08502b-2b0f-460c-8875-7512862d716b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump peer dependency to require non-rc version of react-native",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/package.json
+++ b/packages/react-native-win32/package.json
@@ -77,7 +77,7 @@
   },
   "peerDependencies": {
     "react": "17.0.1",
-    "react-native": "^0.64.0-rc.1"
+    "react-native": "^0.64.0"
   },
   "beachball": {
     "defaultNpmTag": "latest",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "react": "17.0.1",
-    "react-native": "^0.64.0-rc.1"
+    "react-native": "^0.64.0"
   },
   "beachball": {
     "defaultNpmTag": "latest",


### PR DESCRIPTION
We actually require a change that happened in the final release of react-native, so bumping our peerDependency to reflect that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7478)