### PR TITLE
Enable building as C++20

### DIFF
--- a/change/react-native-windows-8a4ee3b9-b983-45f4-bc70-277b2f519700.json
+++ b/change/react-native-windows-8a4ee3b9-b983-45f4-bc70-277b2f519700.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable C++20 builds",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -67,6 +67,10 @@
     <Import Project="$(ConfigurationType)\$(Configuration).props" />
   </ImportGroup>
 
+  <PropertyGroup>
+    <CppStandard Condition="'$(CppStandard)'==''">stdcpp17</CppStandard>
+  </PropertyGroup>
+
   <ItemDefinitionGroup>
     <ClCompile>
       <!--
@@ -94,7 +98,7 @@
         WINRT_LEAN_AND_MEAN;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>$(CppStandard)</LanguageStandard>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <ShowIncludes Condition="'$(ShowIncludes)'=='true'">true</ShowIncludes>


### PR DESCRIPTION
This uses an msbuild variable to specify what language standard to use; currently it's hardcoded to C++17