### PR TITLE
Remove Forking Due to "acceptsKeyboardFocus" Invariant Checks

### DIFF
--- a/change/@office-iss-react-native-win32-5bc205b1-20a9-4f4b-8adb-032b9febbebd.json
+++ b/change/@office-iss-react-native-win32-5bc205b1-20a9-4f4b-8adb-032b9febbebd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Forking Due to \"acceptsKeyboardFocus\" Invariant Checks",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-75512eb9-5b0d-4789-b68e-6c0358fb8aee.json
+++ b/change/react-native-windows-75512eb9-5b0d-4789-b68e-6c0358fb8aee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove Forking Due to \"acceptsKeyboardFocus\" Invariant Checks",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -211,7 +211,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372",
+      "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372"
     },
     {
       "type": "platform",

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -212,7 +212,6 @@
       "file": "src/Libraries/Components/View/View.win32.js",
       "baseFile": "Libraries/Components/View/View.js",
       "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372",
-      "issue": 5843
     },
     {
       "type": "platform",

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -28,14 +28,6 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
-  // [Win32
-  invariant(
-    // $FlowFixMe Wanting to catch untyped usages
-    props.acceptsKeyboardFocus === undefined,
-    'Support for the "acceptsKeyboardFocus" property has been removed in favor of "focusable"',
-  );
-  // Win32]
-
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -303,7 +303,7 @@
       "type": "patch",
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
-      "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372",
+      "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372"
     },
     {
       "type": "patch",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -304,7 +304,6 @@
       "file": "src/Libraries/Components/View/View.windows.js",
       "baseFile": "Libraries/Components/View/View.js",
       "baseHash": "77bfbef8e835e4fee49311779bb039a99ae44372",
-      "issue": 5843
     },
     {
       "type": "patch",

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -28,14 +28,6 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
-  // [Windows
-  invariant(
-    // $FlowFixMe Wanting to catch untyped usages
-    !props || props.acceptsKeyboardFocus === undefined,
-    'Support for the "acceptsKeyboardFocus" property has been removed in favor of "focusable"',
-  );
-  // Windows]
-
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See


### PR DESCRIPTION
Fixes #5843

It's been two versions since yellowbox and one since redbox. Remove the forking to catch users using the unsupported prop.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7684)