### PR TITLE
Visual tests: snapshot update accounting for fix in width inconsistency. 

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/DisplayNone/DisplayNoneExample.windows.tsx
@@ -22,7 +22,7 @@ export class DisplayNoneExample extends React.Component<{}> {
       <RNTesterPage>
         <RNTesterBlock title="Display:none style with TextInput">
           <View testID="view-component-switch-view">
-            <View style={{width: 1074}}>
+            <View>
               <Text>toggle display:none TextInput1</Text>
               <Switch
                 onValueChange={this._handlePress}

--- a/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
@@ -33,7 +33,7 @@ Object {
       "Top": 0,
       "VerticalAlignment": "Stretch",
       "Visibility": "Visible",
-      "Width": 1074,
+      "Width": 718,
       "XamlType": "Microsoft.ReactNative.ViewPanel",
       "children": Array [
         Object {
@@ -49,7 +49,7 @@ Object {
           "Top": 0,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",
-          "Width": 1074,
+          "Width": 718,
           "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
         },
         Object {
@@ -283,7 +283,7 @@ Object {
           "Top": 50,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",
-          "Width": 1074,
+          "Width": 718,
           "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
         },
         Object {
@@ -940,7 +940,7 @@ Object {
       "Top": 0,
       "VerticalAlignment": "Stretch",
       "Visibility": "Visible",
-      "Width": 1074,
+      "Width": 718,
       "XamlType": "Microsoft.ReactNative.ViewPanel",
       "children": Array [
         Object {
@@ -956,7 +956,7 @@ Object {
           "Top": 0,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",
-          "Width": 1074,
+          "Width": 718,
           "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
         },
         Object {
@@ -1190,7 +1190,7 @@ Object {
           "Top": 50,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",
-          "Width": 1074,
+          "Width": 718,
           "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
         },
         Object {


### PR DESCRIPTION
Recent [change](https://github.com/microsoft/react-native-windows/pull/7683) to set a fixed width for RootView in E2E fixes the inconsistency for width in CI vs local -- closes #7589.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7694)