### PR TITLE
Prep for 0.65 by adding 0.65-stable to publish scheduled branch filter

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -42,7 +42,8 @@ schedules:
   displayName: Weekly stable publish build
   branches:
     include:
-    - refs/heads/0.64-stable
+    - 0.64-stable
+    - 0.65-stable
 - cron: "0 5 * * *" # 5AM Daily UTC (10PM Daily PST)
   displayName: Nightly canary publish build
   branches:


### PR DESCRIPTION
I think this needs to be in place _before_ we create the 0.65-stable branch, otherwise the scheduler won't pick it up.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7697)