### PR TITLE
[0.64] Ensure C# apps have ConfigurationType set to Application

### DIFF
--- a/change/react-native-windows-ecacfce3-6205-448e-add8-90a67e03a626.json
+++ b/change/react-native-windows-ecacfce3-6205-448e-add8-90a67e03a626.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Ensure C# apps have ConfigurationType set to Application",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -14,6 +14,7 @@
           Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.props')" />
 
   <PropertyGroup>
+    <ConfigurationType Condition="'$(ConfigurationType)' == ''">Application</ConfigurationType>
     <ReactNativeCodeGenEnabled Condition="'$(ReactNativeCodeGenEnabled)' == ''">true</ReactNativeCodeGenEnabled>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR backports #7783 to 0.64.

We use some logic in the External PropertySheets to control how
winmd references are included in output directories. We key off
of `ConfigurationType` to make sure that apps/modules don't double
include transitive dependencies.

However C# apps don't set ConfigurationType, so this leads to runtime
exceptions as sometimes transitive dependencies aren't even included
once. Specifically, this means new C# apps targeting the new nuget
packages don't include Microsoft.UI.Xaml.Markup (which both the app
and the M.RN nuget require).

Closes #7764

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7784)