### PR TITLE
[0.64] Re-enabling CG checks in PR

### DIFF
--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -164,7 +164,6 @@ jobs:
         inputs:
           alertWarningLevel: Medium
           scanType: 'Register'
-        condition: false # Temporarily disabling CG, see https://github.com/microsoft/react-native-windows/issues/7261
 
   - job: RNW_WinUI3
     variables:
@@ -510,7 +509,6 @@ jobs:
         inputs:
           alertWarningLevel: Medium
           scanType: 'Register'
-        condition: false # Temporarily disabling CG, see https://github.com/microsoft/react-native-windows/issues/7261
 
   - job: CliInit
     variables:


### PR DESCRIPTION
This change re-enables the CG checks for PR builds. The builds won't
fail on an alert, but the alerts will be raised so we can work to fix
them before a release.

Closes #7261

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7656)