### PR TITLE
Update PlatformColor brushes upon theme change

### DIFF
--- a/change/react-native-windows-4062d121-1aa5-49ae-b74c-861571c1fcd5.json
+++ b/change/react-native-windows-4062d121-1aa5-49ae-b74c-861571c1fcd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update brush cache when theme changes",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -67,7 +67,7 @@ xaml::Media::Brush BrushFromTheme(winrt::hstring resourceName) {
   return brush;
 }
 
-struct BrushCache : public std::map<winrt::hstring, winrt::weak_ref<xaml::Media::SolidColorBrush>> {
+struct BrushCache {
   std::map<winrt::hstring, xaml::Media::Brush> m_map;
   winrt::Windows::UI::ViewManagement::UISettings m_uiSettings{nullptr};
   BrushCache() {

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -3,8 +3,11 @@
 
 #include "pch.h"
 
+#include <CppWinRTIncludes.h>
 #include <UI.Xaml.Markup.h>
+#include <UI.Xaml.Media.h>
 #include <Utils/ValueUtils.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include "Unicode.h"
 
 #include <JSValue.h>
@@ -44,58 +47,105 @@ struct ColorComp {
   }
 };
 
-xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
-  thread_local static std::map<winrt::hstring, winrt::weak_ref<xaml::Media::SolidColorBrush>> accentColorMap = {
-      {L"SystemAccentColor", {nullptr}},
-      {L"SystemAccentColorLight1", {nullptr}},
-      {L"SystemAccentColorLight2", {nullptr}},
-      {L"SystemAccentColorLight3", {nullptr}},
-      {L"SystemAccentColorDark1", {nullptr}},
-      {L"SystemAccentColorDark2", {nullptr}},
-      {L"SystemAccentColorDark3", {nullptr}},
-      {L"SystemListAccentLowColor", {nullptr}},
-      {L"SystemListAccentMediumColor", {nullptr}},
-      {L"SystemListAccentHighColor", {nullptr}}};
+xaml::Media::Brush BrushFromTheme(winrt::hstring resourceName) {
+  winrt::hstring xamlString =
+      L"<ResourceDictionary"
+      L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
+      L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
+      L"  <SolidColorBrush"
+      L"      x:Key='" +
+      resourceName +
+      L"'"
+      L"      Color='{ThemeResource " +
+      resourceName +
+      "}' />"
+      L"</ResourceDictionary>";
 
-  if (accentColorMap.find(resourceName) != accentColorMap.end()) {
-    if (auto brush = accentColorMap.at(resourceName).get()) {
-      return brush;
+  auto dictionary{winrt::unbox_value<winrt::ResourceDictionary>(winrt::Markup::XamlReader::Load(xamlString))};
+
+  auto brush{winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.Lookup(winrt::box_value(resourceName)))};
+  return brush;
+}
+
+struct BrushCache : public std::map<winrt::hstring, winrt::weak_ref<xaml::Media::SolidColorBrush>> {
+  std::map<winrt::hstring, xaml::Media::Brush> m_map;
+  winrt::Windows::UI::ViewManagement::UISettings m_uiSettings{nullptr};
+  BrushCache() {
+    m_map = {
+        {L"SystemAccentColor", {nullptr}},
+        {L"SystemAccentColorLight1", {nullptr}},
+        {L"SystemAccentColorLight2", {nullptr}},
+        {L"SystemAccentColorLight3", {nullptr}},
+        {L"SystemAccentColorDark1", {nullptr}},
+        {L"SystemAccentColorDark2", {nullptr}},
+        {L"SystemAccentColorDark3", {nullptr}},
+        {L"SystemListAccentLowColor", {nullptr}},
+        {L"SystemListAccentMediumColor", {nullptr}},
+        {L"SystemListAccentHighColor", {nullptr}}};
+
+    m_uiSettings = winrt::Windows::UI::ViewManagement::UISettings();
+    auto dq = winrt::system::DispatcherQueue::GetForCurrentThread();
+    m_uiSettings.ColorValuesChanged([this, dq](auto &&sender, auto &&args) {
+      dq.TryEnqueue([this]() {
+        for (auto &entry : m_map) {
+          winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(entry.first))};
+          if (auto oldSCBrush = entry.second.try_as<xaml::Media::SolidColorBrush>()) {
+            if (auto newSCBrush = resource.try_as<xaml::Media::SolidColorBrush>()) {
+              oldSCBrush.Color(newSCBrush.Color());
+            }
+          }
+          // Similar logic can be applied to copy Acrylic or Reveal brushes
+          /*
+          else if (auto oldAcBrush = entry.second.try_as<xaml::Media::AcrylicBrush>()) {
+            if (auto newAcBrush = resource.try_as<xaml::Media::AcrylicBrush>()) {
+              // ...
+            }
+          }
+          */
+        }
+      });
+    });
+  }
+
+  xaml::Media::Brush BrushFromResourceName(winrt::hstring resourceName) {
+    if (m_map.find(resourceName) != m_map.end()) {
+      if (auto brush = m_map.at(resourceName)) {
+        return brush;
+      }
+
+      auto brush = BrushFromTheme(resourceName);
+      return RegisterBrush(resourceName, brush);
     }
 
-    winrt::hstring xamlString =
-        L"<ResourceDictionary"
-        L"    xmlns='http://schemas.microsoft.com/winfx/2006/xaml/presentation'"
-        L"    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>"
-        L"  <SolidColorBrush"
-        L"      x:Key='" +
-        resourceName +
-        L"'"
-        L"      Color='{ThemeResource " +
-        resourceName +
-        "}' />"
-        L"</ResourceDictionary>";
+    winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
 
-    auto dictionary{winrt::unbox_value<winrt::ResourceDictionary>(winrt::Markup::XamlReader::Load(xamlString))};
+    if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+      return RegisterBrush(resourceName, brush);
+    } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+      auto brush = xaml::Media::SolidColorBrush(color.value());
+      return RegisterBrush(resourceName, brush);
+    }
 
-    auto brush{winrt::unbox_value<xaml::Media::SolidColorBrush>(dictionary.Lookup(winrt::box_value(resourceName)))};
-
-    accentColorMap[resourceName] = winrt::make_weak(brush);
-
-    return brush;
+    assert(false && "Resource is not a Color or Brush");
+    return nullptr;
   }
 
-  winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
-
-  if (auto brush = resource.try_as<xaml::Media::Brush>()) {
-    return brush;
-  } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
-    auto brush = xaml::Media::SolidColorBrush(color.value());
-    accentColorMap[resourceName] = winrt::make_weak(brush);
-    return brush;
+  xaml::Media::Brush RegisterBrush(winrt::hstring resourceName, const xaml::Media::Brush &brush) {
+    if (auto scb = brush.try_as<xaml::Media::SolidColorBrush>()) {
+      auto scb2 = xaml::Media::SolidColorBrush{scb.Color()};
+      m_map.emplace(resourceName, scb2);
+      return scb2;
+    } else {
+      m_map.emplace(resourceName, brush);
+      return brush;
+    }
   }
+};
 
-  assert(false && "Resource is not a Color or Brush");
-  return nullptr;
+xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
+  thread_local static BrushCache accentColorMap;
+
+  return accentColorMap.BrushFromResourceName(resourceName);
 }
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {


### PR DESCRIPTION
Fixes #7640 

The brush cache was keeping weak pointers to the brushes it returned. However upon a theme change, XAML will recreate the theme brushes in the Application resources, but those were not being transferred back onto the app's UI elements.
The fix is to listen for theme events and shuttle the color values for `SolidColorBrush` instances between the new values and the values we have in the cache (which are what the UI will use).

We have to do this ourselves as opposed to relying on XAML to propagate the brushes, because the UI elements are all created dynamically and can't use the markup `ThemeResource` construct.

With this change, an element that uses PlatformColor( ... ) with a Brush name that is a solid color, will correctly update upon a theme refresh. If the brush is not a solid color (e.g. Acrylic, or Reveal), then they won't be updated by this code. We still need to figure out a way to address that but I wanted to fix the 90% case now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7663)