### PR TITLE
Restoring warnings for SDL compliance

### DIFF
--- a/change/react-native-windows-4ce5570d-3577-4e55-9aff-a07ec887c09f.json
+++ b/change/react-native-windows-4ce5570d-3577-4e55-9aff-a07ec887c09f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "restore some SDL warnings",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/cppExtensions/autoRestore.h
+++ b/vnext/Mso/cppExtensions/autoRestore.h
@@ -15,17 +15,12 @@
 #ifdef __cplusplus
 // 4091: extern __declspec(dllimport)' : ignored on left of 'double' when no variable is declared
 // 4472: 'pointer_safety' is a native enum: add an access specifier (private/public) to declare a managed enum
-// 4996: 'wmemcpy': This function or variable may be unsafe. Consider using wmemcpy_s instead
 #pragma warning(push)
-#pragma warning(disable : 4091 4472 4996)
+#pragma warning(disable : 4091 4472)
 #include <memory>
 #pragma warning(pop)
 
-// 4996: 'wmemcpy': This function or variable may be unsafe. Consider using wmemcpy_s instead
-#pragma warning(push)
-#pragma warning(disable : 4996)
 #include <utility>
-#pragma warning(pop)
 
 namespace Mso {
 

--- a/vnext/Mso/debugAssertApi/debugAssertDetails.h
+++ b/vnext/Mso/debugAssertApi/debugAssertDetails.h
@@ -109,7 +109,7 @@ static
           DeclareMsoAssertParams(dwTag, szFile, iLine);                                                         \
       params.framesToSkip++;                                                                                    \
       const int32_t _assertResult_ = MsoAssertSzTagProcInline(PassMsoAssertParams(params), szFmt, __VA_ARGS__); \
-          if (_assertResult_ == c_assertDebugBreak) {                                                           \
+      if (_assertResult_ == c_assertDebugBreak) {                                                               \
         AssertBreak(wzAnnotation);                                                                              \
       }                                                                                                         \
       _fIgnore_ = (_assertResult_ == c_assertAlwaysIgnore);                                                     \

--- a/vnext/Mso/debugAssertApi/debugAssertDetails.h
+++ b/vnext/Mso/debugAssertApi/debugAssertDetails.h
@@ -109,7 +109,6 @@ static
           DeclareMsoAssertParams(dwTag, szFile, iLine);                                                         \
       params.framesToSkip++;                                                                                    \
       const int32_t _assertResult_ = MsoAssertSzTagProcInline(PassMsoAssertParams(params), szFmt, __VA_ARGS__); \
-      __pragma(warning(suppress : 4700)) /* MSVC is unhappy with this used in a loop conditional */             \
           if (_assertResult_ == c_assertDebugBreak) {                                                           \
         AssertBreak(wzAnnotation);                                                                              \
       }                                                                                                         \

--- a/vnext/Mso/motifCpp/motifCppTest.h
+++ b/vnext/Mso/motifCpp/motifCppTest.h
@@ -238,8 +238,6 @@ struct TerminateHandlerRestorer {
   std::terminate_handler Handler;
 };
 
-#pragma warning(push)
-#pragma warning(disable : 4611) // interaction between '_setjmp' and C++ object destruction is non-portable
 template <class TLambda>
 inline bool ExpectTerminateCore(TLambda const &lambda) {
   static jmp_buf buf;
@@ -255,7 +253,6 @@ inline bool ExpectTerminateCore(TLambda const &lambda) {
     return true; // executed if longjmp is executed in the terminate handler.
   }
 }
-#pragma warning(pop)
 
 template <class TLambda>
 inline void

--- a/vnext/Mso/smartPtr/smartPointerBase.h
+++ b/vnext/Mso/smartPtr/smartPointerBase.h
@@ -10,10 +10,7 @@
 #include "debugAssertApi/debugAssertApi.h"
 #include "typeTraits/typeTraits.h"
 
-#pragma warning(push)
-#pragma warning(disable : 4996) // wmemcpy
 #include <utility>
-#pragma warning(pop)
 
 namespace Mso {
 
@@ -255,7 +252,6 @@ class THolder {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
-#pragma warning(suppress : 4996) // deprecated function
     TEmptyTraits::UnsafeEmpty(m_pT);
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/vnext/Shared/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.cpp
@@ -19,7 +19,7 @@
 
 // Hx/OFFICEDEV: Ignore warnings
 #pragma warning(push)
-#pragma warning(disable : 4100 4101 4244 4290 4456)
+#pragma warning(disable : 4100 4101 4290 4456)
 
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
@@ -277,7 +277,7 @@ void WebSocketJSExecutor::OnMessageReceived(const std::string &msg) {
   folly::dynamic parsed = folly::parseJson(msg);
   auto it_parsed = parsed.find("replyID");
   if (it_parsed != parsed.items().end()) {
-    int replyId = it_parsed->second.asInt();
+    int replyId = static_cast<int>(it_parsed->second.asInt());
 
     std::lock_guard<std::mutex> lock(m_lockPromises);
     auto it_promise = m_promises.find(replyId);


### PR DESCRIPTION
Re-enabling some warnings that are required per SDL - going towards #6918. C4996, C4700, and C4611 were no longer needed. C4244 fixed with an explicit static cast to int. 

The only remaining suppressions blocking us from SDL compliance are coming from folly(4244 and 4267 being set off from ToAscii.h), which I will address next. 