### PR TITLE
Restore nested press events in Text, and prevent crash.

### DIFF
--- a/change/react-native-windows-477fa69f-8746-46c3-8a5d-0847b9e41add.json
+++ b/change/react-native-windows-477fa69f-8746-46c3-8a5d-0847b9e41add.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert \"Fix touch event crash (#6692)\"",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -411,8 +411,9 @@ bool TouchEventHandler::TagFromOriginalSource(
   winrt::IPropertyValue tag(nullptr);
 
   while (sourceElement) {
-    tag = sourceElement.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-    if (tag) {
+    auto tagValue = sourceElement.ReadLocalValue(xaml::FrameworkElement::TagProperty());
+    if (tagValue != xaml::DependencyProperty::UnsetValue()) {
+      tag = tagValue.try_as<winrt::IPropertyValue>();
       // If a TextBlock was the UIElement event source, perform a more accurate hit test,
       // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
       // This is to support nested <Text> elements in React.

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -411,29 +411,28 @@ bool TouchEventHandler::TagFromOriginalSource(
   winrt::IPropertyValue tag(nullptr);
 
   while (sourceElement) {
-    if (auto fe = sourceElement.try_as<xaml::FrameworkElement>()) {
-      tag = fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-      if (tag) {
-        // If a TextBlock was the UIElement event source, perform a more accurate hit test,
-        // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
-        // This is to support nested <Text> elements in React.
-        // Nested React <Text> elements get translated into nested XAML <Span> elements,
-        // while the content of the <Text> becomes a list of XAML <Run> elements.
-        // However, we should report the Text element as the target, not the contexts of the text.
-        if (const auto textBlock = sourceElement.try_as<xaml::Controls::TextBlock>()) {
-          const auto pointerPos = args.GetCurrentPoint(textBlock).RawPosition();
-          const auto inlines = textBlock.Inlines().GetView();
+    tag = sourceElement.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+    if (tag) {
+      // If a TextBlock was the UIElement event source, perform a more accurate hit test,
+      // searching for the tag of the nested Run/Span XAML elements that the user actually clicked.
+      // This is to support nested <Text> elements in React.
+      // Nested React <Text> elements get translated into nested XAML <Span> elements,
+      // while the content of the <Text> becomes a list of XAML <Run> elements.
+      // However, we should report the Text element as the target, not the contexts of the text.
+      if (const auto textBlock = sourceElement.try_as<xaml::Controls::TextBlock>()) {
+        const auto pointerPos = args.GetCurrentPoint(textBlock).RawPosition();
+        const auto inlines = textBlock.Inlines().GetView();
 
-          bool isHit = false;
-          const auto finerTag = TestHit(inlines, pointerPos, isHit);
-          if (finerTag) {
-            tag = finerTag;
-          }
+        bool isHit = false;
+        const auto finerTag = TestHit(inlines, pointerPos, isHit);
+        if (finerTag) {
+          tag = finerTag;
         }
-
-        break;
       }
+
+      break;
     }
+
     sourceElement = winrt::VisualTreeHelper::GetParent(sourceElement).try_as<xaml::UIElement>();
   }
 
@@ -463,11 +462,9 @@ winrt::IPropertyValue TouchEventHandler::TestHit(
         return resTag;
 
       if (isHit) {
-        if (auto fe = el.try_as<xaml::FrameworkElement>()) {
-          tag = fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-          if (tag) {
-            return tag;
-          }
+        tag = el.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+        if (tag) {
+          return tag;
         }
       }
     } else if (const auto run = el.try_as<xaml::Documents::Run>()) {

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -10,7 +10,12 @@ namespace Microsoft::ReactNative {
 using XamlView = xaml::DependencyObject;
 
 inline int64_t GetTag(XamlView view) {
-  return view.GetValue(xaml::FrameworkElement::TagProperty()).as<winrt::IPropertyValue>().GetInt64();
+  auto tagValue = view.ReadLocalValue(xaml::FrameworkElement::TagProperty());
+  if (tagValue != xaml::DependencyProperty::UnsetValue()) {
+    return tagValue.as<winrt::IPropertyValue>().GetInt64();
+  } else {
+    return -1;
+  }
 }
 
 inline void SetTag(XamlView view, int64_t tag) {

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -9,16 +9,8 @@ namespace Microsoft::ReactNative {
 
 using XamlView = xaml::DependencyObject;
 
-inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
-  assert(fe);
-  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-}
-
 inline int64_t GetTag(XamlView view) {
-  if (auto fe = view.try_as<xaml::FrameworkElement>()) {
-    return GetTagAsPropertyValue(fe).GetInt64();
-  }
-  return 0;
+  return view.GetValue(xaml::FrameworkElement::TagProperty()).as<winrt::IPropertyValue>().GetInt64();
 }
 
 inline void SetTag(XamlView view, int64_t tag) {
@@ -37,6 +29,11 @@ inline bool IsValidTag(winrt::IPropertyValue value) {
 inline int64_t GetTag(winrt::IPropertyValue value) {
   assert(value);
   return value.GetInt64();
+}
+
+inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
+  assert(fe);
+  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);


### PR DESCRIPTION
This reverts commit 7d293b35946f417e3928811c53c9707c953335c7.

https://github.com/microsoft/react-native-windows/pull/6692 fixed a crash we experienced in the e2e app when clicking on the test result hyperlink (a `TextBlock` created outside of RNW, which didn't have a Tag, and our hit test crashed when trying to access the TagProperty which wasn't there.)

However, this broke the entire hit testing algorithm for nested Text elements - the added check for whether an element was a `FrameworkElement` before calling el.GetValue(TagProperty) skips the iteration over `Inline` elements of a `Span` in a `TextBlock`, because they're not FE.

Instead, using `ReadLocalValue` since it returns `UnsetValue` in case a dependency property is not present on an element.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7507)