### PR TITLE
Link to curated release notes in patch release notes

### DIFF
--- a/change/@rnw-scripts-create-github-releases-66a4f00b-4060-4b68-af9d-db87150537ff.json
+++ b/change/@rnw-scripts-create-github-releases-66a4f00b-4060-4b68-af9d-db87150537ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Link to curated release notes in patch release notes",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Fixes #7429

Still needs testing, but this should lead to release notes linking to the much more detailed, intitial curated notes. The latest version of this tool is automatically pulled in by older branches, so no need to backport.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7676)