### PR TITLE
README update for `good first issue` label

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Search the [existing issues](https://github.com/microsoft/react-native-windows/i
 ## Contributing
 See [Contributing guidelines](https://github.com/microsoft/react-native-windows/blob/master/docs/contributing.md) for how to setup your fork of the repo and start a PR to contribute to React Native for Windows.
 
-[Good First Task](https://github.com/microsoft/react-native-windows/labels/Good%20First%20Task) and [help wanted](https://github.com/microsoft/react-native-windows/labels/help%20wanted) are great starting points for PRs.
+[good first issue](https://github.com/microsoft/react-native-windows/labels/good%20first%20issue) and [help wanted](https://github.com/microsoft/react-native-windows/labels/help%20wanted) are great starting points for PRs.
 
 ## Documentation
 [React Native already has great documentation](https://reactnative.dev/docs/getting-started) and we're working to ensure the React Native Windows is part of that documentation story.


### PR DESCRIPTION
`Good First Task` label was recently changed to [`good first issue`](https://github.com/microsoft/react-native-windows/labels/good%20first%20issue) to match GitHub's preferences. This updates a link in README to reflect that change. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7596)