### PR TITLE
[0.64] Enable any platform color to be used in PlatformColor()

### DIFF
--- a/change/react-native-windows-1fda6013-a5ec-4ebc-8298-dfeab73f228a.json
+++ b/change/react-native-windows-1fda6013-a5ec-4ebc-8298-dfeab73f228a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "[0.64] Enable any platform color to be used in PlatformColor()",
+  "comment": "Enable any platform color to be used in PlatformColor()",
   "packageName": "react-native-windows",
   "email": "asklar@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-1fda6013-a5ec-4ebc-8298-dfeab73f228a.json
+++ b/change/react-native-windows-1fda6013-a5ec-4ebc-8298-dfeab73f228a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Enable any platform color to be used in PlatformColor()",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -89,7 +89,16 @@ xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
 
   winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
 
-  return winrt::unbox_value<winrt::Brush>(resource);
+  if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+    return brush;
+  } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+    auto brush = xaml::Media::SolidColorBrush(color.value());
+    accentColorMap[resourceName] = winrt::make_weak(brush);
+    return brush;
+  }
+
+  assert(false && "Resource is not a Color or Brush");
+  return nullptr;
 }
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {


### PR DESCRIPTION
Fixes #7576 (backport of #7577 to 0.64)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7581)