### PR TITLE
Fixes bug where raw text update overwrites all text

### DIFF
--- a/change/react-native-windows-0ab53fc0-24ac-4a26-bb0c-fae123303cc9.json
+++ b/change/react-native-windows-0ab53fc0-24ac-4a26-bb0c-fae123303cc9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes bug where raw text update overwrites all text",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -197,9 +197,11 @@ export class TextExample extends React.Component<
               </Text>
             </Text>
             <Text onPress={() => this.setState({toggle2: !this.state.toggle2})}>
-              Click to change raw text:{' '}
-              <Text style={{textTransform: 'uppercase'}}>
-                Hello {this.state.toggle2 ? 'Earth' : 'World'}
+              <Text>
+                Click to change raw text:{' '}
+                <Text style={{textTransform: 'uppercase'}}>
+                  Hello {this.state.toggle2 ? 'Earth' : 'World'}
+                </Text>
               </Text>
             </Text>
             <TouchableWithoutFeedback

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -63,6 +63,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
     auto host = uiManager->getHost();
     ShadowNodeBase *parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(nodeToUpdate->GetParent()));
     TextTransform textTransform = TextTransform::Undefined;
+    auto isNested = false;
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
@@ -75,7 +76,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
         VirtualTextShadowNode::ApplyTextTransform(
             *nodeToUpdate, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
 
-        if (parent->m_children.size() == 1) {
+        if (!isNested && parent->m_children.size() == 1) {
           auto view = parent->GetView();
           auto textBlock = view.try_as<winrt::TextBlock>();
           if (textBlock != nullptr) {
@@ -90,7 +91,9 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
       } else if (!std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
+
       parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(parent->GetParent()));
+      isNested = true;
     }
   }
 }


### PR DESCRIPTION
After fixing issues with textTransform, 278a3c13 introduced a bug where updates to a raw text node can overwrite the TextBlock parent if it has only a single Span child inline. This change ensures we check that the updated raw text Run is indeed the direct child of a TextBlock.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7572)