### PR TITLE
Fabric: Add support View.opacity and View.borderRadius

### DIFF
--- a/change/react-native-windows-802ab7c2-4c7e-4d56-90f9-818472447a8c.json
+++ b/change/react-native-windows-802ab7c2-4c7e-4d56-90f9-818472447a8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: Add support view View.opacity and View.borderRadius",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
@@ -8,6 +8,7 @@
 
 #include <UI.Xaml.Controls.h>
 #include <Utils/ValueUtils.h>
+#include <Views/FrameworkElementTransferProperties.h>
 
 namespace Microsoft::ReactNative {
 
@@ -30,11 +31,11 @@ ViewComponentView::supplementalComponentDescriptorProviders() noexcept {
 }
 
 void ViewComponentView::mountChildComponentView(const IComponentView &childComponentView, uint32_t index) noexcept {
-  m_element.Children().InsertAt(index, static_cast<const BaseComponentView &>(childComponentView).Element());
+  m_panel.Children().InsertAt(index, static_cast<const BaseComponentView &>(childComponentView).Element());
 }
 
 void ViewComponentView::unmountChildComponentView(const IComponentView &childComponentView, uint32_t index) noexcept {
-  m_element.Children().RemoveAt(index);
+  m_panel.Children().RemoveAt(index);
 }
 
 void ViewComponentView::updateProps(
@@ -47,25 +48,34 @@ void ViewComponentView::updateProps(
     auto color = *newViewProps.backgroundColor;
 
     if (newViewProps.backgroundColor) {
-      m_element.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
+      m_panel.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
     } else {
-      m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
+      m_panel.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
     }
   }
 
   if (oldViewProps.borderColors != newViewProps.borderColors) {
     if (newViewProps.borderColors.all) {
-      m_element.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
+      m_panel.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
     } else {
-      m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
+      m_panel.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
     }
   }
 
-  if (oldViewProps.borderStyles != newViewProps.borderStyles) {
+  if (oldViewProps.opacity != newViewProps.opacity) {
+    m_panel.Opacity(newViewProps.opacity);
+  }
+
+  if (oldViewProps.borderStyles != newViewProps.borderStyles || oldViewProps.borderRadii != newViewProps.borderRadii) {
     m_needsBorderUpdate = true;
   }
 
   m_props = std::static_pointer_cast<facebook::react::ViewProps const>(props);
+}
+
+bool ViewComponentView::shouldBeControl() const noexcept {
+  // Fabric does not appear to have the focusable prop right now...
+  return false; // m_props.focusable || HasDynamicAutomationProperties(view);
 }
 
 void ViewComponentView::updateState(
@@ -79,33 +89,109 @@ void ViewComponentView::updateLayoutMetrics(
   m_needsBorderUpdate = true;
   m_layoutMetrics = layoutMetrics;
 
-  winrt::Microsoft::ReactNative::ViewPanel::SetLeft(m_element, layoutMetrics.frame.origin.x);
-  winrt::Microsoft::ReactNative::ViewPanel::SetTop(m_element, layoutMetrics.frame.origin.y);
+  winrt::Microsoft::ReactNative::ViewPanel::SetLeft(m_panel, layoutMetrics.frame.origin.x);
+  winrt::Microsoft::ReactNative::ViewPanel::SetTop(m_panel, layoutMetrics.frame.origin.y);
 
-  m_element.Width(layoutMetrics.frame.size.width);
-  m_element.Height(layoutMetrics.frame.size.height);
+  m_panel.Width(layoutMetrics.frame.size.width);
+  m_panel.Height(layoutMetrics.frame.size.height);
 }
+
 void ViewComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
   if (m_needsBorderUpdate) {
-    m_needsBorderUpdate = false;
     auto const borderMetrics = m_props->resolveBorderMetrics(m_layoutMetrics);
-    m_element.BorderThickness(xaml::ThicknessHelper::FromLengths(
+    m_panel.BorderThickness(xaml::ThicknessHelper::FromLengths(
         borderMetrics.borderWidths.left,
         borderMetrics.borderWidths.top,
         borderMetrics.borderWidths.right,
         borderMetrics.borderWidths.bottom));
+
+    xaml::CornerRadius cornerRadius;
+    cornerRadius.BottomLeft = borderMetrics.borderRadii.bottomLeft;
+    cornerRadius.BottomRight = borderMetrics.borderRadii.bottomRight;
+    cornerRadius.TopLeft = borderMetrics.borderRadii.topLeft;
+    cornerRadius.TopRight = borderMetrics.borderRadii.topRight;
+    m_panel.CornerRadius(cornerRadius);
+
+    m_needsBorderUpdate = false;
   }
 
-  m_element.FinalizeProperties();
+  auto oldControl = m_control;
+  auto oldOuterBorder = m_outerBorder;
+
+  auto oldElement = Element();
+  auto parent = oldElement.Parent();
+
+  m_panel.FinalizeProperties();
+
+  bool needsControl = shouldBeControl();
+  if ((bool)m_control != needsControl || m_outerBorder != m_panel.GetOuterBorder()) {
+    // -- Remove old children that are no longer needed
+    if (needsControl && !m_control) {
+      assert(false); // NYI
+      // m_control = CreateViewControl();
+    } else if (!needsControl && m_control) {
+      m_control.Content(nullptr);
+    }
+    if (!needsControl) {
+      m_control = nullptr;
+    }
+
+    if (m_panel.GetOuterBorder() && !m_outerBorder) {
+      m_panel.GetOuterBorder().Child(nullptr);
+    }
+
+    m_outerBorder = m_panel.GetOuterBorder();
+
+    auto newElement = Element();
+
+    // -- Transfer properties to new element
+    TransferFrameworkElementProperties(oldElement, newElement);
+    m_panel.FinalizeProperties();
+
+    // -- if the root element changes, we need to modify our parents child
+    if (parent && oldElement != newElement) {
+      // RefreshProperties(); - Transfer EnableFocusRing,TabIndex,IsFocusable
+      auto parentPanel = parent.try_as<xaml::Controls::Panel>();
+      if (parentPanel) {
+        uint32_t index;
+        auto found = parentPanel.Children().IndexOf(oldElement, index);
+        assert(found);
+        parentPanel.Children().SetAt(index, newElement);
+      } else {
+        assert(false); // TODO handle border/control parent
+      }
+    }
+
+    // -- Ensure new heirarchy is setup properly
+    if (m_outerBorder) {
+      m_outerBorder.Child(m_panel);
+    }
+
+    if (m_control) {
+      if (m_outerBorder)
+        m_control.Content(m_outerBorder);
+      else
+        m_control.Content(m_panel);
+    }
+  }
 }
+
 void ViewComponentView::prepareForRecycle() noexcept {}
 facebook::react::SharedProps ViewComponentView::props() noexcept {
   assert(false);
   return {};
 }
 
+// View is implemented with up to three elements, which get nested
+// 1) ViewControl  - if focusable
+// 2) Outer Border - if rounded corners or other clipping
+// 3) ViewPanel
 const xaml::FrameworkElement ViewComponentView::Element() const noexcept {
-  return m_element;
+  if (m_control)
+    return m_control;
+  if (m_outerBorder)
+    return m_outerBorder;
+  return m_panel;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.h
@@ -40,10 +40,16 @@ struct ViewComponentView : BaseComponentView {
   virtual const xaml::FrameworkElement Element() const noexcept;
 
  private:
+  bool shouldBeControl() const noexcept;
+
   bool m_needsBorderUpdate{false};
+  bool m_needsControlUpdate{false};
+  bool m_needsControl{false};
   facebook::react::SharedViewProps m_props;
   facebook::react::LayoutMetrics m_layoutMetrics;
-  winrt::Microsoft::ReactNative::ViewPanel m_element;
+  winrt::Microsoft::ReactNative::ViewControl m_control{nullptr};
+  winrt::Microsoft::ReactNative::ViewPanel m_panel;
+  xaml::Controls::Border m_outerBorder{nullptr};
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -313,6 +313,7 @@
     <ClInclude Include="Views\DynamicValueProvider.h" />
     <ClInclude Include="Views\ExpressionAnimationStore.h" />
     <ClInclude Include="Views\FlyoutViewManager.h" />
+    <ClInclude Include="Views\FrameworkElementTransferProperties.h" />
     <ClInclude Include="Views\FrameworkElementViewManager.h" />
     <ClInclude Include="Views\Image\Effects.h" />
     <ClInclude Include="Views\Image\ImageViewManager.h" />
@@ -613,6 +614,7 @@
     <ClCompile Include="Views\DynamicValueProvider.cpp" />
     <ClCompile Include="Views\ExpressionAnimationStore.cpp" />
     <ClCompile Include="Views\FlyoutViewManager.cpp" />
+    <ClCompile Include="Views\FrameworkElementTransferProperties.cpp" />
     <ClCompile Include="Views\FrameworkElementViewManager.cpp" />
     <ClCompile Include="Views\Image\ImageViewManager.cpp" />
     <ClCompile Include="Views\Image\ReactImage.cpp" />

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -6,6 +6,7 @@
 #include <UI.Xaml.Controls.h>
 
 #include <Views/ControlViewManager.h>
+#include <Views/FrameworkElementTransferProperties.h>
 #include <Views/ShadowNodeBase.h>
 
 #include <JSValueWriter.h>

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <UI.Xaml.Automation.h>
+#include <UI.Xaml.Controls.h>
+#include "DynamicAutomationProperties.h"
+#include "FrameworkElementTransferProperties.h"
+
+namespace Microsoft::ReactNative {
+
+void TransferProperty(
+    const xaml::DependencyObject &oldView,
+    const xaml::DependencyObject &newView,
+    xaml::DependencyProperty oldViewDP,
+    xaml::DependencyProperty newViewDP) {
+  auto oldValue = oldView.ReadLocalValue(oldViewDP);
+  if (oldValue != nullptr) {
+    oldView.ClearValue(oldViewDP);
+    newView.SetValue(newViewDP, oldValue);
+  }
+}
+
+void TransferProperty(
+    const xaml::DependencyObject &oldView,
+    const xaml::DependencyObject &newView,
+    xaml::DependencyProperty dp) {
+  TransferProperty(oldView, newView, dp, dp);
+}
+
+void TransferFrameworkElementProperties(const xaml::DependencyObject &oldView, const xaml::DependencyObject &newView) {
+  // Render Properties
+  TransferProperty(oldView, newView, xaml::UIElement::OpacityProperty());
+
+  // Layout Properties
+  TransferProperty(oldView, newView, xaml::FrameworkElement::WidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::HeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MinWidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MinHeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxWidthProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
+  TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
+  TransferProperty(oldView, newView, xaml::Controls::Canvas::ZIndexProperty());
+  TransferProperty(oldView, newView, winrt::Microsoft::ReactNative::ViewPanel::LeftProperty());
+  TransferProperty(oldView, newView, winrt::Microsoft::ReactNative::ViewPanel::TopProperty());
+
+  // Accessibility Properties
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::AutomationIdProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::NameProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::HelpTextProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::LiveSettingProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::PositionInSetProperty());
+  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::SizeOfSetProperty());
+  auto accessibilityView = xaml::Automation::AutomationProperties::GetAccessibilityView(oldView);
+  xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
+  xaml::Automation::AutomationProperties::SetAccessibilityView(
+      oldView, xaml::Automation::Peers::AccessibilityView::Raw);
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityRoleProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateSelectedProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateDisabledProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateCheckedProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateUncheckedProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateBusyProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateExpandedProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityStateCollapsedProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityValueMinProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityValueMaxProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityValueNowProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityValueTextProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityInvokeEventHandlerProperty());
+  TransferProperty(
+      oldView,
+      newView,
+      winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityActionEventHandlerProperty());
+  TransferProperty(
+      oldView, newView, winrt::Microsoft::ReactNative::DynamicAutomationProperties::AccessibilityActionsProperty());
+
+  auto tooltip = xaml::Controls::ToolTipService::GetToolTip(oldView);
+  oldView.ClearValue(xaml::Controls::ToolTipService::ToolTipProperty());
+  xaml::Controls::ToolTipService::SetToolTip(newView, tooltip);
+
+  // Clear the TransformMatrix from the old View.  The TransformMatrix will be
+  // set on the new View a bit later in RefreshProperties() (as we need data
+  // from the ShadowNode not available here).
+  auto oldElement = oldView.try_as<xaml::UIElement>();
+  if (oldElement && oldElement.try_as<xaml::IUIElement10>()) {
+    oldElement.TransformMatrix(winrt::Windows::Foundation::Numerics::float4x4::identity());
+  }
+}
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "CppWinRTIncludes.h"
+
+namespace Microsoft::ReactNative {
+
+void TransferProperty(
+    const xaml::DependencyObject &oldView,
+    const xaml::DependencyObject &newView,
+    xaml::DependencyProperty dp);
+
+void TransferProperty(
+    const xaml::DependencyObject &oldView,
+    const xaml::DependencyObject &newView,
+    xaml::DependencyProperty oldViewDP,
+    xaml::DependencyProperty newViewDP);
+
+void TransferFrameworkElementProperties(const xaml::DependencyObject &oldView, const xaml::DependencyObject &newView);
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -6,6 +6,7 @@
 #include <IReactInstance.h>
 
 #include <Views/ExpressionAnimationStore.h>
+#include <Views/FrameworkElementTransferProperties.h>
 #include <Views/FrameworkElementViewManager.h>
 
 #include <JSValueWriter.h>
@@ -75,78 +76,8 @@ using DynamicAutomationProperties = Microsoft::ReactNative::DynamicAutomationPro
 
 FrameworkElementViewManager::FrameworkElementViewManager(const Mso::React::IReactContext &context) : Super(context) {}
 
-void FrameworkElementViewManager::TransferProperty(
-    const XamlView &oldView,
-    const XamlView &newView,
-    xaml::DependencyProperty dp) {
-  TransferProperty(oldView, newView, dp, dp);
-}
-
-void FrameworkElementViewManager::TransferProperty(
-    const XamlView &oldView,
-    const XamlView &newView,
-    xaml::DependencyProperty oldViewDP,
-    xaml::DependencyProperty newViewDP) {
-  auto oldValue = oldView.ReadLocalValue(oldViewDP);
-  if (oldValue != nullptr) {
-    oldView.ClearValue(oldViewDP);
-    newView.SetValue(newViewDP, oldValue);
-  }
-}
-
 void FrameworkElementViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
-  // Render Properties
-  TransferProperty(oldView, newView, xaml::UIElement::OpacityProperty());
-
-  // Layout Properties
-  TransferProperty(oldView, newView, xaml::FrameworkElement::WidthProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::HeightProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::MinWidthProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::MinHeightProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxWidthProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
-  TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
-  TransferProperty(oldView, newView, winrt::Canvas::ZIndexProperty());
-  TransferProperty(oldView, newView, Microsoft::ReactNative::ViewPanel::LeftProperty());
-  TransferProperty(oldView, newView, Microsoft::ReactNative::ViewPanel::TopProperty());
-
-  // Accessibility Properties
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::AutomationIdProperty());
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::NameProperty());
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::HelpTextProperty());
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::LiveSettingProperty());
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::PositionInSetProperty());
-  TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::SizeOfSetProperty());
-  auto accessibilityView = xaml::Automation::AutomationProperties::GetAccessibilityView(oldView);
-  xaml::Automation::AutomationProperties::SetAccessibilityView(newView, accessibilityView);
-  xaml::Automation::AutomationProperties::SetAccessibilityView(oldView, winrt::Peers::AccessibilityView::Raw);
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityRoleProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateSelectedProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateDisabledProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateCheckedProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateUncheckedProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateBusyProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateExpandedProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityStateCollapsedProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityValueMinProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityValueMaxProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityValueNowProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityValueTextProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityInvokeEventHandlerProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityActionEventHandlerProperty());
-  TransferProperty(oldView, newView, DynamicAutomationProperties::AccessibilityActionsProperty());
-
-  auto tooltip = winrt::ToolTipService::GetToolTip(oldView);
-  oldView.ClearValue(winrt::ToolTipService::ToolTipProperty());
-  winrt::ToolTipService::SetToolTip(newView, tooltip);
-
-  // Clear the TransformMatrix from the old View.  The TransformMatrix will be
-  // set on the new View a bit later in RefreshProperties() (as we need data
-  // from the ShadowNode not available here).
-  auto oldElement = oldView.try_as<xaml::UIElement>();
-  if (oldElement && oldElement.try_as<xaml::IUIElement10>()) {
-    oldElement.TransformMatrix(winrt::Windows::Foundation::Numerics::float4x4::identity());
-  }
+  TransferFrameworkElementProperties(oldView, newView);
 }
 
 static void GetAccessibilityStateProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.h
@@ -27,14 +27,6 @@ class REACTWINDOWS_EXPORT FrameworkElementViewManager : public ViewManagerBase {
       const std::string &propertyName,
       const winrt::Microsoft::ReactNative::JSValue &propertyValue) override;
 
-  void TransferProperty(const XamlView &oldView, const XamlView &newView, xaml::DependencyProperty dp);
-
-  void TransferProperty(
-      const XamlView &oldView,
-      const XamlView &newView,
-      xaml::DependencyProperty oldViewDP,
-      xaml::DependencyProperty newViewDP);
-
  private:
   void ApplyTransformMatrix(
       xaml::UIElement uielement,

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -18,6 +18,7 @@
 #include <IReactInstance.h>
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#include <Views/FrameworkElementTransferProperties.h>
 
 #ifdef USE_WINUI3
 namespace winrt::Microsoft::UI::Xaml::Controls {


### PR DESCRIPTION
This adds support for View.opacity and View.borderRadius properties.

The opacity change is pretty simple.

Hooking up borderRadius was more work though.  Panel which is what view is implemented on doesn't support borderRadius properties, so to implement borderRadius ViewPanel adds a border element around the panel element.  To get this to properly inject in the UI tree requires logic outside of ViewPanel.  In paper this is done inside the ViewManager.  -- that code is pretty hard to shared between the view manager and the fabric viewcomponent.  So there is some duplication of the logic.   I did extract the TransferProperties function at least.  

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7776)