### PR TITLE
[0.64] Calling UIManager.dispatchViewManagerCommand should trigger updates

### DIFF
--- a/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
+++ b/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Calling UIManager.dispatchViewManagerCommand should trigger updates",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
+++ b/change/react-native-windows-f78483b0-732a-44b0-98f4-7becc372e8e3.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Calling UIManager.dispatchViewManagerCommand should trigger updates",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -112,48 +112,50 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
   virtual ~BridgeUIBatchInstanceCallback() = default;
   void onBatchComplete() override {
     if (auto instance = m_wkInstance.GetStrongPtr()) {
-      if (instance->UseWebDebugger()) {
-        // While using a CxxModule for UIManager (which we do when running under webdebugger)
-        // We need to post the batch complete to the NativeQueue to ensure that the UIManager
-        // has posted everything from this batch into its queue before we complete the batch.
-        instance->m_jsDispatchQueue.Load().Post([wkInstance = m_wkInstance]() {
-          if (auto instance = wkInstance.GetStrongPtr()) {
-            instance->m_batchingUIThread->runOnQueue([wkInstance]() {
-              if (auto instance = wkInstance.GetStrongPtr()) {
-                if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
-                  uiManager->onBatchComplete();
+      if (instance->IsLoaded()) {
+        if (instance->UseWebDebugger()) {
+          // While using a CxxModule for UIManager (which we do when running under webdebugger)
+          // We need to post the batch complete to the NativeQueue to ensure that the UIManager
+          // has posted everything from this batch into its queue before we complete the batch.
+          instance->m_jsDispatchQueue.Load().Post([wkInstance = m_wkInstance]() {
+            if (auto instance = wkInstance.GetStrongPtr()) {
+              instance->m_batchingUIThread->runOnQueue([wkInstance]() {
+                if (auto instance = wkInstance.GetStrongPtr()) {
+                  if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
+                    uiManager->onBatchComplete();
+                  }
                 }
-              }
-            });
+              });
 
 #ifdef WINRT
-            // For UWP we use a batching message queue to optimize the usage
-            // of the CoreDispatcher.  Win32 already has an optimized queue.
-            facebook::react::BatchingMessageQueueThread *batchingUIThread =
-                static_cast<facebook::react::BatchingMessageQueueThread *>(instance->m_batchingUIThread.get());
-            if (batchingUIThread != nullptr) {
-              batchingUIThread->onBatchComplete();
-            }
+              // For UWP we use a batching message queue to optimize the usage
+              // of the CoreDispatcher.  Win32 already has an optimized queue.
+              facebook::react::BatchingMessageQueueThread *batchingUIThread =
+                  static_cast<facebook::react::BatchingMessageQueueThread *>(instance->m_batchingUIThread.get());
+              if (batchingUIThread != nullptr) {
+                batchingUIThread->onBatchComplete();
+              }
 #endif
-          }
-        });
-      } else {
-        instance->m_batchingUIThread->runOnQueue([wkInstance = m_wkInstance]() {
-          if (auto instance = wkInstance.GetStrongPtr()) {
-            if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
-              uiManager->onBatchComplete();
             }
-          }
-        });
+          });
+        } else {
+          instance->m_batchingUIThread->runOnQueue([wkInstance = m_wkInstance]() {
+            if (auto instance = wkInstance.GetStrongPtr()) {
+              if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
+                uiManager->onBatchComplete();
+              }
+            }
+          });
 #ifdef WINRT
-        // For UWP we use a batching message queue to optimize the usage
-        // of the CoreDispatcher.  Win32 already has an optimized queue.
-        facebook::react::BatchingMessageQueueThread *batchingUIThread =
-            static_cast<facebook::react::BatchingMessageQueueThread *>(instance->m_batchingUIThread.get());
-        if (batchingUIThread != nullptr) {
-          batchingUIThread->onBatchComplete();
-        }
+          // For UWP we use a batching message queue to optimize the usage
+          // of the CoreDispatcher.  Win32 already has an optimized queue.
+          facebook::react::BatchingMessageQueueThread *batchingUIThread =
+              static_cast<facebook::react::BatchingMessageQueueThread *>(instance->m_batchingUIThread.get());
+          if (batchingUIThread != nullptr) {
+            batchingUIThread->onBatchComplete();
+          }
 #endif
+        }
       }
     }
   }
@@ -595,7 +597,13 @@ void ReactInstanceWin::InitUIMessageThread() noexcept {
   m_uiMessageThread.Exchange(
       std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
-  m_batchingUIThread = react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());
+  auto batchingUIThread = react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());
+  m_batchingUIThread = batchingUIThread;
+
+  m_jsDispatchQueue.Load().Post(
+      [batchingUIThread, instance = std::weak_ptr<facebook::react::Instance>(m_instance.Load())]() noexcept {
+        batchingUIThread->decoratedNativeCallInvokerReady(instance);
+      });
 }
 
 void ReactInstanceWin::InitUIManager() noexcept {

--- a/vnext/Shared/BatchingMessageQueueThread.h
+++ b/vnext/Shared/BatchingMessageQueueThread.h
@@ -8,9 +8,12 @@
 namespace facebook {
 namespace react {
 
+class Instance;
+
 class BatchingMessageQueueThread : public MessageQueueThread {
  public:
   virtual void onBatchComplete() = 0;
+  virtual void decoratedNativeCallInvokerReady(std::weak_ptr<facebook::react::Instance> wkInstance) noexcept = 0;
 };
 
 } // namespace react

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -3,20 +3,17 @@
 
 #include "pch.h"
 #include "Threading/BatchingQueueThread.h"
+#include <cxxreact/Instance.h>
 #include <eventWaitHandle/eventWaitHandle.h>
 #include <cassert>
 
 namespace react::uwp {
 
-BatchingQueueThread::BatchingQueueThread(
-    std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept
-    : m_queueThread{queueThread} {}
+BatchingQueueCallInvoker::BatchingQueueCallInvoker(
+    std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread)
+    : m_queueThread(queueThread) {}
 
-BatchingQueueThread::~BatchingQueueThread() noexcept {}
-
-void BatchingQueueThread::runOnQueue(std::function<void()> &&func) noexcept {
-  std::scoped_lock lck(m_mutex);
-
+void BatchingQueueCallInvoker::invokeAsync(std::function<void()> &&func) noexcept {
   EnsureQueue();
   m_taskQueue->emplace_back(std::move(func));
 
@@ -29,24 +26,14 @@ void BatchingQueueThread::runOnQueue(std::function<void()> &&func) noexcept {
 #endif
 }
 
-void BatchingQueueThread::ThreadCheck() noexcept {
-#if DEBUG
-  if (m_expectedThreadId == std::thread::id{}) {
-    m_expectedThreadId = std::this_thread::get_id();
-  } else {
-    assert(m_expectedThreadId == std::this_thread::get_id());
-  }
-#endif
-}
-
-void BatchingQueueThread::EnsureQueue() noexcept {
+void BatchingQueueCallInvoker::EnsureQueue() noexcept {
   if (!m_taskQueue) {
     m_taskQueue = std::make_shared<WorkItemQueue>();
     m_taskQueue->reserve(2048);
   }
 }
 
-void BatchingQueueThread::PostBatch() noexcept {
+void BatchingQueueCallInvoker::PostBatch() noexcept {
   if (m_taskQueue) {
     m_queueThread->runOnQueue([taskQueue{std::move(m_taskQueue)}]() noexcept {
       for (auto &task : *taskQueue) {
@@ -57,9 +44,49 @@ void BatchingQueueThread::PostBatch() noexcept {
   }
 }
 
+void BatchingQueueCallInvoker::onBatchComplete() noexcept {
+  PostBatch();
+}
+
+void BatchingQueueCallInvoker::quitSynchronous() noexcept {
+  PostBatch();
+  m_queueThread->quitSynchronous();
+}
+
+void BatchingQueueCallInvoker::invokeSync(std::function<void()> &&func) noexcept {
+  assert(false && "Not supported");
+  std::terminate();
+}
+
+BatchingQueueThread::BatchingQueueThread(
+    std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept {
+  m_batchingQueueCallInvoker = std::make_shared<BatchingQueueCallInvoker>(queueThread);
+  m_callInvoker = m_batchingQueueCallInvoker;
+}
+
+// Called from the JS thread, once the instance has had a chance to setup the NativeToJsBridge and calls to
+// getDecoratedNativeCallInvoker will work.
+void BatchingQueueThread::decoratedNativeCallInvokerReady(
+    std::weak_ptr<facebook::react::Instance> wkInstance) noexcept {
+  std::scoped_lock lck(m_mutex);
+  m_callInvoker->invokeAsync([wkInstance, this] {
+    if (auto instance = wkInstance.lock()) {
+      std::scoped_lock lck(m_mutex);
+      m_callInvoker = instance->getDecoratedNativeCallInvoker(m_callInvoker);
+    }
+  });
+}
+
+BatchingQueueThread::~BatchingQueueThread() noexcept {}
+
+void BatchingQueueThread::runOnQueue(std::function<void()> &&func) noexcept {
+  std::scoped_lock lck(m_mutex);
+  m_callInvoker->invokeAsync(std::move(func));
+}
+
 void BatchingQueueThread::onBatchComplete() noexcept {
   std::scoped_lock lck(m_mutex);
-  PostBatch();
+  m_batchingQueueCallInvoker->onBatchComplete();
 }
 
 void BatchingQueueThread::runOnQueueSync(std::function<void()> && /*func*/) noexcept {
@@ -69,8 +96,7 @@ void BatchingQueueThread::runOnQueueSync(std::function<void()> && /*func*/) noex
 
 void BatchingQueueThread::quitSynchronous() noexcept {
   std::scoped_lock lck(m_mutex);
-  PostBatch();
-  m_queueThread->quitSynchronous();
+  m_batchingQueueCallInvoker->quitSynchronous();
 }
 
 } // namespace react::uwp

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -3,10 +3,32 @@
 
 #pragma once
 
+#include <ReactCommon/CallInvoker.h>
 #include <Shared/BatchingMessageQueueThread.h>
 #include <thread>
 
+namespace facebook::react {
+class Instance;
+}
+
 namespace react::uwp {
+
+struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
+  BatchingQueueCallInvoker(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread);
+
+  void invokeAsync(std::function<void()> &&func) noexcept override;
+  void EnsureQueue() noexcept;
+  void onBatchComplete() noexcept;
+  void quitSynchronous() noexcept;
+  void PostBatch() noexcept;
+  void invokeSync(std::function<void()> &&func) noexcept override;
+
+ private:
+  std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
+
+  using WorkItemQueue = std::vector<std::function<void()>>;
+  std::shared_ptr<WorkItemQueue> m_taskQueue;
+};
 
 // Executes the function on the provided UI Dispatcher
 struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
@@ -15,6 +37,8 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
 
   BatchingQueueThread() = delete;
   BatchingQueueThread(const BatchingQueueThread &other) = delete;
+
+  void decoratedNativeCallInvokerReady(std::weak_ptr<facebook::react::Instance> wkInstance) noexcept override;
 
  public: // facebook::react::MessageQueueThread
   void runOnQueue(std::function<void()> &&func) noexcept override;
@@ -25,20 +49,9 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
   void onBatchComplete() noexcept override;
 
  private:
-  void EnsureQueue() noexcept;
-  void ThreadCheck() noexcept;
-  void PostBatch() noexcept;
-
- private:
-  std::shared_ptr<facebook::react::MessageQueueThread> m_queueThread;
-
-  using WorkItemQueue = std::vector<std::function<void()>>;
-  std::shared_ptr<WorkItemQueue> m_taskQueue;
   std::mutex m_mutex;
-
-#if DEBUG
-  std::thread::id m_expectedThreadId{};
-#endif
+  std::shared_ptr<facebook::react::CallInvoker> m_callInvoker;
+  std::shared_ptr<BatchingQueueCallInvoker> m_batchingQueueCallInvoker;
 };
 
 } // namespace react::uwp


### PR DESCRIPTION
Port of #7575 to 0.64

This fixes some cases where UI updates are not reflected immediately due to a queue not getting flushed when it should.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7603)