### PR TITLE
[0.64] Fix transitive dependencies for C# nuget-based apps #7786

### DIFF
--- a/change/react-native-windows-04b9c2df-23f5-477f-a5ba-82830126ca11.json
+++ b/change/react-native-windows-04b9c2df-23f5-477f-a5ba-82830126ca11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Fix transitive dependencies for C# nuget-based apps #7786",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -37,9 +37,4 @@
           Condition="!$(UseExperimentalNuget)" />
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
-  <ItemDefinitionGroup>
-    <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
-    </Reference>
-  </ItemDefinitionGroup>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -13,9 +13,4 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
-  <ItemDefinitionGroup>
-    <Reference>
-        <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>
-    </Reference>
-  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
This PR backports #7786 to 0.64.

A fix for transitive winmd dependencies for C++/WinRT apps was also
applied to C# apps, which causes runtime errors when consuming
transitive dependencies such as Microsoft.UI.Xaml.Markup.

Closes #7764


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7787)