### PR TITLE
Fix PlatformColor when using color names

### DIFF
--- a/change/react-native-windows-843fc71e-c555-4165-bb7c-8b9230109b8e.json
+++ b/change/react-native-windows-843fc71e-c555-4165-bb7c-8b9230109b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable any platform color to be used in PlatformColor()",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -86,11 +86,17 @@ xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
 
   winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
 
-  if (auto color = resource.try_as<ui::Color>()) {
-    return xaml::Media::SolidColorBrush(color.value());
+  if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+    return brush;
+  }
+  else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+    auto brush = xaml::Media::SolidColorBrush(color.value());
+    accentColorMap[resourceName] = winrt::make_weak(brush);
+    return brush;
   }
 
-  return winrt::unbox_value<winrt::Brush>(resource);
+  assert(false && "Resource is not a Color or Brush");
+  return nullptr;
 }
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -86,6 +86,10 @@ xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
 
   winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
 
+  if (auto color = resource.try_as<ui::Color>()) {
+    return xaml::Media::SolidColorBrush(color.value());
+  }
+
   return winrt::unbox_value<winrt::Brush>(resource);
 }
 

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -88,8 +88,7 @@ xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
 
   if (auto brush = resource.try_as<xaml::Media::Brush>()) {
     return brush;
-  }
-  else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+  } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
     auto brush = xaml::Media::SolidColorBrush(color.value());
     accentColorMap[resourceName] = winrt::make_weak(brush);
     return brush;


### PR DESCRIPTION
We have a short list of brush colors we allow, and if the requested PlatformColor value is not in the list we fall back to asking the app's resources for it and we expect the value to be a brush. However, some of these values will just be Color values.
When using ` style = {{ color: PlatformColor("SystemChromeAltLowColor") }} ` , we crashe because this is an `IReference<Color>` not a `Brush`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7577)