### PR TITLE
Remove incorrect mapping from virtual key 192

### DIFF
--- a/change/react-native-windows-cb98b272-df33-4b32-b571-f8796d620d35.json
+++ b/change/react-native-windows-cb98b272-df33-4b32-b571-f8796d620d35.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove incorrect mapping from virtual key 192",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -369,7 +369,6 @@ static const std::vector<std::pair<int, std::string>> g_virtualKeyToCode{
     {to_underlying(winrt::Windows::System::VirtualKey::Back), "Backspace"},
     {219, "BracketLeft"},
     {221, "BracketRight"},
-    {192, "BracketLeft"},
     {188, "Comma"},
     {187, "Equal"},
     //{to_underlying(winrt::Windows::System::None), "IntlBackslash"},


### PR DESCRIPTION
At least on the keyboard I tested on, virtual key 192 maps to `Backquote`, which is already configured on L367. Seems like this may have been included by mistake.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7692)