### PR TITLE
[0.64] Enable apps to override WinUI and SDK version for RNW framework projects 

### DIFF
--- a/change/react-native-windows-c07dd628-fa24-4ff3-967e-d2ba099bd9b5.json
+++ b/change/react-native-windows-c07dd628-fa24-4ff3-967e-d2ba099bd9b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Enable apps to override WinUI and SDK version for RNW framework projects",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
+++ b/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Enable overriding WinUI and SDK versions via ExperimentalFeatures.props",
-  "packageName": "react-native-windows",
-  "email": "asklar@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
+++ b/change/react-native-windows-e728b500-ee03-4b06-924f-c68a28f5f091.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable overriding WinUI and SDK versions via ExperimentalFeatures.props",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -35,7 +35,6 @@
    <!-- Ensure the Win10 SDK binaries loaded by the unittest match our apps SDK versions -->
   <PropertyGroup>
     <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersionEncoded>$(WindowsTargetPlatformVersion.Replace('.', '_'))</WindowsTargetPlatformVersionEncoded>
     <DefineConstants>$(p:DefineConstants);win10SdkVersion$(WindowsTargetPlatformVersionEncoded)</DefineConstants>
   </PropertyGroup>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -5,8 +5,8 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <!-- Use 19H1 SDK (10.0.18362.0)  Support running on RS3+ (10.0.16299.0) -->
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)'=='' Or '$(WindowsTargetPlatformVersion)'=='10.0.0.0'">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion Condition="'$(WindowsTargetPlatformMinVersion)'=='' Or '$(WindowsTargetPlatformMinVersion)'=='10.0.0.0'">10.0.16299.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -1,8 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="WinUI3 versioning">
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI3Version>3.0.0-preview3.201113.0</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">3.0.0-preview3.201113.0</WinUI3Version>
+  </PropertyGroup>
+
+  <PropertyGroup Label="WinUI2x versioning">
+		<!--This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
+    <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.3.191129002</WinUI2xVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseWinUI3)'=='true'">
@@ -19,7 +24,7 @@
 
   <PropertyGroup Condition="'$(UseWinUI3)'!='true'">
     <WinUIPackageName>Microsoft.UI.Xaml</WinUIPackageName>
-    <WinUIPackageVersion>2.3.191129002</WinUIPackageVersion>
+    <WinUIPackageVersion>$(WinUI2xVersion)</WinUIPackageVersion>
     <!-- In WinUI 2.x, the props file is imported for us by the targets file -->
     <WinUIPackageProps />
   </PropertyGroup>


### PR DESCRIPTION
Fixes #7416 in 0.64

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7498)