### PR TITLE
Moved Component Governance task into template

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -157,8 +157,4 @@ jobs:
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
 
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Component Governance Detection'
-        inputs:
-          alertWarningLevel: Medium
-          scanType: 'Register'
+      - template: ../templates/component-governance.yml

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -100,11 +100,7 @@
                       Microsoft.ReactNative.Managed\**
                       Microsoft.ReactNative.Managed.CodeGen\**
                 
-                - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-                  displayName: 'Component Governance Detection'
-                  inputs:
-                    alertWarningLevel: Medium
-                    scanType: 'Register'
+                - template: ../templates/component-governance.yml
 
                 
             - job: UniversalTest${{ matrix.Name }}

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -81,6 +81,15 @@ jobs:
       - script: yarn build
         displayName: yarn build
 
+      # Ensure EnableCodesign is set properly so CG fails appropriately
+      - script: |
+          echo ##vso[task.setvariable variable=EnableCodesign]true
+        displayName: Set EnableCodesign
+        condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
+      
+      # Running CG here as a sanity check to fail the job before any beachball bump
+      - template: templates/component-governance.yml
+
       - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public --no-git-tags
         displayName: Beachball Publish (Master Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
@@ -197,23 +206,18 @@ jobs:
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
 
+      # Ensure EnableCodesign is set properly so CG fails appropriately
       - script: |
           echo ##vso[task.setvariable variable=EnableCodesign]true
         displayName: Set EnableCodesign
         condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
 
+      # We are not codesigning Desktop at this time, so turning it off. Remove this script task if we do start signing Desktop
       - script: |
-          echo ##vso[task.setvariable variable=FailCGOnAlert]true
-        displayName: Set FailCGOnAlert
-        condition: or(eq(variables['FailCGOnAlert'], 'true'), eq(variables['EnableCodesign'], 'true'))
-
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Component Governance Detection'
-        inputs:
-          alertWarningLevel: Medium
-          scanType: 'Register'
-          # Uncomment this once we have codesigning for Desktop working
-          # failOnAlert: $(FailCGOnAlert) # Alerts must fail the run to prevent codesigning
+          echo ##vso[task.setvariable variable=EnableCodesign]false
+        displayName: Set EnableCodesign to false for Desktop
+      
+      - template: templates/component-governance.yml
 
   - job: RnwNativeBuildUniversal
     displayName: Build Universal
@@ -261,23 +265,14 @@ jobs:
             Microsoft.ReactNative\**
             Microsoft.ReactNative.Managed\**
             Microsoft.ReactNative.Managed.CodeGen\**
-
+      
+      # Ensure EnableCodesign is set properly so CG fails appropriately
       - script: |
           echo ##vso[task.setvariable variable=EnableCodesign]true
         displayName: Set EnableCodesign
         condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
-
-      - script: |
-          echo ##vso[task.setvariable variable=FailCGOnAlert]true
-        displayName: Set FailCGOnAlert
-        condition: or(eq(variables['FailCGOnAlert'], 'true'), eq(variables['EnableCodesign'], 'true'))
-
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Component Governance Detection'
-        inputs:
-          alertWarningLevel: Medium
-          scanType: 'Register'
-          failOnAlert: $(FailCGOnAlert) # Alerts must fail the run to prevent codesigning
+      
+      - template: templates/component-governance.yml
 
       # Make symbols available through http://symweb.
       - task: PublishSymbols@2

--- a/.ado/templates/component-governance.yml
+++ b/.ado/templates/component-governance.yml
@@ -1,0 +1,13 @@
+steps:
+  # Alerts must always fail the run if EnableCodesign == true, to prevent codesigning
+  - script: |
+      echo ##vso[task.setvariable variable=FailCGOnAlert]true
+    displayName: Set FailCGOnAlert
+    condition: or(eq(variables['FailCGOnAlert'], 'true'), eq(variables['EnableCodesign'], 'true'))
+
+  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+    displayName: 'Component Governance Detection'
+    inputs:
+      alertWarningLevel: Medium
+      scanType: 'Register'
+      failOnAlert: $(FailCGOnAlert)


### PR DESCRIPTION
This PR consolidates some of the logic for running the Component Governance task into `templates\component-governance.yml`.

Specifically, the logic that, if EnableCodesign == true, CG must fail the job if there are any alerts. FYI, in our whole ecosystem of pipelines, EnableCodesign should only be true in the Publish pipeline against stable branches.

This PR also adds a CG check _before_ beachball bump in Publish, so the publish can be aborted without publishing to NPM and GitHub.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7686)