### PR TITLE
Fix transitive dependencies for C# nuget-based apps

### DIFF
--- a/change/react-native-windows-17c03193-3fbf-480e-ae5a-0fdc80198079.json
+++ b/change/react-native-windows-17c03193-3fbf-480e-ae5a-0fdc80198079.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix transitive dependencies for C# nuget-based apps",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -37,9 +37,4 @@
           Condition="!$(UseExperimentalNuget)" />
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
-  <ItemDefinitionGroup>
-    <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
-    </Reference>
-  </ItemDefinitionGroup>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -13,9 +13,4 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
-  <ItemDefinitionGroup>
-    <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
-    </Reference>
-  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
A fix for transitive winmd dependencies for C++/WinRT apps was also applied to C# apps, which causes runtime errors when consuming transitive dependencies such as Microsoft.UI.Xaml.Markup.

Closes #7764

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7786)