### PR TITLE
[0.64] Controlled TextInput doesn't work most of the time

### DIFF
--- a/change/react-native-windows-9aaace3c-20a8-4c24-90b2-d777742f65ba.json
+++ b/change/react-native-windows-9aaace3c-20a8-4c24-90b2-d777742f65ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "If initial value is set, updated TextInput.value changes will not be reflected",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -1162,6 +1162,7 @@ function InternalTextInput(props: Props): React.Node {
         ref={_setNativeRef}
         {...props}
         dataDetectorTypes={props.dataDetectorTypes}
+        mostRecentEventCount={mostRecentEventCount}
         onBlur={_onBlur}
         onChange={_onChange}
         onContentSizeChange={props.onContentSizeChange}


### PR DESCRIPTION
Port #7658 to 0.64

This issue affects some basic functionality of TextInput, so should be backported to 0.64.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7713)