### PR TITLE
[0.63] Force xmldom to version ^0.5.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "**/@wdio/sync": "5.12.1",
     "**/@wdio/utils": "5.12.1",
     "**/webdriver": "git+https://github.com/react-native-windows/webdriver.git",
-    "**/webdriverio": "5.12.1"
+    "**/webdriverio": "5.12.1",
+    "xmldom": "^0.5.0"
   },
   "beachball": {
     "gitTags": false

--- a/yarn.lock
+++ b/yarn.lock
@@ -14360,12 +14360,7 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
-  integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
-
-xmldom@^0.5.0:
+xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, xmldom@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
   integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==


### PR DESCRIPTION
There is a security vulnerability in xmldom versions below 0.5.0. This PR adds a yarn resolution to force xmldom to be at 0.5.0.

The dependency chain that brings in the vulnerable xmldom is as follows: react-native@0.0.0-d477f8011 -> @react-native-community/cli-platform-ios@^5.0.1-alpha.0 -> xcode@^2.0.0 -> simple-plist@^1.0.0 -> plist@^3.0.1 -> xmldom "0.1.x. So bumping the xmldom used here would require considerable work, which is why we use yarn resolution here.

Backport of #7514.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7515)