### PR TITLE
Add isSelected property to ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-c17f39b5-73aa-431a-9412-8594af02ccfd.json
+++ b/change/@office-iss-react-native-win32-c17f39b5-73aa-431a-9412-8594af02ccfd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add isSelected prop to ViewWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -203,7 +203,8 @@ export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>,
   accessibilitySetSize?: number;
   animationClass?: string;
   focusable?: boolean;
-
+  isSelected?: boolean;
+  
   /**
    * The onBlur event occurs when an element loses focus.  The opposite of onBlur is onFocus.  Note that in React
    * Native, unlike in the web, the onBlur event bubbles (similar to onFocusOut in the web).


### PR DESCRIPTION
Aims to fix [Tabbing via Keyboard into RadioGroup incorrectly selects first RadioButton instead of currently selected RadioButton](https://github.com/microsoft/fluentui-react-native/issues/604) in the FURN repo.

Problem: 

- Since we don't have a way to mark elements as selected, the native isSelected property isn't being set. This prevents  KeyboardTabElement from knowing whether or not a child is selected. 

Solution:

- Add a isSelected property to ViewWin32 to enable elements to be marked as selected. This will allow KeyboardTabElement to place keyboard focus on the selected element when a user tabs into it.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7513)