### PR TITLE
Calling UIManager.dispatchViewManagerCommand doesn't trigger a UI update

### DIFF
--- a/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
+++ b/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Calling UIManager.dispatchViewManagerCommand should trigger updates",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/BatchingMessageQueueThread.h
+++ b/vnext/Shared/BatchingMessageQueueThread.h
@@ -8,9 +8,12 @@
 namespace facebook {
 namespace react {
 
+class Instance;
+
 class BatchingMessageQueueThread : public MessageQueueThread {
  public:
   virtual void onBatchComplete() = 0;
+  virtual void decoratedNativeCallInvokerReady(std::weak_ptr<facebook::react::Instance> wkInstance) noexcept = 0;
 };
 
 } // namespace react

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -71,6 +71,7 @@ void BatchingQueueThread::decoratedNativeCallInvokerReady(
   std::scoped_lock lck(m_mutex);
   m_callInvoker->invokeAsync([wkInstance, this] {
     if (auto instance = wkInstance.lock()) {
+      std::scoped_lock lck(m_mutex);
       m_callInvoker = instance->getDecoratedNativeCallInvoker(m_callInvoker);
     }
   });

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -26,16 +26,6 @@ void BatchingQueueCallInvoker::invokeAsync(std::function<void()> &&func) noexcep
 #endif
 }
 
-void BatchingQueueCallInvoker::ThreadCheck() noexcept {
-#if DEBUG
-  if (m_expectedThreadId == std::thread::id{}) {
-    m_expectedThreadId = std::this_thread::get_id();
-  } else {
-    assert(m_expectedThreadId == std::this_thread::get_id());
-  }
-#endif
-}
-
 void BatchingQueueCallInvoker::EnsureQueue() noexcept {
   if (!m_taskQueue) {
     m_taskQueue = std::make_shared<WorkItemQueue>();

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -29,7 +29,6 @@ struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
 
   using WorkItemQueue = std::vector<std::function<void()>>;
   std::shared_ptr<WorkItemQueue> m_taskQueue;
-  std::mutex m_mutex;
 
 #if DEBUG
   std::thread::id m_expectedThreadId{};
@@ -55,6 +54,7 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
   void onBatchComplete() noexcept override;
 
  private:
+  std::mutex m_mutex;
   std::shared_ptr<facebook::react::CallInvoker> m_callInvoker;
   std::shared_ptr<BatchingQueueCallInvoker> m_batchingQueueCallInvoker;
 };

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -16,7 +16,6 @@ namespace react::uwp {
 struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
   BatchingQueueCallInvoker(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread);
 
-  void ThreadCheck() noexcept;
   void invokeAsync(std::function<void()> &&func) noexcept override;
   void EnsureQueue() noexcept;
   void onBatchComplete() noexcept;
@@ -29,10 +28,6 @@ struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
 
   using WorkItemQueue = std::vector<std::function<void()>>;
   std::shared_ptr<WorkItemQueue> m_taskQueue;
-
-#if DEBUG
-  std::thread::id m_expectedThreadId{};
-#endif
 };
 
 // Executes the function on the provided UI Dispatcher

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -13,8 +13,6 @@ class Instance;
 
 namespace react::uwp {
 
-struct BatchingQueueThread;
-
 struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
   BatchingQueueCallInvoker(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread);
 

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -3,31 +3,28 @@
 
 #pragma once
 
+#include <ReactCommon/CallInvoker.h>
 #include <Shared/BatchingMessageQueueThread.h>
 #include <thread>
 
+namespace facebook::react {
+class Instance;
+}
+
 namespace react::uwp {
 
-// Executes the function on the provided UI Dispatcher
-struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
-  BatchingQueueThread(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept;
-  ~BatchingQueueThread() noexcept override;
+struct BatchingQueueThread;
 
-  BatchingQueueThread() = delete;
-  BatchingQueueThread(const BatchingQueueThread &other) = delete;
+struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
+  BatchingQueueCallInvoker(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread);
 
- public: // facebook::react::MessageQueueThread
-  void runOnQueue(std::function<void()> &&func) noexcept override;
-  void runOnQueueSync(std::function<void()> &&func) noexcept override;
-  void quitSynchronous() noexcept override;
-
- public: // facebook::react::BatchingMessageQueueThread
-  void onBatchComplete() noexcept override;
-
- private:
-  void EnsureQueue() noexcept;
   void ThreadCheck() noexcept;
+  void invokeAsync(std::function<void()> &&func) noexcept override;
+  void EnsureQueue() noexcept;
+  void onBatchComplete() noexcept;
+  void quitSynchronous() noexcept;
   void PostBatch() noexcept;
+  void invokeSync(std::function<void()> &&func) noexcept override;
 
  private:
   std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
@@ -39,6 +36,29 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
 #if DEBUG
   std::thread::id m_expectedThreadId{};
 #endif
+};
+
+// Executes the function on the provided UI Dispatcher
+struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
+  BatchingQueueThread(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept;
+  ~BatchingQueueThread() noexcept override;
+
+  BatchingQueueThread() = delete;
+  BatchingQueueThread(const BatchingQueueThread &other) = delete;
+
+  void decoratedNativeCallInvokerReady(std::weak_ptr<facebook::react::Instance> wkInstance) noexcept override;
+
+ public: // facebook::react::MessageQueueThread
+  void runOnQueue(std::function<void()> &&func) noexcept override;
+  void runOnQueueSync(std::function<void()> &&func) noexcept override;
+  void quitSynchronous() noexcept override;
+
+ public: // facebook::react::BatchingMessageQueueThread
+  void onBatchComplete() noexcept override;
+
+ private:
+  std::shared_ptr<facebook::react::CallInvoker> m_callInvoker;
+  std::shared_ptr<BatchingQueueCallInvoker> m_batchingQueueCallInvoker;
 };
 
 } // namespace react::uwp


### PR DESCRIPTION
Fixes #7543.

When running in release mode, we run a bunch of native modules as JSI modules.  When making a call from JS -> Native using a native module, this triggers a new UI batch.   When going through a JSI module, this doesn't happen.  

This change causes any call to BatchingMessageQueueThread to cause a new batch to happen.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7575)