### PR TITLE
Remove version from ExperimentalFeatures.props links 

### DIFF
--- a/change/@react-native-windows-cli-21b8c27c-4f1b-459e-a14e-52a01774729b.json
+++ b/change/@react-native-windows-cli-21b8c27c-4f1b-459e-a14e-52a01774729b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove version from ExperimentalFeatures.props links",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-286084fd-2a87-474f-9806-269f85faf51e.json
+++ b/change/react-native-windows-286084fd-2a87-474f-9806-269f85faf51e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove version from ExperimentalFeatures.props links",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
+++ b/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
@@ -154,7 +154,7 @@ exports[`useWinUI3=true in react-native.config.js, useWinUI3=false in Experiment
     <!--
       Enables default usage of Hermes.
       
-      See https://microsoft.github.io/react-native-windows/docs/0.64/hermes
+      See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
     <UseHermes>false</UseHermes>
 
@@ -162,7 +162,7 @@ exports[`useWinUI3=true in react-native.config.js, useWinUI3=false in Experiment
       Changes compilation to assume use of WinUI 3 instead of System XAML.
       Requires creation of new project.
 
-      See https://microsoft.github.io/react-native-windows/docs/0.64/winui3
+      See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
     <UseWinUI3>true</UseWinUI3>
   

--- a/vnext/template/shared-app/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-app/proj/ExperimentalFeatures.props
@@ -6,7 +6,7 @@
     <!--
       Enables default usage of Hermes.
       
-      See https://microsoft.github.io/react-native-windows/docs/0.64/hermes
+      See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
     <UseHermes>{{useHermes}}</UseHermes>
 
@@ -14,7 +14,7 @@
       Changes compilation to assume use of WinUI 3 instead of System XAML.
       Requires creation of new project.
 
-      See https://microsoft.github.io/react-native-windows/docs/0.64/winui3
+      See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
     <UseWinUI3>{{useWinUI3}}</UseWinUI3>
   


### PR DESCRIPTION
These links don't work until 0.65 is published. We might be able to do permalinks for this later (esp with docusaurus V2) but for now, remove the version.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7670)