### PR TITLE
[0.63] Bump handlebars to 4.7.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "resolutions": {
     "acorn": "^7.1.1",
-    "handlebars": "^4.7.7",
     "logkitty": "^0.7.1",
     "**/eslint-plugin-react": "^7.14.1",
     "**/@wdio/appium-service": "5.12.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "resolutions": {
     "acorn": "^7.1.1",
+    "handlebars": "^4.7.7",
     "logkitty": "^0.7.1",
     "**/eslint-plugin-react": "^7.14.1",
     "**/@wdio/appium-service": "5.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7540,10 +7540,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.12, handlebars@^4.1.2:
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
-  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+handlebars@^4.0.12, handlebars@^4.1.2, handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7540,7 +7540,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.12, handlebars@^4.1.2, handlebars@^4.7.7:
+handlebars@^4.0.12, handlebars@^4.1.2:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==


### PR DESCRIPTION
handlebars before v4.7.7 are vulnerable to Remote Code Execution (RCE) when selecting certain compiling options to compile templates coming from an untrusted source. This PR bumps the version of handlebars we use to 4.7.7.

Backport of #7583.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7587)