### PR TITLE
Add check to cancel publish if the last commit was itself a publish

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -17,6 +17,10 @@ parameters:
   displayName: Skip Codesigning for Stable Branch
   type: boolean
   default: false
+- name: stopOnNoCI
+  displayName: Stop if latest commit is ***NO_CI***
+  type: boolean
+  default: true
 
 variables:
   - template: variables/msbuild.yml
@@ -55,6 +59,11 @@ jobs:
       - template: templates/configure-git.yml
 
       - template: templates/prepare-env.yml
+
+      - powershell: |
+          Write-Error "Stopping because commit message contains ***NO_CI***."
+        displayName: Stop pipeline if latest commit message contains ***NO_CI***
+        condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
 
       - script: |
           echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish


### PR DESCRIPTION
If the last commit was from the React-Native-Windows Bot and includes `***NO_CI***` in the subject line, throw an error so the pipeline stops before wasting time building, or worse, trying to publish.

Closes #7547

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7716)