### PR TITLE
Remove the *-stable branch filter from publish.yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -43,7 +43,6 @@ schedules:
   branches:
     include:
       - "0.64-stable"
-      - "*-stable"
 - cron: "0 5 * * *" # 5AM Daily UTC (10PM Daily PST)
   displayName: Nightly canary publish build
   branches:


### PR DESCRIPTION
It's possible that our internal ADO doesn't even see the cron schedule for our stable branches because it doesn't support wildcards.

Trying to see if this fixes it - plus, we'll have more control over which branches get automatically published.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7539)