### PR TITLE
Emit TextInput onChangeText before onSelectionChange

### DIFF
--- a/change/react-native-windows-60609fec-a316-43d0-b789-deb31e09b2f7.json
+++ b/change/react-native-windows-60609fec-a316-43d0-b789-deb31e09b2f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Emit TextInput onChangeText before onSelectionChange",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
@@ -120,7 +120,7 @@ async function assertLogContainsInOrder(...expectedLines: string[]) {
       const actualLines = loggedText.split('\n');
       let previousIndex = Number.MAX_VALUE;
       for (const line of expectedLines) {
-        const index = actualLines.findIndex(l => l === line)
+        const index = actualLines.findIndex(l => l === line);
         if (index === -1 || index > previousIndex) {
           return false;
         }
@@ -131,7 +131,9 @@ async function assertLogContainsInOrder(...expectedLines: string[]) {
       return true;
     },
     {
-      timeoutMsg: `"${await textLogComponent.getText()}" did not contain lines "${expectedLines.join(', ')}"`,
+      timeoutMsg: `"${await textLogComponent.getText()}" did not contain lines "${expectedLines.join(
+        ', ',
+      )}"`,
     },
   );
 }

--- a/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
@@ -74,6 +74,15 @@ describe('LegacyTextInputTest', () => {
 
     expect(await textInput.getText()).toBe('abc\rdef');
   });
+
+  test('TextInput onChange before onSelectionChange', async () => {
+    const textInput = await textInputField();
+    await textInput.setValue('a');
+    await assertLogContainsInOrder(
+      'onChange text: a',
+      'onSelectionChange range: 1,1',
+    );
+  });
 });
 
 async function textInputField() {
@@ -98,6 +107,31 @@ async function assertLogContains(text: string) {
     },
     {
       timeoutMsg: `"${await textLogComponent.getText()}" did not contain "${text}"`,
+    },
+  );
+}
+
+async function assertLogContainsInOrder(...expectedLines: string[]) {
+  const textLogComponent = await $('~textinput-log');
+
+  await browser.waitUntil(
+    async () => {
+      const loggedText = await textLogComponent.getText();
+      const actualLines = loggedText.split('\n');
+      let previousIndex = Number.MAX_VALUE;
+      for (const line of expectedLines) {
+        const index = actualLines.findIndex(l => l === line)
+        if (index === -1 || index > previousIndex) {
+          return false;
+        }
+
+        previousIndex = index;
+      }
+
+      return true;
+    },
+    {
+      timeoutMsg: `"${await textLogComponent.getText()}" did not contain lines "${expectedLines.join(', ')}"`,
     },
   );
 }

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -176,6 +176,9 @@ void TextInputShadowNode::createView(const winrt::Microsoft::ReactNative::JSValu
 }
 
 void TextInputShadowNode::dispatchTextInputChangeEvent(winrt::hstring newText) {
+  if (!m_initialUpdateComplete) {
+    return;
+  }
   m_nativeEventCount++;
   folly::dynamic eventData =
       folly::dynamic::object("target", m_tag)("text", HstringToDynamic(newText))("eventCount", m_nativeEventCount);

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -203,7 +203,7 @@ void TextInputShadowNode::registerEvents() {
     m_passwordBoxPasswordChangingRevoker = {};
     auto textBox = control.as<xaml::Controls::TextBox>();
     m_textBoxTextChangingRevoker = textBox.TextChanging(
-      winrt::auto_revoke, [=](auto &&, auto &&) { dispatchTextInputChangeEvent(textBox.Text()); });
+        winrt::auto_revoke, [=](auto &&, auto &&) { dispatchTextInputChangeEvent(textBox.Text()); });
   } else {
     m_textBoxTextChangingRevoker = {};
     auto passwordBox = control.as<xaml::Controls::PasswordBox>();


### PR DESCRIPTION
Previously, TextInputViewManager subscribed to two events to implement `onChangeText`:
1. TextChanging - used to increment a native counter to ensure JS changes to text do not overwrite native changes to text.
2. TextChanged - used to emit the `onChangeText` event and surprisingly also incremented the native counter.

Additionally, the view manager subscribed to SelectionChanged to emit the `onSelectionChange` event.

In XAML, the sequence of native events is as follows:
1. TextChanging
2. SelectionChanged
3. TextChanged

Since we emit the event that ultimately triggers `onChangeText` via the TextChanged native event, this means that we actually receive the cursor position change before the text change. This is different from other React Native platforms and makes it more difficult to implement behaviors based off the se`onSelectionChange` event.

One concern with this change is if there are any repercussions of eliminating the two phased approach to the native counter and firing of the event. Here is why I don't believe this will create any issues:

1. Previously, we incremented `m_nativeEventCount` twice, once in `TextChanging` and once in `TextChanged`. Reducing this to incrementing only once will not introduce any bugs, as JavaScript does not increment the `mostRecentEventCount` prop, so the only requirement is that a native change to the TextBox content increases the count.

2. Previously, we emitted the event in `TextChanged`. It appears that the `TextBox.Text()` property is already updated at the time that `TextChanging` is called, whether the `Text()` property was set externally or it was updated internally by a key event. The only difference between the two events is that `TextChanged` is called after the text is rendered (which may occur asynchronously from the actual text change). This is the reason we needed to introduce the dependency on `TextChanging` in the first place, as `TextChanging` is guaranteed to be called synchronously with the value change (and could not be interrupted by, e.g., an update from JS).

3. Is it a problem that JavaScript receives the text changed event before it actually renders? This is a good question, but I can't think of any scenarios where it's important that the TextBox has actually rendered the change before emitting the event, and since JS runs asynchronously from the UI thread, it's likely that by the time any UI changes / side effects triggered by JS make their way back to the UI thread, the text will have been rendered.

Fixes #7740

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7742)