### PR TITLE
[0.64] Suppress onLayout event when layout has not changed (#7470)

### DIFF
--- a/change/react-native-windows-5eed73aa-6cf2-4940-9e6e-d2ae1d5b0740.json
+++ b/change/react-native-windows-5eed73aa-6cf2-4940-9e6e-d2ae1d5b0740.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Suppress onLayout event when layout has not changed",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e07fd82b-045a-44b9-a416-642e23b1ff67.json
+++ b/change/react-native-windows-e07fd82b-045a-44b9-a416-642e23b1ff67.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "Suppress onLayout event when layout has not changed",
+  "type": "patch",
+  "comment": "Suppress onLayout event when layout has not changed (#7470)",
   "packageName": "react-native-windows",
   "email": "erozell@outlook.com",
   "dependentChangeType": "patch"

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -324,6 +324,9 @@ void ViewManagerBase::SetLayoutProps(
   }
   auto fe = element.as<xaml::FrameworkElement>();
 
+  const bool layoutHasChanged = left != react::uwp::ViewPanel::GetLeft(element) ||
+      top != react::uwp::ViewPanel::GetTop(element) || width != fe.Width() || height != fe.Height();
+
   // Set Position & Size Properties
   react::uwp::ViewPanel::SetLeft(element, left);
   react::uwp::ViewPanel::SetTop(element, top);
@@ -332,7 +335,7 @@ void ViewManagerBase::SetLayoutProps(
   fe.Height(height);
 
   // Fire Events
-  if (nodeToUpdate.m_onLayoutRegistered) {
+  if (layoutHasChanged && nodeToUpdate.m_onLayoutRegistered) {
     int64_t tag = GetTag(viewToUpdate);
     folly::dynamic layout = folly::dynamic::object("x", left)("y", top)("height", height)("width", width);
 


### PR DESCRIPTION
* Suppress onLayout event when layout has not changed

Yoga sometimes sets `hasNewLayout` on nodes even when their layout has
not changed. One common case where this occurs is in lists. Any time the
parent container of a list is dirtied, even for something that does not
affect it's dimensions, all elements in the list go through a layout
pass and set `hasNewLayout`. This change at least reduces the number of
events sent to JS when layout has not really changed, though a more
effective fix would be to have Yoga be a little smarter about when to
layout. If you're interested, here's where Yoga decides to update layout
on all stretch aligned children of a parent container:
https://github.com/facebook/yoga/blob/master/yoga/Yoga.cpp#L3104-L3107

iOS and Android already do this, so this change should serve to make
things more consistent:
iOS:
https://github.com/facebook/react-native/blob/0f4f91766339f2cf4189446d7d575493d33b4009/React/Views/RCTShadowView.m#L305
Android:
https://github.com/facebook/react-native/blob/6e6443afd04a847ef23fb6254a84e48c70b45896/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java#L363-L367

* Updating with results of yarn format

* Change files

* Fixes nit

Closes #7602 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7636)