### PR TITLE
Restore Some SDL Warnings

### DIFF
--- a/change/react-native-windows-d484dd4c-0884-428b-9f78-a4e81ae18e7e.json
+++ b/change/react-native-windows-d484dd4c-0884-428b-9f78-a4e81ae18e7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "restore some SDL warnings",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/ReactRootViewTagGenerator.h
+++ b/vnext/Microsoft.ReactNative/Modules/ReactRootViewTagGenerator.h
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#pragma warning(push)
-#pragma warning(disable : 4244)
 #include <react/renderer/core/ReactPrimitives.h>
-#pragma warning(pop)
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -184,7 +184,7 @@
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModuleUtils.h" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\LongLivedObject.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboCxxModule.cpp" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModule.cpp" DisableSpecificWarnings="4267;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModule.cpp"/>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModuleBinding.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\core\ReactCommon\TurboModuleUtils.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\react\nativemodule\samples\ReactCommon\NativeSampleTurboCxxModuleSpecJSI.cpp" />

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -137,7 +137,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\JSBundleType.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\JSExecutor.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\JSIndexedRAMBundle.cpp" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\MethodCall.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\MethodCall.cpp"/>
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\ModuleRegistry.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\NativeToJsBridge.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\cxxreact\RAMBundleRegistry.cpp" />
@@ -150,17 +150,17 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\BridgeNativeModulePerfLogger.cpp" />
-    <ClCompile Include="$(YogaDir)\yoga\log.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(YogaDir)\yoga\log.cpp"/>
     <!-- We should ideally upstream a fix for missing stdexcept, but Yoga hasn't been accepting PRs as of May 2020 -->
-    <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)">
+    <ClCompile Include="$(YogaDir)\yoga\Utils.cpp">
       <ForcedIncludeFiles>stdexcept;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="$(YogaDir)\yoga\YGConfig.cpp" />
-    <ClCompile Include="$(YogaDir)\yoga\YGEnums.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
-    <ClCompile Include="$(YogaDir)\yoga\YGLayout.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
-    <ClCompile Include="$(YogaDir)\yoga\YGNode.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
-    <ClCompile Include="$(YogaDir)\yoga\YGNodePrint.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
-    <ClCompile Include="$(YogaDir)\yoga\YGStyle.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
+    <ClCompile Include="$(YogaDir)\yoga\YGEnums.cpp"/>
+    <ClCompile Include="$(YogaDir)\yoga\YGLayout.cpp"/>
+    <ClCompile Include="$(YogaDir)\yoga\YGNode.cpp"/>
+    <ClCompile Include="$(YogaDir)\yoga\YGNodePrint.cpp"/>
+    <ClCompile Include="$(YogaDir)\yoga\YGStyle.cpp"/>
     <ClCompile Include="$(YogaDir)\yoga\YGValue.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\core\Sealable.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\debug\DebugStringConvertible.cpp" />
@@ -171,7 +171,7 @@
     <!--
       Using a patched copy of Yoga due to https://github.com/microsoft/react-native-windows/issues/3994
     -->
-    <ClCompile Include="Yoga.cpp" AdditionalIncludeDirectories="$(YogaDir)\yoga;%(AdditionalIncludeDirectories)" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)" />
+    <ClCompile Include="Yoga.cpp" AdditionalIncludeDirectories="$(YogaDir)\yoga;%(AdditionalIncludeDirectories)"/>
     <ClCompile Include="$(YogaDir)\yoga\event\event.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -22,7 +22,7 @@
 #include <winrt/Windows.Web.Http.h>
 
 #pragma warning(push)
-#pragma warning(disable : 4244 4068 4251 4101 4267 4804 4309)
+#pragma warning(disable : 4068 4251 4101 4804 4309)
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/MessageQueueThread.h>
 #pragma warning(pop)


### PR DESCRIPTION
Re-enabling some SDL warnings that are required per SDL. Thanks to a fix [upstream](https://github.com/facebook/react-native/pull/31002), these are no longer needed. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7614)