### PR TITLE
Bump RN peerDependency whenever it is prerelease

### DIFF
--- a/change/@rnw-scripts-integrate-rn-1b977494-5cfd-40f4-b3cd-937b35bd3e6d.json
+++ b/change/@rnw-scripts-integrate-rn-1b977494-5cfd-40f4-b3cd-937b35bd3e6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump RN peerDependency whenever it is prerelease",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/test/upgradeDependencies.test.ts
@@ -543,6 +543,64 @@ test('Out-of-tree platform (RN peerDependency satisfied)', () => {
   expectSortedDeps(deps);
 });
 
+test('Out-of-tree platform (RN peerDependency prerelease to prerelease)', () => {
+  const outOfTreeDeps: LocalPackageDeps = {
+    ...olderReactNative,
+    peerDependencies: {
+      ...olderReactNative.peerDependencies,
+      'react-native': '^0.63.0-rc.0',
+    },
+    packageName: 'react-native-windows',
+    outOfTreePlatform: true,
+  };
+
+  const deps = calcPackageDependencies('0.63.0-rc.1', rnDiff, repoConfigDiff, [
+    outOfTreeDeps,
+  ]);
+
+  expect(deps.length).toEqual(1);
+  expect(deps[0]).toEqual({
+    ...outOfTreeDeps,
+    dependencies: newerReactNative.dependencies,
+    peerDependencies: {
+      ...newerReactNative.peerDependencies,
+      'react-native': '^0.63.0-rc.1',
+    },
+    devDependencies: newerReactNative.devDependencies,
+  });
+
+  expectSortedDeps(deps);
+});
+
+test('Out-of-tree platform (RN peerDependency prerelease to release)', () => {
+  const outOfTreeDeps: LocalPackageDeps = {
+    ...olderReactNative,
+    peerDependencies: {
+      ...olderReactNative.peerDependencies,
+      'react-native': '^0.63.0-rc.1',
+    },
+    packageName: 'react-native-windows',
+    outOfTreePlatform: true,
+  };
+
+  const deps = calcPackageDependencies('0.63.0', rnDiff, repoConfigDiff, [
+    outOfTreeDeps,
+  ]);
+
+  expect(deps.length).toEqual(1);
+  expect(deps[0]).toEqual({
+    ...outOfTreeDeps,
+    dependencies: newerReactNative.dependencies,
+    peerDependencies: {
+      ...newerReactNative.peerDependencies,
+      'react-native': '^0.63.0',
+    },
+    devDependencies: newerReactNative.devDependencies,
+  });
+
+  expectSortedDeps(deps);
+});
+
 test('Out-of-tree platform (RN peerDependency version unsatisfied)', () => {
   const outOfTreeDeps: LocalPackageDeps = {
     ...olderReactNative,

--- a/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
@@ -436,33 +436,3 @@ function bumpSemver(origVersion: string, newVersion: string): string {
     return newVersion;
   }
 }
-
-/**
- * Checks whether a semver version of range includes a prerelease segment.
- *
- * @param version semver version/range
- */
-function isPrerelease(version: string): boolean {
-  if (semver.valid(version)) {
-    return semver.prerelease(version) !== null;
-  }
-
-  if (semver.validRange(version)) {
-    return semver.prerelease(version) !== null;
-  }
-
-  throw new Error(`Invalid semver ${version}`);
-
-  // Semver allows multiple ranges, hypen ranges, star ranges, etc. Don't try
-  // to reason about how to bump all of those and just bail if we see them.
-  const simpleSemver = /([\^~]?)(\d+\.\d+(\.\d+)?(-\w+\.\d+)?)/;
-  if (!simpleSemver.test(version)) {
-    throw new Error(`Unable to bump complicated semver '${origVersion}'`);
-  }
-
-  if (origVersion.startsWith(`~`) || origVersion.startsWith('^')) {
-    return `${origVersion[0]}${newVersion}`;
-  } else {
-    return newVersion;
-  }
-}


### PR DESCRIPTION
Fixes #7485

RN prereleases can contain breaking changes. Make sure to update the peerDependency if we take in a new one, to ensure users see warnings if they include too old a version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7674)