### PR TITLE
Fix ReactContext::DispatchEvent

### DIFF
--- a/change/react-native-windows-e84bc040-e439-490a-9ecc-25bbfc3bace2.json
+++ b/change/react-native-windows-e84bc040-e439-490a-9ecc-25bbfc3bace2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactContext::DispatchEvent",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/sample-apps/windows/SampleLibraryCPP/CustomUserControlViewManagerCPP.cpp
+++ b/packages/sample-apps/windows/SampleLibraryCPP/CustomUserControlViewManagerCPP.cpp
@@ -38,12 +38,7 @@ FrameworkElement CustomUserControlViewManagerCpp::CreateView() noexcept {
       [this](
           winrt::Windows::UI::Xaml::DependencyObject obj, winrt::Windows::UI::Xaml::DependencyProperty prop) noexcept {
         if (auto c = obj.try_as<winrt::SampleLibraryCpp::CustomUserControlCpp>()) {
-          ReactContext().DispatchEvent(
-              c,
-              L"topLabelChanged",
-              [this, c](winrt::Microsoft::ReactNative::IJSValueWriter const &eventDataWriter) noexcept {
-                eventDataWriter.WriteString(c.Label());
-              });
+          XamlUIService::FromContext(ReactContext()).DispatchEvent(c, L"topLabelChanged", MakeJSValueWriter(c.Label()));
         }
       });
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactContext.h
@@ -65,12 +65,13 @@ struct ReactContext {
     m_handle.EmitJSEvent(eventEmitterName, eventName, MakeJSValueWriter(std::forward<TArgs>(args)...));
   }
 
-#if !defined(CORE_ABI) && !defined(__APPLE__)
+#if !defined(CORE_ABI) && !defined(__APPLE__) && !defined(CXXUNITTESTS)
   // Dispatch eventName event to the view.
   // args are either function arguments or a single lambda with 'IJSValueWriter const&' argument.
   template <class... TArgs>
   void DispatchEvent(xaml::FrameworkElement const &view, std::wstring_view eventName, TArgs &&... args) const noexcept {
-    m_handle.DispatchEvent(view, eventName, MakeJSValueArgWriter(std::forward<TArgs>(args)...));
+    XamlUIService::FromContext(m_handle).DispatchEvent(
+        view, eventName, MakeJSValueWriter(std::forward<TArgs>(args)...));
   }
 #endif
 


### PR DESCRIPTION
Current `ReactContext::DispatchEvent` method in `Microsoft.ReactNative.Cxx` C++ helper classes project has a bug that it wraps up arguments into an array. It make it impossible to use for the custom view implementation. It is a lower impact change because all current custom view implementations use the `IReactContext` interface as it was shown in our C++ library samples project. Also, we have deprecated the `IReactContext::DispatchEvent` method in 0.64. At some point we must deprecate the `ReactContext::DispatchEvent` method as well, but for now we just fix it until we have a helper class for the `XamlUIService`.

These PR has the following changes:
- Fixed `ReactContext::DispatchEvent` and changed it to use the `XamlUIService::DispatchEvent`.
- Improved the `XamlUIService::DispatchEvent` implementation to allow multiple event arguments as RN allows for its events.
- Changed the C++ library sample project to use the `XamlUIService::DispatchEvent`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7732)