### PR TITLE
Reunion prep

### DIFF
--- a/change/react-native-windows-1a01dcab-b7ee-4d5c-8afd-b230de0b44ce.json
+++ b/change/react-native-windows-1a01dcab-b7ee-4d5c-8afd-b230de0b44ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Changes required to run in a Reunion app",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -161,7 +161,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Midl>
-      <PreprocessorDefinitions>USE_DOCSTRING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(UseDocString)'!='false'">USE_DOCSTRING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -17,7 +17,9 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
   // We need to register for notifications from the XAML thread.
   if (auto dispatcher = reactContext.UIDispatcher()) {
     dispatcher.Post([this]() {
-      if (auto currentApp = xaml::TryGetCurrentApplication()) {
+      auto currentApp = xaml::TryGetCurrentApplication();
+
+      if (!react::uwp::IsWinUI3Island() && currentApp != nullptr) {
         m_enteredBackgroundRevoker = currentApp.EnteredBackground(
             winrt::auto_revoke,
             [weakThis = weak_from_this()](

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -37,6 +37,7 @@ ReactApplication::ReactApplication(IInspectable const &outer) noexcept : ReactAp
         f.CreateInstance(outer ? outer : static_cast<IInspectable const &>(*this), this->m_inner);
   });
 
+#ifndef USE_WINUI3
   Suspending({this, &ReactApplication::OnSuspending});
 
 #if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
@@ -46,6 +47,7 @@ ReactApplication::ReactApplication(IInspectable const &outer) noexcept : ReactAp
       __debugbreak();
     }
   });
+#endif
 #endif
 }
 

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -142,15 +142,15 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
       m_redboxContent.Width(root.ActualWidth());
 
       m_sizeChangedRevoker = root.SizeChanged(
-        winrt::auto_revoke,
-        [wkThis = weak_from_this()](auto const& /*sender*/, xaml::SizeChangedEventArgs const& args) {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->m_redboxContent.MaxHeight(args.NewSize().Height);
-          strongThis->m_redboxContent.Height(args.NewSize().Height);
-          strongThis->m_redboxContent.MaxWidth(args.NewSize().Width);
-          strongThis->m_redboxContent.Width(args.NewSize().Width);
-        }
-      });
+          winrt::auto_revoke,
+          [wkThis = weak_from_this()](auto const & /*sender*/, xaml::SizeChangedEventArgs const &args) {
+            if (auto strongThis = wkThis.lock()) {
+              strongThis->m_redboxContent.MaxHeight(args.NewSize().Height);
+              strongThis->m_redboxContent.Height(args.NewSize().Height);
+              strongThis->m_redboxContent.MaxWidth(args.NewSize().Width);
+              strongThis->m_redboxContent.Width(args.NewSize().Width);
+            }
+          });
     }
 
     m_tokenClosed = m_popup.Closed(
@@ -248,9 +248,8 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
     m_stackPanel.Children().Clear();
     m_stackPanel.Children().Append(webView);
 #ifdef USE_WINUI3
-    webView.EnsureCoreWebView2Async().Completed([content, webView](auto&& sender, auto&& args) {
-      webView.NavigateToString(content);
-      });
+    webView.EnsureCoreWebView2Async().Completed(
+        [content, webView](auto &&sender, auto &&args) { webView.NavigateToString(content); });
 #else
     webView.NavigateToString(content);
 #endif


### PR DESCRIPTION
This introduces some changes required for Reunion:
- removed app lifecycle events (Suspending/UnhandledException)
- ensure we call EnsureCoreWebView2 before we show the error text in RedBox (filed a doc bug too since this isn't documented)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7657)