### PR TITLE
Allow `lineHeight` settings less than font height

### DIFF
--- a/change/react-native-windows-41786510-3be7-441f-81e2-882e46ed5bf7.json
+++ b/change/react-native-windows-41786510-3be7-441f-81e2-882e46ed5bf7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow `lineHeight` settings less than font height",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -501,6 +501,11 @@ export class TextExample extends React.Component<
             benefits. <Text style={{fontSize: 20}}>Continually</Text> expedite
             magnetic potentialities rather than client-focused interfaces.
           </Text>
+          <Text style={{lineHeight: 15}}>
+            Holisticly formulate inexpensive ideas before best-of-breed
+            benefits. <Text style={{fontSize: 20}}>Continually</Text> expedite
+            magnetic potentialities rather than client-focused interfaces.
+          </Text>
         </RNTesterBlock>
         <RNTesterBlock title="Letter Spacing">
           <View>

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -187,10 +187,13 @@ bool TextViewManager::UpdateProperty(
     }
   } else if (propertyName == "lineHeight") {
     if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||
-        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)
+        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
       textBlock.LineHeight(propertyValue.AsInt32());
-    else if (propertyValue.IsNull())
+      textBlock.LineStackingStrategy(xaml::LineStackingStrategy::BlockLineHeight);
+    } else if (propertyValue.IsNull()) {
       textBlock.ClearValue(xaml::Controls::TextBlock::LineHeightProperty());
+      textBlock.ClearValue(xaml::Controls::TextBlock::LineStackingStrategyProperty());
+    }
   } else if (propertyName == "selectable") {
     if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
       textBlock.IsTextSelectionEnabled(propertyValue.AsBoolean());


### PR DESCRIPTION
Since the default LineStackingStrategy for XAML TextBlock uses`LineStackingStrategy::MaxHeight`, when the <Text> `lineHeight` prop is set to a value smaller than the calculated max height for the text, it is ignored.

Setting LineStackingStrategy to `LineStackingStrategy::BlockLineHeight` enables `lineHeight` settings smaller than the font height, and has identical behavior when the `lineHeight` value is larger than the max font height.

Fixes #7695

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7696)