### PR TITLE
Adds 'autoFocus' prop to TextInput

### DIFF
--- a/change/react-native-windows-a83fe313-38da-4b46-a583-6f8346f1d41b.json
+++ b/change/react-native-windows-a83fe313-38da-4b46-a583-6f8346f1d41b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds 'autoFocus' prop to TextInput",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -133,6 +133,7 @@ class TextInputShadowNode : public ShadowNodeBase {
   void SetSelection(int64_t start, int64_t end);
   winrt::Shape FindCaret(xaml::DependencyObject element);
 
+  bool m_autoFocus = false;
   bool m_shouldClearTextOnFocus = false;
   bool m_shouldSelectTextOnFocus = false;
   bool m_contextMenuHidden = false;
@@ -308,6 +309,10 @@ void TextInputShadowNode::registerEvents() {
       });
 
   m_controlLoadedRevoker = control.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
+    if (m_autoFocus) {
+      control.Focus(xaml::FocusState::Keyboard);
+    }
+
     auto contentElement = control.GetTemplateChild(L"ContentElement");
     auto textBoxView = contentElement.as<xaml::Controls::ScrollViewer>();
     if (textBoxView) {
@@ -599,6 +604,9 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
         m_submitKeyEvents.clear();
     } else if (propertyName == "keyDownEvents") {
       hasKeyDownEvents = propertyValue.ItemCount() > 0;
+    } else if (propertyName == "autoFocus") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
+        m_autoFocus = propertyValue.AsBoolean();
     } else {
       if (m_isTextBox) { // Applicable properties for TextBox
         if (TryUpdateTextAlignment(textBox, propertyName, propertyValue)) {
@@ -761,6 +769,7 @@ void TextInputViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::I
   React::WriteProperty(writer, L"autoCapitalize", L"string");
   React::WriteProperty(writer, L"clearTextOnSubmit", L"boolean");
   React::WriteProperty(writer, L"submitKeyEvents", L"array");
+  React::WriteProperty(writer, L"autoFocus", L"boolean");
 }
 
 void TextInputViewManager::GetExportedCustomDirectEventTypeConstants(


### PR DESCRIPTION
The 'autoFocus' feature is a useful way to ensure the TextInput gets focus as soon as it comes into view. This change implements autoFocus by storing a boolean in the shadow node and calling Control::Focus on the TextBox or PasswordBox in the Loaded event. FocusState::Keyboard is used because this is the same state the [UIManager uses](https://github.com/microsoft/react-native-windows/blob/2c5ba22a3cfa4447dd227b4f7274c882e1786fed/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp#L1103).

See https://reactnative.dev/docs/textinput#autofocus

Fixes #2198

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7664)