### PR TITLE
Re-enabling CG checks in CI/PR

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -169,4 +169,3 @@ jobs:
         inputs:
           alertWarningLevel: Medium
           scanType: 'Register'
-        condition: false # Temporarily disabling CG, see https://github.com/microsoft/react-native-windows/issues/7261

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -113,7 +113,6 @@
                   inputs:
                     alertWarningLevel: Medium
                     scanType: 'Register'
-                  condition: false # Temporarily disabling CG, see https://github.com/microsoft/react-native-windows/issues/7261
 
                 
             - job: UniversalTest${{ matrix.Name }}


### PR DESCRIPTION
This change re-enables the CG checks for CI/PR builds. The builds won't
fail on an alert, but the alerts will be raised so we can work to fix
them before a release.

Closes #7261

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7655)