### PR TITLE
[0.64] Generate WinRT docs in CI

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -73,10 +73,10 @@ steps:
         Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
         & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
     displayName: "Generate WinRT API docs"
-    condition: and ( eq('${{parameters.buildConfiguration}}', 'Debug'), eq('${{parameters.buildPlatform}}', 'x86') )
+    condition: and ( eq('$(BuildConfiguration)', 'Debug'), eq('$(BuildPlatform)', 'x86') )
   - task: PublishBuildArtifacts@1
     displayName: Upload WinRT API docs
-    condition:  and ( eq('${{parameters.buildConfiguration}}', 'Debug'), eq('${{parameters.buildPlatform}}', 'x86') )
+    condition:  and ( eq('$(BuildConfiguration)', 'Debug'), eq('$(BuildPlatform)', 'x86') )
     inputs:
       pathtoPublish: 'vnext\target\winmd2md'
       artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -73,10 +73,10 @@ steps:
         Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
         & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
     displayName: "Generate WinRT API docs"
-    condition: and ( eq('$(BuildConfiguration)', 'Debug'), eq('$(BuildPlatform)', 'x86') )
+    condition: and ( eq('${{variables.BuildConfiguration}}', 'Debug'), eq('${{variables.BuildPlatform}}', 'x86') )
   - task: PublishBuildArtifacts@1
     displayName: Upload WinRT API docs
-    condition:  and ( eq('$(BuildConfiguration)', 'Debug'), eq('$(BuildPlatform)', 'x86') )
+    condition:  and ( eq('${{variables.BuildConfiguration}}', 'Debug'), eq('${{variables.BuildPlatform}}', 'x86') )
     inputs:
       pathtoPublish: 'vnext\target\winmd2md'
       artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -68,15 +68,3 @@ steps:
     parameters:
       buildLogDirectory: '${{ parameters.BuildLogDirectory }}'
 
-  - powershell: |
-        $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.12/winmd2md.exe"
-        Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
-        & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
-    displayName: "Generate WinRT API docs"
-    condition: and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
-  - task: PublishBuildArtifacts@1
-    displayName: Upload WinRT API docs
-    condition:  and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
-    inputs:
-      pathtoPublish: 'vnext\target\winmd2md'
-      artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -71,7 +71,7 @@ steps:
   - powershell: |
         $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.12/winmd2md.exe"
         Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
-        & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
+        & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
     displayName: "Generate WinRT API docs"
     condition: and ( eq('${{parameters.buildConfiguration}}', 'Debug'), eq('${{parameters.buildPlatform}}', 'x86') )
   - task: PublishBuildArtifacts@1

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -73,10 +73,10 @@ steps:
         Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
         & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
     displayName: "Generate WinRT API docs"
-    condition: and ( eq('${{variables.BuildConfiguration}}', 'Debug'), eq('${{variables.BuildPlatform}}', 'x86') )
+    condition: and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
   - task: PublishBuildArtifacts@1
     displayName: Upload WinRT API docs
-    condition:  and ( eq('${{variables.BuildConfiguration}}', 'Debug'), eq('${{variables.BuildPlatform}}', 'x86') )
+    condition:  and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
     inputs:
       pathtoPublish: 'vnext\target\winmd2md'
       artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -67,3 +67,16 @@ steps:
   - template: upload-build-logs.yml
     parameters:
       buildLogDirectory: '${{ parameters.BuildLogDirectory }}'
+
+  - powershell: |
+        $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.12/winmd2md.exe"
+        Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
+        & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
+    displayName: "Generate WinRT API docs"
+    condition: and ( eq('${{parameters.buildConfiguration}}', 'Debug'), eq('${{parameters.buildPlatform}}', 'x86') )
+  - task: PublishBuildArtifacts@1
+    displayName: Upload WinRT API docs
+    condition:  and ( eq('${{parameters.buildConfiguration}}', 'Debug'), eq('${{parameters.buildPlatform}}', 'x86') )
+    inputs:
+      pathtoPublish: 'vnext\target\winmd2md'
+      artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -78,6 +78,20 @@ jobs:
           project: vnext/Microsoft.ReactNative.sln
 
       - powershell: |
+            $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.12/winmd2md.exe"
+            Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
+            & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiVersion 0.64 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
+        displayName: "Generate WinRT API docs"
+        condition: and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
+
+      - task: PublishBuildArtifacts@1
+        displayName: Upload WinRT API docs
+        condition:  and ( eq(variables.BuildConfiguration, 'Debug'), eq(variables.BuildPlatform, 'x86') )
+        inputs:
+          pathtoPublish: 'vnext\target\winmd2md'
+          artifactName: 'WinRT API docs - $(Agent.JobName)-$(System.JobAttempt)'
+          
+      - powershell: |
           Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
           Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"
           Write-Host "Set environment variable to ($env:GoogleTestAdapterPath)"

--- a/change/@react-native-windows-cli-c72ce637-d6f6-44cc-ab0d-4cdac7419cea.json
+++ b/change/@react-native-windows-cli-c72ce637-d6f6-44cc-ab0d-4cdac7419cea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "always write nuget.config since it seems to be required now",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-c72ce637-d6f6-44cc-ab0d-4cdac7419cea.json
+++ b/change/@react-native-windows-cli-c72ce637-d6f6-44cc-ab0d-4cdac7419cea.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "always write nuget.config since it seems to be required now",
-  "packageName": "@react-native-windows/cli",
-  "email": "asklar@microsoft.com",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
This PR adds auto-generating the WinRT API docs in CI so they can be plopped over on the website repo (it will show up in the build's artifacts)
![image](https://user-images.githubusercontent.com/22989529/114922407-753b7c80-9de0-11eb-846a-89cd6d38b85a.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7526)