### PR TITLE
Removing some disable warnings due to fix in RN 

### DIFF
--- a/change/react-native-windows-a3b2efc1-a095-4e99-be23-627563c4674c.json
+++ b/change/react-native-windows-a3b2efc1-a095-4e99-be23-627563c4674c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "re-enabling 4267 & 4100",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -98,26 +98,17 @@
       Make sure all FB code uses the same flags to improve build parallelism.
       This is because msbuild has to invoke different cl.exe invocations for each
       set of flags and msbuild inside a project is single threaded.
-
-      For TurboModule cpp we have to temporarily disable 4267 because that is a security
-      warning and we want to make sure we error out if we ever introduce it in our code
-      bug #6986 tracks fixing FB's
-      To manage perf we disable the warning on the other files that come from FB as well.
     -->
     <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp">
-      <DisableSpecificWarnings>4100;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\LongLivedObject.cpp">
-      <DisableSpecificWarnings>4100;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModule.cpp">
-      <DisableSpecificWarnings>4100;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModuleUtils.cpp">
-      <DisableSpecificWarnings>4100;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Some warnings were disabled in #6984, they can be reenabled thanks to a fix upstream: https://github.com/facebook/react-native/pull/31002.

Closes #6986.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7592)