### PR TITLE
Fixes textTransform recursion

### DIFF
--- a/change/react-native-windows-8168ecc3-8f90-47c9-8ff0-bfe30f1d2ba7.json
+++ b/change/react-native-windows-8168ecc3-8f90-47c9-8ff0-bfe30f1d2ba7.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix textTransform recursion",
+  "comment": "Fixes textTransform recursion", 
   "packageName": "react-native-windows",
   "email": "erozell@outlook.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-8168ecc3-8f90-47c9-8ff0-bfe30f1d2ba7.json
+++ b/change/react-native-windows-8168ecc3-8f90-47c9-8ff0-bfe30f1d2ba7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix textTransform recursion",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -8,7 +8,7 @@
 // Image inline in Text removed
 
 import * as React from 'react';
-import {/*Image,*/ StyleSheet, Text, View, TextStyle} from 'react-native';
+import {/*Image,*/ StyleSheet, Text, View, TextStyle, TouchableWithoutFeedback} from 'react-native';
 const RNTesterBlock = require('../../components/RNTesterBlock');
 const RNTesterPage = require('../../components/RNTesterPage');
 
@@ -124,10 +124,10 @@ export class BackgroundColorDemo extends React.Component<{}> {
   }
 }
 
-export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2: boolean }> {
+export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2: boolean, toggle3: boolean }> {
   constructor(props: any) {
     super(props)
-    this.state = {toggle1: false, toggle2: false}
+    this.state = {toggle1: false, toggle2: false, toggle3: false}
   }
 
   public render() {
@@ -138,7 +138,7 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
       <RNTesterPage>
         <RNTesterBlock title="textTransform">
           <View>
-          <Text style={{textTransform: 'uppercase'}}>
+            <Text style={{textTransform: 'uppercase'}}>
               <Text>This</Text>
               {' '}
               text should be uppercased.
@@ -175,6 +175,16 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
             <Text onPress={() => this.setState({toggle2: !this.state.toggle2})}>
               Click to change raw text: <Text style={{textTransform: 'uppercase'}}>Hello {this.state.toggle2 ? 'Earth' : 'World'}</Text>
             </Text>
+            <TouchableWithoutFeedback onPress={() => this.setState({toggle3: !this.state.toggle3})}>
+              <View>
+                <Text>
+                  Click to toggle fast text on next line (should remain uppercase):
+                </Text>
+                <Text style={{textTransform: 'uppercase'}}>
+                  {this.state.toggle3 ? 'Hello' : 'Howdy'}
+                </Text>
+              </View>
+            </TouchableWithoutFeedback>
           </View>
         </RNTesterBlock>
         <RNTesterBlock title="Wrap">

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -8,7 +8,13 @@
 // Image inline in Text removed
 
 import * as React from 'react';
-import {/*Image,*/ StyleSheet, Text, View, TextStyle, TouchableWithoutFeedback} from 'react-native';
+import {
+  /*Image,*/ StyleSheet,
+  Text,
+  View,
+  TextStyle,
+  TouchableWithoutFeedback,
+} from 'react-native';
 const RNTesterBlock = require('../../components/RNTesterBlock');
 const RNTesterPage = require('../../components/RNTesterPage');
 
@@ -124,10 +130,13 @@ export class BackgroundColorDemo extends React.Component<{}> {
   }
 }
 
-export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2: boolean, toggle3: boolean }> {
+export class TextExample extends React.Component<
+  {},
+  {toggle1: boolean; toggle2: boolean; toggle3: boolean}
+> {
   constructor(props: any) {
-    super(props)
-    this.state = {toggle1: false, toggle2: false, toggle3: false}
+    super(props);
+    this.state = {toggle1: false, toggle2: false, toggle3: false};
   }
 
   public render() {
@@ -139,9 +148,7 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
         <RNTesterBlock title="textTransform">
           <View>
             <Text style={{textTransform: 'uppercase'}}>
-              <Text>This</Text>
-              {' '}
-              text should be uppercased.
+              <Text>This</Text> text should be uppercased.
             </Text>
             <Text style={{textTransform: 'lowercase'}}>
               This TEXT SHOULD be lowercased.
@@ -160,7 +167,10 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
             <Text>
               Should be "ABC":
               <Text style={{textTransform: 'uppercase'}}>
-                a<Text>b<Text>c</Text></Text>
+                a
+                <Text>
+                  b<Text>c</Text>
+                </Text>
               </Text>
             </Text>
             <Text>
@@ -178,15 +188,26 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
               </Text>
             </Text>
             <Text onPress={() => this.setState({toggle1: !this.state.toggle1})}>
-              Click to toggle uppercase: <Text style={{textTransform: this.state.toggle1 ? 'uppercase' : 'none'}}>Hello</Text>
+              Click to toggle uppercase:{' '}
+              <Text
+                style={{
+                  textTransform: this.state.toggle1 ? 'uppercase' : 'none',
+                }}>
+                Hello
+              </Text>
             </Text>
             <Text onPress={() => this.setState({toggle2: !this.state.toggle2})}>
-              Click to change raw text: <Text style={{textTransform: 'uppercase'}}>Hello {this.state.toggle2 ? 'Earth' : 'World'}</Text>
+              Click to change raw text:{' '}
+              <Text style={{textTransform: 'uppercase'}}>
+                Hello {this.state.toggle2 ? 'Earth' : 'World'}
+              </Text>
             </Text>
-            <TouchableWithoutFeedback onPress={() => this.setState({toggle3: !this.state.toggle3})}>
+            <TouchableWithoutFeedback
+              onPress={() => this.setState({toggle3: !this.state.toggle3})}>
               <View>
                 <Text>
-                  Click to toggle fast text on next line (should remain uppercase):
+                  Click to toggle fast text on next line (should remain
+                  uppercase):
                 </Text>
                 <Text style={{textTransform: 'uppercase'}}>
                   {this.state.toggle3 ? 'Hello' : 'Howdy'}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -169,6 +169,14 @@ export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2
                 x<Text style={{textTransform: 'none'}}>y</Text>z
               </Text>
             </Text>
+            <Text>
+              <Text>
+                Should be "xYz":
+                <Text>
+                  x<Text style={{textTransform: 'uppercase'}}>y</Text>z
+                </Text>
+              </Text>
+            </Text>
             <Text onPress={() => this.setState({toggle1: !this.state.toggle1})}>
               Click to toggle uppercase: <Text style={{textTransform: this.state.toggle1 ? 'uppercase' : 'none'}}>Hello</Text>
             </Text>

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -124,7 +124,12 @@ export class BackgroundColorDemo extends React.Component<{}> {
   }
 }
 
-export class TextExample extends React.Component<{}> {
+export class TextExample extends React.Component<{}, { toggle1: boolean, toggle2: boolean }> {
+  constructor(props: any) {
+    super(props)
+    this.state = {toggle1: false, toggle2: false}
+  }
+
   public render() {
     const lorumIpsum =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed dapibus felis eget augue condimentum suscipit. Suspendisse hendrerit, libero aliquet malesuada tempor, urna nibh consectetur tellus, vitae efficitur quam erat non mi. Maecenas vitae eros sit amet quam vestibulum porta sed sit amet tellus. Fusce quis lectus congue, fringilla arcu id, luctus urna. Cras sagittis ornare mauris sit amet dictum. Vestibulum feugiat laoreet fringilla. Vivamus ac diam vehicula felis venenatis sagittis vitae ultrices elit. Curabitur libero augue, laoreet quis orci vitae, congue euismod massa. Aenean nec odio sed urna vehicula fermentum non a magna. Quisque ut commodo neque, eget eleifend odio. Sed sit amet lacinia sem. Suspendisse in metus in purus scelerisque vestibulum. Nam metus dui, efficitur nec metus non, tincidunt pharetra sapien. Praesent id convallis metus, ut malesuada arcu. Quisque quam libero, pharetra eu tellus ac, aliquam fringilla erat. Quisque tempus in lorem ac suscipit.';
@@ -133,8 +138,10 @@ export class TextExample extends React.Component<{}> {
       <RNTesterPage>
         <RNTesterBlock title="textTransform">
           <View>
-            <Text style={{textTransform: 'uppercase'}}>
-              This text should be uppercased.
+          <Text style={{textTransform: 'uppercase'}}>
+              <Text>This</Text>
+              {' '}
+              text should be uppercased.
             </Text>
             <Text style={{textTransform: 'lowercase'}}>
               This TEXT SHOULD be lowercased.
@@ -153,7 +160,7 @@ export class TextExample extends React.Component<{}> {
             <Text>
               Should be "ABC":
               <Text style={{textTransform: 'uppercase'}}>
-                a<Text>b</Text>c
+                a<Text>b<Text>c</Text></Text>
               </Text>
             </Text>
             <Text>
@@ -161,6 +168,12 @@ export class TextExample extends React.Component<{}> {
               <Text style={{textTransform: 'uppercase'}}>
                 x<Text style={{textTransform: 'none'}}>y</Text>z
               </Text>
+            </Text>
+            <Text onPress={() => this.setState({toggle1: !this.state.toggle1})}>
+              Click to toggle uppercase: <Text style={{textTransform: this.state.toggle1 ? 'uppercase' : 'none'}}>Hello</Text>
+            </Text>
+            <Text onPress={() => this.setState({toggle2: !this.state.toggle2})}>
+              Click to change raw text: <Text style={{textTransform: 'uppercase'}}>Hello {this.state.toggle2 ? 'Earth' : 'World'}</Text>
             </Text>
           </View>
         </RNTesterBlock>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -305,6 +305,7 @@
     <ClInclude Include="Utils\PropertyUtils.h" />
     <ClInclude Include="Utils\ResourceBrushUtils.h" />
     <ClInclude Include="Utils\StandardControlResourceKeyNames.h" />
+    <ClInclude Include="Utils\TextTransform.h" />
     <ClInclude Include="Utils\TransformableText.h" />
     <ClInclude Include="Utils\UwpPreparedScriptStore.h" />
     <ClInclude Include="Utils\UwpScriptStore.h" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -678,6 +678,9 @@
     <ClInclude Include="ReactHost\JSCallInvokerScheduler.h">
       <Filter>ReactHost</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\TextTransform.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/Utils/TextTransform.h
+++ b/vnext/Microsoft.ReactNative/Utils/TextTransform.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace Microsoft::ReactNative {
+enum class TextTransform : uint8_t { Undefined, None, Uppercase, Lowercase, Capitalize };
+}

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -7,9 +7,7 @@ namespace Microsoft::ReactNative {
 struct TransformableText final {
   enum class TextTransform : uint8_t { Undefined, None, Uppercase, Lowercase, Capitalize };
 
-  static winrt::hstring TransformText(
-      winrt::hstring originalText,
-      TextTransform textTransform) noexcept {
+  static winrt::hstring TransformText(winrt::hstring originalText, TextTransform textTransform) noexcept {
     if (textTransform == TextTransform::Undefined || textTransform == TextTransform::None) {
       return originalText;
     }
@@ -31,12 +29,7 @@ struct TransformableText final {
     }
 
     const int reqChars = LCMapStringW(
-        LOCALE_NAME_USER_DEFAULT,
-        dwMapFlags,
-        originalText.c_str(),
-        static_cast<int>(originalText.size()),
-        nullptr,
-        0);
+        LOCALE_NAME_USER_DEFAULT, dwMapFlags, originalText.c_str(), static_cast<int>(originalText.size()), nullptr, 0);
 
     std::wstring str;
     str.resize(reqChars);

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -7,7 +7,6 @@
 
 namespace Microsoft::ReactNative {
 struct TransformableText final {
-
   static winrt::hstring TransformText(winrt::hstring originalText, TextTransform textTransform) noexcept {
     if (textTransform == TextTransform::Undefined || textTransform == TextTransform::None) {
       return originalText;

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -7,7 +7,7 @@
 
 namespace Microsoft::ReactNative {
 struct TransformableText final {
-  static winrt::hstring TransformText(winrt::hstring originalText, TextTransform textTransform) noexcept {
+  static winrt::hstring TransformText(const winrt::hstring &originalText, TextTransform textTransform) noexcept {
     if (textTransform == TextTransform::Undefined || textTransform == TextTransform::None) {
       return originalText;
     }

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
+#include <Utils/TextTransform.h>
+
 namespace Microsoft::ReactNative {
 struct TransformableText final {
-  enum class TextTransform : uint8_t { Undefined, None, Uppercase, Lowercase, Capitalize };
 
   static winrt::hstring TransformText(winrt::hstring originalText, TextTransform textTransform) noexcept {
     if (textTransform == TextTransform::Undefined || textTransform == TextTransform::None) {

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -7,13 +7,13 @@ namespace Microsoft::ReactNative {
 struct TransformableText final {
   enum class TextTransform : uint8_t { Undefined, None, Uppercase, Lowercase, Capitalize };
 
-  TextTransform textTransform{TextTransform::Undefined};
-  std::wstring originalText{};
-
-  std::wstring TransformText() const noexcept {
+  static winrt::hstring TransformText(
+      winrt::hstring originalText,
+      TextTransform textTransform) noexcept {
     if (textTransform == TextTransform::Undefined || textTransform == TextTransform::None) {
       return originalText;
     }
+
     DWORD dwMapFlags{};
     switch (textTransform) {
       case TextTransform::Uppercase:
@@ -34,7 +34,7 @@ struct TransformableText final {
         LOCALE_NAME_USER_DEFAULT,
         dwMapFlags,
         originalText.c_str(),
-        static_cast<int>(originalText.length()),
+        static_cast<int>(originalText.size()),
         nullptr,
         0);
 
@@ -44,12 +44,13 @@ struct TransformableText final {
         LOCALE_NAME_USER_DEFAULT,
         dwMapFlags,
         originalText.c_str(),
-        static_cast<int>(originalText.length()),
+        static_cast<int>(originalText.size()),
         str.data(),
         reqChars);
     str.resize(nChars);
     assert(nChars == reqChars);
-    return str;
+    winrt::hstring result{str.c_str()};
+    return result;
   }
 
   static TextTransform GetTextTransform(const winrt::Microsoft::ReactNative::JSValue &propertyValue) noexcept {

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -50,7 +50,7 @@ bool RawTextViewManager::UpdateProperty(
 
   if (propertyName == "text") {
     run.Text(react::uwp::asHstring(propertyValue));
-
+    static_cast<RawTextShadowNode *>(nodeToUpdate)->originalText = winrt::hstring{};
     if (nodeToUpdate->GetParent() != -1) {
       if (auto uiManager = GetNativeUIManager(*m_context).lock()) {
         const ShadowNodeBase *parent =
@@ -76,13 +76,13 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
   if (auto uiManager = GetNativeUIManager(GetReactContext()).lock()) {
     auto host = uiManager->getHost();
     ShadowNodeBase *parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(nodeToUpdate->GetParent()));
-    TransformableText::TextTransform textTransform = TransformableText::TextTransform::Undefined;
+    TextTransform textTransform = TextTransform::Undefined;
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
       if (!std::wcscmp(nodeType, L"RCTText")) {
         const auto textViewManager = static_cast<TextViewManager *>(viewManager);
-        if (textTransform == TransformableText::TextTransform::Undefined) {
+        if (textTransform == TextTransform::Undefined) {
           textTransform = textViewManager->GetTextTransformValue(parent);
         }
 
@@ -90,7 +90,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
             *nodeToUpdate, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
         (static_cast<TextViewManager *>(viewManager))->OnDescendantTextPropertyChanged(parent);
       } else if (
-          !std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TransformableText::TextTransform::Undefined) {
+          !std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
       parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(parent->GetParent()));

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -87,8 +87,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
         }
 
         (static_cast<TextViewManager *>(viewManager))->OnDescendantTextPropertyChanged(parent);
-      } else if (
-          !std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
+      } else if (!std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
       parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(parent->GetParent()));

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#include <Views/ShadowNodeBase.h>
 #include <Views/ViewManagerBase.h>
-
 #include <folly/dynamic.h>
 
 namespace Microsoft::ReactNative {
+
+struct RawTextShadowNode final : public ShadowNodeBase {
+  using Super = ShadowNodeBase;
+  winrt::hstring originalText{};
+};
 
 class RawTextViewManager : public ViewManagerBase {
   using Super = ViewManagerBase;
@@ -16,6 +21,9 @@ class RawTextViewManager : public ViewManagerBase {
   RawTextViewManager(const Mso::React::IReactContext &context);
 
   const wchar_t *GetName() const override;
+  ShadowNode *createShadow() const override {
+    return new RawTextShadowNode();
+  }
 
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -125,7 +125,7 @@ class TextShadowNode final : public ShadowNodeBase {
     Super::RemoveChildAt(indexToRemove);
   }
 
-  TransformableText::TextTransform textTransform{TransformableText::TextTransform::Undefined};
+  TextTransform textTransform{TextTransform::Undefined};
 };
 
 TextViewManager::TextViewManager(const Mso::React::IReactContext &context) : Super(context) {}
@@ -262,7 +262,7 @@ void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node) {
   }
 }
 
-TransformableText::TextTransform GetTextTransformValue(ShadowNodeBase *node) {
+TextTransform TextViewManager::GetTextTransformValue(ShadowNodeBase *node) {
   return static_cast<TextShadowNode *>(node)->textTransform;
 }
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -48,8 +48,8 @@ class TextShadowNode final : public ShadowNodeBase {
     VirtualTextShadowNode::ApplyTextTransform(
         childNode, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
 
-    auto run = childNode.GetView().try_as<winrt::Run>();
     if (index == 0) {
+      auto run = childNode.GetView().try_as<winrt::Run>();
       if (run != nullptr) {
         m_firstChildNode = &child;
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
@@ -263,7 +263,11 @@ void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node) {
 }
 
 TextTransform TextViewManager::GetTextTransformValue(ShadowNodeBase *node) {
-  return static_cast<TextShadowNode *>(node)->textTransform;
+  if (!std::wcscmp(node->GetViewManager()->GetName(), GetName())) {
+    return static_cast<TextShadowNode *>(node)->textTransform;
+  }
+
+  return TextTransform::Undefined;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -47,7 +47,7 @@ class TextShadowNode final : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override {
     auto &childNode = static_cast<ShadowNodeBase &>(child);
-    VirtualTextShadowNode::ApplyTextTransformToNode(childNode, textTransform);
+    VirtualTextShadowNode::ApplyTextTransformToNode(childNode, textTransform, /* hasChanged = */false);
 
     auto run = childNode.GetView().try_as<winrt::Run>();
     if (index == 0) {
@@ -115,14 +115,11 @@ class TextShadowNode final : public ShadowNodeBase {
   }
 
   void UpdateTextTransform(TransformableText::TextTransform transform) {
-    const auto previousTransform = textTransform;
     textTransform = transform;
-    if (previousTransform != transform) {
-      if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
-        for (auto childTag : m_children) {
-          const auto childNode = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(childTag));
-          VirtualTextShadowNode::ApplyTextTransformToNode(*childNode, transform);
-        }
+    if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+      for (auto childTag : m_children) {
+        const auto childNode = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(childTag));
+        VirtualTextShadowNode::ApplyTextTransformToNode(*childNode, transform, true);
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <Utils/TextTransform.h>
 #include <Views/FrameworkElementViewManager.h>
 
 namespace Microsoft::ReactNative {
@@ -25,7 +26,7 @@ class TextViewManager : public FrameworkElementViewManager {
 
   void OnDescendantTextPropertyChanged(ShadowNodeBase *node);
 
-  TransformableText::TextTransform GetTextTransformValue(ShadowNodeBase *node);
+  TextTransform GetTextTransformValue(ShadowNodeBase *node);
 
  protected:
   bool UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -25,6 +25,8 @@ class TextViewManager : public FrameworkElementViewManager {
 
   void OnDescendantTextPropertyChanged(ShadowNodeBase *node);
 
+  TransformableText::TextTransform GetTextTransformValue(ShadowNodeBase *node);
+
  protected:
   bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -12,6 +12,7 @@
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <Utils/PropertyUtils.h>
+#include <Utils/TransformableText.h>
 #include <Utils/ValueUtils.h>
 
 namespace winrt {
@@ -35,15 +36,15 @@ void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
 
 void VirtualTextShadowNode::ApplyTextTransform(
     ShadowNodeBase &node,
-    TransformableText::TextTransform transform,
+    TextTransform transform,
     bool forceUpdate,
     bool isRoot) {
   // The `forceUpdate` option is used to force the tree to update, even if the
   // transform value is undefined or set to 'none'. This is used when a leaf
   // raw text value has changed, or a textTransform prop has changed.
   if (forceUpdate ||
-      (transform != TransformableText::TextTransform::Undefined &&
-       transform != TransformableText::TextTransform::None)) {
+      (transform != TextTransform::Undefined &&
+       transform != TextTransform::None)) {
     // Use the view manager name to determine the node type
     const auto viewManager = node.GetViewManager();
     const auto nodeType = viewManager->GetName();
@@ -53,7 +54,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
       auto &rawTextNode = static_cast<RawTextShadowNode &>(node);
       auto originalText = rawTextNode.originalText;
       auto run = node.GetView().try_as<winrt::Run>();
-      if (std::wcscmp(originalText.c_str(), run.Text().c_str())) {
+      if (originalText.size() == 0) {
         // Lazily setting original text to avoid keeping two copies of all raw text strings
         originalText = run.Text();
         rawTextNode.originalText = originalText;
@@ -70,7 +71,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
       if (!std::wcscmp(nodeType, L"RCTVirtualText")) {
         auto &virtualTextNode = static_cast<VirtualTextShadowNode &>(node);
         // If this is not the root call, we can skip sub-trees with explicit textTransform settings.
-        if (!isRoot && virtualTextNode.textTransform != TransformableText::TextTransform::Undefined) {
+        if (!isRoot && virtualTextNode.textTransform != TextTransform::Undefined) {
           return;
         }
       }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -42,9 +42,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
   // The `forceUpdate` option is used to force the tree to update, even if the
   // transform value is undefined or set to 'none'. This is used when a leaf
   // raw text value has changed, or a textTransform prop has changed.
-  if (forceUpdate ||
-      (transform != TextTransform::Undefined &&
-       transform != TextTransform::None)) {
+  if (forceUpdate || (transform != TextTransform::Undefined && transform != TextTransform::None)) {
     // Use the view manager name to determine the node type
     const auto viewManager = node.GetViewManager();
     const auto nodeType = viewManager->GetName();
@@ -54,6 +52,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
       auto &rawTextNode = static_cast<RawTextShadowNode &>(node);
       auto originalText = rawTextNode.originalText;
       auto run = node.GetView().try_as<winrt::Run>();
+      // Set originalText on the raw text node if it hasn't been set yet
       if (originalText.size() == 0) {
         // Lazily setting original text to avoid keeping two copies of all raw text strings
         originalText = run.Text();
@@ -66,8 +65,8 @@ void VirtualTextShadowNode::ApplyTextTransform(
         // If the transformed text is the same as the original, we no longer need a second copy
         rawTextNode.originalText = winrt::hstring{};
       }
-      // Recursively apply the textTransform to the children of the composite text node
     } else {
+      // Recursively apply the textTransform to the children of the composite text node
       if (!std::wcscmp(nodeType, L"RCTVirtualText")) {
         auto &virtualTextNode = static_cast<VirtualTextShadowNode &>(node);
         // If this is not the root call, we can skip sub-trees with explicit textTransform settings.

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -17,9 +17,9 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override;
 
-  void ApplyTextTransform(TransformableText::TextTransform transform, bool fromParent);
+  void ApplyTextTransform(TransformableText::TextTransform transform, bool hasChanged, bool inherited);
 
-  static void ApplyTextTransformToNode(ShadowNodeBase &node, TransformableText::TextTransform transform);
+  static void ApplyTextTransformToNode(ShadowNodeBase &node, TransformableText::TextTransform transform, bool hasChanged);
   
   struct HighlightData {
     std::vector<HighlightData> data;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -17,10 +17,9 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override;
 
-  void ApplyTextTransform(TransformableText::TextTransform transform, bool hasChanged, bool inherited);
+  static void
+  ApplyTextTransform(ShadowNodeBase &node, TransformableText::TextTransform transform, bool forceUpdate, bool isRoot);
 
-  static void ApplyTextTransformToNode(ShadowNodeBase &node, TransformableText::TextTransform transform, bool hasChanged);
-  
   struct HighlightData {
     std::vector<HighlightData> data;
     size_t spanIdx = 0;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -6,19 +6,19 @@
 #include <INativeUIManager.h>
 #include <ShadowNodeBase.h>
 #include <UI.Xaml.Documents.h>
-#include <Utils/TransformableText.h>
+#include <Utils/TextTransform.h>
 #include <Views/FrameworkElementViewManager.h>
 
 namespace Microsoft::ReactNative {
 
 struct VirtualTextShadowNode final : public ShadowNodeBase {
   using Super = ShadowNodeBase;
-  TransformableText::TextTransform textTransform{TransformableText::TextTransform::Undefined};
+  TextTransform textTransform{TextTransform::Undefined};
 
   void AddView(ShadowNode &child, int64_t index) override;
 
   static void
-  ApplyTextTransform(ShadowNodeBase &node, TransformableText::TextTransform transform, bool forceUpdate, bool isRoot);
+  ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
   struct HighlightData {
     std::vector<HighlightData> data;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -17,8 +17,7 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   void AddView(ShadowNode &child, int64_t index) override;
 
-  static void
-  ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
+  static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
   struct HighlightData {
     std::vector<HighlightData> data;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -13,10 +13,14 @@ namespace Microsoft::ReactNative {
 
 struct VirtualTextShadowNode final : public ShadowNodeBase {
   using Super = ShadowNodeBase;
-  TransformableText transformableText{};
+  TransformableText::TextTransform textTransform{TransformableText::TextTransform::Undefined};
 
   void AddView(ShadowNode &child, int64_t index) override;
 
+  void ApplyTextTransform(TransformableText::TextTransform transform, bool fromParent);
+
+  static void ApplyTextTransformToNode(ShadowNodeBase &node, TransformableText::TextTransform transform);
+  
   struct HighlightData {
     std::vector<HighlightData> data;
     size_t spanIdx = 0;


### PR DESCRIPTION
This change includes a number of fixes to the approach to textTransform. There were 4 issues with the previous textTransform approach that this diff solves:
1. The textTransform prop was only applied to the parent TextBlock when it had a single raw text child
2. The textTransform prop on a virtual text Span only recursed one level
3. The one-level textTransform approach had a bug where the last raw text value overwrote all Run text values (#7534)
4. The textTransform prop did not update correctly when changed

Rather than holding state in the TransformableText struct, this change keeps the originalText state exclusively in RawTextShadowNode, and only when a parent VirtualTextShadowNode or TextShadowNode has a textTransform setting (that is not "none" or undefined). The VirtualTextShadowNode and TextShadowNode holds only the TextTransform prop value (and not any originalText value which was causing the issue in #7534). When a child is added to either a TextShadowNode or VirtualTextShadowNode, we now attempt to recursively apply the textTransform on the child sub-tree (wherever textTransform is not explicitly overwritten). Whenever the textTransform prop changes on VirtualTextShadowNode or TextShadowNode, we now attempt to recurse over all children of that node to apply the textTransform (wherever it is not explicitly overwritten).

Fixes #7534
Fixes #7535

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7538)