### PR TITLE
Fixes issue with Run text getting overwritten

### DIFF
--- a/change/react-native-windows-f9a0a6cf-8a26-41f5-84d8-89860cac9334.json
+++ b/change/react-native-windows-f9a0a6cf-8a26-41f5-84d8-89860cac9334.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issue with Run text getting overwritten",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -33,6 +33,7 @@ void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
       if (auto run = i.try_as<xaml::Documents::Run>()) {
         if (transform == TransformableText::TextTransform::Undefined) {
           // project the parent transform onto the child
+          childVTSN.transformableText.originalText = run.Text().c_str();
           childVTSN.transformableText.textTransform = transformableText.textTransform;
           run.Text(childVTSN.transformableText.TransformText());
         }


### PR DESCRIPTION
There are a few issues with how `textTransform` is currently implemented, but one particular issue is that the shallow application algorithm for the `textTransform` inadvertently applies the text of the last Run in the InlineCollection to all runs in the collection when trying to apply an inherited transform.

Please note, this fix is a temporary patch to eliminate the specific bug described in #7534.  Obviously this change has a major limitation where the original state of raw text is not kept anywhere, but I believe this patch makes things no worse than they already are. There is a more comprehensive fix that I will send a follow-up PR for related to #7535. 

Fixes #7534

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7536)