### PR TITLE
Ensure C# apps have ConfigurationType set to Application

### DIFF
--- a/change/react-native-windows-ce4d752d-7a27-467e-843c-c6c398d44946.json
+++ b/change/react-native-windows-ce4d752d-7a27-467e-843c-c6c398d44946.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure C# apps have ConfigurationType set to Application",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -14,6 +14,7 @@
           Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.props')" />
 
   <PropertyGroup>
+    <ConfigurationType Condition="'$(ConfigurationType)' == ''">Application</ConfigurationType>
     <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">true</ReactNativeCodeGenEnabled>
   </PropertyGroup>
 

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -14,7 +14,6 @@
           Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.props')" />
 
   <PropertyGroup>
-    <ConfigurationType Condition="'$(ConfigurationType)' == ''">Application</ConfigurationType>
     <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">true</ReactNativeCodeGenEnabled>
   </PropertyGroup>
 

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -39,7 +39,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
   <ItemDefinitionGroup>
     <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
+        <Private Condition="'$(OutputType)' != 'AppContainerExe'">false</Private>
     </Reference>
   </ItemDefinitionGroup>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -15,7 +15,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <ItemDefinitionGroup>
     <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
+        <Private Condition="'$(OutputType)' != 'AppContainerExe'">false</Private>
     </Reference>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
We use some logic in the External PropertySheets to control how
winmd references are included in output directories. We key off
of `ConfigurationType` to make sure that apps/modules don't double
include transitive dependencies.

However C# apps don't set ConfigurationType, so this leads to runtime
exceptions as sometimes transitive dependencies aren't even included
once. Specifically, this means new C# apps targeting the new nuget
packages don't include Microsoft.UI.Xaml.Markup (which both the app
and the M.RN nuget require).

Closes #7764

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7783)