### PR TITLE
[0.64] Fix Text.Color not working with backgroundColor

### DIFF
--- a/change/react-native-windows-e7751624-0752-4e22-9095-937978ff2335.json
+++ b/change/react-native-windows-e7751624-0752-4e22-9095-937978ff2335.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Text.BackgroundColor overwriting foreground. (#7707)",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextBackgroundColorTestPage.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/LegacyTests/TextBackgroundColorTestPage.tsx
@@ -17,6 +17,40 @@ export function TextBackgroundColorTestPage() {
   return (
     <View>
       <View testID={'TextColorBackgroundView'}>
+<Text style={{color: 'pink'}}>Outer pink</Text>
+         <Text style={{}}>
+           Outer <Text style={{color: 'red'}}>red nested</Text>
+         </Text>
+         <Text style={{}}>
+           Outer{' '}
+           <Text style={{backgroundColor: 'blue', color: 'white'}}>
+             nested white on blue
+           </Text>
+         </Text>
+         <Text style={{color: 'pink'}}>
+           Outer pink <Text style={{color: 'red'}}>nested red</Text>
+         </Text>
+         <Text style={{backgroundColor: 'green'}}>
+           Outer on green{' '}
+           <Text style={{color: 'white'}}>nested white on inherit green</Text>
+         </Text>
+         <Text style={{backgroundColor: 'green', color: 'orange'}}>
+           Outer orange on green{' '}
+           <Text style={{backgroundColor: 'blue', color: 'white'}}>
+             nested white on blue
+           </Text>
+         </Text>
+         <Text style={{color: 'orange'}}>
+           Outer orange{' '}
+           <Text style={{backgroundColor: 'blue', color: 'white'}}>
+             nested white on blue
+           </Text>
+         </Text>
+         <Text style={{color: 'orange'}}>
+           <Text style={{backgroundColor: 'blue'}}>
+             nested orange inherit on blue
+           </Text>
+         </Text>
         <Text>
           Outer no_color{' '}
           <Text style={{ backgroundColor: 'green' }}>

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -76,11 +76,48 @@ export class BackgroundColorDemo extends React.Component<{}> {
   public render() {
     return (
       <View>
+        <Text style={{color: 'pink'}}>Outer pink</Text>
+        <Text style={{}}>
+          Outer <Text style={{color: 'red'}}>red nested</Text>
+        </Text>
+        <Text style={{}}>
+          Outer{' '}
+          <Text style={{backgroundColor: 'blue', color: 'white'}}>
+            nested white on blue
+          </Text>
+        </Text>
+        <Text style={{color: 'pink'}}>
+          Outer pink <Text style={{color: 'red'}}>nested red</Text>
+        </Text>
+        <Text style={{backgroundColor: 'green'}}>
+          Outer on green{' '}
+          <Text style={{color: 'white'}}>nested white on inherit green</Text>
+        </Text>
+        <Text style={{backgroundColor: 'green', color: 'orange'}}>
+          Outer orange on green{' '}
+          <Text style={{backgroundColor: 'blue', color: 'white'}}>
+            nested white on blue
+          </Text>
+        </Text>
+        <Text style={{color: 'orange'}}>
+          Outer orange{' '}
+          <Text style={{backgroundColor: 'blue', color: 'white'}}>
+            nested white on blue
+          </Text>
+        </Text>
+        <Text style={{color: 'orange'}}>
+          <Text style={{backgroundColor: 'blue'}}>
+            nested orange inherit on blue
+          </Text>
+        </Text>
+
         <Text>
           Outer no_color{' '}
-          <Text style={{backgroundColor: 'green'}}>
+          <Text style={{backgroundColor: 'green', color: 'white'}}>
             START_NESTED green{' '}
-            <Text style={{backgroundColor: 'blue'}}>DEEPER_NESTED blue</Text>{' '}
+            <Text style={{backgroundColor: 'blue', color: 'magenta'}}>
+              DEEPER_NESTED magenta on blue
+            </Text>{' '}
             END_NESTED
           </Text>{' '}
           attributes.

--- a/packages/E2ETest/windows/ReactUWPTestApp/Assets/TreeDump/masters/TextColorBackground.json
+++ b/packages/E2ETest/windows/ReactUWPTestApp/Assets/TreeDump/masters/TextColorBackground.json
@@ -6,15 +6,188 @@
   "Clip": null,
   "CornerRadius": "0,0,0,0",
   "FlowDirection": "LeftToRight",
-  "Height": 95,
+  "Height": 247,
   "HorizontalAlignment": "Stretch",
   "Margin": "0,0,0,0",
-  "RenderSize": [800, 95],
+  "RenderSize": [800, 247],
   "VerticalAlignment": "Stretch",
   "Visibility": "Visible",
   "Width": 800,
   "AutomationId": "TextColorBackgroundView",
   "children": [
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FFFFC0CB",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer pink",
+    "TextHighlighters": [],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer red nested",
+    "TextHighlighters": [],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer nested white on blue",
+    "TextHighlighters": [{
+"Background": "#FF0000FF",
+"Foreground": "#FFFFFFFF",
+"Ranges": [{"StartIndex":6,"Length":20}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FFFFC0CB",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer pink nested red",
+    "TextHighlighters": [],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FF000000",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer on green nested white on inherit green",
+    "TextHighlighters": [{
+"Background": "#FF008000",
+"Foreground": null,
+"Ranges": [{"StartIndex":0,"Length":14}]
+}
+,{
+"Background": "#FF008000",
+"Foreground": null,
+"Ranges": [{"StartIndex":14,"Length":1}]
+}
+,{
+"Background": "#FF008000",
+"Foreground": "#FFFFFFFF",
+"Ranges": [{"StartIndex":15,"Length":29}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FFFFA500",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer orange on green nested white on blue",
+    "TextHighlighters": [{
+"Background": "#FF008000",
+"Foreground": "#FFFFA500",
+"Ranges": [{"StartIndex":0,"Length":21}]
+}
+,{
+"Background": "#FF008000",
+"Foreground": "#FFFFA500",
+"Ranges": [{"StartIndex":21,"Length":1}]
+}
+,{
+"Background": "#FF0000FF",
+"Foreground": "#FFFFFFFF",
+"Ranges": [{"StartIndex":22,"Length":20}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FFFFA500",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "Outer orange nested white on blue",
+    "TextHighlighters": [{
+"Background": "#FF0000FF",
+"Foreground": "#FFFFFFFF",
+"Ranges": [{"StartIndex":13,"Length":20}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
+  {
+    "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
+    "Clip": null,
+    "FlowDirection": "LeftToRight",
+    "Foreground": "#FFFFA500",
+    "Height": 19,
+    "HorizontalAlignment": "Stretch",
+    "Margin": "0,0,0,0",
+    "Padding": "0,0,0,0",
+    "RenderSize": [800, 19],
+    "Text": "nested orange inherit on blue",
+    "TextHighlighters": [{
+"Background": "#FF0000FF",
+"Foreground": "#FFFFA500",
+"Ranges": [{"StartIndex":0,"Length":29}]
+}
+],
+    "VerticalAlignment": "Stretch",
+    "Visibility": "Visible",
+    "Width": 800
+  },
   {
     "XamlType": "Windows.UI.Xaml.Controls.TextBlock",
     "Clip": null,
@@ -28,22 +201,27 @@
     "Text": "Outer no_color START_NESTED green DEEPER_NESTED blue END_NESTED attributes.",
     "TextHighlighters": [{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":15,"Length":18}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":33,"Length":1}]
 }
 ,{
 "Background": "#FF0000FF",
+"Foreground": null,
 "Ranges": [{"StartIndex":34,"Length":18}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":52,"Length":1}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":53,"Length":10}]
 }
 ],
@@ -64,6 +242,7 @@
     "Text": "Outer no_color START_NESTED no_color DEEPER_NESTED blue END_NESTED attributes.",
     "TextHighlighters": [{
 "Background": "#FF0000FF",
+"Foreground": null,
 "Ranges": [{"StartIndex":37,"Length":18}]
 }
 ],
@@ -84,18 +263,22 @@
     "Text": "Outer no_color START_NESTED green DEEPER_NESTED inherit green END_NESTED attributes.",
     "TextHighlighters": [{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":15,"Length":19}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":34,"Length":27}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":61,"Length":1}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":62,"Length":10}]
 }
 ],
@@ -116,34 +299,42 @@
     "Text": "Outer red START_NESTED inherit red DEEPER_NESTED inherit red END_NESTED attributes.",
     "TextHighlighters": [{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":0,"Length":9}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":9,"Length":1}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":10,"Length":25}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":35,"Length":25}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":60,"Length":1}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":61,"Length":10}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":71,"Length":1}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":72,"Length":11}]
 }
 ],
@@ -164,38 +355,47 @@
     "Text": "Outer red START_NESTED green DEEPER_NESTED blue END_NESTED attributes.",
     "TextHighlighters": [{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":0,"Length":9}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":9,"Length":1}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":10,"Length":18}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":28,"Length":1}]
 }
 ,{
 "Background": "#FF0000FF",
+"Foreground": null,
 "Ranges": [{"StartIndex":29,"Length":18}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":47,"Length":1}]
 }
 ,{
 "Background": "#FF008000",
+"Foreground": null,
 "Ranges": [{"StartIndex":48,"Length":10}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":58,"Length":1}]
 }
 ,{
 "Background": "#FFFF0000",
+"Foreground": null,
 "Ranges": [{"StartIndex":59,"Length":11}]
 }
 ],

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -159,7 +159,7 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="XamlTreeDump">
-      <Version>1.0.5</Version>
+      <Version>1.0.9</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
+++ b/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
@@ -106,7 +106,7 @@ namespace TreeDumpLibrary
 
         public async static Task<bool> DoesTreeDumpMatchForRNTester(DependencyObject root)
         {
-            string json = VisualTreeDumper.DumpTree(root, null, new string[] { }, DumpTreeMode.Json);
+            string json = VisualTreeDumper.DumpTree(root, null, new string[] { }, new AttachedProperty[] { });
             try
             {
                 var obj = JsonValue.Parse(json).GetObject();
@@ -181,7 +181,7 @@ namespace TreeDumpLibrary
             }
         }
 
-        internal static async Task<bool> MatchTreeDumpFromLayoutUpdateAsync(string dumpID, string uiaId, TextBlock textBlock, IList<string> additionalProperties, DumpTreeMode mode, string dumpExpectedText)
+        internal static async Task<bool> MatchTreeDumpFromLayoutUpdateAsync(string dumpID, string uiaId, TextBlock textBlock, IList<string> additionalProperties, string dumpExpectedText)
         {
             // First find root
             DependencyObject current = textBlock;
@@ -203,7 +203,7 @@ namespace TreeDumpLibrary
                 }
             }
 
-            string dumpText = VisualTreeDumper.DumpTree(dumpRoot, textBlock, additionalProperties, mode);
+            string dumpText = VisualTreeDumper.DumpTree(dumpRoot, textBlock, additionalProperties, new AttachedProperty[] { });
             if (dumpText != dumpExpectedText)
             {
                 return await MatchDump(dumpText, GetMasterFile(dumpID), GetOutputFile(dumpID));
@@ -216,7 +216,7 @@ namespace TreeDumpLibrary
             m_timer.Stop();
             if (VisualTreeHelper.GetParent(m_textBlock) != null)
             {
-                var matchSuccessful = await MatchTreeDumpFromLayoutUpdateAsync(m_dumpID, m_uiaID, m_textBlock, m_additionalProperties, DumpTreeMode.Json, m_dumpExpectedText);
+                var matchSuccessful = await MatchTreeDumpFromLayoutUpdateAsync(m_dumpID, m_uiaID, m_textBlock, m_additionalProperties, m_dumpExpectedText);
                 if (!matchSuccessful)
                 {
                     StorageFolder storageFolder = KnownFolders.DocumentsLibrary;

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -31,7 +31,9 @@ class TextShadowNode final : public ShadowNodeBase {
  private:
   ShadowNode *m_firstChildNode;
 
-  std::optional<winrt::Windows::UI::Color> m_ColorValue = std::nullopt;
+  std::optional<winrt::Windows::UI::Color> m_backgroundColor = std::nullopt;
+  std::optional<winrt::Windows::UI::Color> m_foregroundColor = std::nullopt;
+
   int32_t m_prevCursorEnd = 0;
 
  public:
@@ -53,10 +55,9 @@ class TextShadowNode final : public ShadowNodeBase {
         text = transformableText.TransformText();
         textBlock.Text(winrt::hstring(text));
 
-        if (m_ColorValue) {
-          AddHighlighter(m_ColorValue.value(), text.size());
+        if (m_backgroundColor) {
+          AddHighlighter(m_backgroundColor.value(), m_foregroundColor, textBlock.Text().size());
         }
-
         m_prevCursorEnd += textBlock.Text().size();
 
         return;
@@ -71,40 +72,53 @@ class TextShadowNode final : public ShadowNodeBase {
     Super::AddView(child, index);
 
     if (auto run = static_cast<ShadowNodeBase &>(child).GetView().try_as<winrt::Run>()) {
-      if (m_ColorValue) {
-        AddHighlighter(m_ColorValue.value(), run.Text().size());
+      if (m_backgroundColor) {
+        AddHighlighter(m_backgroundColor.value(), m_foregroundColor, run.Text().size());
       }
-
       m_prevCursorEnd += run.Text().size();
     } else if (auto span = static_cast<ShadowNodeBase &>(child).GetView().try_as<winrt::Span>()) {
-      AddNestedTextHighlighter(m_ColorValue, span, static_cast<VirtualTextShadowNode &>(child).m_highlightData);
+      AddNestedTextHighlighter(
+          m_backgroundColor, m_foregroundColor, span, static_cast<VirtualTextShadowNode &>(child).m_highlightData);
     }
   }
 
   void AddNestedTextHighlighter(
-      const std::optional<winrt::Windows::UI::Color> &parentColor,
+      const std::optional<winrt::Windows::UI::Color> &parentBackColor,
+      const std::optional<winrt::Windows::UI::Color> &parentForeColor,
       winrt::Span &span,
       VirtualTextShadowNode::HighlightData highData) {
-    if (!highData.color && parentColor) {
-      highData.color = parentColor;
+    if (!highData.backgroundColor && parentBackColor) {
+      highData.backgroundColor = parentBackColor;
+    }
+
+    if (!highData.foregroundColor && parentForeColor) {
+      highData.foregroundColor = parentForeColor;
     }
 
     for (const auto &el : span.Inlines()) {
       if (auto run = el.try_as<winrt::Run>()) {
-        if (highData.color) {
-          AddHighlighter(highData.color.value(), run.Text().size());
+        if (highData.backgroundColor) {
+          AddHighlighter(highData.backgroundColor.value(), highData.foregroundColor, run.Text().size());
         }
 
         m_prevCursorEnd += run.Text().size();
       } else if (auto spanChild = el.try_as<winrt::Span>()) {
-        AddNestedTextHighlighter(highData.color, spanChild, highData.data[highData.spanIdx++]);
+        AddNestedTextHighlighter(
+            highData.backgroundColor, highData.foregroundColor, spanChild, highData.data[highData.spanIdx++]);
       }
     }
   }
 
-  void AddHighlighter(const winrt::Windows::UI::Color &color, size_t runSize) {
+  void AddHighlighter(
+      const winrt::Windows::UI::Color &backgroundColor,
+      const std::optional<winrt::Windows::UI::Color> &foregroundColor,
+      size_t runSize) {
     auto newHigh = winrt::TextHighlighter{};
-    newHigh.Background(react::uwp::SolidBrushFromColor(color));
+    newHigh.Background(react::uwp::SolidBrushFromColor(backgroundColor));
+
+    if (foregroundColor) {
+      newHigh.Foreground(react::uwp::SolidBrushFromColor(foregroundColor.value()));
+    }
 
     winrt::TextRange newRange{m_prevCursorEnd, static_cast<int32_t>(runSize)};
     newHigh.Ranges().Append(newRange);
@@ -152,6 +166,7 @@ bool TextViewManager::UpdateProperty(
     return true;
 
   if (TryUpdateForeground(textBlock, propertyName, propertyValue)) {
+    static_cast<TextShadowNode *>(nodeToUpdate)->m_foregroundColor = react::uwp::ColorFrom(propertyValue);
   } else if (TryUpdateFontProperties(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "textTransform") {
     auto textNode = static_cast<TextShadowNode *>(nodeToUpdate);
@@ -202,7 +217,7 @@ bool TextViewManager::UpdateProperty(
       textBlock.ClearValue(xaml::Controls::TextBlock::SelectionHighlightColorProperty());
   } else if (propertyName == "backgroundColor") {
     if (react::uwp::IsValidColorValue(propertyValue)) {
-      static_cast<TextShadowNode *>(nodeToUpdate)->m_ColorValue = react::uwp::ColorFrom(propertyValue);
+      static_cast<TextShadowNode *>(nodeToUpdate)->m_backgroundColor = react::uwp::ColorFrom(propertyValue);
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -65,6 +65,8 @@ bool VirtualTextViewManager::UpdateProperty(
   // FUTURE: In the future cppwinrt will generate code where static methods on
   // base types can be called.  For now we specify the base type explicitly
   if (TryUpdateForeground<winrt::TextElement>(span, propertyName, propertyValue)) {
+    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.foregroundColor =
+        react::uwp::ColorFrom(propertyValue);
   } else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
@@ -73,11 +75,13 @@ bool VirtualTextViewManager::UpdateProperty(
     node->transformableText.textTransform = TransformableText::GetTextTransform(propertyValue);
   } else if (propertyName == "backgroundColor") {
     if (react::uwp::IsValidColorValue(propertyValue)) {
-      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.color = react::uwp::ColorFrom(propertyValue);
+      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.backgroundColor =
+          react::uwp::ColorFrom(propertyValue);
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }
+
   return true;
 }
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -20,7 +20,8 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   struct HighlightData {
     std::vector<HighlightData> data;
     size_t spanIdx = 0;
-    std::optional<winrt::Windows::UI::Color> color;
+    std::optional<winrt::Windows::UI::Color> backgroundColor;
+    std::optional<winrt::Windows::UI::Color> foregroundColor;
   };
 
   HighlightData m_highlightData;


### PR DESCRIPTION
Backport: Fix Text.BackgroundColor overwriting foreground. (#7707)

* Change files

* Fix Text.BackgroundColor overwriting foreground prop.

* Update snapshot.

* fix optional param.

Co-authored-by: Igor Klemenski <igklemen@microsoft.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7794)