### PR TITLE
Remove react::uwp namespace

### DIFF
--- a/change/react-native-windows-6f946c3d-5ed8-4159-b955-90af96c8c498.json
+++ b/change/react-native-windows-6f946c3d-5ed8-4159-b955-90af96c8c498.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Remove macro that was used for react::uwp namespace replacement",
+  "comment": "Rename remaining react::uwp namespaces to Microsoft::ReactNative",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-6f946c3d-5ed8-4159-b955-90af96c8c498.json
+++ b/change/react-native-windows-6f946c3d-5ed8-4159-b955-90af96c8c498.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove macro that was used for react::uwp namespace replacement",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/metro.config.js
+++ b/packages/playground/metro.config.js
@@ -165,6 +165,7 @@ module.exports = {
       new RegExp(
         `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
       ),
+      /.*.tlog/,
     ]),
     resolveRequest: devResolveRequest,
   },

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -294,7 +294,7 @@ struct WindowData {
 
             // auto cmbEngines = GetDlgItem(hwnd, IDC_JSENGINE);
             // int itemIndex = (int)SendMessageW(cmbEngines, (UINT)CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
-            // self->m_jsEngine = static_cast<react::uwp::JSIEngine>(itemIndex);
+            // self->m_jsEngine = static_cast<Microsoft::ReactNative::JSIEngine>(itemIndex);
           }
             [[fallthrough]];
           case IDCANCEL:

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -67,7 +67,7 @@ EXPORTS
 ??0WebSocketModule@React@Microsoft@@QEAA@XZ
 ??0NetworkingModule@React@Microsoft@@QEAA@XZ
 ?CreateAsyncStorageModule@react@facebook@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@PEB_W@Z
-?MakeJSQueueThread@uwp@react@@YA?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
+?MakeJSQueueThread@ReactNative@Microsoft@@YA?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
 ?Hash128@SpookyHashV2@hash@folly@@SAXPEBX_KPEA_K2@Z
 ??1Instance@react@facebook@@QEAA@XZ
 ?invokeAsync@JSCallInvoker@Instance@react@facebook@@UEAAX$$QEAV?$function@$$A6AXXZ@std@@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -66,7 +66,7 @@ EXPORTS
 ?CreateAsyncStorageModule@react@facebook@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@PB_W@Z
 ?Make@IHttpResource@React@Microsoft@@SG?AV?$unique_ptr@UIHttpResource@React@Microsoft@@U?$default_delete@UIHttpResource@React@Microsoft@@@std@@@std@@XZ
 ??0NetworkingModule@React@Microsoft@@QAE@XZ
-?MakeJSQueueThread@uwp@react@@YG?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
+?MakeJSQueueThread@ReactNative@Microsoft@@YG?AV?$shared_ptr@VMessageQueueThread@react@facebook@@@std@@XZ
 ?Hash128@SpookyHashV2@hash@folly@@SGXPBXIPA_K1@Z
 ?assertionFailure@detail@folly@@YGXPBD00I0H@Z
 ??1Instance@react@facebook@@QAE@XZ

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -41,8 +41,8 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
     string &&jsBundleFile,
     vector<tuple<string, CxxModule::Provider>> &&cxxModules,
     shared_ptr<DevSettings> devSettings) noexcept {
-  auto nativeQueue = react::uwp::MakeJSQueueThread();
-  auto jsQueue = react::uwp::MakeJSQueueThread();
+  auto nativeQueue = Microsoft::ReactNative::MakeJSQueueThread();
+  auto jsQueue = Microsoft::ReactNative::MakeJSQueueThread();
 
   vector<tuple<string, CxxModule::Provider, shared_ptr<MessageQueueThread>>> extraModules{
       {"AsyncLocalStorage",

--- a/vnext/Desktop.UnitTests/WebSocketJSExecutorTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketJSExecutorTest.cpp
@@ -4,7 +4,7 @@
 #include <CppUnitTest.h>
 #include <Executors/WebSocketJSExecutor.h>
 
-using namespace react::uwp;
+using namespace Microsoft::ReactNative;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace Microsoft::React::Test {

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -21,7 +21,7 @@
 // Shared
 #include <CreateModules.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 namespace {
 
@@ -45,7 +45,7 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     const std::shared_ptr<facebook::react::MessageQueueThread> &batchingUIMessageQueue,
     const std::shared_ptr<facebook::react::MessageQueueThread>
         &jsMessageQueue, // JS engine thread (what we use for external modules)
-    std::shared_ptr<react::uwp::AppTheme> &&appTheme,
+    std::shared_ptr<AppTheme> &&appTheme,
     Mso::CntPtr<AppearanceChangeListener> &&appearanceListener,
     Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept {
   std::vector<facebook::react::NativeModuleDescription> modules;
@@ -74,10 +74,8 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
       batchingUIMessageQueue);
 
   modules.emplace_back(
-      react::uwp::AppThemeModule::Name,
-      [appTheme = std::move(appTheme)]() mutable {
-        return std::make_unique<react::uwp::AppThemeModule>(std::move(appTheme));
-      },
+      AppThemeModule::Name,
+      [appTheme = std::move(appTheme)]() mutable { return std::make_unique<AppThemeModule>(std::move(appTheme)); },
       batchingUIMessageQueue);
 
   modules.emplace_back(
@@ -108,4 +106,4 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
   return modules;
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.h
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.h
@@ -18,17 +18,17 @@ class IUIManager;
 class MessageQueueThread;
 } // namespace facebook::react
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
-class DeviceInfo;
+struct DeviceInfo;
 struct IReactInstance;
 struct ViewManagerProvider;
 
 std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     const std::shared_ptr<facebook::react::MessageQueueThread> &batchingUIMessageQueue,
     const std::shared_ptr<facebook::react::MessageQueueThread> &jsMessageQueue,
-    std::shared_ptr<react::uwp::AppTheme> &&appTheme,
+    std::shared_ptr<AppTheme> &&appTheme,
     Mso::CntPtr<AppearanceChangeListener> &&appearanceListener,
     Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -223,7 +223,7 @@ void FabricUIManager::startSurface(
     facebook::react::SurfaceId surfaceId,
     const std::string &moduleName,
     const folly::dynamic &initialProps) noexcept {
-  auto xamlRootView = static_cast<::react::uwp::IXamlRootView *>(rootview);
+  auto xamlRootView = static_cast<IXamlRootView *>(rootview);
   auto rootFE = xamlRootView->GetXamlView().as<xaml::FrameworkElement>();
 
   m_surfaceRegistry.insert({surfaceId, xamlRootView->GetXamlView()});

--- a/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
@@ -19,7 +19,7 @@
 namespace Microsoft::ReactNative {
 
 ImageComponentView::ImageComponentView(winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : m_context(reactContext), m_element(::react::uwp::ReactImage::Create()) {
+    : m_context(reactContext), m_element(ReactImage::Create()) {
   static auto const defaultProps = std::make_shared<facebook::react::ImageProps const>();
   m_props = defaultProps;
 }
@@ -49,7 +49,7 @@ void ImageComponentView::updateProps(
     if (newImageProps.sources.empty()) {
       // TODO clear image
     } else {
-      ::react::uwp::ReactImageSource ris;
+      ReactImageSource ris;
       ris.uri = newImageProps.sources[0].uri;
       ris.width = newImageProps.sources[0].size.width;
       ris.height = newImageProps.sources[0].size.height;

--- a/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.h
@@ -40,7 +40,7 @@ struct ImageComponentView : BaseComponentView {
  private:
   facebook::react::SharedViewProps m_props;
   facebook::react::LayoutMetrics m_layoutMetrics;
-  winrt::com_ptr<::react::uwp::ReactImage> m_element;
+  winrt::com_ptr<ReactImage> m_element;
   winrt::Microsoft::ReactNative::ReactContext m_context;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ParagraphComponentView.cpp
@@ -48,7 +48,7 @@ void ParagraphComponentView::updateProps(
 
   if (oldViewProps.textAttributes.foregroundColor != newViewProps.textAttributes.foregroundColor) {
     if (newViewProps.textAttributes.foregroundColor)
-      m_element.Foreground(::react::uwp::SolidColorBrushFrom(newViewProps.textAttributes.foregroundColor));
+      m_element.Foreground(SolidColorBrushFrom(newViewProps.textAttributes.foregroundColor));
     else
       m_element.ClearValue(::xaml::Controls::TextBlock::ForegroundProperty());
   }

--- a/vnext/Microsoft.ReactNative/Fabric/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ScrollViewComponentView.cpp
@@ -138,7 +138,7 @@ void ScrollViewComponentView::updateProps(
     auto color = *newViewProps.backgroundColor;
 
     if (newViewProps.backgroundColor) {
-      m_element.ViewBackground(::react::uwp::SolidColorBrushFrom(newViewProps.backgroundColor));
+      m_element.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
     }
@@ -146,7 +146,7 @@ void ScrollViewComponentView::updateProps(
 
   if (oldViewProps.borderColors != newViewProps.borderColors) {
     if (newViewProps.borderColors.all) {
-      m_element.BorderBrush(::react::uwp::SolidColorBrushFrom(*newViewProps.borderColors.all));
+      m_element.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
     }

--- a/vnext/Microsoft.ReactNative/Fabric/TextComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/TextComponentView.cpp
@@ -44,7 +44,7 @@ void TextComponentView::updateProps(
     auto color = *newViewProps.backgroundColor;
 
     if (newViewProps.backgroundColor) {
-      m_element.ViewBackground(::react::uwp::SolidColorBrushFrom(newViewProps.backgroundColor));
+      m_element.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
     }
@@ -52,7 +52,7 @@ void TextComponentView::updateProps(
 
   if (oldViewProps.borderColors != newViewProps.borderColors) {
     if (newViewProps.borderColors.all) {
-      m_element.BorderBrush(::react::uwp::SolidColorBrushFrom(*newViewProps.borderColors.all));
+      m_element.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
     }

--- a/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
@@ -47,7 +47,7 @@ void ViewComponentView::updateProps(
     auto color = *newViewProps.backgroundColor;
 
     if (newViewProps.backgroundColor) {
-      m_element.ViewBackground(::react::uwp::SolidColorBrushFrom(newViewProps.backgroundColor));
+      m_element.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
     }
@@ -55,7 +55,7 @@ void ViewComponentView::updateProps(
 
   if (oldViewProps.borderColors != newViewProps.borderColors) {
     if (newViewProps.borderColors.all) {
-      m_element.BorderBrush(::react::uwp::SolidColorBrushFrom(*newViewProps.borderColors.all));
+      m_element.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
     } else {
       m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
     }

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
@@ -59,8 +59,8 @@ void GlyphShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueObj
     const auto &propertyValue = pair.second;
 
     if (propertyName == "color") {
-      if (react::uwp::IsValidColorValue(propertyValue))
-        glyphs.Fill(react::uwp::BrushFrom(propertyValue));
+      if (IsValidColorValue(propertyValue))
+        glyphs.Fill(BrushFrom(propertyValue));
 #ifdef DEBUG
       else if (propertyValue.IsNull()) {
         // Log error, must have a color
@@ -69,12 +69,12 @@ void GlyphShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueObj
 #endif
     } else if (propertyName == "fontUri") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        auto uri = winrt::Uri(react::uwp::asHstring(propertyValue));
+        auto uri = winrt::Uri(asHstring(propertyValue));
         glyphs.FontUri(uri);
       }
     } else if (propertyName == "glyph") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        glyphs.Indices(react::uwp::asHstring(propertyValue));
+        glyphs.Indices(asHstring(propertyValue));
       }
     } else if (propertyName == "colorEnabled") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -131,7 +131,6 @@
         WIN32=0;
         WINRT=1;
         _HAS_AUTO_PTR_ETC;
-        PROJECT_ROOT_NAMESPACE=Microsoft::ReactNative;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(RNW_FASTBUILD)' == 'true'">RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -166,8 +165,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup>
     <Midl>
-      <!-- Custom XAML types must be in the project namespace to be usable by XAML -->
-      <PreprocessorDefinitions>PROJECT_ROOT_NAMESPACE=$(RootNamespace);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
     <ClCompile>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -45,7 +45,7 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
     // So we need to find something to raise the notification event from.
     xaml::UIElement element{nullptr};
 
-    if (react::uwp::IsXamlIsland()) {
+    if (IsXamlIsland()) {
       if (auto accessibleRoot =
               winrt::Microsoft::ReactNative::XamlUIService::GetAccessibleRoot(context.Properties().Handle())) {
         element = accessibleRoot;

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -26,7 +26,7 @@ void Alert::showAlert(ShowAlertArgs const &args, std::function<void(std::string)
       dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
       dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
 
-      if (react::uwp::Is19H1OrHigher()) {
+      if (Is19H1OrHigher()) {
         // XamlRoot added in 19H1
         if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context.Properties().Handle())) {
           dialog.XamlRoot(xamlRoot);

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
@@ -7,7 +7,7 @@
 #include "AdditionAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 AdditionAnimatedNode::AdditionAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -32,4 +32,4 @@ AdditionAnimatedNode::AdditionAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class AdditionAnimatedNode final : public ValueAnimatedNode {
  public:
   AdditionAnimatedNode(
@@ -16,4 +16,4 @@ class AdditionAnimatedNode final : public ValueAnimatedNode {
  private:
   std::unordered_set<int64_t> m_inputNodes{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 AnimatedNode::AnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : m_tag(tag), m_manager(manager) {}
@@ -36,4 +36,4 @@ AnimatedNode *AnimatedNode::GetChildNode(int64_t tag) {
 
   return static_cast<AnimatedNode *>(nullptr);
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class NativeAnimatedNodeManager;
 class AnimatedNode {
  public:
@@ -27,4 +27,4 @@ class AnimatedNode {
   const std::weak_ptr<NativeAnimatedNodeManager> m_manager;
   std::vector<int64_t> m_children{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
@@ -6,7 +6,7 @@
 #include <UI.Composition.h>
 #include "AnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 AnimationDriver::AnimationDriver(
     int64_t id,
@@ -90,4 +90,4 @@ ValueAnimatedNode *AnimationDriver::GetAnimatedValue() {
   }
   return nullptr;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -6,7 +6,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 typedef std::function<void(std::vector<folly::dynamic>)> Callback;
 
 class ValueAnimatedNode;
@@ -73,4 +73,4 @@ class AnimationDriver {
   // #22399779
   winrt::event_token m_scopedBatchCompletedToken{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -6,7 +6,7 @@
 #include <math.h>
 #include "CalculatedAnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
     const folly::dynamic & /*config*/) {
@@ -54,4 +54,4 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
   return std::make_tuple(animation, scopedBatch);
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
@@ -7,7 +7,7 @@
 #include "AnimatedNode.h"
 #include "AnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class CalculatedAnimationDriver : public AnimationDriver {
  public:
   using AnimationDriver::AnimationDriver;
@@ -21,4 +21,4 @@ class CalculatedAnimationDriver : public AnimationDriver {
   virtual bool IsAnimationDone(double currentValue, double currentVelocity) = 0;
   double m_startValue{0};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
@@ -6,7 +6,7 @@
 #include <math.h>
 #include "DecayAnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 DecayAnimationDriver::DecayAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
@@ -43,4 +43,4 @@ double DecayAnimationDriver::ToValue() {
   return m_startValue + m_velocity / (1 - m_deceleration);
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "CalculatedAnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class DecayAnimationDriver : public CalculatedAnimationDriver {
  public:
   DecayAnimationDriver(
@@ -33,4 +33,4 @@ class DecayAnimationDriver : public CalculatedAnimationDriver {
   static constexpr std::wstring_view s_decelerationParameterName{L"deceleration"};
   static constexpr std::wstring_view s_durationName{L"duration"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "DiffClampAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 DiffClampAnimatedNode::DiffClampAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -27,4 +27,4 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class DiffClampAnimatedNode final : public ValueAnimatedNode {
  public:
   DiffClampAnimatedNode(
@@ -25,4 +25,4 @@ class DiffClampAnimatedNode final : public ValueAnimatedNode {
   static constexpr std::wstring_view s_minParameterName{L"min"};
   static constexpr std::wstring_view s_maxParameterName{L"max"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "DivisionAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 DivisionAnimatedNode::DivisionAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -37,4 +37,4 @@ DivisionAnimatedNode::DivisionAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class DivisionAnimatedNode final : public ValueAnimatedNode {
  public:
   DivisionAnimatedNode(
@@ -21,4 +21,4 @@ class DivisionAnimatedNode final : public ValueAnimatedNode {
 
   static constexpr std::wstring_view s_baseName{L"base"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.cpp
@@ -6,7 +6,7 @@
 #include "EventAnimationDriver.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 EventAnimationDriver::EventAnimationDriver(
     const folly::dynamic &eventPath,
     int64_t animatedValueTag,
@@ -24,4 +24,4 @@ ValueAnimatedNode *EventAnimationDriver::AnimatedValue() {
   return static_cast<ValueAnimatedNode *>(nullptr);
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class ValueAnimatedNode;
 class EventAnimationDriver {
  public:
@@ -21,4 +21,4 @@ class EventAnimationDriver {
   int64_t m_animatedValueTag{};
   std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
@@ -6,7 +6,7 @@
 #include "FrameAnimationDriver.h"
 #include "Utils/Helpers.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 FrameAnimationDriver::FrameAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
@@ -26,8 +26,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimat
     const auto compositor = Microsoft::ReactNative::GetCompositor();
     return std::make_tuple(
         compositor.CreateScopedBatch(
-            react::uwp::IsRS5OrHigher() ? comp::CompositionBatchTypes::AllAnimations
-                                        : comp::CompositionBatchTypes::Animation),
+            IsRS5OrHigher() ? comp::CompositionBatchTypes::AllAnimations : comp::CompositionBatchTypes::Animation),
         compositor.CreateScalarKeyFrameAnimation());
   }();
 
@@ -58,4 +57,4 @@ double FrameAnimationDriver::ToValue() {
   return m_toValue;
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "AnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class FrameAnimationDriver : public AnimationDriver {
  public:
   FrameAnimationDriver(
@@ -29,4 +29,4 @@ class FrameAnimationDriver : public AnimationDriver {
   std::vector<double> m_frames{};
   double m_toValue{0};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -7,7 +7,7 @@
 #include "InterpolationAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 InterpolationAnimatedNode::InterpolationAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -166,4 +166,4 @@ winrt::hstring InterpolationAnimatedNode::GetRightExpression(
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class InterpolationAnimatedNode final : public ValueAnimatedNode {
  public:
@@ -55,4 +55,4 @@ class InterpolationAnimatedNode final : public ValueAnimatedNode {
   static constexpr std::wstring_view s_inputName{L"i"};
   static constexpr std::wstring_view s_outputName{L"o"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "ModulusAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 ModulusAnimatedNode::ModulusAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -25,4 +25,4 @@ ModulusAnimatedNode::ModulusAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class ModulusAnimatedNode final : public ValueAnimatedNode {
  public:
   ModulusAnimatedNode(
@@ -22,4 +22,4 @@ class ModulusAnimatedNode final : public ValueAnimatedNode {
   static constexpr std::wstring_view s_inputParameterName{L"input"};
   static constexpr std::wstring_view s_modName{L"mod"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "MultiplicationAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 MultiplicationAnimatedNode::MultiplicationAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -31,4 +31,4 @@ MultiplicationAnimatedNode::MultiplicationAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class MultiplicationAnimatedNode final : public ValueAnimatedNode {
  public:
   MultiplicationAnimatedNode(
@@ -16,4 +16,4 @@ class MultiplicationAnimatedNode final : public ValueAnimatedNode {
  private:
   std::unordered_set<int64_t> m_inputNodes{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
@@ -9,7 +9,7 @@
 #include <cxxreact/Instance.h>
 #include <cxxreact/JsArgumentHelpers.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 const char *NativeAnimatedModule::name{"NativeAnimatedModule"};
 
 NativeAnimatedModule::NativeAnimatedModule(Mso::CntPtr<Mso::React::IReactContext> &&context)
@@ -235,4 +235,4 @@ void NativeAnimatedModule::StartListeningToAnimatedNodeValue(int64_t /*tag*/) {
 void NativeAnimatedModule::StopListeningToAnimatedNodeValue(int64_t /*tag*/) {
   // NotImplemented
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
@@ -52,7 +52,7 @@
 /// from JS and the main class that coordinates all the action:
 /// <see cref="NativeAnimatedNodeManager"/>.
 /// </remarks>
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class NativeAnimatedModule final : public facebook::xplat::module::CxxModule {
  public:
   NativeAnimatedModule(Mso::CntPtr<Mso::React::IReactContext> &&context);
@@ -95,4 +95,4 @@ class NativeAnimatedModule final : public facebook::xplat::module::CxxModule {
   std::shared_ptr<NativeAnimatedNodeManager> m_nodesManager{};
   Mso::CntPtr<Mso::React::IReactContext> m_context;
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -26,7 +26,7 @@
 #include <Modules/PaperUIManagerModule.h>
 #include <Windows.Foundation.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 void NativeAnimatedNodeManager::CreateAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -406,4 +406,4 @@ TrackingAnimatedNode *NativeAnimatedNodeManager::GetTrackingAnimatedNode(int64_t
 void NativeAnimatedNodeManager::RemoveActiveAnimation(int64_t tag) {
   m_activeAnimations.erase(tag);
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
@@ -16,7 +16,7 @@
 #include "TransformAnimatedNode.h"
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 /// <summary>
 /// This is the main class that coordinates how native animated JS
 /// implementation drives UI changes.
@@ -106,4 +106,4 @@ class NativeAnimatedNodeManager {
   static constexpr std::string_view s_framesName{"frames"};
   static constexpr std::string_view s_dynamicToValuesName{"dynamicToValues"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -12,7 +12,7 @@
 #include "PropsAnimatedNode.h"
 #include "StyleAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 PropsAnimatedNode::PropsAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -279,4 +279,4 @@ xaml::UIElement PropsAnimatedNode::GetUIElement() {
   }
   return nullptr;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
@@ -13,7 +13,7 @@ namespace Microsoft::ReactNative {
 struct ShadowNodeBase;
 }
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class PropsAnimatedNode final : public AnimatedNode {
  public:
   PropsAnimatedNode(
@@ -50,4 +50,4 @@ class PropsAnimatedNode final : public AnimatedNode {
 
   static constexpr int64_t s_connectedViewTagUnset{-1};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
@@ -7,7 +7,7 @@
 #include <math.h>
 #include "SpringAnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 SpringAnimationDriver::SpringAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
@@ -85,4 +85,4 @@ double SpringAnimationDriver::ToValue() {
   return m_endValue;
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
@@ -7,7 +7,7 @@
 #include "AnimatedNode.h"
 #include "CalculatedAnimationDriver.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class SpringAnimationDriver : public CalculatedAnimationDriver {
  public:
   SpringAnimationDriver(
@@ -48,5 +48,5 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
   static constexpr std::string_view s_displacementFromRestThresholdParameterName{"restDisplacementThreshold"};
   static constexpr std::string_view s_overshootClampingEnabledParameterName{"overshootClamping"};
   static constexpr std::string_view s_iterationsParameterName{"iterations"};
-}; // namespace uwp
-} // namespace react::uwp
+};
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "StyleAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 StyleAnimatedNode::StyleAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -33,4 +33,4 @@ std::unordered_map<FacadeType, int64_t> StyleAnimatedNode::GetMapping() {
   }
   return mapping;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "FacadeType.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class StyleAnimatedNode final : public AnimatedNode {
  public:
   StyleAnimatedNode(
@@ -22,4 +22,4 @@ class StyleAnimatedNode final : public AnimatedNode {
 
   static constexpr std::string_view s_styleName{"style"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "SubtractionAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 SubtractionAnimatedNode::SubtractionAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -37,4 +37,4 @@ SubtractionAnimatedNode::SubtractionAnimatedNode(
     return anim;
   }());
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class SubtractionAnimatedNode final : public ValueAnimatedNode {
  public:
   SubtractionAnimatedNode(
@@ -21,4 +21,4 @@ class SubtractionAnimatedNode final : public ValueAnimatedNode {
 
   static constexpr std::wstring_view s_baseName{L"base"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "TrackingAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 TrackingAnimatedNode::TrackingAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -35,4 +35,4 @@ void TrackingAnimatedNode::StartAnimation() {
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
@@ -5,7 +5,7 @@
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class TrackingAnimatedNode final : public AnimatedNode {
  public:
   TrackingAnimatedNode(
@@ -28,5 +28,5 @@ class TrackingAnimatedNode final : public AnimatedNode {
   static constexpr std::string_view s_valueIdName{"value"};
   static constexpr std::string_view s_animationConfigName{"animationConfig"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative
 #pragma once

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "FacadeType.h"
 #include "TransformAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 TransformAnimatedNode::TransformAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -33,4 +33,4 @@ std::unordered_map<FacadeType, int64_t> TransformAnimatedNode::GetMapping() {
   }
   return mapping;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
@@ -6,7 +6,7 @@
 #include "AnimatedNode.h"
 #include "FacadeType.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 struct TransformConfig {
  public:
   std::string property;
@@ -34,4 +34,4 @@ class TransformAnimatedNode final : public AnimatedNode {
   static constexpr std::string_view s_nodeTagName{"nodeTag"};
   static constexpr std::string_view s_valueName{"value"};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
@@ -6,7 +6,7 @@
 #include "NativeAnimatedNodeManager.h"
 #include "ValueAnimatedNode.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 ValueAnimatedNode::ValueAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
@@ -124,4 +124,4 @@ void ValueAnimatedNode::UpdateTrackingNodes() {
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
@@ -10,7 +10,7 @@ namespace winrt {
 using namespace comp;
 }
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class ValueAnimatedNode : public AnimatedNode {
  public:
   ValueAnimatedNode(
@@ -53,4 +53,4 @@ class ValueAnimatedNode : public AnimatedNode {
   std::unordered_set<int64_t> m_activeAnimations{};
   std::unordered_set<int64_t> m_activeTrackingNodes{};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -19,7 +19,7 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
     dispatcher.Post([this]() {
       auto currentApp = xaml::TryGetCurrentApplication();
 
-      if (!react::uwp::IsWinUI3Island() && currentApp != nullptr) {
+      if (!IsWinUI3Island() && currentApp != nullptr) {
         m_enteredBackgroundRevoker = currentApp.EnteredBackground(
             winrt::auto_revoke,
             [weakThis = weak_from_this()](
@@ -40,7 +40,7 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
               }
             });
       } else {
-        assert(react::uwp::IsXamlIsland());
+        assert(IsXamlIsland());
       }
     });
   }

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.cpp
@@ -27,7 +27,7 @@ using namespace Windows::UI::ViewManagement;
 
 using namespace winrt::Microsoft::ReactNative;
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 //
 // AppTheme
@@ -41,7 +41,7 @@ AppTheme::AppTheme(
     m_isHighContrast = getIsHighContrast();
     m_highContrastColors = getHighContrastColors();
 
-    if (react::uwp::IsWinUI3Island()) {
+    if (IsWinUI3Island()) {
       m_wmSubscription = SubscribeToWindowMessage(
           ReactNotificationService(m_context->Notifications()), WM_THEMECHANGED, [this](const auto &, const auto &) {
             NotifyHighContrastChanged();
@@ -106,4 +106,4 @@ auto AppThemeModule::getMethods() -> std::vector<facebook::xplat::module::CxxMod
   return {};
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
@@ -9,7 +9,7 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class AppTheme : public std::enable_shared_from_this<AppTheme> {
  public:
@@ -53,4 +53,4 @@ class AppThemeModule : public facebook::xplat::module::CxxModule {
   std::shared_ptr<AppTheme> m_appTheme;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
@@ -12,7 +12,7 @@ using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
 
 using Method = facebook::xplat::module::CxxModule::Method;
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 AppearanceChangeListener::AppearanceChangeListener(
     const Mso::React::IReactContext &context,
@@ -65,4 +65,4 @@ std::vector<Method> AppearanceModule::getMethods() {
       "getColorScheme", [this](folly::dynamic /*args*/) { return m_changeListener->GetColorScheme(); }, SyncTag)};
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -12,7 +12,7 @@
 #include <React.h>
 #include "IReactInstance.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 // Listens for the current theme on the UI thread, storing the most recent. Will emit JS events on Appearance change.
 class AppearanceChangeListener final : public Mso::ActiveObject<> {
@@ -46,4 +46,4 @@ class AppearanceModule final : public facebook::xplat::module::CxxModule {
   Mso::CntPtr<AppearanceChangeListener> m_changeListener;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/CreateModules.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/CreateModules.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<IWebSocketResource> IWebSocketResource::Make(std::string &&urlSt
 std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule(
     Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept {
   if (context && QuirkSettings::GetUseLegacyWebSocketModule(ReactPropertyBag(context->Properties()))) {
-    return std::make_unique<react::uwp::LegacyWebSocketModule>();
+    return std::make_unique<Microsoft::ReactNative::LegacyWebSocketModule>();
   }
   return std::make_unique<WebSocketModule>();
 }

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -47,13 +47,13 @@ void DeviceInfoHolder::InitDeviceInfoHolder(const Mso::React::IReactContext &con
             }
           });
     } else {
-      assert(react::uwp::IsXamlIsland());
+      assert(IsXamlIsland());
       // This is either a WinUI 3 island or a system XAML island
       // system XAML islands have a CoreWindow so we want to use the GetForCurrentView APIs
       // For WinUI 3 islands we require the app to forward window messages as ReactNotifications
     }
 
-    if (!react::uwp::IsWinUI3Island()) {
+    if (!IsWinUI3Island()) {
       // UWP or system XAML island
       auto const &displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
 
@@ -142,7 +142,7 @@ void DeviceInfoHolder::updateDeviceInfo() noexcept {
 
   winrt::Windows::UI::ViewManagement::UISettings uiSettings;
   m_textScaleFactor = uiSettings.TextScaleFactor();
-  if (!react::uwp::IsWinUI3Island()) {
+  if (!IsWinUI3Island()) {
     auto const displayInfo = winrt::Windows::Graphics::Display::DisplayInformation::GetForCurrentView();
     m_scale = static_cast<float>(displayInfo.ResolutionScale()) / 100;
     m_dpi = displayInfo.LogicalDpi();

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
@@ -28,7 +28,7 @@ static const React::ReactPropertyId<bool> &ForceRTLPropertyId() noexcept {
 }
 
 void I18nManager::InitI18nInfo(const winrt::Microsoft::ReactNative::ReactPropertyBag &propertyBag) noexcept {
-  if (xaml::TryGetCurrentApplication() && !react::uwp::IsXamlIsland()) {
+  if (xaml::TryGetCurrentApplication() && !IsXamlIsland()) {
     // TODO: Figure out packaged win32 app story for WinUI 3
     auto layoutDirection = winrt::Windows::ApplicationModel::Resources::Core::ResourceContext()
                                .GetForCurrentView()

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
@@ -21,7 +21,7 @@ using namespace Windows::Storage::Streams;
 using namespace xaml::Media::Imaging;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 //
 // ImageViewManagerModule::ImageViewManagerModuleImpl
 //
@@ -168,4 +168,4 @@ auto ImageViewManagerModule::getMethods() -> std::vector<Method> {
   };
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
@@ -10,7 +10,7 @@ class MessageQueueThread;
 }
 } // namespace facebook
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class ImageViewManagerModule : public facebook::xplat::module::CxxModule {
  public:
@@ -29,4 +29,4 @@ class ImageViewManagerModule : public facebook::xplat::module::CxxModule {
   std::shared_ptr<ImageViewManagerModuleImpl> m_imageViewManagerModule;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -23,7 +23,7 @@ using namespace Windows::Foundation;
 using namespace Windows::System;
 using namespace ::Microsoft::Common::Unicode;
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 //
 // LinkingManagerModule helpers
@@ -124,4 +124,4 @@ auto LinkingManagerModule::getMethods() -> std::vector<Method> {
   };
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
@@ -6,7 +6,7 @@
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 struct LinkingManagerModule final : facebook::xplat::module::CxxModule {
   LinkingManagerModule() noexcept;
@@ -28,4 +28,4 @@ struct LinkingManagerModule final : facebook::xplat::module::CxxModule {
   static std::vector<LinkingManagerModule *> s_linkingModules;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -45,7 +45,7 @@ void LogBox::ShowOnUIThread() noexcept {
   m_popup = xaml::Controls::Primitives::Popup{};
   xaml::FrameworkElement root{nullptr};
 
-  if (react::uwp::Is19H1OrHigher()) {
+  if (Is19H1OrHigher()) {
     // XamlRoot added in 19H1 - is required to be set for XamlIsland scenarios
     if (auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle())) {
       m_popup.XamlRoot(xamlRoot);

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -152,7 +152,7 @@ struct RootShadowNode final : public ShadowNodeBase {
   RootShadowNode() = delete;
 
   RootShadowNode(facebook::react::IReactRootView *rootView, INativeUIManagerHost *host) {
-    auto reactRootView = static_cast<react::uwp::IXamlRootView *>(rootView);
+    auto reactRootView = static_cast<IXamlRootView *>(rootView);
     m_view = reactRootView->GetXamlView();
   }
 
@@ -214,7 +214,7 @@ int64_t NativeUIManager::AddMeasuredRootView(facebook::react::IReactRootView *ro
 }
 
 void NativeUIManager::AddRootView(ShadowNode &shadowNode, facebook::react::IReactRootView *pReactRootView) {
-  auto xamlRootView = static_cast<react::uwp::IXamlRootView *>(pReactRootView);
+  auto xamlRootView = static_cast<IXamlRootView *>(pReactRootView);
   XamlView view = xamlRootView->GetXamlView();
   m_tagsToXamlReactControl.emplace(shadowNode.m_tag, xamlRootView->GetXamlReactControl());
 
@@ -1124,7 +1124,7 @@ void NativeUIManager::blur(int64_t reactTag) {
 // ReactControl is used here. To get the IXamlReactControl for any node, we
 // first iterate its parent until reaching the root node. Then look up
 // m_tagsToXamlReactControl to get the IXamlReactControl
-std::weak_ptr<react::uwp::IXamlReactControl> NativeUIManager::GetParentXamlReactControl(int64_t tag) const {
+std::weak_ptr<IXamlReactControl> NativeUIManager::GetParentXamlReactControl(int64_t tag) const {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindParentRootShadowNode(tag))) {
     auto it = m_tagsToXamlReactControl.find(shadowNode->m_tag);
     if (it != m_tagsToXamlReactControl.end()) {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 struct IXamlReactControl;
 }
 
@@ -98,7 +98,7 @@ class NativeUIManager final : public INativeUIManager {
   void UpdateExtraLayout(int64_t tag);
   YGNodeRef GetYogaNode(int64_t tag) const;
 
-  std::weak_ptr<::react::uwp::IXamlReactControl> GetParentXamlReactControl(int64_t tag) const;
+  std::weak_ptr<IXamlReactControl> GetParentXamlReactControl(int64_t tag) const;
 
  private:
   INativeUIManagerHost *m_host = nullptr;
@@ -112,7 +112,7 @@ class NativeUIManager final : public INativeUIManager {
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
   std::vector<int64_t> m_extraLayoutNodes;
 
-  std::map<int64_t, std::weak_ptr<::react::uwp::IXamlReactControl>> m_tagsToXamlReactControl;
+  std::map<int64_t, std::weak_ptr<IXamlReactControl>> m_tagsToXamlReactControl;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -25,7 +25,7 @@ using namespace xaml::Media;
 } // namespace winrt
 using namespace std;
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 //
 // TimerQueue
@@ -198,14 +198,14 @@ auto TimingModule::getMethods() -> std::vector<Method> {
   };
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative
 
 namespace facebook {
 namespace react {
 
 std::unique_ptr<facebook::xplat::module::CxxModule> CreateTimingModule(
     const std::shared_ptr<facebook::react::MessageQueueThread> &) noexcept {
-  return std::make_unique<::react::uwp::TimingModule>();
+  return std::make_unique<Microsoft::ReactNative::TimingModule>();
 }
 
 } // namespace react

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <winrt/Windows.Foundation.h>
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 typedef winrt::Windows::Foundation::DateTime TDateTime;
 typedef winrt::Windows::Foundation::TimeSpan TTimeSpan;
@@ -88,4 +88,4 @@ class TimingModule : public facebook::xplat::module::CxxModule {
   std::shared_ptr<Timing> m_timing;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.cpp
@@ -26,7 +26,7 @@ namespace winrt {
 using namespace Windows::Networking::Sockets;
 }
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 void OutputDebugString(const char *format, winrt::hresult_error const &e) {
   char buffer[1024];
@@ -315,4 +315,4 @@ auto LegacyWebSocketModule::getMethods() -> std::vector<Method> {
   };
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/WebSocketModuleUwp.h
@@ -6,7 +6,7 @@
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class LegacyWebSocketModule : public facebook::xplat::module::CxxModule {
  public:
@@ -25,4 +25,4 @@ class LegacyWebSocketModule : public facebook::xplat::module::CxxModule {
   std::shared_ptr<WebSocket> m_webSocket;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -104,7 +104,7 @@ void ReactApplication::JavaScriptBundleFile(hstring const &value) noexcept {
 void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
   if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
     auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
-    react::uwp::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
+    ::Microsoft::ReactNative::LinkingManagerModule::OpenUri(protocolActivatedEventArgs.Uri());
   }
   this->OnCreate(e);
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
@@ -12,16 +12,13 @@
 #include <string>
 
 namespace Microsoft::ReactNative {
+
 struct INativeUIManager;
 class ExpressionAnimationStore;
-} // namespace Microsoft::ReactNative
-
-namespace react::uwp {
-
 struct IXamlRootView;
 
 typedef unsigned int LiveReloadCallbackCookie;
 typedef unsigned int ErrorCallbackCookie;
 typedef unsigned int DebuggerAttachCallbackCookie;
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -325,12 +325,12 @@ void ReactInstanceWin::Initialize() noexcept {
   Mso::PostFuture(m_uiQueue, [weakThis = Mso::WeakPtr{this}]() noexcept {
     // Objects that must be created on the UI thread
     if (auto strongThis = weakThis.GetStrongPtr()) {
-      strongThis->m_appTheme = std::make_shared<::react::uwp::AppTheme>(
+      strongThis->m_appTheme = std::make_shared<Microsoft::ReactNative::AppTheme>(
           strongThis->GetReactContext(), strongThis->m_uiMessageThread.LoadWithLock());
       Microsoft::ReactNative::I18nManager::InitI18nInfo(
           winrt::Microsoft::ReactNative::ReactPropertyBag(strongThis->Options().Properties));
-      strongThis->m_appearanceListener =
-          Mso::Make<::react::uwp::AppearanceChangeListener>(strongThis->GetReactContext(), strongThis->m_uiQueue);
+      strongThis->m_appearanceListener = Mso::Make<Microsoft::ReactNative::AppearanceChangeListener>(
+          strongThis->GetReactContext(), strongThis->m_uiQueue);
 
       Microsoft::ReactNative::DeviceInfoHolder::InitDeviceInfoHolder(strongThis->GetReactContext());
     }
@@ -374,7 +374,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
       // Acquire default modules and then populate with custom modules.
       // Note that some of these have custom thread affinity.
-      std::vector<facebook::react::NativeModuleDescription> cxxModules = ::react::uwp::GetCoreModules(
+      std::vector<facebook::react::NativeModuleDescription> cxxModules = Microsoft::ReactNative::GetCoreModules(
           m_batchingUIThread,
           m_jsMessageThread.Load(),
           std::move(m_appTheme),
@@ -416,9 +416,9 @@ void ReactInstanceWin::Initialize() noexcept {
 #endif
         case JSIEngine::Chakra:
           if (m_options.EnableByteCodeCaching || !m_options.ByteCodeFileUri.empty()) {
-            scriptStore = std::make_unique<::react::uwp::UwpScriptStore>();
-            preparedScriptStore =
-                std::make_unique<::react::uwp::UwpPreparedScriptStore>(winrt::to_hstring(m_options.ByteCodeFileUri));
+            scriptStore = std::make_unique<Microsoft::ReactNative::UwpScriptStore>();
+            preparedScriptStore = std::make_unique<Microsoft::ReactNative::UwpPreparedScriptStore>(
+                winrt::to_hstring(m_options.ByteCodeFileUri));
           }
           devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
               devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
@@ -620,7 +620,7 @@ void ReactInstanceWin::InitUIMessageThread() noexcept {
   m_uiMessageThread.Exchange(
       std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
-  auto batchingUIThread = ::react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());
+  auto batchingUIThread = Microsoft::ReactNative::MakeBatchingQueueThread(m_uiMessageThread.Load());
   m_batchingUIThread = batchingUIThread;
 
   m_jsDispatchQueue.Load().Post(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -174,8 +174,8 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
 
   std::shared_ptr<IRedBoxHandler> m_redboxHandler;
 #ifndef CORE_ABI
-  std::shared_ptr<react::uwp::AppTheme> m_appTheme;
-  Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
+  std::shared_ptr<Microsoft::ReactNative::AppTheme> m_appTheme;
+  Mso::CntPtr<Microsoft::ReactNative::AppearanceChangeListener> m_appearanceListener;
 #endif
   Mso::DispatchQueue m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;

--- a/vnext/Microsoft.ReactNative/ReactHost/ViewManagerProvider.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ViewManagerProvider.h
@@ -6,18 +6,14 @@
 #include <memory>
 #include <vector>
 
-namespace react::uwp {
-struct IReactInstance;
-} // namespace react::uwp
-
 namespace Microsoft::ReactNative {
 class IViewManager;
+struct IReactInstance;
 
 using NativeViewManager = std::unique_ptr<Microsoft::ReactNative::IViewManager>;
 
 struct ViewManagerProvider {
-  virtual std::vector<NativeViewManager> GetViewManagers(
-      const std::shared_ptr<::react::uwp::IReactInstance> &instance) = 0;
+  virtual std::vector<NativeViewManager> GetViewManagers(const std::shared_ptr<IReactInstance> &instance) = 0;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -10,7 +10,7 @@
 namespace winrt::Microsoft::ReactNative::implementation {
 
 ReactRootView::ReactRootView() noexcept {
-  m_rootControl = std::make_shared<react::uwp::ReactRootControl>(*this);
+  m_rootControl = std::make_shared<::Microsoft::ReactNative::ReactRootControl>(*this);
   UpdatePerspective();
   Loaded([this](auto &&, auto &&) {
     ::Microsoft::ReactNative::SetCompositor(::Microsoft::ReactNative::GetCompositor(*this));

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -45,7 +45,7 @@ struct ReactRootView : ReactRootViewT<ReactRootView> {
   ReactNative::JSValueArgWriter m_initialPropsWriter;
   folly::dynamic m_initialProps;
   bool m_isPerspectiveEnabled{true};
-  std::shared_ptr<react::uwp::ReactRootControl> m_rootControl;
+  std::shared_ptr<::Microsoft::ReactNative::ReactRootControl> m_rootControl;
 
   void UpdatePerspective();
 };

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -118,7 +118,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
     xaml::FrameworkElement root{nullptr};
 
-    if (react::uwp::Is19H1OrHigher()) {
+    if (Microsoft::ReactNative::Is19H1OrHigher()) {
       // XamlRoot added in 19H1
       if (auto reactHost = m_weakReactHost.GetStrongPtr()) {
         if (auto xamlRoot =

--- a/vnext/Microsoft.ReactNative/Utils/AccessibilityUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/AccessibilityUtils.cpp
@@ -9,7 +9,7 @@
 #include <UI.Xaml.Automation.h>
 #include <Views/DynamicAutomationProperties.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 REACTWINDOWS_API_(void)
 AnnounceLiveRegionChangedIfNeeded(const xaml::FrameworkElement &element) {
@@ -33,4 +33,4 @@ HasDynamicAutomationProperties(const xaml::UIElement &element) {
 
   return false;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/AccessibilityUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/AccessibilityUtils.h
@@ -5,11 +5,11 @@
 
 #include <Shared/ReactWindowsAPI.h>
 #include "CppWinRTIncludes.h"
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 REACTWINDOWS_API_(void)
 AnnounceLiveRegionChangedIfNeeded(const xaml::FrameworkElement &element);
 
 REACTWINDOWS_API_(bool)
 HasDynamicAutomationProperties(const xaml::UIElement &element);
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -18,7 +18,7 @@ using namespace xaml::Media;
 using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 // Not only react-native, native modules could set tag too for controls.
 // For example, to identify an clicked item, customer may add tag in
@@ -107,8 +107,8 @@ bool IsWinUI3Island() {
 #ifndef USE_WINUI3
   return false;
 #else
-  return react::uwp::IsXamlIsland();
+  return IsXamlIsland();
 #endif
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -8,7 +8,7 @@
 #include <React.h>
 #include <stdint.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 using namespace std;
 
@@ -33,4 +33,4 @@ bool Is19H1OrHigher();
 bool IsXamlIsland();
 bool IsWinUI3Island();
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
@@ -13,7 +13,7 @@
 #pragma optimize("", off)
 #endif
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string &bundleUri) {
   winrt::hstring str(Microsoft::Common::Unicode::Utf8ToUtf16(bundleUri));
@@ -76,4 +76,4 @@ void StorageFileBigString::ensure() const {
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.h
+++ b/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.h
@@ -6,7 +6,7 @@
 #include <future>
 #include <string>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class LocalBundleReader {
  public:
@@ -28,4 +28,4 @@ class StorageFileBigString : public facebook::react::JSBigString {
   mutable std::string m_string;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
@@ -101,13 +101,13 @@ bool TryUpdateBackgroundBrush(
     const std::string &propertyName,
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   if (propertyName == "backgroundColor") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      const auto brush = react::uwp::BrushFrom(propertyValue);
+    if (IsValidColorValue(propertyValue)) {
+      const auto brush = BrushFrom(propertyValue);
       element.Background(brush);
-      react::uwp::UpdateControlBackgroundResourceBrushes(element, brush);
+      UpdateControlBackgroundResourceBrushes(element, brush);
     } else if (propertyValue.IsNull()) {
       element.ClearValue(T::BackgroundProperty());
-      react::uwp::UpdateControlBackgroundResourceBrushes(element, nullptr);
+      UpdateControlBackgroundResourceBrushes(element, nullptr);
     }
 
     return true;
@@ -139,13 +139,13 @@ bool TryUpdateForeground(
     const std::string &propertyName,
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   if (propertyName == "color") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      const auto brush = react::uwp::BrushFrom(propertyValue);
+    if (IsValidColorValue(propertyValue)) {
+      const auto brush = BrushFrom(propertyValue);
       element.Foreground(brush);
-      react::uwp::UpdateControlForegroundResourceBrushes(element, brush);
+      UpdateControlForegroundResourceBrushes(element, brush);
     } else if (propertyValue.IsNull()) {
       element.ClearValue(T::ForegroundProperty());
-      react::uwp::UpdateControlForegroundResourceBrushes(element, nullptr);
+      UpdateControlForegroundResourceBrushes(element, nullptr);
     }
 
     return true;
@@ -163,18 +163,18 @@ bool TryUpdateBorderProperties(
   bool isBorderProperty = true;
 
   if (propertyName == "borderColor") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      const auto brush = react::uwp::BrushFrom(propertyValue);
+    if (IsValidColorValue(propertyValue)) {
+      const auto brush = BrushFrom(propertyValue);
       element.BorderBrush(brush);
-      react::uwp::UpdateControlBorderResourceBrushes(element, brush);
+      UpdateControlBorderResourceBrushes(element, brush);
     } else if (propertyValue.IsNull()) {
       // If there's still a border thickness, use the default border brush.
       if (element.BorderThickness() != xaml::ThicknessHelper::FromUniformLength(0.0)) {
-        element.BorderBrush(react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
+        element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
       } else {
         element.ClearValue(T::BorderBrushProperty());
       }
-      react::uwp::UpdateControlBorderResourceBrushes(element, nullptr);
+      UpdateControlBorderResourceBrushes(element, nullptr);
     }
   } else {
     auto iter = edgeTypeMap.find(propertyName);
@@ -186,7 +186,7 @@ bool TryUpdateBorderProperties(
           // Borders with no brush draw something other than transparent on other platforms.
           // To match, we'll use a default border brush if one isn't already set.
           // Note:  Keep this in sync with code in ViewPanel::FinalizeProperties().
-          element.BorderBrush(react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
+          element.BorderBrush(DefaultBrushStore::Instance().GetDefaultBorderBrush());
         }
       } else if (propertyValue.IsNull()) {
         SetBorderThickness(node, element, iter->second, 0);

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -6,7 +6,7 @@
 #include <Utils/ResourceBrushUtils.h>
 #include <Utils/StandardControlResourceKeyNames.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 DefaultBrushStore::DefaultBrushStore() {}
 
@@ -147,4 +147,4 @@ void UpdateControlBorderResourceBrushes(const xaml::FrameworkElement &element, c
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.h
@@ -5,7 +5,7 @@
 #include <UI.Xaml.Media.h>
 #include "CppWinRTIncludes.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 // Helper per-UI-thread singleton class to cache brushes used as defaults.
 class DefaultBrushStore {
@@ -47,4 +47,4 @@ void UpdateToggleSwitchTrackResourceBrushes(
     const xaml::Media::Brush onTrackBrush,
     const xaml::Media::Brush offTrackBrush);
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/UwpPreparedScriptStore.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/UwpPreparedScriptStore.cpp
@@ -17,7 +17,7 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Storage;
 }; // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 UwpPreparedScriptStore::UwpPreparedScriptStore(winrt::hstring uri) {
   if (!uri.empty()) {
     m_byteCodeFileAsync = winrt::StorageFile::GetFileFromApplicationUriAsync(winrt::Uri(uri));
@@ -104,4 +104,4 @@ winrt::StorageFile UwpPreparedScriptStore::TryGetByteCodeFileSync(
 
   return byteCodeVersion > scriptSignature.version ? file : nullptr;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/UwpPreparedScriptStore.h
+++ b/vnext/Microsoft.ReactNative/Utils/UwpPreparedScriptStore.h
@@ -7,7 +7,7 @@
 #include <future>
 #include <string>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 class UwpPreparedScriptStore : public facebook::jsi::PreparedScriptStore {
  public:
   UwpPreparedScriptStore(winrt::hstring uri);
@@ -61,4 +61,4 @@ class ByteCodeBuffer final : public facebook::jsi::Buffer {
   int size_;
   std::unique_ptr<uint8_t[]> byteArray_;
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/UwpScriptStore.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/UwpScriptStore.cpp
@@ -12,7 +12,7 @@ using namespace winrt::Windows::Foundation;
 using namespace winrt::Windows::Storage;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 UwpScriptStore::UwpScriptStore() {}
 
@@ -53,4 +53,4 @@ std::future<facebook::jsi::ScriptVersion_t> UwpScriptStore::getScriptVersionAsyn
   co_return GetFileVersion(file.Path().c_str());
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/UwpScriptStore.h
+++ b/vnext/Microsoft.ReactNative/Utils/UwpScriptStore.h
@@ -2,7 +2,7 @@
 #include <JSI/ScriptStore.h>
 #include <future>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class UwpScriptStore : public facebook::jsi::ScriptStore {
  public:
@@ -19,4 +19,4 @@ class UwpScriptStore : public facebook::jsi::ScriptStore {
   std::future<facebook::jsi::ScriptVersion_t> getScriptVersionAsync(const std::string &bundleUri);
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -24,7 +24,7 @@ using namespace xaml::Input;
 using namespace xaml::Media;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 inline BYTE GetAFromArgb(DWORD v) {
   return ((BYTE)((v & 0xFF000000) >> 24));
@@ -326,4 +326,4 @@ winrt::Uri UriTryCreate(winrt::param::hstring const &uri) {
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -18,7 +18,7 @@ namespace winrt::Microsoft::ReactNative {
 struct JSValue;
 }
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v);
@@ -61,4 +61,4 @@ winrt::Uri UriTryCreate(winrt::param::hstring const &uri);
 winrt::Windows::UI::Color ColorFromNumber(DWORD argb) noexcept;
 xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::Color) noexcept;
 xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::SharedColor) noexcept;
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ConfigureBundlerDlg.cpp
@@ -123,7 +123,7 @@ struct ConfigureBundlerDlg : winrt::implements<ConfigureBundlerDlg, winrt::IInsp
 
       m_flyout = xaml::Controls::Flyout{};
       m_flyout.Content(configureUI);
-      if (react::uwp::Is19H1OrHigher()) {
+      if (Is19H1OrHigher()) {
         // ShouldConstrainToRootBounds added in 19H1
         m_flyout.ShouldConstrainToRootBounds(false);
       }

--- a/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DatePickerViewManager.cpp
@@ -65,12 +65,12 @@ void DatePickerShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
 
     if (propertyName == "dayOfWeekFormat") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String)
-        datePicker.DayOfWeekFormat(react::uwp::asHstring(propertyValue));
+        datePicker.DayOfWeekFormat(asHstring(propertyValue));
       else if (propertyValue.IsNull())
         datePicker.ClearValue(xaml::Controls::CalendarDatePicker::DayOfWeekFormatProperty());
     } else if (propertyName == "dateFormat") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String)
-        datePicker.DateFormat(react::uwp::asHstring(propertyValue));
+        datePicker.DateFormat(asHstring(propertyValue));
       else if (propertyValue.IsNull())
         datePicker.ClearValue(xaml::Controls::CalendarDatePicker::DateFormatProperty());
     } else if (propertyName == "firstDayOfWeek") {
@@ -97,7 +97,7 @@ void DatePickerShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
       }
     } else if (propertyName == "placeholderText") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String)
-        datePicker.PlaceholderText(react::uwp::asHstring(propertyValue));
+        datePicker.PlaceholderText(asHstring(propertyValue));
       else if (propertyValue.IsNull())
         datePicker.ClearValue(xaml::Controls::CalendarDatePicker::PlaceholderTextProperty());
     } else if (propertyName == "selectedDate") {
@@ -118,13 +118,13 @@ void DatePickerShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
   }
 
   if (updateMaxDate)
-    datePicker.MaxDate(react::uwp::DateTimeFrom(m_maxTime, m_timeZoneOffsetInSeconds));
+    datePicker.MaxDate(DateTimeFrom(m_maxTime, m_timeZoneOffsetInSeconds));
 
   if (updateMinDate)
-    datePicker.MinDate(react::uwp::DateTimeFrom(m_minTime, m_timeZoneOffsetInSeconds));
+    datePicker.MinDate(DateTimeFrom(m_minTime, m_timeZoneOffsetInSeconds));
 
   if (updateSelectedDate)
-    datePicker.Date(react::uwp::DateTimeFrom(m_selectedTime, m_timeZoneOffsetInSeconds));
+    datePicker.Date(DateTimeFrom(m_selectedTime, m_timeZoneOffsetInSeconds));
 
   Super::updateProperties(props);
   m_updating = false;
@@ -134,7 +134,7 @@ void DatePickerShadowNode::OnDateChanged(
     const Mso::React::IReactContext &context,
     int64_t tag,
     winrt::DateTime const &newDate) {
-  auto timeInMilliseconds = react::uwp::DateTimeToDynamic(newDate, m_timeZoneOffsetInSeconds);
+  auto timeInMilliseconds = DateTimeToDynamic(newDate, m_timeZoneOffsetInSeconds);
   if (!timeInMilliseconds.isNull()) {
     folly::dynamic eventData = folly::dynamic::object("target", tag)("newDate", timeInMilliseconds);
     context.DispatchEvent(tag, "topChange", std::move(eventData));

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -53,7 +53,7 @@ void DevMenuManager::Init() noexcept {
     if (auto strongThis = weakThis.lock()) {
       auto context = strongThis->m_context;
 
-      if (react::uwp::Is19H1OrHigher()) {
+      if (Is19H1OrHigher()) {
         // XamlRoot added in 19H1
         if (auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context->Properties())) {
           if (auto rootContent = xamlRoot.Content()) {
@@ -206,7 +206,7 @@ void DevMenuManager::CreateAndShowUI() noexcept {
 
   m_flyout = xaml::Controls::Flyout{};
   m_flyout.Content(devMenu);
-  if (react::uwp::Is19H1OrHigher()) {
+  if (Is19H1OrHigher()) {
     // ShouldConstrainToRootBounds added in 19H1
     m_flyout.ShouldConstrainToRootBounds(false);
   }

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -25,7 +25,7 @@ using namespace xaml::Interop;
 using namespace xaml::Media;
 } // namespace winrt
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 DynamicAutomationPeer::DynamicAutomationPeer(xaml::FrameworkElement const &owner) : Super(owner) {}
 
@@ -47,57 +47,57 @@ winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore
   auto accessibilityRole = GetAccessibilityRole();
 
   switch (accessibilityRole) {
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Button:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ImageButton:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Switch: // Both ToggleSwitch and
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Button:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Switch: // Both ToggleSwitch and
                                                                     // ToggleButton return
                                                                     // "Button"
       return winrt::AutomationControlType::Button;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Link:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Link:
       return winrt::AutomationControlType::Hyperlink;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Image:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Image:
       return winrt::AutomationControlType::Image;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::KeyboardKey:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::KeyboardKey:
       return winrt::AutomationControlType::Custom;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Text:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Header:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Summary:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Alert:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Text:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Header:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Summary:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Alert:
       return winrt::AutomationControlType::Text;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Adjustable:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Adjustable:
       return winrt::AutomationControlType::Slider;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::CheckBox:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::CheckBox:
       return winrt::AutomationControlType::CheckBox;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ComboBox:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ComboBox:
       return winrt::AutomationControlType::ComboBox;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Menu:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Menu:
       return winrt::AutomationControlType::Menu;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::MenuBar:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::MenuBar:
       return winrt::AutomationControlType::MenuBar;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::MenuItem:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::MenuItem:
       return winrt::AutomationControlType::MenuItem;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ProgressBar:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ProgressBar:
       return winrt::AutomationControlType::ProgressBar;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Radio:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Radio:
       return winrt::AutomationControlType::RadioButton;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ScrollBar:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ScrollBar:
       return winrt::AutomationControlType::ScrollBar;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::SpinButton:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::SpinButton:
       return winrt::AutomationControlType::Spinner;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Tab:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Tab:
       return winrt::AutomationControlType::TabItem;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::TabList:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::TabList:
       return winrt::AutomationControlType::Tab;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ToolBar:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ToolBar:
       return winrt::AutomationControlType::ToolBar;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::List:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::List:
       return winrt::AutomationControlType::List;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ListItem:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ListItem:
       return winrt::AutomationControlType::ListItem;
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::None:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Search:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::RadioGroup:
-    case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Timer:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::None:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Search:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::RadioGroup:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Timer:
       return winrt::AutomationControlType::Group;
   }
 
@@ -108,45 +108,45 @@ winrt::IInspectable DynamicAutomationPeer::GetPatternCore(winrt::PatternInterfac
   auto accessibilityRole = GetAccessibilityRole();
 
   if (patternInterface == winrt::PatternInterface::Invoke &&
-      (accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Button ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ImageButton ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Radio)) {
+      (accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Button ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio)) {
     return *this;
   } else if (
       (patternInterface == winrt::PatternInterface::Selection ||
        patternInterface == winrt::PatternInterface::SelectionItem) &&
-      HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Selected)) {
+      HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Selected)) {
     return *this;
   } else if (
       patternInterface == winrt::PatternInterface::Toggle &&
-      (accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::CheckBox ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Switch ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Radio) &&
-      (HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Checked) ||
-       HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Unchecked))) {
+      (accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::CheckBox ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Switch ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio) &&
+      (HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Checked) ||
+       HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked))) {
     return *this;
   } else if (
       patternInterface == winrt::PatternInterface::ExpandCollapse &&
-      (HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Expanded) ||
-       HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Collapsed))) {
+      (HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Expanded) ||
+       HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed))) {
     return *this;
   } else if (
       patternInterface == winrt::PatternInterface::Value &&
-      accessibilityRole != winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ProgressBar &&
-      accessibilityRole != winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Adjustable &&
-      accessibilityRole != winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ScrollBar &&
-      (HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Text) ||
-       HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Now))) {
-    return winrt::make<winrt::PROJECT_ROOT_NAMESPACE::implementation::DynamicValueProvider>(
+      accessibilityRole != winrt::Microsoft::ReactNative::AccessibilityRoles::ProgressBar &&
+      accessibilityRole != winrt::Microsoft::ReactNative::AccessibilityRoles::Adjustable &&
+      accessibilityRole != winrt::Microsoft::ReactNative::AccessibilityRoles::ScrollBar &&
+      (HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue::Text) ||
+       HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue::Now))) {
+    return winrt::make<winrt::Microsoft::ReactNative::implementation::DynamicValueProvider>(
         this->try_as<winrt::FrameworkElementAutomationPeer>());
   } else if (
       patternInterface == winrt::PatternInterface::RangeValue &&
-      (accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ProgressBar ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Adjustable ||
-       accessibilityRole == winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::ScrollBar) &&
-      (HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Now) &&
-       HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Min) &&
-       HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Max))) {
+      (accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::ProgressBar ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Adjustable ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::ScrollBar) &&
+      (HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue::Now) &&
+       HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue::Min) &&
+       HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue::Max))) {
     return *this;
   }
 
@@ -154,8 +154,8 @@ winrt::IInspectable DynamicAutomationPeer::GetPatternCore(winrt::PatternInterfac
 }
 
 bool DynamicAutomationPeer::IsEnabledCore() const {
-  bool disabled = HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Disabled) &&
-      GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Disabled);
+  bool disabled = HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Disabled) &&
+      GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Disabled);
   return !disabled && Super::IsEnabledCore();
 }
 
@@ -163,8 +163,8 @@ winrt::hstring DynamicAutomationPeer::GetItemStatusCore() const {
   winrt::hstring itemStatus = Super::GetItemStatusCore();
 
   if (itemStatus.empty()) {
-    if (HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Busy) &&
-        GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Busy)) {
+    if (HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Busy) &&
+        GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Busy)) {
       itemStatus = L"Busy";
     }
   }
@@ -195,7 +195,7 @@ winrt::com_array<winrt::IRawElementProviderSimple> DynamicAutomationPeer::GetSel
 // ISelectionItemProvider
 
 bool DynamicAutomationPeer::IsSelected() const {
-  return GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Selected);
+  return GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Selected);
 }
 
 winrt::IRawElementProviderSimple DynamicAutomationPeer::SelectionContainer() const {
@@ -222,8 +222,8 @@ void DynamicAutomationPeer::Select() const {
 // IToggleProvider
 
 winrt::ToggleState DynamicAutomationPeer::ToggleState() const {
-  bool checkedState = GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Checked);
-  bool uncheckedState = GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Unchecked);
+  bool checkedState = GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Checked);
+  bool uncheckedState = GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked);
 
   if (!checkedState && uncheckedState) {
     return winrt::ToggleState::Off;
@@ -245,8 +245,8 @@ void DynamicAutomationPeer::Toggle() const {
 // IExpandCollapseProvider
 
 winrt::ExpandCollapseState DynamicAutomationPeer::ExpandCollapseState() const {
-  bool expandedState = GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Expanded);
-  bool collapsedState = GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Collapsed);
+  bool expandedState = GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Expanded);
+  bool collapsedState = GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed);
 
   if (!expandedState && collapsedState) {
     return winrt::ExpandCollapseState::Collapsed;
@@ -269,15 +269,15 @@ void DynamicAutomationPeer::Collapse() const {
 
 // IRangeValueProvider
 double DynamicAutomationPeer::Minimum() {
-  return GetAccessibilityValueRange(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Min);
+  return GetAccessibilityValueRange(winrt::Microsoft::ReactNative::AccessibilityValue::Min);
 }
 
 double DynamicAutomationPeer::Maximum() {
-  return GetAccessibilityValueRange(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Max);
+  return GetAccessibilityValueRange(winrt::Microsoft::ReactNative::AccessibilityValue::Max);
 }
 
 double DynamicAutomationPeer::Value() {
-  return GetAccessibilityValueRange(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Now);
+  return GetAccessibilityValueRange(winrt::Microsoft::ReactNative::AccessibilityValue::Now);
 }
 
 // Controls such as Slider, ProgressBar, ScrollBar are by definition interactive.
@@ -311,7 +311,7 @@ winrt::hstring DynamicAutomationPeer::GetContentName() const {
   winrt::hstring name = L"";
 
   try {
-    if (auto const &viewControl = Owner().try_as<winrt::PROJECT_ROOT_NAMESPACE::ViewControl>()) {
+    if (auto const &viewControl = Owner().try_as<winrt::Microsoft::ReactNative::ViewControl>()) {
       auto viewPanel = viewControl.GetPanel();
 
       for (auto const &child : viewPanel.Children()) {
@@ -328,39 +328,39 @@ winrt::hstring DynamicAutomationPeer::GetContentName() const {
   return name;
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles DynamicAutomationPeer::GetAccessibilityRole() const {
+winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationPeer::GetAccessibilityRole() const {
   try {
     return DynamicAutomationProperties::GetAccessibilityRole(Owner());
   } catch (...) {
   }
 
-  return winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::None;
+  return winrt::Microsoft::ReactNative::AccessibilityRoles::None;
 }
 
-bool DynamicAutomationPeer::HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates state) const {
+bool DynamicAutomationPeer::HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const {
   try {
     auto const &owner = Owner();
     winrt::IInspectable value = nullptr;
     switch (state) {
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Selected:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Selected:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateSelectedProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Disabled:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Disabled:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateDisabledProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Checked:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Checked:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateCheckedProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Unchecked:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateUncheckedProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Busy:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Busy:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateBusyProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Expanded:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Expanded:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateExpandedProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Collapsed:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityStateCollapsedProperty());
         break;
     }
@@ -371,23 +371,23 @@ bool DynamicAutomationPeer::HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE:
   return false;
 }
 
-bool DynamicAutomationPeer::GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates state) const {
+bool DynamicAutomationPeer::GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const {
   try {
     auto const &owner = Owner();
     switch (state) {
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Selected:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Selected:
         return DynamicAutomationProperties::GetAccessibilityStateSelected(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Disabled:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Disabled:
         return DynamicAutomationProperties::GetAccessibilityStateDisabled(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Checked:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Checked:
         return DynamicAutomationProperties::GetAccessibilityStateChecked(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Unchecked:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked:
         return DynamicAutomationProperties::GetAccessibilityStateUnchecked(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Busy:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Busy:
         return DynamicAutomationProperties::GetAccessibilityStateBusy(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Expanded:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Expanded:
         return DynamicAutomationProperties::GetAccessibilityStateExpanded(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates::Collapsed:
+      case winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed:
         return DynamicAutomationProperties::GetAccessibilityStateCollapsed(owner);
     }
   } catch (...) {
@@ -396,22 +396,22 @@ bool DynamicAutomationPeer::GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE:
   return false;
 }
 
-bool DynamicAutomationPeer::HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue accValue) const {
+bool DynamicAutomationPeer::HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue accValue) const {
   try {
     auto const &owner = Owner();
     winrt::IInspectable value = nullptr;
 
     switch (accValue) {
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Min:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Min:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityValueMinProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Max:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Max:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityValueMaxProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Now:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Now:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityValueNowProperty());
         break;
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Text:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Text:
         value = owner.ReadLocalValue(DynamicAutomationProperties::AccessibilityValueTextProperty());
         break;
     }
@@ -422,7 +422,7 @@ bool DynamicAutomationPeer::HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE:
   return false;
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler
+winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler
 DynamicAutomationPeer::GetAccessibilityInvokeEventHandler() const {
   try {
     return DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(Owner());
@@ -433,16 +433,16 @@ DynamicAutomationPeer::GetAccessibilityInvokeEventHandler() const {
 }
 
 double DynamicAutomationPeer::GetAccessibilityValueRange(
-    winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue accValue) const {
+    winrt::Microsoft::ReactNative::AccessibilityValue accValue) const {
   try {
     auto const &owner = Owner();
 
     switch (accValue) {
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Min:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Min:
         return DynamicAutomationProperties::GetAccessibilityValueMin(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Max:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Max:
         return DynamicAutomationProperties::GetAccessibilityValueMax(owner);
-      case winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue::Now:
+      case winrt::Microsoft::ReactNative::AccessibilityValue::Now:
         return DynamicAutomationProperties::GetAccessibilityValueNow(owner);
     }
   } catch (...) {
@@ -451,4 +451,4 @@ double DynamicAutomationPeer::GetAccessibilityValueRange(
   return 0;
 }
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
@@ -9,7 +9,7 @@
 
 #include "DynamicAutomationPeer.g.h"
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 //
 // DynamicAutomationPeer translates the values of the attached properties in
@@ -71,30 +71,30 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
 
  private:
   winrt::hstring GetContentName() const;
-  winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles GetAccessibilityRole() const;
-  bool HasAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates state) const;
-  bool GetAccessibilityState(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityStates state) const;
-  bool HasAccessibilityValue(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue value) const;
-  double GetAccessibilityValueRange(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityValue value) const;
+  winrt::Microsoft::ReactNative::AccessibilityRoles GetAccessibilityRole() const;
+  bool HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const;
+  bool GetAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const;
+  bool HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue value) const;
+  double GetAccessibilityValueRange(winrt::Microsoft::ReactNative::AccessibilityValue value) const;
 
-  winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler() const;
+  winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler() const;
 
   static xaml::DependencyProperty AccessibilityActionsProperty();
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-      Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value);
-  static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
+      Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
+  static Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(
       xaml::UIElement const &element,
-      winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value);
-  static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
+      winrt::Microsoft::ReactNative::AccessibilityActionEventHandler const &value);
+  static winrt::Microsoft::ReactNative::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
       xaml::UIElement const &element);
 };
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation {
+namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer, implementation::DynamicAutomationPeer> {};
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
@@ -20,7 +20,7 @@ using namespace xaml::Interop;
 using namespace winrt::Windows::UI::Xaml::Interop;
 } // namespace winrt
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 const winrt::TypeName dynamicAutomationTypeName{
     winrt::hstring{L"DynamicAutomationProperties"},
@@ -29,22 +29,22 @@ const winrt::TypeName dynamicAutomationTypeName{
 xaml::DependencyProperty DynamicAutomationProperties::AccessibilityRoleProperty() {
   static xaml::DependencyProperty s_AccessibilityRoleProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityRole",
-      winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(),
+      winrt::xaml_typename<winrt::Microsoft::ReactNative::AccessibilityRoles>(),
       dynamicAutomationTypeName,
-      winrt::PropertyMetadata(winrt::box_value(winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles::Unknown)));
+      winrt::PropertyMetadata(winrt::box_value(winrt::Microsoft::ReactNative::AccessibilityRoles::Unknown)));
 
   return s_AccessibilityRoleProperty;
 }
 
 void DynamicAutomationProperties::SetAccessibilityRole(
     xaml::UIElement const &element,
-    winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles const &value) {
-  element.SetValue(AccessibilityRoleProperty(), winrt::box_value<PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(value));
+    winrt::Microsoft::ReactNative::AccessibilityRoles const &value) {
+  element.SetValue(AccessibilityRoleProperty(), winrt::box_value<Microsoft::ReactNative::AccessibilityRoles>(value));
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles DynamicAutomationProperties::GetAccessibilityRole(
+winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationProperties::GetAccessibilityRole(
     xaml::UIElement const &element) {
-  return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles>(
+  return winrt::unbox_value<winrt::Microsoft::ReactNative::AccessibilityRoles>(
       element.GetValue(AccessibilityRoleProperty()));
 }
 
@@ -250,32 +250,32 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityInvokeEventHa
   static xaml::DependencyProperty s_AccessibilityInvokeEventHandlerProperty =
       xaml::DependencyProperty::RegisterAttached(
           L"AccessibilityInvokeEventHandler",
-          winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(),
+          winrt::xaml_typename<winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler>(),
           dynamicAutomationTypeName,
           winrt::PropertyMetadata(
-              winrt::box_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(nullptr)));
+              winrt::box_value<winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler>(nullptr)));
 
   return s_AccessibilityInvokeEventHandlerProperty;
 }
 
 void DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(
     xaml::UIElement const &element,
-    winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler const &value) {
+    winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler const &value) {
   element.SetValue(
       AccessibilityInvokeEventHandlerProperty(),
-      winrt::box_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(value));
+      winrt::box_value<winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler>(value));
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler
+winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler
 DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(xaml::UIElement const &element) {
-  return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler>(
+  return winrt::unbox_value<winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler>(
       element.GetValue(AccessibilityInvokeEventHandlerProperty()));
 }
 
 xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
   static xaml::DependencyProperty s_AccessibilityActionsProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityActions",
-      winrt::xaml_typename<Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>>(),
+      winrt::xaml_typename<Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(),
       dynamicAutomationTypeName,
       winrt::PropertyMetadata(nullptr));
 
@@ -284,13 +284,13 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProper
 
 void DynamicAutomationProperties::SetAccessibilityActions(
     xaml::UIElement const &element,
-    Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value) {
+    Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value) {
   return element.SetValue(AccessibilityActionsProperty(), winrt::box_value(value));
 }
 
-Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>
+Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
 DynamicAutomationProperties::GetAccessibilityActions(xaml::UIElement const &element) {
-  return winrt::unbox_value<Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction>>(
+  return winrt::unbox_value<Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(
       element.GetValue(AccessibilityActionsProperty()));
 }
 
@@ -317,25 +317,25 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionEventHa
   static xaml::DependencyProperty s_AccessibilityActionEventHandlerProperty =
       xaml::DependencyProperty::RegisterAttached(
           L"AccessibilityActionEventHandler",
-          winrt::xaml_typename<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(),
+          winrt::xaml_typename<winrt::Microsoft::ReactNative::AccessibilityActionEventHandler>(),
           dynamicAutomationTypeName,
           winrt::PropertyMetadata(
-              winrt::box_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(nullptr)));
+              winrt::box_value<winrt::Microsoft::ReactNative::AccessibilityActionEventHandler>(nullptr)));
 
   return s_AccessibilityActionEventHandlerProperty;
 }
 
 void DynamicAutomationProperties::SetAccessibilityActionEventHandler(
     xaml::UIElement const &element,
-    winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value) {
+    winrt::Microsoft::ReactNative::AccessibilityActionEventHandler const &value) {
   element.SetValue(
       AccessibilityActionEventHandlerProperty(),
-      winrt::box_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(value));
+      winrt::box_value<winrt::Microsoft::ReactNative::AccessibilityActionEventHandler>(value));
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler
+winrt::Microsoft::ReactNative::AccessibilityActionEventHandler
 DynamicAutomationProperties::GetAccessibilityActionEventHandler(xaml::UIElement const &element) {
-  return winrt::unbox_value<winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler>(
+  return winrt::unbox_value<winrt::Microsoft::ReactNative::AccessibilityActionEventHandler>(
       element.GetValue(AccessibilityActionEventHandlerProperty()));
 }
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
@@ -5,16 +5,7 @@
 
 #include "DynamicAutomationProperties.g.h"
 
-#ifndef PROJECT_ROOT_NAMESPACE
-#define PROJECT_ROOT_NAMESPACE react::uwp
-#else
-namespace winrt::Microsoft::ReactNative {}
-namespace winrt::react::uwp {
-using namespace winrt::Microsoft::ReactNative;
-}
-#endif
-
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 //
 // DynamicAutomationProperties provides attached properties for the various
@@ -32,7 +23,7 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
   static xaml::DependencyProperty AccessibilityRoleProperty();
   static void SetAccessibilityRole(
       xaml::UIElement const &element,
-      winrt::PROJECT_ROOT_NAMESPACE::AccessibilityRoles const &value);
+      winrt::Microsoft::ReactNative::AccessibilityRoles const &value);
   static AccessibilityRoles GetAccessibilityRole(xaml::UIElement const &element);
 
   static xaml::DependencyProperty AccessibilityStateSelectedProperty();
@@ -82,17 +73,17 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
   static xaml::DependencyProperty AccessibilityInvokeEventHandlerProperty();
   static void SetAccessibilityInvokeEventHandler(
       xaml::UIElement const &element,
-      winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler const &value);
-  static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(
+      winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler const &value);
+  static winrt::Microsoft::ReactNative::AccessibilityInvokeEventHandler GetAccessibilityInvokeEventHandler(
       xaml::UIElement const &element);
 
   static xaml::DependencyProperty AccessibilityActionsProperty();
 
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-      Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> const &value);
+      Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
 
-  static Windows::Foundation::Collections::IVector<PROJECT_ROOT_NAMESPACE::AccessibilityAction> GetAccessibilityActions(
+  static Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
 
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
@@ -100,17 +91,17 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(
       xaml::UIElement const &element,
-      winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler const &value);
-  static winrt::PROJECT_ROOT_NAMESPACE::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
+      winrt::Microsoft::ReactNative::AccessibilityActionEventHandler const &value);
+  static winrt::Microsoft::ReactNative::AccessibilityActionEventHandler GetAccessibilityActionEventHandler(
       xaml::UIElement const &element);
 };
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation {
+namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct DynamicAutomationProperties
     : DynamicAutomationPropertiesT<DynamicAutomationProperties, implementation::DynamicAutomationProperties> {};
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::factory_implementation
 
 namespace react::uwp {
 // Issue #2172: Calling static members on
@@ -120,5 +111,5 @@ namespace react::uwp {
 // using cppwinrt. This workaround is so that consumers in react::uwp can just
 // call DynamicAutomationProperties
 
-using DynamicAutomationProperties = winrt::PROJECT_ROOT_NAMESPACE::implementation::DynamicAutomationProperties;
+using DynamicAutomationProperties = winrt::Microsoft::ReactNative::implementation::DynamicAutomationProperties;
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
@@ -103,13 +103,13 @@ struct DynamicAutomationProperties
     : DynamicAutomationPropertiesT<DynamicAutomationProperties, implementation::DynamicAutomationProperties> {};
 } // namespace winrt::Microsoft::ReactNative::factory_implementation
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 // Issue #2172: Calling static members on
-// winrt::react::uwp::DynamicAutomationProperties fails to call
-// down into winrt::react::uwp::implementation::DynamicAutomationProperties
+// winrt::Microsoft::ReactNative::DynamicAutomationProperties fails to call
+// down into winrt::Microsoft::ReactNative::implementation::DynamicAutomationProperties
 // because of how we're
-// using cppwinrt. This workaround is so that consumers in react::uwp can just
+// using cppwinrt. This workaround is so that consumers in Microsoft::ReactNative can just
 // call DynamicAutomationProperties
 
 using DynamicAutomationProperties = winrt::Microsoft::ReactNative::implementation::DynamicAutomationProperties;
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DynamicValueProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicValueProvider.cpp
@@ -13,7 +13,7 @@
 #include "DynamicValueProvider.g.cpp"
 #endif
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 DynamicValueProvider::DynamicValueProvider(xaml::Automation::Peers::FrameworkElementAutomationPeer peer)
     : m_peer(peer) {}
@@ -56,4 +56,4 @@ winrt::hstring DynamicValueProvider::GetAccessibilityValue() const {
   return L"";
 }
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/DynamicValueProvider.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicValueProvider.h
@@ -8,7 +8,7 @@
 #include "DynamicAutomationPeer.g.h"
 #include "DynamicValueProvider.g.h"
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 struct DynamicValueProvider : DynamicValueProviderT<DynamicValueProvider> {
   using Super = DynamicValueProviderT<DynamicValueProvider>;
@@ -25,8 +25,8 @@ struct DynamicValueProvider : DynamicValueProviderT<DynamicValueProvider> {
   winrt::hstring GetAccessibilityValue() const;
   xaml::Automation::Peers::FrameworkElementAutomationPeer m_peer{nullptr};
 };
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation {
+namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct DynamicValueProvider : DynamicValueProviderT<DynamicValueProvider, implementation::DynamicValueProvider> {};
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -202,7 +202,7 @@ void FlyoutShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueOb
         // of open popups/flyouts. We apply this translation on open of the
         // flyout. (Translation is only supported on RS5+, eg. IUIElement9)
         if (auto uiElement9 = GetView().try_as<xaml::IUIElement9>()) {
-          auto numOpenPopups = react::uwp::CountOpenPopups();
+          auto numOpenPopups = CountOpenPopups();
           if (numOpenPopups > 0) {
             winrt::Numerics::float3 translation{0, 0, (float)16 * numOpenPopups};
             flyoutPresenter.Translation(translation);
@@ -435,7 +435,7 @@ const wchar_t *FlyoutViewManager::GetName() const {
 }
 
 XamlView FlyoutViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
-  return winrt::make<winrt::react::uwp::implementation::ViewPanel>().as<XamlView>();
+  return winrt::make<winrt::Microsoft::ReactNative::implementation::ViewPanel>().as<XamlView>();
 }
 
 ShadowNode *FlyoutViewManager::createShadow() const {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -35,15 +35,16 @@ using namespace Windows::Foundation::Collections;
 } // namespace winrt
 
 template <>
-struct json_type_traits<winrt::react::uwp::AccessibilityAction> {
-  static winrt::react::uwp::AccessibilityAction parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
-    auto action = winrt::react::uwp::AccessibilityAction();
+struct json_type_traits<winrt::Microsoft::ReactNative::AccessibilityAction> {
+  static winrt::Microsoft::ReactNative::AccessibilityAction parseJson(
+      const winrt::Microsoft::ReactNative::JSValue &json) {
+    auto action = winrt::Microsoft::ReactNative::AccessibilityAction();
 
     for (auto &item : json.AsObject()) {
       if (item.first == "name") {
-        action.Name = react::uwp::asHstring(item.second);
+        action.Name = Microsoft::ReactNative::asHstring(item.second);
       } else if (item.first == "label") {
-        action.Label = react::uwp::asHstring(item.second);
+        action.Label = Microsoft::ReactNative::asHstring(item.second);
       }
     }
     return action;
@@ -51,17 +52,17 @@ struct json_type_traits<winrt::react::uwp::AccessibilityAction> {
 };
 
 template <>
-struct json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>> {
-  static winrt::IVector<winrt::react::uwp::AccessibilityAction> parseJson(
+struct json_type_traits<winrt::IVector<winrt::Microsoft::ReactNative::AccessibilityAction>> {
+  static winrt::IVector<winrt::Microsoft::ReactNative::AccessibilityAction> parseJson(
       const winrt::Microsoft::ReactNative::JSValue &json) {
-    auto vector = winrt::single_threaded_vector<winrt::react::uwp::AccessibilityAction>();
+    auto vector = winrt::single_threaded_vector<winrt::Microsoft::ReactNative::AccessibilityAction>();
 
     if (json.Type() == winrt::Microsoft::ReactNative::JSValueType::Array) {
       for (const auto &action : json.AsArray()) {
         if (action.Type() != winrt::Microsoft::ReactNative::JSValueType::Object)
           continue;
 
-        vector.Append(json_type_traits<winrt::react::uwp::AccessibilityAction>::parseJson(action));
+        vector.Append(json_type_traits<winrt::Microsoft::ReactNative::AccessibilityAction>::parseJson(action));
       }
     }
     return vector;
@@ -70,7 +71,7 @@ struct json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>> 
 
 namespace Microsoft::ReactNative {
 
-using DynamicAutomationProperties = react::uwp::DynamicAutomationProperties;
+using DynamicAutomationProperties = Microsoft::ReactNative::DynamicAutomationProperties;
 
 FrameworkElementViewManager::FrameworkElementViewManager(const Mso::React::IReactContext &context) : Super(context) {}
 
@@ -106,8 +107,8 @@ void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, co
   TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
   TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
   TransferProperty(oldView, newView, winrt::Canvas::ZIndexProperty());
-  TransferProperty(oldView, newView, react::uwp::ViewPanel::LeftProperty());
-  TransferProperty(oldView, newView, react::uwp::ViewPanel::TopProperty());
+  TransferProperty(oldView, newView, Microsoft::ReactNative::ViewPanel::LeftProperty());
+  TransferProperty(oldView, newView, Microsoft::ReactNative::ViewPanel::TopProperty());
 
   // Accessibility Properties
   TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::AutomationIdProperty());
@@ -310,7 +311,7 @@ bool FrameworkElementViewManager::UpdateProperty(
 
     } else if (propertyName == "accessibilityHint") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        auto value = react::uwp::asHstring(propertyValue);
+        auto value = asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
         element.SetValue(xaml::Automation::AutomationProperties::HelpTextProperty(), boxedValue);
@@ -319,14 +320,14 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "accessibilityLabel") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        auto value = react::uwp::asHstring(propertyValue);
+        auto value = asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
         element.SetValue(xaml::Automation::AutomationProperties::NameProperty(), boxedValue);
       } else if (propertyValue.IsNull()) {
         element.ClearValue(xaml::Automation::AutomationProperties::NameProperty());
       }
-      react::uwp::AnnounceLiveRegionChangedIfNeeded(element);
+      AnnounceLiveRegionChangedIfNeeded(element);
     } else if (propertyName == "accessible") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean) {
         if (!propertyValue.AsBoolean())
@@ -348,7 +349,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       } else if (propertyValue.IsNull()) {
         element.ClearValue(xaml::Automation::AutomationProperties::LiveSettingProperty());
       }
-      react::uwp::AnnounceLiveRegionChangedIfNeeded(element);
+      AnnounceLiveRegionChangedIfNeeded(element);
     } else if (propertyName == "accessibilityPosInSet") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||
           propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
@@ -373,73 +374,100 @@ bool FrameworkElementViewManager::UpdateProperty(
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
         const std::string &role = propertyValue.AsString();
         if (role == "none")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::None);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::None);
         else if (role == "button")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Button);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Button);
         else if (role == "link")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Link);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Link);
         else if (role == "search")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Search);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Search);
         else if (role == "image")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Image);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Image);
         else if (role == "keyboardkey")
           DynamicAutomationProperties::SetAccessibilityRole(
-              element, winrt::react::uwp::AccessibilityRoles::KeyboardKey);
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::KeyboardKey);
         else if (role == "text")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Text);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Text);
         else if (role == "adjustable")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Adjustable);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Adjustable);
         else if (role == "imagebutton")
           DynamicAutomationProperties::SetAccessibilityRole(
-              element, winrt::react::uwp::AccessibilityRoles::ImageButton);
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton);
         else if (role == "header")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Header);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Header);
         else if (role == "summary")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Summary);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Summary);
         else if (role == "alert")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Alert);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Alert);
         else if (role == "checkbox")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::CheckBox);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::CheckBox);
         else if (role == "combobox")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::ComboBox);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ComboBox);
         else if (role == "menu")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Menu);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Menu);
         else if (role == "menubar")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::MenuBar);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::MenuBar);
         else if (role == "menuitem")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::MenuItem);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::MenuItem);
         else if (role == "progressbar")
           DynamicAutomationProperties::SetAccessibilityRole(
-              element, winrt::react::uwp::AccessibilityRoles::ProgressBar);
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ProgressBar);
         else if (role == "radio")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Radio);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Radio);
         else if (role == "radiogroup")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::RadioGroup);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::RadioGroup);
         else if (role == "scrollbar")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::ScrollBar);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ScrollBar);
         else if (role == "spinbutton")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::SpinButton);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::SpinButton);
         else if (role == "switch")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Switch);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Switch);
         else if (role == "tab")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Tab);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Tab);
         else if (role == "tablist")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::TabList);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::TabList);
         else if (role == "timer")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Timer);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Timer);
         else if (role == "toolbar")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::ToolBar);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ToolBar);
         else if (role == "list")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::List);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::List);
         else if (role == "listitem")
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::ListItem);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ListItem);
         else
-          DynamicAutomationProperties::SetAccessibilityRole(element, winrt::react::uwp::AccessibilityRoles::Unknown);
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::Unknown);
       } else if (propertyValue.IsNull()) {
         element.ClearValue(DynamicAutomationProperties::AccessibilityRoleProperty());
       }
     } else if (propertyName == "accessibilityState") {
-      bool states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::CountStates)] = {};
+      bool states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::CountStates)] = {};
 
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Object) {
         for (const auto &pair : propertyValue.AsObject()) {
@@ -447,43 +475,45 @@ bool FrameworkElementViewManager::UpdateProperty(
           const auto &innerValue = pair.second;
 
           if (innerName == "selected")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)] = innerValue.AsBoolean();
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Selected)] =
+                innerValue.AsBoolean();
           else if (innerName == "disabled")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)] = innerValue.AsBoolean();
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Disabled)] =
+                innerValue.AsBoolean();
           else if (innerName == "checked") {
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)] =
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Checked)] =
                 innerValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean && innerValue.AsBoolean();
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)] =
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked)] =
                 innerValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean && !innerValue.AsBoolean();
             // If the state is "mixed" we'll just set both Checked and Unchecked to false,
             // then later in the IToggleProvider implementation it will return the Intermediate state
             // due to both being set to false (see  DynamicAutomationPeer::ToggleState()).
           } else if (innerName == "busy")
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)] =
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Busy)] =
                 !innerValue.IsNull() && innerValue.AsBoolean();
           else if (innerName == "expanded") {
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)] =
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Expanded)] =
                 !innerValue.IsNull() && innerValue.AsBoolean();
-            states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)] =
+            states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed)] =
                 innerValue.IsNull() || !innerValue.AsBoolean();
           }
         }
       }
 
       DynamicAutomationProperties::SetAccessibilityStateSelected(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Selected)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Selected)]);
       DynamicAutomationProperties::SetAccessibilityStateDisabled(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Disabled)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Disabled)]);
       DynamicAutomationProperties::SetAccessibilityStateChecked(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Checked)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Checked)]);
       DynamicAutomationProperties::SetAccessibilityStateUnchecked(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Unchecked)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked)]);
       DynamicAutomationProperties::SetAccessibilityStateBusy(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Busy)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Busy)]);
       DynamicAutomationProperties::SetAccessibilityStateExpanded(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Expanded)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Expanded)]);
       DynamicAutomationProperties::SetAccessibilityStateCollapsed(
-          element, states[static_cast<int32_t>(winrt::react::uwp::AccessibilityStates::Collapsed)]);
+          element, states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed)]);
     } else if (propertyName == "accessibilityValue") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Object) {
         for (const auto &pair : propertyValue.AsObject()) {
@@ -503,14 +533,14 @@ bool FrameworkElementViewManager::UpdateProperty(
               innerValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
             DynamicAutomationProperties::SetAccessibilityValueNow(element, innerValue.AsDouble());
           } else if (innerName == "text" && innerValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-            auto value = react::uwp::asHstring(innerValue);
+            auto value = asHstring(innerValue);
             DynamicAutomationProperties::SetAccessibilityValueText(element, value);
           }
         }
       }
     } else if (propertyName == "testID") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        auto value = react::uwp::asHstring(propertyValue);
+        auto value = asHstring(propertyValue);
         auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
         element.SetValue(xaml::Automation::AutomationProperties::AutomationIdProperty(), boxedValue);
@@ -519,7 +549,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (propertyName == "tooltip") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        winrt::ToolTipService::SetToolTip(element, winrt::box_value(react::uwp::asHstring(propertyValue)));
+        winrt::ToolTipService::SetToolTip(element, winrt::box_value(asHstring(propertyValue)));
       }
     } else if (propertyName == "zIndex") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||
@@ -533,7 +563,8 @@ bool FrameworkElementViewManager::UpdateProperty(
       }
     } else if (TryUpdateFlowDirection(element, propertyName, propertyValue)) {
     } else if (propertyName == "accessibilityActions") {
-      auto value = json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>>::parseJson(propertyValue);
+      auto value = json_type_traits<winrt::IVector<winrt::Microsoft::ReactNative::AccessibilityAction>>::parseJson(
+          propertyValue);
       DynamicAutomationProperties::SetAccessibilityActions(element, value);
     } else if (propertyName == "display") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {

--- a/vnext/Microsoft.ReactNative/Views/IXamlRootView.h
+++ b/vnext/Microsoft.ReactNative/Views/IXamlRootView.h
@@ -8,7 +8,7 @@
 #include <folly/dynamic.h>
 #include "XamlView.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 struct IXamlReactControl {
   virtual void blur(Microsoft::ReactNative::XamlView const &xamlView) noexcept = 0;
@@ -27,4 +27,4 @@ struct IXamlRootView : public facebook::react::IReactRootView {
   virtual std::shared_ptr<IXamlReactControl> GetXamlReactControl() const noexcept = 0;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -23,9 +23,9 @@ using namespace xaml::Controls;
 
 // Such code is better to move to a seperate parser layer
 template <>
-struct json_type_traits<react::uwp::ReactImageSource> {
-  static react::uwp::ReactImageSource parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
-    react::uwp::ReactImageSource source;
+struct json_type_traits<Microsoft::ReactNative::ReactImageSource> {
+  static Microsoft::ReactNative::ReactImageSource parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
+    Microsoft::ReactNative::ReactImageSource source;
     for (auto &item : json.AsObject()) {
       if (item.first == "uri")
         source.uri = item.second.AsString();
@@ -49,20 +49,20 @@ struct json_type_traits<react::uwp::ReactImageSource> {
 };
 
 template <>
-struct json_type_traits<react::uwp::ResizeMode> {
-  static react::uwp::ResizeMode parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
-    auto resizeMode{react::uwp::ResizeMode::Contain};
+struct json_type_traits<facebook::react::ImageResizeMode> {
+  static facebook::react::ImageResizeMode parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
+    auto resizeMode{facebook::react::ImageResizeMode::Contain};
 
     if (json == "cover") {
-      resizeMode = react::uwp::ResizeMode::Cover;
+      resizeMode = facebook::react::ImageResizeMode::Cover;
     } else if (json == "contain") {
-      resizeMode = react::uwp::ResizeMode::Contain;
+      resizeMode = facebook::react::ImageResizeMode::Contain;
     } else if (json == "stretch") {
-      resizeMode = react::uwp::ResizeMode::Stretch;
+      resizeMode = facebook::react::ImageResizeMode::Stretch;
     } else if (json == "center") {
-      resizeMode = react::uwp::ResizeMode::Center;
+      resizeMode = facebook::react::ImageResizeMode::Center;
     } else if (json == "repeat") {
-      resizeMode = react::uwp::ResizeMode::Repeat;
+      resizeMode = facebook::react::ImageResizeMode::Repeat;
     }
 
     return resizeMode;
@@ -70,8 +70,6 @@ struct json_type_traits<react::uwp::ResizeMode> {
 };
 
 namespace Microsoft::ReactNative {
-
-using ReactImage = react::uwp::ReactImage;
 
 class ImageShadowNode : public ShadowNodeBase {
  public:
@@ -83,7 +81,7 @@ class ImageShadowNode : public ShadowNodeBase {
 
     m_onLoadEndToken = reactImage->OnLoadEnd([imageViewManager{static_cast<ImageViewManager *>(GetViewManager())},
                                               reactImage](const auto &, const bool &succeeded) {
-      react::uwp::ReactImageSource source{reactImage->Source()};
+      ReactImageSource source{reactImage->Source()};
 
       imageViewManager->EmitImageEvent(reactImage.as<winrt::Grid>(), succeeded ? "topLoad" : "topError", source);
       imageViewManager->EmitImageEvent(reactImage.as<winrt::Grid>(), "topLoadEnd", source);
@@ -128,7 +126,7 @@ bool ImageViewManager::UpdateProperty(
   if (propertyName == "source") {
     setSource(grid, propertyValue);
   } else if (propertyName == "resizeMode") {
-    auto resizeMode{json_type_traits<react::uwp::ResizeMode>::parseJson(propertyValue)};
+    auto resizeMode{json_type_traits<facebook::react::ImageResizeMode>::parseJson(propertyValue)};
     auto reactImage{grid.as<ReactImage>()};
     reactImage->ResizeMode(resizeMode);
   } else if (
@@ -137,9 +135,9 @@ bool ImageViewManager::UpdateProperty(
        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)) {
     auto reactImage{grid.as<ReactImage>()};
     reactImage->BlurRadius(propertyValue.AsSingle());
-  } else if (propertyName == "tintColor" && react::uwp::IsValidColorValue(propertyValue)) {
+  } else if (propertyName == "tintColor" && IsValidColorValue(propertyValue)) {
     auto reactImage{grid.as<ReactImage>()};
-    reactImage->TintColor(react::uwp::ColorFrom(propertyValue));
+    reactImage->TintColor(ColorFrom(propertyValue));
   } else if (TryUpdateCornerRadiusOnNode(nodeToUpdate, grid, propertyName, propertyValue)) {
     finalizeBorderRadius = true;
   } else if (TryUpdateBorderProperties(nodeToUpdate, grid, propertyName, propertyValue)) {
@@ -154,7 +152,7 @@ bool ImageViewManager::UpdateProperty(
   return ret;
 }
 
-void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, react::uwp::ReactImageSource &source) {
+void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, ReactImageSource &source) {
   int64_t tag = grid.Tag().as<winrt::IPropertyValue>().GetInt64();
   folly::dynamic imageSource =
       folly::dynamic::object()("uri", source.uri)("width", source.width)("height", source.height);
@@ -164,7 +162,7 @@ void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, r
 }
 
 void ImageViewManager::setSource(winrt::Grid grid, const winrt::Microsoft::ReactNative::JSValue &data) {
-  auto sources{json_type_traits<std::vector<react::uwp::ReactImageSource>>::parseJson(data)};
+  auto sources{json_type_traits<std::vector<ReactImageSource>>::parseJson(data)};
   sources[0].bundleRootPath = GetReactContext().SettingsSnapshot().BundleRootPath();
 
   if (sources[0].packagerAsset && sources[0].uri.find("file://") == 0) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
@@ -18,7 +18,7 @@ class ImageViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   ShadowNode *createShadow() const override;
-  void EmitImageEvent(xaml::Controls::Grid grid, const char *eventName, react::uwp::ReactImageSource &source);
+  void EmitImageEvent(xaml::Controls::Grid grid, const char *eventName, ReactImageSource &source);
 
  protected:
   bool UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -29,7 +29,7 @@ using namespace Windows::Web::Http;
 
 using Microsoft::Common::Unicode::Utf8ToUtf16;
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 /*static*/ winrt::com_ptr<ReactImage> ReactImage::Create() {
   auto reactImage = winrt::make_self<ReactImage>();
@@ -57,11 +57,12 @@ void ReactImage::OnLoadEnd(winrt::event_token const &token) noexcept {
   m_onLoadEndEvent.remove(token);
 }
 
-void ReactImage::ResizeMode(react::uwp::ResizeMode value) {
+void ReactImage::ResizeMode(facebook::react::ImageResizeMode value) {
   if (m_resizeMode != value) {
     m_resizeMode = value;
 
-    bool shouldUseCompositionBrush{m_resizeMode == ResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
+    bool shouldUseCompositionBrush{
+        m_resizeMode == facebook::react::ImageResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
     bool switchBrushes{m_useCompositionBrush != shouldUseCompositionBrush};
 
     if (switchBrushes) {
@@ -79,7 +80,8 @@ void ReactImage::BlurRadius(float value) {
   if (m_blurRadius != value) {
     m_blurRadius = value;
 
-    bool shouldUseCompositionBrush{m_resizeMode == ResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
+    bool shouldUseCompositionBrush{
+        m_resizeMode == facebook::react::ImageResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
     bool switchBrushes{m_useCompositionBrush != shouldUseCompositionBrush};
 
     if (switchBrushes) {
@@ -97,7 +99,8 @@ void ReactImage::TintColor(winrt::Color value) {
 
   if (!sameColor) {
     m_tintColor = value;
-    bool shouldUseCompositionBrush{m_resizeMode == ResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
+    bool shouldUseCompositionBrush{
+        m_resizeMode == facebook::react::ImageResizeMode::Repeat || m_blurRadius > 0 || m_tintColor.A != 0};
     bool switchBrushes{m_useCompositionBrush != shouldUseCompositionBrush};
 
     if (switchBrushes) {
@@ -109,13 +112,13 @@ void ReactImage::TintColor(winrt::Color value) {
   }
 }
 
-winrt::Stretch ReactImage::ResizeModeToStretch(react::uwp::ResizeMode value) {
+winrt::Stretch ReactImage::ResizeModeToStretch(facebook::react::ImageResizeMode value) {
   switch (value) {
-    case ResizeMode::Cover:
+    case facebook::react::ImageResizeMode::Cover:
       return winrt::Stretch::UniformToFill;
-    case ResizeMode::Stretch:
+    case facebook::react::ImageResizeMode::Stretch:
       return winrt::Stretch::Fill;
-    case ResizeMode::Contain:
+    case facebook::react::ImageResizeMode::Contain:
       return winrt::Stretch::Uniform;
     default: // ResizeMode::Center || ResizeMode::Repeat
       if (m_imageSource.height < ActualHeight() && m_imageSource.width < ActualWidth()) {
@@ -133,7 +136,7 @@ void ReactImage::Source(ReactImageSource source) {
   }
 
   try {
-    winrt::Uri uri{react::uwp::UriTryCreate(Utf8ToUtf16(source.uri))};
+    winrt::Uri uri{UriTryCreate(Utf8ToUtf16(source.uri))};
     winrt::hstring scheme{uri ? uri.SchemeName() : L""};
     winrt::hstring ext{uri ? uri.Extension() : L""};
 
@@ -196,7 +199,7 @@ void ImageFailed(const TImage &image, const TSourceFailedEventArgs &args) {
 
 winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   const ReactImageSource source{m_imageSource};
-  winrt::Uri uri{react::uwp::UriTryCreate(Utf8ToUtf16(source.uri))};
+  winrt::Uri uri{UriTryCreate(Utf8ToUtf16(source.uri))};
 
   // Increment the image source ID before any co_await calls
   auto currentImageSourceId = ++m_imageSourceId;
@@ -458,4 +461,4 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageInlineDataAsyn
 
   co_return nullptr;
 }
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -11,7 +11,7 @@
 #include <JSValue.h>
 #include <folly/dynamic.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2 };
 enum class ImageSourceFormat { Bitmap = 0, Svg = 1 };
@@ -50,10 +50,10 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   }
   void Source(ReactImageSource source);
 
-  ::react::uwp::ResizeMode ResizeMode() {
+  facebook::react::ImageResizeMode ResizeMode() {
     return m_resizeMode;
   }
-  void ResizeMode(::react::uwp::ResizeMode value);
+  void ResizeMode(facebook::react::ImageResizeMode value);
 
   float BlurRadius() {
     return m_blurRadius;
@@ -66,7 +66,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   void TintColor(winrt::Windows::UI::Color value);
 
  private:
-  xaml::Media::Stretch ResizeModeToStretch(::react::uwp::ResizeMode value);
+  xaml::Media::Stretch ResizeModeToStretch(facebook::react::ImageResizeMode value);
   winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
   GetImageMemoryStreamAsync(ReactImageSource source);
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
@@ -75,7 +75,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   float m_blurRadius{0};
   int m_imageSourceId{0};
   ReactImageSource m_imageSource;
-  ::react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
+  facebook::react::ImageResizeMode m_resizeMode{facebook::react::ImageResizeMode::Contain};
   winrt::Windows::UI::Color m_tintColor{winrt::Colors::Transparent()};
 
   winrt::event<winrt::Windows::Foundation::EventHandler<bool>> m_onLoadEndEvent;
@@ -93,4 +93,4 @@ winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::In
 GetImageStreamAsync(ReactImageSource source);
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
 GetImageInlineDataAsync(ReactImageSource source);
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.cpp
@@ -20,7 +20,7 @@ using namespace xaml::Media;
 using namespace comp::Effects;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 /*static*/ winrt::com_ptr<ReactImageBrush> ReactImageBrush::Create() {
   return winrt::make_self<ReactImageBrush>();
 }
@@ -36,9 +36,10 @@ void ReactImageBrush::OnDisconnected() {
   }
 }
 
-void ReactImageBrush::ResizeMode(react::uwp::ResizeMode value) {
+void ReactImageBrush::ResizeMode(facebook::react::ImageResizeMode value) {
   if (m_resizeMode != value) {
-    const bool forceEffectBrush{value == ResizeMode::Repeat || m_resizeMode == ResizeMode::Repeat};
+    const bool forceEffectBrush{
+        value == facebook::react::ImageResizeMode::Repeat || m_resizeMode == facebook::react::ImageResizeMode::Repeat};
     m_resizeMode = value;
     UpdateCompositionBrush(forceEffectBrush);
   }
@@ -91,7 +92,7 @@ void ReactImageBrush::UpdateCompositionBrush(bool forceEffectBrush) {
     surfaceBrush.Stretch(ResizeModeToStretch());
 
     auto compositionBrush{surfaceBrush.as<comp::CompositionBrush>()};
-    if (ResizeMode() == ResizeMode::Repeat || BlurRadius() > 0 || m_tintColor.A != 0) {
+    if (ResizeMode() == facebook::react::ImageResizeMode::Repeat || BlurRadius() > 0 || m_tintColor.A != 0) {
       // The effects used for ResizeMode::Repeat and tintColor are conditional, so if we
       // are switching to/from those modes, then we need to create a new CompositionBrush.
       // The CompositionSurfaceBrush holding the image is used as its source.
@@ -113,7 +114,7 @@ void ReactImageBrush::UpdateCompositionBrush(bool forceEffectBrush) {
     // The CompositionBrush is only set after the image is first loaded and anytime
     // we switch between Surface and Effect brushes (to/from ResizeMode::Repeat)
     if (CompositionBrush() != compositionBrush) {
-      if (ResizeMode() == ResizeMode::Repeat) {
+      if (ResizeMode() == facebook::react::ImageResizeMode::Repeat) {
         surfaceBrush.HorizontalAlignmentRatio(0.0f);
         surfaceBrush.VerticalAlignmentRatio(0.0f);
       } else {
@@ -141,20 +142,20 @@ comp::CompositionStretch ReactImageBrush::ResizeModeToStretch() {
   auto stretch{comp::CompositionStretch::None};
 
   switch (ResizeMode()) {
-    case ResizeMode::Contain:
+    case facebook::react::ImageResizeMode::Contain:
       stretch = comp::CompositionStretch::Uniform;
       break;
 
-    case ResizeMode::Cover:
+    case facebook::react::ImageResizeMode::Cover:
       stretch = comp::CompositionStretch::UniformToFill;
       break;
 
-    case ResizeMode::Stretch:
+    case facebook::react::ImageResizeMode::Stretch:
       stretch = comp::CompositionStretch::Fill;
       break;
 
-    case ResizeMode::Center:
-    case ResizeMode::Repeat:
+    case facebook::react::ImageResizeMode::Center:
+    case facebook::react::ImageResizeMode::Repeat:
       stretch = IsImageSmallerThanView() ? comp::CompositionStretch::None : comp::CompositionStretch::Uniform;
       break;
   }
@@ -193,7 +194,7 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
     winrt::IGraphicsEffect effect{nullptr};
     std::vector<winrt::hstring> animatedProperties;
 
-    if (ResizeMode() == ResizeMode::Repeat) {
+    if (ResizeMode() == facebook::react::ImageResizeMode::Repeat) {
       // BorderEffect
       auto borderEffect{winrt::make<winrt::Microsoft::ReactNative::implementation::BorderEffect>()};
 
@@ -243,4 +244,4 @@ comp::CompositionEffectBrush ReactImageBrush::GetOrCreateEffectBrush(
   return m_effectBrush;
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImageBrush.h
@@ -8,9 +8,7 @@
 #include <winrt/Windows.Foundation.h>
 #include "CppWinRTIncludes.h"
 
-namespace react::uwp {
-
-using ResizeMode = facebook::react::ImageResizeMode;
+namespace Microsoft::ReactNative {
 
 struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush> {
   using Super = xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>;
@@ -25,10 +23,10 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
   void OnDisconnected();
 
   // Public Properties
-  ::react::uwp::ResizeMode ResizeMode() {
+  facebook::react::ImageResizeMode ResizeMode() {
     return m_resizeMode;
   }
-  void ResizeMode(::react::uwp::ResizeMode value);
+  void ResizeMode(facebook::react::ImageResizeMode value);
 
   float BlurRadius() {
     return m_blurRadius;
@@ -60,10 +58,10 @@ struct ReactImageBrush : xaml::Media::XamlCompositionBrushBaseT<ReactImageBrush>
       bool forceEffectBrush = false);
 
   float m_blurRadius{0};
-  ::react::uwp::ResizeMode m_resizeMode{ResizeMode::Contain};
+  facebook::react::ImageResizeMode m_resizeMode{facebook::react::ImageResizeMode::Contain};
   winrt::Windows::UI::Color m_tintColor{winrt::Colors::Transparent()};
   winrt::Windows::Foundation::Size m_availableSize{};
   xaml::Media::LoadedImageSurface m_loadedImageSurface{nullptr};
   comp::CompositionEffectBrush m_effectBrush{nullptr};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Impl/ScrollViewUWPImplementation.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Impl/ScrollViewUWPImplementation.cpp
@@ -3,7 +3,7 @@
 #include <UI.Xaml.Controls.h>
 #include "ScrollViewUWPImplementation.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 ScrollViewUWPImplementation::ScrollViewUWPImplementation(const winrt::ScrollViewer &scrollViewer) {
   assert(scrollViewer);
@@ -103,4 +103,4 @@ winrt::com_ptr<SnapPointManagingContentControl> ScrollViewUWPImplementation::Scr
   return nullptr;
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Impl/ScrollViewUWPImplementation.h
+++ b/vnext/Microsoft.ReactNative/Views/Impl/ScrollViewUWPImplementation.h
@@ -17,7 +17,7 @@ using namespace xaml::Controls;
 using namespace xaml::Controls::Primitives;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class ScrollViewUWPImplementation {
  public:
@@ -40,4 +40,4 @@ class ScrollViewUWPImplementation {
   winrt::weak_ref<winrt::ScrollViewer> m_scrollViewer{};
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Impl/SnapPointManagingContentControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Impl/SnapPointManagingContentControl.cpp
@@ -2,7 +2,7 @@
 
 #include "SnapPointManagingContentControl.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 SnapPointManagingContentControl::SnapPointManagingContentControl() {
   IsTabStop(false);
@@ -175,4 +175,4 @@ void SnapPointManagingContentControl::SetHeightBounds(float startHeight, float e
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Impl/SnapPointManagingContentControl.h
+++ b/vnext/Microsoft.ReactNative/Views/Impl/SnapPointManagingContentControl.h
@@ -13,7 +13,7 @@ using namespace xaml::Controls;
 using namespace xaml::Controls::Primitives;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class SnapPointManagingContentControl
     : public xaml::Controls::ContentControlT<SnapPointManagingContentControl, winrt::IScrollSnapPointsInfo> {
@@ -74,4 +74,4 @@ class SnapPointManagingContentControl
   float m_viewportHeight{0};
   float m_viewportWidth{0};
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -21,8 +21,6 @@ static constexpr auto KEY = "key";
 static constexpr auto TARGET = "target";
 static constexpr auto CODE = "code";
 
-using namespace react::uwp;
-
 template <>
 struct json_type_traits<Microsoft::ReactNative::HandledKeyboardEvent> {
   static Microsoft::ReactNative::HandledKeyboardEvent parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
@@ -43,7 +41,8 @@ struct json_type_traits<Microsoft::ReactNative::HandledKeyboardEvent> {
       else if (propertyName == CODE)
         event.code = propertyValue.AsString();
       else if (propertyName == EVENT_PHASE)
-        event.handledEventPhase = asEnum<Microsoft::ReactNative::HandledEventPhase>(propertyValue);
+        event.handledEventPhase =
+            Microsoft::ReactNative::asEnum<Microsoft::ReactNative::HandledEventPhase>(propertyValue);
     }
 
     return event;

--- a/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PickerViewManager.cpp
@@ -83,7 +83,7 @@ void PickerShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueOb
       }
       folly::dynamic text;
       if (s_isEditableComboboxSupported == TriBit::Set && index == -1)
-        text = react::uwp::HstringToDynamic(combobox.Text());
+        text = HstringToDynamic(combobox.Text());
       OnSelectionChanged(GetViewManager()->GetReactContext(), m_tag, std::move(value), index, std::move(text));
     }
   });
@@ -115,7 +115,7 @@ void PickerShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueOb
     } else if (propertyName == "text") {
       if (s_isEditableComboboxSupported == TriBit::Set) {
         if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String)
-          combobox.Text(react::uwp::asHstring(propertyValue));
+          combobox.Text(asHstring(propertyValue));
         else if (propertyValue.IsNull())
           combobox.ClearValue(xaml::Controls::ComboBox::TextProperty());
       }
@@ -155,8 +155,8 @@ void PickerShadowNode::RepopulateItems() {
 
       comboboxItem.Content(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(label)));
 
-      if (!item["textColor"].IsNull() && react::uwp::IsValidColorValue(item["textColor"]))
-        comboboxItem.Foreground(react::uwp::BrushFrom(item["textColor"]));
+      if (!item["textColor"].IsNull() && IsValidColorValue(item["textColor"]))
+        comboboxItem.Foreground(BrushFrom(item["textColor"]));
 
       comboBoxItems.Append(comboboxItem);
     }

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -95,7 +95,7 @@ void PopupShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObj
       // popups/flyouts. We apply this translation on open of the popup.
       // (Translation is only supported on RS5+, eg. IUIElement9)
       if (auto uiElement9 = GetView().try_as<xaml::IUIElement9>()) {
-        auto numOpenPopups = react::uwp::CountOpenPopups();
+        auto numOpenPopups = CountOpenPopups();
         if (numOpenPopups > 0) {
           winrt::Numerics::float3 translation{0, 0, (float)16 * numOpenPopups};
           popup.Translation(translation);

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -49,7 +49,7 @@ bool RawTextViewManager::UpdateProperty(
     return true;
 
   if (propertyName == "text") {
-    run.Text(react::uwp::asHstring(propertyValue));
+    run.Text(asHstring(propertyValue));
     static_cast<RawTextShadowNode *>(nodeToUpdate)->originalText = winrt::hstring{};
     NotifyAncestorsTextChanged(nodeToUpdate);
   } else {

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.cpp
@@ -44,9 +44,7 @@
 #include "DevMenu.h"
 #include "Modules/DevSettingsModule.h"
 
-namespace react::uwp {
-
-using XamlView = Microsoft::ReactNative::XamlView;
+namespace Microsoft::ReactNative {
 
 //===========================================================================
 // ReactRootControl implementation
@@ -406,7 +404,7 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
    * we should just skip hooking up the BackButton handler. SystemNavigationManager->GetForCurrentView seems to
    * crash with XamlIslands so we can't just bail if that call fails.
    */
-  if (::react::uwp::IsXamlIsland())
+  if (IsXamlIsland())
     return;
 
   auto weakThis = weak_from_this();
@@ -453,7 +451,7 @@ void ReactRootControl::AttachBackHandlers(XamlView const &rootView) noexcept {
   altLeft.Modifiers(winrt::Windows::System::VirtualKeyModifiers::Menu);
 
   // Hide keyboard accelerator tooltips
-  if (::react::uwp::IsRS4OrHigher()) {
+  if (IsRS4OrHigher()) {
     rootElement.KeyboardAcceleratorPlacementMode(xaml::Input::KeyboardAcceleratorPlacementMode::Hidden);
   }
 }
@@ -523,4 +521,4 @@ Mso::Future<void> ReactViewInstance::UninitRootView() noexcept {
   return PostInUIQueue([](ReactRootControl &rootControl) mutable noexcept { rootControl.UninitRootView(); });
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ReactRootControl.h
@@ -22,7 +22,7 @@ using namespace Windows::Foundation;
 using namespace xaml::Media;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 // A class that implements IXamlRootView and IXamlReactControl interfaces.
 // It keeps a weak reference to the XAML ReactRootView.
@@ -152,4 +152,4 @@ inline Mso::Future<void> ReactViewInstance::PostInUIQueue(TAction &&action) noex
       });
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -82,7 +82,7 @@ const wchar_t *RefreshControlViewManager::GetName() const {
 XamlView RefreshControlViewManager::CreateViewCore(
     int64_t /*tag*/,
     const winrt::Microsoft::ReactNative::JSValueObject &) {
-  if (react::uwp::IsRS4OrHigher()) {
+  if (IsRS4OrHigher()) {
     // refreshContainer is supported >= RS4
     return winrt::RefreshContainer();
   } else {

--- a/vnext/Microsoft.ReactNative/Views/SIPEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SIPEventHandler.cpp
@@ -42,12 +42,12 @@ void SIPEventHandler::AttachView(XamlView xamlView, bool fireKeyboardEvents) {
 
 void SIPEventHandler::InitializeCoreInputView() {
   if (const auto xamlView = m_view.get()) {
-    if (!react::uwp::IsRS3OrHigher()) {
+    if (!IsRS3OrHigher()) {
       return; // CoreInputView is only supported on >= RS3.
     }
 
 #ifndef USE_WINUI3
-    if (react::uwp::Is19H1OrHigher()) {
+    if (Is19H1OrHigher()) {
       // 19H1 and higher supports island scenarios
       auto uiElement(xamlView.as<xaml::UIElement>());
       m_coreInputView = winrt::CoreInputView::GetForUIContext(uiElement.UIContext());
@@ -92,8 +92,7 @@ if (IsRS5OrHigher() && m_coreInputView && !m_isShowing) { // CoreInputView.TrySh
 */
 
 void SIPEventHandler::TryHide() {
-  if (react::uwp::IsRS5OrHigher() && m_coreInputView &&
-      m_isShowing) { // CoreInputView.TryHide is only avaliable after RS5
+  if (IsRS5OrHigher() && m_coreInputView && m_isShowing) { // CoreInputView.TryHide is only avaliable after RS5
     m_coreInputView.TryHide();
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -104,7 +104,7 @@ void ScrollViewShadowNode::createView(const winrt::Microsoft::ReactNative::JSVal
   Super::createView(props);
 
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
-  const auto scrollViewUWPImplementation = react::uwp::ScrollViewUWPImplementation(scrollViewer);
+  const auto scrollViewUWPImplementation = ScrollViewUWPImplementation(scrollViewer);
   scrollViewUWPImplementation.ScrollViewerSnapPointManager();
 
   AddHandlers(scrollViewer);
@@ -145,7 +145,7 @@ void ScrollViewShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
       const auto [valid, horizontal] = getPropertyAndValidity(propertyValue, false);
       if (valid) {
         m_isHorizontal = horizontal;
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SetHorizontal(horizontal);
+        ScrollViewUWPImplementation(scrollViewer).SetHorizontal(horizontal);
         SetScrollMode(scrollViewer);
       }
     }
@@ -188,7 +188,7 @@ void ScrollViewShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
     } else if (propertyName == "snapToInterval") {
       const auto [valid, snapToInterval] = getPropertyAndValidity(propertyValue, 0.0);
       if (valid) {
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToInterval(static_cast<float>(snapToInterval));
+        ScrollViewUWPImplementation(scrollViewer).SnapToInterval(static_cast<float>(snapToInterval));
       }
     } else if (propertyName == "snapToOffsets") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Array) {
@@ -198,17 +198,17 @@ void ScrollViewShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
               val.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)
             snapToOffsets.Append(val.AsSingle());
         }
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToOffsets(snapToOffsets.GetView());
+        ScrollViewUWPImplementation(scrollViewer).SnapToOffsets(snapToOffsets.GetView());
       }
     } else if (propertyName == "snapToStart") {
       const auto [valid, snaptoStart] = getPropertyAndValidity(propertyValue, true);
       if (valid) {
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToStart(snaptoStart);
+        ScrollViewUWPImplementation(scrollViewer).SnapToStart(snaptoStart);
       }
     } else if (propertyName == "snapToEnd") {
       const auto [valid, snapToEnd] = getPropertyAndValidity(propertyValue, true);
       if (valid) {
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToEnd(snapToEnd);
+        ScrollViewUWPImplementation(scrollViewer).SnapToEnd(snapToEnd);
       }
     } else if (propertyName == "keyboardDismissMode") {
       m_dismissKeyboardOnDrag = false;
@@ -222,12 +222,12 @@ void ScrollViewShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSVal
     } else if (propertyName == "snapToAlignment") {
       const auto [valid, snapToAlignment] = getPropertyAndValidity(propertyValue, winrt::SnapPointsAlignment::Near);
       if (valid) {
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapPointAlignment(snapToAlignment);
+        ScrollViewUWPImplementation(scrollViewer).SnapPointAlignment(snapToAlignment);
       }
     } else if (propertyName == "pagingEnabled") {
       const auto [valid, pagingEnabled] = getPropertyAndValidity(propertyValue, false);
       if (valid) {
-        react::uwp::ScrollViewUWPImplementation(scrollViewer).PagingEnabled(pagingEnabled);
+        ScrollViewUWPImplementation(scrollViewer).PagingEnabled(pagingEnabled);
       }
     }
   }
@@ -494,7 +494,7 @@ XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microso
   scrollViewer.HorizontalSnapPointsType(winrt::SnapPointsType::Mandatory);
   scrollViewer.HorizontalScrollMode(winrt::ScrollMode::Disabled);
 
-  const auto snapPointManager = react::uwp::SnapPointManagingContentControl::Create();
+  const auto snapPointManager = SnapPointManagingContentControl::Create();
   scrollViewer.Content(*snapPointManager);
 
   return scrollViewer;
@@ -504,13 +504,13 @@ void ScrollViewManager::AddView(const XamlView &parent, const XamlView &child, [
   assert(index == 0);
 
   auto scrollViewer = parent.as<winrt::ScrollViewer>();
-  auto snapPointManager = scrollViewer.Content().as<react::uwp::SnapPointManagingContentControl>();
+  auto snapPointManager = scrollViewer.Content().as<SnapPointManagingContentControl>();
   snapPointManager->Content(child);
 }
 
 void ScrollViewManager::RemoveAllChildren(const XamlView &parent) {
   auto scrollViewer = parent.as<winrt::ScrollViewer>();
-  auto snapPointManager = scrollViewer.Content().as<react::uwp::SnapPointManagingContentControl>();
+  auto snapPointManager = scrollViewer.Content().as<SnapPointManagingContentControl>();
   snapPointManager->Content(nullptr);
 }
 
@@ -522,7 +522,7 @@ void ScrollViewManager::RemoveChildAt(const XamlView &parent, [[maybe_unused]] i
 void ScrollViewManager::SnapToInterval(const XamlView &parent, float interval) {
   if (parent) {
     if (const auto scrollViewer = parent.as<winrt::ScrollViewer>()) {
-      react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToInterval(interval);
+      ScrollViewUWPImplementation(scrollViewer).SnapToInterval(interval);
     }
   }
 }
@@ -530,7 +530,7 @@ void ScrollViewManager::SnapToInterval(const XamlView &parent, float interval) {
 void ScrollViewManager::SnapToOffsets(const XamlView &parent, const winrt::IVectorView<float> &offsets) {
   if (parent) {
     if (const auto scrollViewer = parent.as<winrt::ScrollViewer>()) {
-      react::uwp::ScrollViewUWPImplementation(scrollViewer).SnapToOffsets(offsets);
+      ScrollViewUWPImplementation(scrollViewer).SnapToOffsets(offsets);
     }
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/SwitchViewManager.cpp
@@ -65,8 +65,8 @@ void SwitchShadowNode::UpdateThumbColor() {
   if (toggleSwitch == nullptr)
     return;
 
-  const auto thumbBrush = react::uwp::IsValidColorValue(m_thumbColor) ? react::uwp::BrushFrom(m_thumbColor) : nullptr;
-  react::uwp::UpdateToggleSwitchThumbResourceBrushes(toggleSwitch, thumbBrush);
+  const auto thumbBrush = IsValidColorValue(m_thumbColor) ? BrushFrom(m_thumbColor) : nullptr;
+  UpdateToggleSwitchThumbResourceBrushes(toggleSwitch, thumbBrush);
 }
 
 void SwitchShadowNode::UpdateTrackColor() {
@@ -74,11 +74,9 @@ void SwitchShadowNode::UpdateTrackColor() {
   if (toggleSwitch == nullptr)
     return;
 
-  const auto onTrackBrush =
-      react::uwp::IsValidColorValue(m_onTrackColor) ? react::uwp::BrushFrom(m_onTrackColor) : nullptr;
-  const auto offTrackBrush =
-      react::uwp::IsValidColorValue(m_offTrackColor) ? react::uwp::BrushFrom(m_offTrackColor) : nullptr;
-  react::uwp::UpdateToggleSwitchTrackResourceBrushes(toggleSwitch, onTrackBrush, offTrackBrush);
+  const auto onTrackBrush = IsValidColorValue(m_onTrackColor) ? BrushFrom(m_onTrackColor) : nullptr;
+  const auto offTrackBrush = IsValidColorValue(m_offTrackColor) ? BrushFrom(m_offTrackColor) : nullptr;
+  UpdateToggleSwitchTrackResourceBrushes(toggleSwitch, onTrackBrush, offTrackBrush);
 }
 
 void SwitchShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueObject &props) {

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -32,18 +32,18 @@ using namespace xaml::Media;
 using namespace xaml::Shapes;
 } // namespace winrt
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 struct Selection {
   int64_t start = -1;
   int64_t end = -1;
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative
 
 // Such code is better to move to a seperate parser layer
 template <>
-struct json_type_traits<react::uwp::Selection> {
-  static react::uwp::Selection parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
-    react::uwp::Selection selection;
+struct json_type_traits<Microsoft::ReactNative::Selection> {
+  static Microsoft::ReactNative::Selection parseJson(const winrt::Microsoft::ReactNative::JSValue &json) {
+    Microsoft::ReactNative::Selection selection;
     for (auto &item : json.AsObject()) {
       if (item.first == "start") {
         auto start = item.second.AsInt64();
@@ -181,8 +181,8 @@ void TextInputShadowNode::dispatchTextInputChangeEvent(winrt::hstring newText) {
     return;
   }
   m_nativeEventCount++;
-  folly::dynamic eventData = folly::dynamic::object("target", m_tag)("text", react::uwp::HstringToDynamic(newText))(
-      "eventCount", m_nativeEventCount);
+  folly::dynamic eventData =
+      folly::dynamic::object("target", m_tag)("text", HstringToDynamic(newText))("eventCount", m_nativeEventCount);
   GetViewManager()->GetReactContext().DispatchEvent(m_tag, "topTextInputChange", std::move(eventData));
 }
 
@@ -280,11 +280,11 @@ void TextInputShadowNode::registerEvents() {
     folly::dynamic eventDataBlur = folly::dynamic::object("target", tag);
     folly::dynamic eventDataEndEditing = {};
     if (m_isTextBox) {
-      eventDataEndEditing = folly::dynamic::object("target", tag)(
-          "text", react::uwp::HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
+      eventDataEndEditing =
+          folly::dynamic::object("target", tag)("text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
     } else {
       eventDataEndEditing = folly::dynamic::object("target", tag)(
-          "text", react::uwp::HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
+          "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
     }
     if (!m_updating) {
       GetViewManager()->GetReactContext().DispatchEvent(tag, "topTextInputBlur", std::move(eventDataBlur));
@@ -407,10 +407,10 @@ void TextInputShadowNode::registerPreviewKeyDown() {
           folly::dynamic eventDataSubmitEditing = {};
           if (m_isTextBox) {
             eventDataSubmitEditing = folly::dynamic::object("target", tag)(
-                "text", react::uwp::HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
+                "text", HstringToDynamic(control.as<xaml::Controls::TextBox>().Text()));
           } else {
             eventDataSubmitEditing = folly::dynamic::object("target", tag)(
-                "text", react::uwp::HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
+                "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
           }
 
           if (m_shouldClearTextOnSubmit) {
@@ -467,7 +467,7 @@ void TextInputShadowNode::setPasswordBoxPlaceholderForeground(
     const winrt::Microsoft::ReactNative::JSValue &color) {
   m_placeholderTextColor = color.Copy();
   auto defaultRD = xaml::ResourceDictionary();
-  auto solidColorBrush = react::uwp::ColorFrom(m_placeholderTextColor);
+  auto solidColorBrush = ColorFrom(m_placeholderTextColor);
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForeground"), winrt::box_value(solidColorBrush));
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForegroundFocused"), winrt::box_value(solidColorBrush));
   defaultRD.Insert(winrt::box_value(L"TextControlPlaceholderForegroundPointerOver"), winrt::box_value(solidColorBrush));
@@ -541,7 +541,7 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
             control = newTextBox.as<xaml::Controls::Control>();
             textBox = newTextBox;
             if (!m_placeholderTextColor.IsNull()) {
-              textBox.PlaceholderForeground(react::uwp::SolidColorBrushFrom(m_placeholderTextColor));
+              textBox.PlaceholderForeground(SolidColorBrushFrom(m_placeholderTextColor));
             }
           }
         }
@@ -563,18 +563,18 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
         control.SetValue(
             m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty()
                         : xaml::Controls::PasswordBox::PlaceholderTextProperty(),
-            winrt::PropertyValue::CreateString(react::uwp::asHstring(propertyValue)));
+            winrt::PropertyValue::CreateString(asHstring(propertyValue)));
       } else if (propertyValue.IsNull()) {
         control.ClearValue(
             m_isTextBox ? xaml::Controls::TextBox::PlaceholderTextProperty()
                         : xaml::Controls::PasswordBox::PlaceholderTextProperty());
       }
     } else if (propertyName == "selectionColor") {
-      if (react::uwp::IsValidColorValue(propertyValue)) {
+      if (IsValidColorValue(propertyValue)) {
         control.SetValue(
             m_isTextBox ? xaml::Controls::TextBox::SelectionHighlightColorProperty()
                         : xaml::Controls::PasswordBox::SelectionHighlightColorProperty(),
-            react::uwp::SolidColorBrushFrom(propertyValue));
+            SolidColorBrushFrom(propertyValue));
       } else if (propertyValue.IsNull())
         control.ClearValue(
             m_isTextBox ? xaml::Controls::TextBox::SelectionHighlightColorProperty()
@@ -597,12 +597,12 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
     } else if (propertyName == "placeholderTextColor") {
       m_placeholderTextColor = nullptr;
       if (textBox.try_as<xaml::Controls::ITextBox6>() && m_isTextBox) {
-        if (react::uwp::IsValidColorValue(propertyValue)) {
+        if (IsValidColorValue(propertyValue)) {
           m_placeholderTextColor = propertyValue.Copy();
-          textBox.PlaceholderForeground(react::uwp::SolidColorBrushFrom(propertyValue));
+          textBox.PlaceholderForeground(SolidColorBrushFrom(propertyValue));
         } else if (propertyValue.IsNull())
           textBox.ClearValue(xaml::Controls::TextBox::PlaceholderForegroundProperty());
-      } else if (m_isTextBox != true && react::uwp::IsValidColorValue(propertyValue)) {
+      } else if (m_isTextBox != true && IsValidColorValue(propertyValue)) {
         setPasswordBoxPlaceholderForeground(passwordBox, propertyValue);
       }
     } else if (propertyName == "clearTextOnSubmit") {
@@ -644,7 +644,7 @@ void TextInputShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValu
           }
         } else if (propertyName == "selection") {
           if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Object) {
-            auto selection = json_type_traits<react::uwp::Selection>::parseJson(propertyValue);
+            auto selection = json_type_traits<Selection>::parseJson(propertyValue);
             SetSelection(selection.start, selection.end);
           }
         } else if (propertyName == "spellCheck") {
@@ -697,7 +697,7 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
         auto oldCursor = textBox.SelectionStart();
         auto oldSelectionLength = textBox.SelectionLength();
         auto oldValue = textBox.Text();
-        auto newValue = react::uwp::asHstring(text);
+        auto newValue = asHstring(text);
         if (oldValue != newValue) {
           textBox.Text(newValue);
           if (oldValue.size() == newValue.size()) {
@@ -711,7 +711,7 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
     } else {
       if (text.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
         auto oldValue = passwordBox.Password();
-        auto newValue = react::uwp::asHstring(text);
+        auto newValue = asHstring(text);
         if (oldValue != newValue) {
           passwordBox.Password(newValue);
         }

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -116,10 +116,10 @@ class TextShadowNode final : public ShadowNodeBase {
       const std::optional<winrt::Windows::UI::Color> &foregroundColor,
       size_t runSize) {
     auto newHigh = winrt::TextHighlighter{};
-    newHigh.Background(react::uwp::SolidBrushFromColor(backgroundColor));
+    newHigh.Background(SolidBrushFromColor(backgroundColor));
 
     if (foregroundColor) {
-      newHigh.Foreground(react::uwp::SolidBrushFromColor(foregroundColor.value()));
+      newHigh.Foreground(SolidBrushFromColor(foregroundColor.value()));
     }
 
     winrt::TextRange newRange{m_prevCursorEnd, static_cast<int32_t>(runSize)};
@@ -168,7 +168,7 @@ bool TextViewManager::UpdateProperty(
     return true;
 
   if (TryUpdateForeground(textBlock, propertyName, propertyValue)) {
-    static_cast<TextShadowNode *>(nodeToUpdate)->m_foregroundColor = react::uwp::ColorFrom(propertyValue);
+    static_cast<TextShadowNode *>(nodeToUpdate)->m_foregroundColor = ColorFrom(propertyValue);
   } else if (TryUpdateFontProperties(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "textTransform") {
     auto textNode = static_cast<TextShadowNode *>(nodeToUpdate);
@@ -222,13 +222,13 @@ bool TextViewManager::UpdateProperty(
       textBlock.ClearValue(xaml::Controls::TextBlock::IsTextScaleFactorEnabledProperty());
     }
   } else if (propertyName == "selectionColor") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      textBlock.SelectionHighlightColor(react::uwp::SolidColorBrushFrom(propertyValue));
+    if (IsValidColorValue(propertyValue)) {
+      textBlock.SelectionHighlightColor(SolidColorBrushFrom(propertyValue));
     } else
       textBlock.ClearValue(xaml::Controls::TextBlock::SelectionHighlightColorProperty());
   } else if (propertyName == "backgroundColor") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      static_cast<TextShadowNode *>(nodeToUpdate)->m_backgroundColor = react::uwp::ColorFrom(propertyValue);
+    if (IsValidColorValue(propertyValue)) {
+      static_cast<TextShadowNode *>(nodeToUpdate)->m_backgroundColor = ColorFrom(propertyValue);
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
@@ -16,7 +16,7 @@ using namespace xaml::Automation::Peers;
 using namespace xaml;
 } // namespace winrt
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 ViewControl::ViewControl() : Super() {
   VerticalContentAlignment(xaml::VerticalAlignment::Stretch);
@@ -24,20 +24,20 @@ ViewControl::ViewControl() : Super() {
 }
 
 winrt::AutomationPeer ViewControl::OnCreateAutomationPeer() {
-  return winrt::make<winrt::PROJECT_ROOT_NAMESPACE::implementation::DynamicAutomationPeer>(*this);
+  return winrt::make<winrt::Microsoft::ReactNative::implementation::DynamicAutomationPeer>(*this);
 }
 
-winrt::PROJECT_ROOT_NAMESPACE::ViewPanel ViewControl::GetPanel() const {
+winrt::Microsoft::ReactNative::ViewPanel ViewControl::GetPanel() const {
   auto child = Content();
 
   if (auto border = child.try_as<xaml::Controls::Border>()) {
     child = border.Child();
   }
 
-  auto panel = child.try_as<winrt::PROJECT_ROOT_NAMESPACE::ViewPanel>();
+  auto panel = child.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
   assert(panel != nullptr);
 
   return panel;
 }
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.h
@@ -7,7 +7,7 @@
 
 #include "ViewControl.g.h"
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 //
 // ViewControl is a ContentControl that ViewViewManager uses to wrap a ViewPanel
@@ -22,11 +22,11 @@ struct ViewControl : ViewControlT<ViewControl> {
 
   xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
-  winrt::PROJECT_ROOT_NAMESPACE::ViewPanel GetPanel() const;
+  winrt::Microsoft::ReactNative::ViewPanel GetPanel() const;
 };
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation {
+namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct ViewControl : ViewControlT<ViewControl, implementation::ViewControl> {};
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -333,12 +333,12 @@ void ViewManagerBase::SetLayoutProps(
   }
   auto fe = element.as<xaml::FrameworkElement>();
 
-  const bool layoutHasChanged = left != react::uwp::ViewPanel::GetLeft(element) ||
-      top != react::uwp::ViewPanel::GetTop(element) || width != fe.Width() || height != fe.Height();
+  const bool layoutHasChanged = left != ViewPanel::GetLeft(element) || top != ViewPanel::GetTop(element) ||
+      width != fe.Width() || height != fe.Height();
 
   // Set Position & Size Properties
-  react::uwp::ViewPanel::SetLeft(element, left);
-  react::uwp::ViewPanel::SetTop(element, top);
+  ViewPanel::SetLeft(element, left);
+  ViewPanel::SetTop(element, top);
 
   fe.Width(width);
   fe.Height(height);

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -321,7 +321,7 @@ void ViewPanel::FinalizeProperties() {
         // Borders with no brush draw something other than transparent on other platforms.
         // To match, we'll use a default border brush if one isn't already set.
         // Note:  Keep this in sync with code in TryUpdateBorderProperties().
-        m_border.BorderBrush(::react::uwp::DefaultBrushStore::Instance().GetDefaultBorderBrush());
+        m_border.BorderBrush(::Microsoft::ReactNative::DefaultBrushStore::Instance().GetDefaultBorderBrush());
       }
     } else
       m_border.ClearValue(xaml::Controls::Border::BorderThicknessProperty());

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -28,7 +28,7 @@ using namespace xaml::Media;
 using namespace Windows::Foundation;
 } // namespace winrt
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 const winrt::TypeName viewPanelTypeName{winrt::hstring{L"ViewPanel"}, winrt::TypeKind::Metadata};
 
@@ -376,4 +376,4 @@ void ViewPanel::UpdateClip(winrt::Size &finalSize) {
   }
 }
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -5,16 +5,7 @@
 
 #include "ViewPanel.g.h"
 
-#ifndef PROJECT_ROOT_NAMESPACE
-#define PROJECT_ROOT_NAMESPACE react::uwp
-#else
-namespace winrt::Microsoft::ReactNative {}
-namespace winrt::react::uwp {
-using namespace winrt::Microsoft::ReactNative;
-}
-#endif
-
-namespace winrt::PROJECT_ROOT_NAMESPACE::implementation {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 //
 // ViewPanel is our custom Panel used by ViewViewManager
@@ -105,11 +96,11 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   static void PositionPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);
 };
 
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::implementation
+} // namespace winrt::Microsoft::ReactNative::implementation
 
-namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation {
+namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct ViewPanel : ViewPanelT<ViewPanel, implementation::ViewPanel> {};
-} // namespace winrt::PROJECT_ROOT_NAMESPACE::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::factory_implementation
 
 namespace react::uwp {
 // Issue #2172: Calling static members on winrt::react::uwp::ViewPanel fails to
@@ -118,5 +109,5 @@ namespace react::uwp {
 // using cppwinrt. This workaround is so that consumers in react::uwp can just
 // call ViewPanel
 
-using ViewPanel = winrt::PROJECT_ROOT_NAMESPACE::implementation::ViewPanel;
+using ViewPanel = winrt::Microsoft::ReactNative::implementation::ViewPanel;
 } // namespace react::uwp

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -102,12 +102,12 @@ namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct ViewPanel : ViewPanelT<ViewPanel, implementation::ViewPanel> {};
 } // namespace winrt::Microsoft::ReactNative::factory_implementation
 
-namespace react::uwp {
-// Issue #2172: Calling static members on winrt::react::uwp::ViewPanel fails to
+namespace Microsoft::ReactNative {
+// Issue #2172: Calling static members on winrt::Microsoft::ReactNative::ViewPanel fails to
 // call
-// down into winrt::react::uwp::implementation::ViewPanel because of how we're
-// using cppwinrt. This workaround is so that consumers in react::uwp can just
+// down into winrt::Microsoft::ReactNative::implementation::ViewPanel because of how we're
+// using cppwinrt. This workaround is so that consumers in Microsoft::ReactNative can just
 // call ViewPanel
 
 using ViewPanel = winrt::Microsoft::ReactNative::implementation::ViewPanel;
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -44,21 +44,19 @@ class ViewShadowNode : public ShadowNodeBase {
 
     auto panel = GetViewPanel();
 
-    react::uwp::DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(panel, [=]() {
+    DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(panel, [=]() {
       if (OnClick())
         DispatchEvent("topClick", std::move(folly::dynamic::object("target", m_tag)));
       else
         DispatchEvent("topAccessibilityTap", std::move(folly::dynamic::object("target", m_tag)));
     });
 
-    react::uwp::DynamicAutomationProperties::SetAccessibilityActionEventHandler(
-        panel, [=](winrt::react::uwp::AccessibilityAction const &action) {
+    DynamicAutomationProperties::SetAccessibilityActionEventHandler(
+        panel, [=](winrt::Microsoft::ReactNative::AccessibilityAction const &action) {
           folly::dynamic eventData = folly::dynamic::object("target", m_tag);
 
           eventData.insert(
-              "actionName",
-              action.Label.empty() ? react::uwp::HstringToDynamic(action.Name)
-                                   : react::uwp::HstringToDynamic(action.Label));
+              "actionName", action.Label.empty() ? HstringToDynamic(action.Name) : HstringToDynamic(action.Label));
 
           DispatchEvent("topAccessibilityAction", std::move(eventData));
         });
@@ -197,7 +195,7 @@ class ViewShadowNode : public ShadowNodeBase {
     static_cast<FrameworkElementViewManager *>(GetViewManager())->RefreshTransformMatrix(this);
   }
 
-  winrt::react::uwp::ViewPanel GetViewPanel() {
+  winrt::Microsoft::ReactNative::ViewPanel GetViewPanel() {
     XamlView current = m_view;
 
     if (IsControl()) {
@@ -212,18 +210,18 @@ class ViewShadowNode : public ShadowNodeBase {
       }
     }
 
-    auto panel = current.try_as<winrt::react::uwp::ViewPanel>();
+    auto panel = current.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
     assert(panel != nullptr);
 
     return panel;
   }
 
-  winrt::react::uwp::ViewControl GetControl() {
-    return IsControl() ? m_view.as<winrt::react::uwp::ViewControl>() : nullptr;
+  winrt::Microsoft::ReactNative::ViewControl GetControl() {
+    return IsControl() ? m_view.as<winrt::Microsoft::ReactNative::ViewControl>() : nullptr;
   }
 
   XamlView CreateViewControl() {
-    auto contentControl = winrt::make<winrt::react::uwp::implementation::ViewControl>();
+    auto contentControl = winrt::make<winrt::Microsoft::ReactNative::implementation::ViewControl>();
 
     m_contentControlGotFocusRevoker = contentControl.GotFocus(winrt::auto_revoke, [=](auto &&, auto &&args) {
       if (args.OriginalSource().try_as<xaml::UIElement>() == contentControl.as<xaml::UIElement>()) {
@@ -263,19 +261,19 @@ class ViewShadowNode : public ShadowNodeBase {
 // specialize
 // PropertyUtils' TryUpdateBackgroundBrush to use ViewBackground.
 // Issue #2172: Additionally, we need to use
-// winrt::react::uwp::ViewPanel::implementation::ViewBackgroundProperty
+// winrt::Microsoft::ReactNative::ViewPanel::implementation::ViewBackgroundProperty
 // rather than the proper projected type, because of how we're using cppwinrt.
 
 template <>
 bool TryUpdateBackgroundBrush(
-    const winrt::react::uwp::ViewPanel &element,
+    const winrt::Microsoft::ReactNative::ViewPanel &element,
     const std::string &propertyName,
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   if (propertyName == "backgroundColor") {
-    if (react::uwp::IsValidColorValue(propertyValue))
-      element.ViewBackground(react::uwp::BrushFrom(propertyValue));
+    if (IsValidColorValue(propertyValue))
+      element.ViewBackground(BrushFrom(propertyValue));
     else if (propertyValue.IsNull())
-      element.ClearValue(react::uwp::ViewPanel::ViewBackgroundProperty());
+      element.ClearValue(ViewPanel::ViewBackgroundProperty());
 
     return true;
   }
@@ -283,26 +281,26 @@ bool TryUpdateBackgroundBrush(
   return false;
 }
 
-// Issue #2172: Calling winrt::react::uwp::ViewPanel::BorderBrushProperty fails
+// Issue #2172: Calling winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty fails
 // to call
-// down into winrt::react::uwp::implementation::ViewPanel::BorderBrushProperty
+// down into winrt::Microsoft::ReactNative::implementation::ViewPanel::BorderBrushProperty
 // because of how we're using cppwinrt. So we specialize PropertyUtils'
 // TryUpdateBorderProperties
-// to use winrt::react::uwp::ViewPanel::implementation::BorderBrushProperty
+// to use winrt::Microsoft::ReactNative::ViewPanel::implementation::BorderBrushProperty
 
 template <>
 bool TryUpdateBorderProperties(
     ShadowNodeBase *node,
-    const winrt::react::uwp::ViewPanel &element,
+    const winrt::Microsoft::ReactNative::ViewPanel &element,
     const std::string &propertyName,
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   bool isBorderProperty = true;
 
   if (propertyName == "borderColor") {
-    if (react::uwp::IsValidColorValue(propertyValue))
-      element.BorderBrush(react::uwp::BrushFrom(propertyValue));
+    if (IsValidColorValue(propertyValue))
+      element.BorderBrush(BrushFrom(propertyValue));
     else if (propertyValue.IsNull())
-      element.ClearValue(react::uwp::ViewPanel::BorderBrushProperty());
+      element.ClearValue(ViewPanel::BorderBrushProperty());
   } else if (propertyName == "borderLeftWidth") {
     if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||
         propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)
@@ -332,7 +330,7 @@ bool TryUpdateBorderProperties(
         propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)
       SetBorderThickness(node, element, ShadowEdges::AllEdges, propertyValue.AsDouble());
     else if (propertyValue.IsNull())
-      element.ClearValue(react::uwp::ViewPanel::BorderThicknessProperty());
+      element.ClearValue(ViewPanel::BorderThicknessProperty());
   } else {
     isBorderProperty = false;
   }
@@ -368,7 +366,7 @@ ShadowNode *ViewViewManager::createShadow() const {
 }
 
 XamlView ViewViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
-  auto panel = winrt::make<winrt::react::uwp::implementation::ViewPanel>();
+  auto panel = winrt::make<winrt::Microsoft::ReactNative::implementation::ViewPanel>();
   panel.VerticalAlignment(xaml::VerticalAlignment::Stretch);
   panel.HorizontalAlignment(xaml::HorizontalAlignment::Stretch);
 
@@ -456,7 +454,7 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
     // DynamicAutomationPeer
-    shouldBeControl = shouldBeControl || react::uwp::HasDynamicAutomationProperties(view);
+    shouldBeControl = shouldBeControl || HasDynamicAutomationProperties(view);
   }
 
   panel.FinalizeProperties();
@@ -466,7 +464,7 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
 
 void ViewViewManager::TryUpdateView(
     ViewShadowNode *pViewShadowNode,
-    winrt::react::uwp::ViewPanel &pPanel,
+    winrt::Microsoft::ReactNative::ViewPanel &pPanel,
     bool useControl) {
   bool isControl = pViewShadowNode->IsControl();
   bool hadOuterBorder = pViewShadowNode->HasOuterBorder();

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -40,7 +40,7 @@ class ViewViewManager : public FrameworkElementViewManager {
   void OnPropertiesUpdated(ShadowNodeBase *node) override;
 
   XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
-  void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::react::uwp::ViewPanel &pPanel, bool useControl);
+  void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::Microsoft::ReactNative::ViewPanel &pPanel, bool useControl);
 
   xaml::Media::SolidColorBrush EnsureTransparentBrush();
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -106,8 +106,7 @@ bool VirtualTextViewManager::UpdateProperty(
   // FUTURE: In the future cppwinrt will generate code where static methods on
   // base types can be called.  For now we specify the base type explicitly
   if (TryUpdateForeground<winrt::TextElement>(span, propertyName, propertyValue)) {
-    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.foregroundColor =
-        react::uwp::ColorFrom(propertyValue);
+    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.foregroundColor = ColorFrom(propertyValue);
   } else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
@@ -117,9 +116,8 @@ bool VirtualTextViewManager::UpdateProperty(
     VirtualTextShadowNode::ApplyTextTransform(
         *node, node->textTransform, /* forceUpdate = */ true, /* isRoot = */ true);
   } else if (propertyName == "backgroundColor") {
-    if (react::uwp::IsValidColorValue(propertyValue)) {
-      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.backgroundColor =
-          react::uwp::ColorFrom(propertyValue);
+    if (IsValidColorValue(propertyValue)) {
+      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.backgroundColor = ColorFrom(propertyValue);
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -12,12 +12,12 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 xaml::Media::Brush XamlHelper::BrushFrom(JSValueArgWriter const &valueProvider) noexcept {
   auto value = GetFollyDynamicFromValueProvider(valueProvider);
-  return react::uwp::IsValidColorValue(value) ? react::uwp::BrushFrom(value) : nullptr;
+  return ::Microsoft::ReactNative::IsValidColorValue(value) ? ::Microsoft::ReactNative::BrushFrom(value) : nullptr;
 }
 
 Windows::UI::Color XamlHelper::ColorFrom(JSValueArgWriter const &valueProvider) noexcept {
   auto value = GetFollyDynamicFromValueProvider(valueProvider);
-  return react::uwp::ColorFrom(value);
+  return ::Microsoft::ReactNative::ColorFrom(value);
 }
 
 folly::dynamic XamlHelper::GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept {

--- a/vnext/Microsoft.ReactNative/XamlLoadState.cpp
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.cpp
@@ -9,7 +9,7 @@
 
 #ifndef DISABLE_XAML_GUARD
 
-using namespace react::uwp;
+using namespace Microsoft::ReactNative;
 
 constexpr std::wstring_view systemXamlDllName{L"Windows.UI.Xaml.dll"};
 constexpr std::wstring_view winUIDllName{L"Microsoft.UI.Xaml.dll"};

--- a/vnext/Microsoft.ReactNative/XamlLoadState.h
+++ b/vnext/Microsoft.ReactNative/XamlLoadState.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 /// <summary>
 /// Implements a guard to ensure that only one XAML dll gets loaded in the current process.
 /// This is important because different XAML dlls are not inter-operable.
@@ -41,4 +41,4 @@ struct XamlLoadState {
 
   static XamlVersion GetXamlVersion(const std::wstring &path) noexcept;
 };
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -42,7 +42,7 @@ void SetCompositor(const comp::Compositor &compositor) {
 }
 
 comp::Compositor GetCompositor() {
-  if (!react::uwp::IsXamlIsland()) {
+  if (!IsXamlIsland()) {
     return xaml::Window::Current().Compositor();
   }
   comp::Compositor compositor;

--- a/vnext/ReactCommon.UnitTests/JsiRuntimeGenerators.cpp
+++ b/vnext/ReactCommon.UnitTests/JsiRuntimeGenerators.cpp
@@ -19,7 +19,7 @@ using facebook::react::CreateMemoryTracker;
 using facebook::react::MessageQueueThread;
 using Microsoft::JSI::ChakraRuntimeArgs;
 using Microsoft::JSI::makeChakraRuntime;
-using react::uwp::MakeJSQueueThread;
+using Microsoft::ReactNative::MakeJSQueueThread;
 
 // TODO: #2729 We need to add tests for ChakraCoreRuntime specific
 // behaviors such as ScriptStore. This may require us to bring back JSITestBase.

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -117,7 +117,7 @@ facebook::react::JSECreator DevSupportManager::LoadJavaScriptInProxyMode(
     return [this, settings, errorCallback](
                std::shared_ptr<facebook::react::ExecutorDelegate> delegate,
                std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) {
-      auto websocketJSE = std::make_unique<react::uwp::WebSocketJSExecutor>(delegate, jsQueue);
+      auto websocketJSE = std::make_unique<WebSocketJSExecutor>(delegate, jsQueue);
       try {
         websocketJSE
             ->ConnectAsync(

--- a/vnext/Shared/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.cpp
@@ -26,7 +26,7 @@
 #pragma optimize("", off)
 #endif
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 WebSocketJSExecutor::WebSocketJSExecutor(
     std::shared_ptr<facebook::react::ExecutorDelegate> delegate,
@@ -296,6 +296,6 @@ void WebSocketJSExecutor::OnMessageReceived(const std::string &msg) {
   }
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative
 
 #pragma warning(pop)

--- a/vnext/Shared/Executors/WebSocketJSExecutor.h
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.h
@@ -22,7 +22,7 @@ class RAMBundleRegistry;
 }
 } // namespace facebook
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 class MessageQueueThread;
 
@@ -121,4 +121,4 @@ class WebSocketJSExecutor : public facebook::react::JSExecutor,
   std::atomic<LONG> m_requestId{0};
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Executors/WebSocketJSExecutorFactory.cpp
+++ b/vnext/Shared/Executors/WebSocketJSExecutorFactory.cpp
@@ -17,7 +17,8 @@ std::unique_ptr<facebook::react::JSExecutor> WebSocketJSExecutorFactory::createJ
   if (m_jseCreator)
     return m_jseCreator(delegate, jsQueue);
   else
-    return std::unique_ptr<facebook::react::JSExecutor>(new ::react::uwp::WebSocketJSExecutor(delegate, jsQueue));
+    return std::unique_ptr<facebook::react::JSExecutor>(
+        new ::Microsoft::ReactNative::WebSocketJSExecutor(delegate, jsQueue));
 }
 
 } // namespace react

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -478,7 +478,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 #else
       std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
 
-      auto bundleString = std::make_unique<::react::uwp::StorageFileBigString>(bundlePath);
+      auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);
       m_innerInstance->loadScriptFromString(std::move(bundleString), jsBundleRelativePath, synchronously);
 #endif
     }

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -7,7 +7,7 @@
 #include <eventWaitHandle/eventWaitHandle.h>
 #include <cassert>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 BatchingQueueCallInvoker::BatchingQueueCallInvoker(
     std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread)
@@ -99,4 +99,4 @@ void BatchingQueueThread::quitSynchronous() noexcept {
   m_batchingQueueCallInvoker->quitSynchronous();
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -11,7 +11,7 @@ namespace facebook::react {
 class Instance;
 }
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 struct BatchingQueueCallInvoker : facebook::react::CallInvoker {
   BatchingQueueCallInvoker(std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread);
@@ -54,4 +54,4 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
   std::shared_ptr<BatchingQueueCallInvoker> m_batchingQueueCallInvoker;
 };
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Threading/MessageQueueThreadFactory.cpp
+++ b/vnext/Shared/Threading/MessageQueueThreadFactory.cpp
@@ -5,7 +5,7 @@
 #include "BatchingQueueThread.h"
 #include "MessageDispatchQueue.h"
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeJSQueueThread() noexcept {
   return std::make_shared<Mso::React::MessageDispatchQueue>(Mso::DispatchQueue::MakeLooperQueue(), nullptr, nullptr);
@@ -23,4 +23,4 @@ std::shared_ptr<facebook::react::BatchingMessageQueueThread> MakeBatchingQueueTh
   return std::make_shared<BatchingQueueThread>(queueThread);
 }
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Threading/MessageQueueThreadFactory.h
+++ b/vnext/Shared/Threading/MessageQueueThreadFactory.h
@@ -6,7 +6,7 @@
 #include <BatchingMessageQueueThread.h>
 #include <cxxreact/MessageQueueThread.h>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 std::shared_ptr<facebook::react::MessageQueueThread> MakeJSQueueThread() noexcept;
 
@@ -15,4 +15,4 @@ std::shared_ptr<facebook::react::MessageQueueThread> MakeUIQueueThread() noexcep
 std::shared_ptr<facebook::react::BatchingMessageQueueThread> MakeBatchingQueueThread(
     std::shared_ptr<facebook::react::MessageQueueThread> const &queueThread) noexcept;
 
-} // namespace react::uwp
+} // namespace Microsoft::ReactNative


### PR DESCRIPTION
PROJECT_ROOT_NAMESPACE was used to allow ReactUwp.dll to use the react::uwp namespace instead of the Microsoft::ReactNative namespace.  ReactUwp.dll is long gone, so we can remove this indirection.

Renamed the remaining react::uwp namespaces to Microsoft::ReactNative.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7715)