### PR TITLE
[0.64] Add check to cancel publish if the last commit was itself a publish (#7716)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -13,6 +13,10 @@ parameters:
   displayName: Skip Codesigning for Stable Branch
   type: boolean
   default: false
+- name: stopOnNoCI
+  displayName: Stop if latest commit is ***NO_CI***
+  type: boolean
+  default: true
 
 variables:
   - template: variables/msbuild.yml
@@ -50,6 +54,11 @@ jobs:
 
       - script: yarn build
         displayName: yarn build
+
+      - powershell: |
+          Write-Error "Stopping because commit message contains ***NO_CI***."
+        displayName: Stop pipeline if latest commit message contains ***NO_CI***
+        condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
 
       - script: |
           echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish


### PR DESCRIPTION
This PR backport #7716 to 0.64.

If the last commit includes `***NO_CI***` in the subject line, throw an error so the pipeline stops before wasting time building, or worse, trying to publish.

Closes #7547

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7725)