### PR TITLE
Update Button Styling for Windows

### DIFF
--- a/change/react-native-windows-2237dc3b-a41e-4123-82db-f5b24fbba30b.json
+++ b/change/react-native-windows-2237dc3b-a41e-4123-82db-f5b24fbba30b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Button Styling for Windows",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,6 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
-  <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.7.2-microsoft.5" targetFramework="native"/>
 </packages>

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -17,13 +17,10 @@ const Text = require('../Text/Text');
 // const TouchableNativeFeedback = require('./Touchable/TouchableNativeFeedback');
 // const TouchableOpacity = require('./Touchable/TouchableOpacity');
 const TouchableHighlight = require('./Touchable/TouchableHighlight');
+const {PlatformColor} = require('../StyleSheet/PlatformColorValueTypes');
 // Windows]
 const View = require('./View/View');
 const invariant = require('invariant');
-// [Windows
-const ReactNative = require('react-native');
-const {PlatformColor} = ReactNative;
-// Windows]
 
 import type {AccessibilityState} from './View/ViewAccessibility';
 import type {PressEvent} from '../Types/CoreEventTypes';
@@ -264,11 +261,14 @@ type ButtonProps = $ReadOnly<{|
   ```
  */
 
-class Button extends React.Component<ButtonProps> {
+class Button extends React.Component<ButtonProps, {hover: boolean}> {
   // [Windows
-  state = {
-    hover: false,
-  };
+  constructor(props: Object) {
+    super(props);
+    this.state = {
+      hover: false,
+    };
+  }
   // Windows]
   render(): React.Node {
     const {

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -339,13 +339,15 @@ class Button extends React.Component<ButtonProps, {hover: boolean}> {
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
-          underlayColor={PlatformColor('SystemBaseMediumLowColor')}
+          underlayColor={PlatformColor('ButtonBackgroundPressed')}
           style={
             this.state.hover
               ? [
                   buttonStyles,
                   {
-                    backgroundColor: PlatformColor('SystemListLowColor'),
+                    backgroundColor: PlatformColor(
+                      'ButtonBackgroundPointerOver',
+                    ),
                   },
                 ]
               : buttonStyles
@@ -401,7 +403,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      backgroundColor: PlatformColor('SystemBaseLowColor'),
+      backgroundColor: PlatformColor('ButtonBackground'),
       borderRadius: 3,
     },
     // Windows]
@@ -421,7 +423,7 @@ const styles = StyleSheet.create({
       },
       // [Windows
       windows: {
-        color: PlatformColor('SystemBaseHighColor'),
+        color: PlatformColor('ButtonForeground'),
         fontWeight: '400',
         fontSize: 14,
       },
@@ -435,7 +437,7 @@ const styles = StyleSheet.create({
       backgroundColor: '#dfdfdf',
     },
     windows: {
-      backgroundColor: PlatformColor('SystemBaseLowColor'),
+      backgroundColor: PlatformColor('ButtonBackgroundDisabled'),
     },
   }),
   textDisabled: Platform.select({
@@ -447,7 +449,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      color: PlatformColor('SystemBaseMediumLowColor'),
+      color: PlatformColor('ButtonForegroundDisabled'),
     },
     // Windows]
   }),

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -265,6 +265,9 @@ type ButtonProps = $ReadOnly<{|
  */
 
 class Button extends React.Component<ButtonProps> {
+  state = {
+    hover: false,
+  };
   render(): React.Node {
     const {
       accessibilityLabel,
@@ -334,14 +337,24 @@ class Button extends React.Component<ButtonProps> {
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
-          underlayColor={
-            color
-              ? PlatformColor('SystemColorWindowColor')
-              : PlatformColor('ButtonBackgroundPressed')
+          underlayColor={PlatformColor('SystemBaseMediumLowColor')}
+          style={
+            this.state.hover
+              ? [
+                  buttonStyles,
+                  {
+                    backgroundColor: PlatformColor('SystemListLowColor'),
+                  },
+                ]
+              : buttonStyles
           }
-          activeOpacity={0.8}
-          style={buttonStyles}>
-          <View style={color ? buttonStyles : {}}>
+          onMouseEnter={() => {
+            if (!disabled) this.setState({hover: true});
+          }}
+          onMouseLeave={() => {
+            if (!disabled) this.setState({hover: false});
+          }}>
+          <View>
             <Text style={textStyles} disabled={disabled}>
               {formattedTitle}
             </Text>
@@ -388,7 +401,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      backgroundColor: PlatformColor('ButtonBackground'),
+      backgroundColor: PlatformColor('SystemBaseLowColor'),
       borderRadius: 3,
     },
     // Windows]
@@ -408,7 +421,7 @@ const styles = StyleSheet.create({
       },
       // [Windows
       windows: {
-        color: PlatformColor('ButtonForeground'),
+        color: PlatformColor('SystemBaseHighColor'),
         fontWeight: '400',
         fontSize: 14,
       },
@@ -422,7 +435,7 @@ const styles = StyleSheet.create({
       backgroundColor: '#dfdfdf',
     },
     windows: {
-      backgroundColor: PlatformColor('ButtonBackgroundDisabled'),
+      backgroundColor: PlatformColor('SystemBaseLowColor'),
     },
   }),
   textDisabled: Platform.select({
@@ -434,7 +447,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      color: PlatformColor('ButtonForegroundDisabled'),
+      color: PlatformColor('SystemBaseMediumLowColor'),
     },
     // Windows]
   }),

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -312,33 +312,70 @@ class Button extends React.Component<ButtonProps> {
     const Touchable = TouchableHighlight;
     //  Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
     // Windows]
-    return (
-      <Touchable
-        accessibilityLabel={accessibilityLabel}
-        accessibilityRole="button"
-        accessibilityState={accessibilityState}
-        hasTVPreferredFocus={hasTVPreferredFocus}
-        nextFocusDown={nextFocusDown}
-        nextFocusForward={nextFocusForward}
-        nextFocusLeft={nextFocusLeft}
-        nextFocusRight={nextFocusRight}
-        nextFocusUp={nextFocusUp}
-        testID={testID}
-        disabled={disabled}
-        onPress={onPress}
-        tabIndex={tabIndex}
-        touchSoundDisabled={touchSoundDisabled}>
-        <View style={buttonStyles}>
-          <Text style={textStyles} disabled={disabled}>
-            {formattedTitle}
-          </Text>
+    // [Windows
+    if (Platform.OS === 'windows') {
+      return (
+        <View style={styles.touchable}>
+          <Touchable
+            accessibilityLabel={accessibilityLabel}
+            accessibilityRole="button"
+            accessibilityState={accessibilityState}
+            hasTVPreferredFocus={hasTVPreferredFocus}
+            nextFocusDown={nextFocusDown}
+            nextFocusForward={nextFocusForward}
+            nextFocusLeft={nextFocusLeft}
+            nextFocusRight={nextFocusRight}
+            nextFocusUp={nextFocusUp}
+            testID={testID}
+            disabled={disabled}
+            onPress={onPress}
+            tabIndex={tabIndex}
+            touchSoundDisabled={touchSoundDisabled}
+            activeOpacity={0.8}
+            underlayColor="#FFFFFF">
+            <View style={buttonStyles}>
+              <Text style={textStyles} disabled={disabled}>
+                {formattedTitle}
+              </Text>
+            </View>
+          </Touchable>
         </View>
-      </Touchable>
-    );
+      );
+    } else {
+      return (
+        <Touchable
+          accessibilityLabel={accessibilityLabel}
+          accessibilityRole="button"
+          accessibilityState={accessibilityState}
+          hasTVPreferredFocus={hasTVPreferredFocus}
+          nextFocusDown={nextFocusDown}
+          nextFocusForward={nextFocusForward}
+          nextFocusLeft={nextFocusLeft}
+          nextFocusRight={nextFocusRight}
+          nextFocusUp={nextFocusUp}
+          testID={testID}
+          disabled={disabled}
+          onPress={onPress}
+          tabIndex={tabIndex}
+          touchSoundDisabled={touchSoundDisabled}>
+          <View style={buttonStyles}>
+            <Text style={textStyles} disabled={disabled}>
+              {formattedTitle}
+            </Text>
+          </View>
+        </Touchable>
+      );
+    }
+    // Windows]
   }
 }
 
 const styles = StyleSheet.create({
+  // [Windows
+  touchable: {
+    borderRadius: 3,
+  },
+  // Windows]
   button: Platform.select({
     ios: {},
     android: {
@@ -349,8 +386,8 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      backgroundColor: '#2196F3',
-      borderRadius: 2,
+      backgroundColor: '#005FB7',
+      borderRadius: 3,
     },
     // Windows]
   }),
@@ -369,8 +406,9 @@ const styles = StyleSheet.create({
       },
       // [Windows
       windows: {
-        color: 'white',
-        fontWeight: '500',
+        color: '#FFFFFF',
+        fontWeight: '400',
+        fontSize: 14,
       },
       // Windows]
     }),
@@ -382,7 +420,7 @@ const styles = StyleSheet.create({
       backgroundColor: '#dfdfdf',
     },
     windows: {
-      backgroundColor: '#dfdfdf',
+      backgroundColor: 'rgba(0, 0, 0, 0.2169);',
     },
   }),
   textDisabled: Platform.select({
@@ -394,7 +432,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      color: '#a1a1a1',
+      color: '#FFFFFF',
     },
     // Windows]
   }),

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -265,9 +265,11 @@ type ButtonProps = $ReadOnly<{|
  */
 
 class Button extends React.Component<ButtonProps> {
+  // [Windows
   state = {
     hover: false,
   };
+  // Windows]
   render(): React.Node {
     const {
       accessibilityLabel,
@@ -354,11 +356,9 @@ class Button extends React.Component<ButtonProps> {
           onMouseLeave={() => {
             if (!disabled) this.setState({hover: false});
           }}>
-          <View>
-            <Text style={textStyles} disabled={disabled}>
-              {formattedTitle}
-            </Text>
-          </View>
+          <Text style={textStyles} disabled={disabled}>
+            {formattedTitle}
+          </Text>
         </Touchable>
       );
     } else {

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -20,10 +20,15 @@ const TouchableHighlight = require('./Touchable/TouchableHighlight');
 // Windows]
 const View = require('./View/View');
 const invariant = require('invariant');
+// [Windows
+const ReactNative = require('react-native');
+const {PlatformColor} = ReactNative;
+// Windows]
 
 import type {AccessibilityState} from './View/ViewAccessibility';
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
+import {PlatformOverride} from 'react-native-platform-override';
 
 type ButtonProps = $ReadOnly<{|
   /**
@@ -315,31 +320,34 @@ class Button extends React.Component<ButtonProps> {
     // [Windows
     if (Platform.OS === 'windows') {
       return (
-        <View style={styles.touchable}>
-          <Touchable
-            accessibilityLabel={accessibilityLabel}
-            accessibilityRole="button"
-            accessibilityState={accessibilityState}
-            hasTVPreferredFocus={hasTVPreferredFocus}
-            nextFocusDown={nextFocusDown}
-            nextFocusForward={nextFocusForward}
-            nextFocusLeft={nextFocusLeft}
-            nextFocusRight={nextFocusRight}
-            nextFocusUp={nextFocusUp}
-            testID={testID}
-            disabled={disabled}
-            onPress={onPress}
-            tabIndex={tabIndex}
-            touchSoundDisabled={touchSoundDisabled}
-            activeOpacity={0.8}
-            underlayColor="#FFFFFF">
-            <View style={buttonStyles}>
-              <Text style={textStyles} disabled={disabled}>
-                {formattedTitle}
-              </Text>
-            </View>
-          </Touchable>
-        </View>
+        <Touchable
+          accessibilityLabel={accessibilityLabel}
+          accessibilityRole="button"
+          accessibilityState={accessibilityState}
+          hasTVPreferredFocus={hasTVPreferredFocus}
+          nextFocusDown={nextFocusDown}
+          nextFocusForward={nextFocusForward}
+          nextFocusLeft={nextFocusLeft}
+          nextFocusRight={nextFocusRight}
+          nextFocusUp={nextFocusUp}
+          testID={testID}
+          disabled={disabled}
+          onPress={onPress}
+          tabIndex={tabIndex}
+          touchSoundDisabled={touchSoundDisabled}
+          underlayColor={
+            color
+              ? PlatformColor('SystemColorWindowColor')
+              : PlatformColor('ButtonBackgroundPressed')
+          }
+          activeOpacity={0.8}
+          style={buttonStyles}>
+          <View style={color ? buttonStyles : {}}>
+            <Text style={textStyles} disabled={disabled}>
+              {formattedTitle}
+            </Text>
+          </View>
+        </Touchable>
       );
     } else {
       return (
@@ -371,11 +379,6 @@ class Button extends React.Component<ButtonProps> {
 }
 
 const styles = StyleSheet.create({
-  // [Windows
-  touchable: {
-    borderRadius: 3,
-  },
-  // Windows]
   button: Platform.select({
     ios: {},
     android: {
@@ -386,7 +389,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      backgroundColor: '#005FB7',
+      backgroundColor: PlatformColor('ButtonBackground'),
       borderRadius: 3,
     },
     // Windows]
@@ -406,7 +409,7 @@ const styles = StyleSheet.create({
       },
       // [Windows
       windows: {
-        color: '#FFFFFF',
+        color: PlatformColor('ButtonForeground'),
         fontWeight: '400',
         fontSize: 14,
       },
@@ -420,7 +423,7 @@ const styles = StyleSheet.create({
       backgroundColor: '#dfdfdf',
     },
     windows: {
-      backgroundColor: 'rgba(0, 0, 0, 0.2169);',
+      backgroundColor: PlatformColor('ButtonBackgroundDisabled'),
     },
   }),
   textDisabled: Platform.select({
@@ -432,7 +435,7 @@ const styles = StyleSheet.create({
     },
     // [Windows
     windows: {
-      color: '#FFFFFF',
+      color: PlatformColor('ButtonForegroundDisabled'),
     },
     // Windows]
   }),

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -28,7 +28,6 @@ const {PlatformColor} = ReactNative;
 import type {AccessibilityState} from './View/ViewAccessibility';
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
-import {PlatformOverride} from 'react-native-platform-override';
 
 type ButtonProps = $ReadOnly<{|
   /**


### PR DESCRIPTION
**_Why_**
Current styling for button control matches android styling. Adjustments here alter styling so that it will match WinUI/MUX button styling.

**_What_**
- Adjusted Button's background color, text color, disabled background color, and disabled text color.
- Needed to create a separate return for the WinUI/MUX case, since adjustments to underlayColor and styles were needed to match styling for pressed Button state. 

Note: Unable to match styling to exactly match  Button due to RNW styling constraints. Missing styling includes: Button Animations.

Note: Current available brushes follow the coloring of v2.5, will automatically upgrade to 2.6 coloring when RNW runs on v2.6.

Note: The coloring of the Button control is different for MUX 2.5 vs WinUI 2.5. Right now playground uses MUX 2.5 as its default for XAML leading to the coloring being different from what is shown in the XAML Controls Gallery which is running on WinUI 2.5. Brush names are the same for both MUX and WinUI just target different colors.

**_Old Button @ Rest_**
![image](https://user-images.githubusercontent.com/34109996/116924128-4e68ad00-ac0c-11eb-8e58-4f80ab9b7bf2.png)

**_Old Button @ Pressed_**
![image](https://user-images.githubusercontent.com/34109996/116924216-6b04e500-ac0c-11eb-805b-5939e94b89ef.png)

**_New Button @ Rest_**
![image](https://user-images.githubusercontent.com/34109996/117087187-961e3000-ad03-11eb-82f4-7f4c01310d52.png)

**_New Button @ Hover_ with WinUI2.5**
![image](https://user-images.githubusercontent.com/34109996/117087232-aafac380-ad03-11eb-9b1d-2564ca124490.png)

**_New Button @ Hover_ with MUX2.5**
![image](https://user-images.githubusercontent.com/34109996/117362618-54f75e80-ae70-11eb-8343-b1f7f5b47607.png)

**_New Button @ Pressed_**
![image](https://user-images.githubusercontent.com/34109996/117087277-cb2a8280-ad03-11eb-925d-f2256feaa47f.png)

**_New Button @ Disabled_**
![image](https://user-images.githubusercontent.com/34109996/117087498-7cc9b380-ad04-11eb-892a-c4cfbf15c026.png)

Resolve #5268

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7714)