### PR TITLE
Remove unnecessary use of yarn resolution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "resolutions": {
     "eslint-plugin-react-hooks": "4.0.7",
-    "handlebars": "^4.7.7",
     "kind-of": "6.0.3",
     "node-fetch": "2.6.1",
     "node-notifier": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,7 +5826,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.7.6:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==


### PR DESCRIPTION
I used yarn resolutions to bump the version of handlebars in #7583 . This is actually unnecessary and this PR removes the resolution usage.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7590)