### PR TITLE
Optimize textTransform parent traversal.

### DIFF
--- a/change/react-native-windows-04a0b9fb-d242-443b-9ec6-9cc2870bbe85.json
+++ b/change/react-native-windows-04a0b9fb-d242-443b-9ec6-9cc2870bbe85.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Exit early during text transform upward tree traversal.",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -88,6 +88,9 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
         }
 
         (static_cast<TextViewManager *>(viewManager))->OnDescendantTextPropertyChanged(parent);
+
+        // We have reached the parent TextBlock, so there're no more parent <Text> elements in this tree.
+        break;
       } else if (!std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }


### PR DESCRIPTION
In `RawTextViewManager::NotifyAncestorsTextChanged` there's a while loop that goes up the parent tree of a `RawTextShadowNode`, when a leaf text value gets updated.
We can break out of this loop, once we have reached the parent `<Text>`, i.e. the XAML TextBlock, rather than traversing all the way up to the react root node.
(We enter this condition on line 71: `if (!std::wcscmp(nodeType, L"RCTText"))`.)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7717)