### PR TITLE
[0.64] Remove version from ExperimentalFeatures.props links

### DIFF
--- a/change/react-native-windows-743fdc9e-558b-4827-9385-81d7b9fb9a41.json
+++ b/change/react-native-windows-743fdc9e-558b-4827-9385-81d7b9fb9a41.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove version from ExperimentalFeatures.props links",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/shared-app/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-app/proj/ExperimentalFeatures.props
@@ -7,7 +7,7 @@
       Changes compilation to assume use of WinUI 3 instead of System XAML.
       Requires creation of new project.
 
-      See https://microsoft.github.io/react-native-windows/docs/0.64/winui3
+      See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
     <UseWinUI3>{{useWinUI3}}</UseWinUI3>
 
@@ -15,7 +15,7 @@
       Compiles Hermes-related code and sets it to the default JS engine.
       Requires the "ReactNative.Hermes.Windows" NuGet package.
       
-      See https://microsoft.github.io/react-native-windows/docs/0.64/hermes
+      See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
     <UseHermes>{{useHermes}}</UseHermes>
   


### PR DESCRIPTION
These links don't work until 0.65 is published. We might be able to do permalinks for this later (esp with docusaurus V2) but for now, remove the version.

Fixes #7427

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7671)