### PR TITLE
Update to latest @types/react-native

### DIFF
--- a/change/@office-iss-react-native-win32-66cdc8c8-5b8e-4fa6-a5e1-8d56ed4177d9.json
+++ b/change/@office-iss-react-native-win32-66cdc8c8-5b8e-4fa6-a5e1-8d56ed4177d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update to latest @types/react-native",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-9f1234cc-6092-4410-96b3-e5c042444d04.json
+++ b/change/react-native-windows-9f1234cc-6092-4410-96b3-e5c042444d04.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update to latest @types/react-native",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^14.14.22",
     "@types/prop-types": "15.7.1",
     "@types/react": "16.9.11",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "babel-eslint": "^10.1.0",
     "eslint": "7.12.0",
     "flow-bin": "^0.148.0",

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "babel-jest": "^26.3.0",
     "eslint": "7.12.0",
     "jest": "^26.5.2",

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -29,7 +29,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/ora": "^3.2.0",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "@types/ws": "^7.4.0",
     "babel-jest": "^26.3.0",
     "eslint": "7.12.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -22,7 +22,7 @@
     "@rnw-scripts/ts-config": "1.1.0",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "eslint": "7.12.0",
     "just-scripts": "^1.3.3",
     "metro-react-native-babel-preset": "^0.56.0",

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -22,7 +22,7 @@
     "@rnw-scripts/eslint-config": "1.1.6",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "eslint": "7.12.0",
     "just-scripts": "^1.3.3",
     "metro-react-native-babel-preset": "^0.56.0",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -59,7 +59,7 @@
     "@rnw-scripts/eslint-config": "1.1.6",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
-    "@types/react-native": "^0.63.46",
+    "@types/react-native": "^0.64.4",
     "eslint": "7.12.0",
     "eslint-plugin-prettier": "2.6.2",
     "flow-bin": "^0.148.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,10 +2108,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/react-native@^0.63.46":
-  version "0.63.52"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.52.tgz#449beb4a413ec0f2c172cbf676a95f5b0952adf4"
-  integrity sha512-sBXvvtJaIUSXQLDh9NZitx1KHkKUdBLZy34lFKJaIXtpHIh5OEbBXeyUTFBtFwjk/RD0tneAtUqsdhheZRzAzw==
+"@types/react-native@^0.64.4":
+  version "0.64.4"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.4.tgz#9f11bef7dd5520801884829c73b19d75aa42e73c"
+  integrity sha512-VqnlmadGkD5usREvnuyVpWDS1W8f6cCz6MP5fZdgONsaZ9/Ijfb9Iq9MZ5O3bnW1OyJixDX9HtSp3COsFSLD8Q==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Fixes #7467

No need to backport since we do not export these types. Only use them as an internal devDependency.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7672)