### PR TITLE
[0.64] getOwnPropertyDescriptor missing implementation

### DIFF
--- a/change/react-native-windows-a1ef06ee-6340-494c-bcec-f6cf094f4c70.json
+++ b/change/react-native-windows-a1ef06ee-6340-494c-bcec-f6cf094f4c70.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Implement JSI getOwnPropertyDescriptor",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/JSI/Shared/ChakraRuntime.cpp
+++ b/vnext/JSI/Shared/ChakraRuntime.cpp
@@ -72,6 +72,7 @@ ChakraRuntime::ChakraRuntime(ChakraRuntimeArgs &&args) noexcept : m_args{std::mo
   m_propertyId.configurable = JsRefHolder{GetPropertyIdFromName(L"configurable")};
   m_propertyId.enumerable = JsRefHolder{GetPropertyIdFromName(L"enumerable")};
   m_propertyId.get = JsRefHolder{GetPropertyIdFromName(L"get")};
+  m_propertyId.getOwnPropertyDescriptor = JsRefHolder{GetPropertyIdFromName(L"getOwnPropertyDescriptor")};
   m_propertyId.hostFunctionSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostFunctionSymbol")};
   m_propertyId.hostObjectSymbol = JsRefHolder{GetPropertyIdFromSymbol(L"hostObjectSymbol")};
   m_propertyId.length = JsRefHolder{GetPropertyIdFromName(L"length")};
@@ -789,6 +790,37 @@ JsValueRef CALLBACK ChakraRuntime::HostFunctionCall(
   });
 }
 
+/*static*/ JsValueRef CALLBACK ChakraRuntime::HostObjectGetOwnPropertyDescriptorTrap(
+    JsValueRef callee,
+    bool isConstructCall,
+    JsValueRef *args,
+    unsigned short argCount,
+    void *callbackState) noexcept {
+  ChakraRuntime *chakraRuntime = static_cast<ChakraRuntime *>(callbackState);
+  return chakraRuntime->HandleCallbackExceptions([&]() {
+    ChakraVerifyElseThrow(
+        !isConstructCall, "Constructor call for HostObjectGetOwnPropertyDescriptorTrap() is not supported.");
+
+    // args[0] - the Proxy handler object (this) (unused).
+    // args[1] - the Proxy target object.
+    // args[2] - the property
+    ChakraVerifyElseThrow(argCount == 3, "HostObjectGetOwnPropertyDescriptorTrap() requires 3 arguments.");
+    const JsValueRef target = args[1];
+    auto const &hostObject = *static_cast<std::shared_ptr<facebook::jsi::HostObject> *>(GetExternalData(target));
+
+    const JsValueRef propertyName = args[2];
+    if (GetValueType(propertyName) == JsValueType::JsString) {
+      const PropNameIDView propertyId{GetPropertyIdFromName(StringToPointer(propertyName).data())};
+      return RunInMethodContext("HostObject::getOwnPropertyDescriptor", [&]() {
+        auto value = chakraRuntime->ToJsValueRef(hostObject->get(*chakraRuntime, propertyId));
+        auto descriptor = chakraRuntime->CreatePropertyDescriptor(value, PropertyAttibutes::None);
+        return descriptor;
+      });
+    }
+    return static_cast<JsValueRef>(chakraRuntime->m_undefinedValue);
+  });
+}
+
 JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
   if (!m_hostObjectProxyHandler) {
     const JsValueRef handler = CreateObject();
@@ -796,6 +828,10 @@ JsValueRef ChakraRuntime::GetHostObjectProxyHandler() {
     SetProperty(handler, m_propertyId.set, CreateExternalFunction(m_propertyId.set, 3, HostObjectSetTrap, this));
     SetProperty(
         handler, m_propertyId.ownKeys, CreateExternalFunction(m_propertyId.ownKeys, 1, HostObjectOwnKeysTrap, this));
+    SetProperty(
+        handler,
+        m_propertyId.getOwnPropertyDescriptor,
+        CreateExternalFunction(m_propertyId.getOwnPropertyDescriptor, 3, HostObjectGetOwnPropertyDescriptorTrap, this));
     m_hostObjectProxyHandler = JsRefHolder{handler};
   }
 

--- a/vnext/JSI/Shared/ChakraRuntime.h
+++ b/vnext/JSI/Shared/ChakraRuntime.h
@@ -273,6 +273,13 @@ class ChakraRuntime : public facebook::jsi::Runtime, ChakraApi, ChakraApi::IExce
       unsigned short argCount,
       void *callbackState) noexcept;
 
+  static JsValueRef CALLBACK HostObjectGetOwnPropertyDescriptorTrap(
+      JsValueRef callee,
+      bool isConstructCall,
+      JsValueRef *args,
+      unsigned short argCount,
+      void *callbackState) noexcept;
+
   JsValueRef GetHostObjectProxyHandler();
 
   // Evaluate lambda and augment exception messages with the methodName.
@@ -445,6 +452,7 @@ class ChakraRuntime : public facebook::jsi::Runtime, ChakraApi, ChakraApi::IExce
     JsRefHolder configurable;
     JsRefHolder enumerable;
     JsRefHolder get;
+    JsRefHolder getOwnPropertyDescriptor;
     JsRefHolder hostFunctionSymbol;
     JsRefHolder hostObjectSymbol;
     JsRefHolder length;


### PR DESCRIPTION
Fixes #7488 (backport to 0.64)
Without this fix, apps cannot enumerate JSI object properties

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7490)