### PR TITLE
Implement JSI getOwnPropertyDescriptor

### DIFF
--- a/change/react-native-windows-dcbf0582-57f0-4850-9088-108360f8205f.json
+++ b/change/react-native-windows-dcbf0582-57f0-4850-9088-108360f8205f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement JSI getOwnPropertyDescriptor",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/JSI/ChakraRuntime.cpp
+++ b/vnext/Shared/JSI/ChakraRuntime.cpp
@@ -72,7 +72,7 @@ ChakraRuntime::ChakraRuntime(ChakraRuntimeArgs &&args) noexcept : m_args{std::mo
   m_propertyId.configurable = JsRefHolder{GetPropertyIdFromName(L"configurable")};
   m_propertyId.enumerable = JsRefHolder{GetPropertyIdFromName(L"enumerable")};
   m_propertyId.get = JsRefHolder{GetPropertyIdFromName(L"get")};
-  m_propertyId.getOwnPropertyDescriptor = JsRefHolder{ GetPropertyIdFromName(L"getOwnPropertyDescriptor") };
+  m_propertyId.getOwnPropertyDescriptor = JsRefHolder{GetPropertyIdFromName(L"getOwnPropertyDescriptor")};
   m_propertyId.hostFunctionSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostFunctionSymbol")};
   m_propertyId.hostObjectSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostObjectSymbol")};
   m_propertyId.length = JsRefHolder{GetPropertyIdFromName(L"length")};
@@ -791,33 +791,34 @@ JsValueRef CALLBACK ChakraRuntime::HostFunctionCall(
 }
 
 /*static*/ JsValueRef CALLBACK ChakraRuntime::HostObjectGetOwnPropertyDescriptorTrap(
-  JsValueRef callee,
-  bool isConstructCall,
-  JsValueRef* args,
-  unsigned short argCount,
-  void* callbackState) noexcept {
-  ChakraRuntime* chakraRuntime = static_cast<ChakraRuntime*>(callbackState);
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *args,
+    unsigned short argCount,
+    void *callbackState) noexcept {
+  ChakraRuntime *chakraRuntime = static_cast<ChakraRuntime *>(callbackState);
   return chakraRuntime->HandleCallbackExceptions([&]() {
-    ChakraVerifyElseThrow(!isConstructCall, "Constructor call for HostObjectGetOwnPropertyDescriptorTrap() is not supported.");
+    ChakraVerifyElseThrow(
+        !isConstructCall, "Constructor call for HostObjectGetOwnPropertyDescriptorTrap() is not supported.");
 
     // args[0] - the Proxy handler object (this) (unused).
     // args[1] - the Proxy target object.
     // args[2] - the property
     ChakraVerifyElseThrow(argCount == 3, "HostObjectGetOwnPropertyDescriptorTrap() requires 3 arguments.");
     const JsValueRef target = args[1];
-    auto const& hostObject = *static_cast<std::shared_ptr<facebook::jsi::HostObject> *>(GetExternalData(target));
+    auto const &hostObject = *static_cast<std::shared_ptr<facebook::jsi::HostObject> *>(GetExternalData(target));
 
     const JsValueRef propertyName = args[2];
     if (GetValueType(propertyName) == JsValueType::JsString) {
-      const PropNameIDView propertyId{ GetPropertyIdFromName(StringToPointer(propertyName).data()) };
+      const PropNameIDView propertyId{GetPropertyIdFromName(StringToPointer(propertyName).data())};
       return RunInMethodContext("HostObject::getOwnPropertyDescriptor", [&]() {
         auto value = chakraRuntime->ToJsValueRef(hostObject->get(*chakraRuntime, propertyId));
         auto descriptor = chakraRuntime->CreatePropertyDescriptor(value, PropertyAttibutes::None);
         return descriptor;
-        });
+      });
     }
     return static_cast<JsValueRef>(chakraRuntime->m_undefinedValue);
-    });
+  });
 }
 
 JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
@@ -828,8 +829,9 @@ JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
     SetProperty(
         handler, m_propertyId.ownKeys, CreateExternalFunction(m_propertyId.ownKeys, 1, HostObjectOwnKeysTrap, this));
     SetProperty(
-      handler, m_propertyId.getOwnPropertyDescriptor, 
-      CreateExternalFunction(m_propertyId.getOwnPropertyDescriptor, 3, HostObjectGetOwnPropertyDescriptorTrap, this));
+        handler,
+        m_propertyId.getOwnPropertyDescriptor,
+        CreateExternalFunction(m_propertyId.getOwnPropertyDescriptor, 3, HostObjectGetOwnPropertyDescriptorTrap, this));
     m_hostObjectProxyHandler = JsRefHolder{handler};
   }
 

--- a/vnext/Shared/JSI/ChakraRuntime.cpp
+++ b/vnext/Shared/JSI/ChakraRuntime.cpp
@@ -816,19 +816,6 @@ JsValueRef CALLBACK ChakraRuntime::HostFunctionCall(
         return descriptor;
         });
     }
-    //else if (GetValueType(propertyName) == JsValueType::JsSymbol) {
-    //  const auto chakraPropertyId = GetPropertyIdFromSymbol(propertyName);
-    //  if (chakraPropertyId == chakraRuntime->m_propertyId.hostObjectSymbol) {
-    //    // The special property to retrieve the target object.
-    //    return target;
-    //  }
-    //  else {
-    //    const PropNameIDView propertyId{ chakraPropertyId };
-    //    return RunInMethodContext("HostObject::getOwnPropertyDescriptor", [&]() {
-    //      return chakraRuntime->ToJsValueRef(hostObject->get(*chakraRuntime, propertyId));
-    //      });
-    //  }
-    //}
     return static_cast<JsValueRef>(chakraRuntime->m_undefinedValue);
     });
 }

--- a/vnext/Shared/JSI/ChakraRuntime.cpp
+++ b/vnext/Shared/JSI/ChakraRuntime.cpp
@@ -72,6 +72,7 @@ ChakraRuntime::ChakraRuntime(ChakraRuntimeArgs &&args) noexcept : m_args{std::mo
   m_propertyId.configurable = JsRefHolder{GetPropertyIdFromName(L"configurable")};
   m_propertyId.enumerable = JsRefHolder{GetPropertyIdFromName(L"enumerable")};
   m_propertyId.get = JsRefHolder{GetPropertyIdFromName(L"get")};
+  m_propertyId.getOwnPropertyDescriptor = JsRefHolder{ GetPropertyIdFromName(L"getOwnPropertyDescriptor") };
   m_propertyId.hostFunctionSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostFunctionSymbol")};
   m_propertyId.hostObjectSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostObjectSymbol")};
   m_propertyId.length = JsRefHolder{GetPropertyIdFromName(L"length")};
@@ -789,6 +790,49 @@ JsValueRef CALLBACK ChakraRuntime::HostFunctionCall(
   });
 }
 
+/*static*/ JsValueRef CALLBACK ChakraRuntime::HostObjectGetOwnPropertyDescriptorTrap(
+  JsValueRef callee,
+  bool isConstructCall,
+  JsValueRef* args,
+  unsigned short argCount,
+  void* callbackState) noexcept {
+  ChakraRuntime* chakraRuntime = static_cast<ChakraRuntime*>(callbackState);
+  return chakraRuntime->HandleCallbackExceptions([&]() {
+    ChakraVerifyElseThrow(!isConstructCall, "Constructor call for HostObjectGetOwnPropertyDescriptorTrap() is not supported.");
+
+    // args[0] - the Proxy handler object (this) (unused).
+    // args[1] - the Proxy target object.
+    // args[2] - the property
+    ChakraVerifyElseThrow(argCount == 3, "HostObjectGetOwnPropertyDescriptorTrap() requires 3 arguments.");
+    const JsValueRef target = args[1];
+    auto const& hostObject = *static_cast<std::shared_ptr<facebook::jsi::HostObject> *>(GetExternalData(target));
+
+    const JsValueRef propertyName = args[2];
+    if (GetValueType(propertyName) == JsValueType::JsString) {
+      const PropNameIDView propertyId{ GetPropertyIdFromName(StringToPointer(propertyName).data()) };
+      return RunInMethodContext("HostObject::getOwnPropertyDescriptor", [&]() {
+        auto value = chakraRuntime->ToJsValueRef(hostObject->get(*chakraRuntime, propertyId));
+        auto descriptor = chakraRuntime->CreatePropertyDescriptor(value, PropertyAttibutes::None);
+        return descriptor;
+        });
+    }
+    //else if (GetValueType(propertyName) == JsValueType::JsSymbol) {
+    //  const auto chakraPropertyId = GetPropertyIdFromSymbol(propertyName);
+    //  if (chakraPropertyId == chakraRuntime->m_propertyId.hostObjectSymbol) {
+    //    // The special property to retrieve the target object.
+    //    return target;
+    //  }
+    //  else {
+    //    const PropNameIDView propertyId{ chakraPropertyId };
+    //    return RunInMethodContext("HostObject::getOwnPropertyDescriptor", [&]() {
+    //      return chakraRuntime->ToJsValueRef(hostObject->get(*chakraRuntime, propertyId));
+    //      });
+    //  }
+    //}
+    return static_cast<JsValueRef>(chakraRuntime->m_undefinedValue);
+    });
+}
+
 JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
   if (!m_hostObjectProxyHandler) {
     const JsValueRef handler = CreateObject();
@@ -796,6 +840,9 @@ JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
     SetProperty(handler, m_propertyId.set, CreateExternalFunction(m_propertyId.set, 3, HostObjectSetTrap, this));
     SetProperty(
         handler, m_propertyId.ownKeys, CreateExternalFunction(m_propertyId.ownKeys, 1, HostObjectOwnKeysTrap, this));
+    SetProperty(
+      handler, m_propertyId.getOwnPropertyDescriptor, 
+      CreateExternalFunction(m_propertyId.getOwnPropertyDescriptor, 3, HostObjectGetOwnPropertyDescriptorTrap, this));
     m_hostObjectProxyHandler = JsRefHolder{handler};
   }
 

--- a/vnext/Shared/JSI/ChakraRuntime.h
+++ b/vnext/Shared/JSI/ChakraRuntime.h
@@ -273,6 +273,13 @@ class ChakraRuntime : public facebook::jsi::Runtime, ChakraApi, ChakraApi::IExce
       unsigned short argCount,
       void *callbackState) noexcept;
 
+  static JsValueRef CALLBACK HostObjectGetOwnPropertyDescriptorTrap(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef* args,
+    unsigned short argCount,
+    void* callbackState) noexcept;
+
   JsValueRef GetHostObjectProxyHandler();
 
   // Evaluate lambda and augment exception messages with the methodName.
@@ -445,6 +452,7 @@ class ChakraRuntime : public facebook::jsi::Runtime, ChakraApi, ChakraApi::IExce
     JsRefHolder configurable;
     JsRefHolder enumerable;
     JsRefHolder get;
+    JsRefHolder getOwnPropertyDescriptor;
     JsRefHolder hostFunctionSymbol;
     JsRefHolder hostObjectSymbol;
     JsRefHolder length;

--- a/vnext/Shared/JSI/ChakraRuntime.h
+++ b/vnext/Shared/JSI/ChakraRuntime.h
@@ -274,11 +274,11 @@ class ChakraRuntime : public facebook::jsi::Runtime, ChakraApi, ChakraApi::IExce
       void *callbackState) noexcept;
 
   static JsValueRef CALLBACK HostObjectGetOwnPropertyDescriptorTrap(
-    JsValueRef callee,
-    bool isConstructCall,
-    JsValueRef* args,
-    unsigned short argCount,
-    void* callbackState) noexcept;
+      JsValueRef callee,
+      bool isConstructCall,
+      JsValueRef *args,
+      unsigned short argCount,
+      void *callbackState) noexcept;
 
   JsValueRef GetHostObjectProxyHandler();
 


### PR DESCRIPTION
Fixes #7488 
The `getOwnPropertyDescriptor` trap will enable enumerating properties so that methods like `JSON.stringify` or iterations like `for ... in` work with JSI objects.

Below is an image where a native hostobject returning a property is correctly shown via `JSON.stringify` in an alert.

![image](https://user-images.githubusercontent.com/22989529/112708778-38c7d100-8e71-11eb-9966-b0174b3135f3.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7489)