### PR TITLE
Adding Accessibility Prop on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-7c50c1a8-c6c6-44d4-bdb1-2d906f8cf9cc.json
+++ b/change/@office-iss-react-native-win32-7c50c1a8-c6c6-44d4-bdb1-2d906f8cf9cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding accessibilityControls property on ViewWin32. Needed for the Live Persona Picker",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -168,6 +168,14 @@ export type BasePropsWin32 = {
   */
   accessibilityDescribedBy?: React.RefObject<any>;
   accessibilityLabeledBy?: React.RefObject<any>;
+
+  /**
+  * Identifies the element whose contents or presence are controlled by another element. 
+  * 
+  * This is mainly used for a Textbox with a Dropdown PeoplePicker-type list.  This allows an 
+  * accessibility tool to query those other providers for properties and listen to their events.
+  */
+   accessibilityControls?: React.RefObject<any>;    
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -47,6 +47,7 @@ export const ViewWin32 = React.forwardRef(
     const [describedByTarget, setDescribedByTarget] = React.useState(null);
     const [controlsTarget, setControlsTarget] = React.useState(null);
     const {accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls, ...rest} = props;
+
     React.useLayoutEffect(() => {
       if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy.current !== null)
       {
@@ -56,7 +57,9 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
+    }, [accessibilityLabeledBy]);
 
+    React.useLayoutEffect(() => {
       if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy.current !== null)
       {
         setDescribedByTarget(findNodeHandle(accessibilityDescribedBy.current as
@@ -65,7 +68,9 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
-
+    }, [accessibilityDescribedBy]);
+    
+    React.useLayoutEffect(() => {
       if(accessibilityControls !== undefined && accessibilityControls.current !== null)
       {
         setControlsTarget(findNodeHandle(accessibilityControls.current as
@@ -74,17 +79,16 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
-    }, [accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls]);
+    }, [accessibilityControls]);
 
     /**
      * Set up the forwarding ref to enable adding the focus method.
      */
     const focusRef = React.useRef<ViewWin32>();
-
     const setNativeRef = setAndForwardRef({
       getForwardedRef: () => ref,
       setLocalRef: localRef => {
-        focusRef.current = localRef;
+        focusRef.current = localRef;  
 
         /**
          * Add focus() as a callable function to the forwarded reference.

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -45,7 +45,8 @@ export const ViewWin32 = React.forwardRef(
 
     const [labeledByTarget, setLabeledByTarget] = React.useState(null);
     const [describedByTarget, setDescribedByTarget] = React.useState(null);
-    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = props;
+    const [controlsTarget, setControlsTarget] = React.useState(null);
+    const {accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls, ...rest} = props;
     React.useLayoutEffect(() => {
       if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy.current !== null)
       {
@@ -64,7 +65,16 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
-    }, [accessibilityLabeledBy, accessibilityDescribedBy]);
+
+      if(accessibilityControls !== undefined && accessibilityControls.current !== null)
+      {
+        setControlsTarget(findNodeHandle(accessibilityControls.current as
+          | null
+          | number
+          | React.Component<any, any, any>
+          | React.ComponentClass<any, any>));
+      }
+    }, [accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls]);
 
     /**
      * Set up the forwarding ref to enable adding the focus method.
@@ -94,6 +104,7 @@ export const ViewWin32 = React.forwardRef(
 
     return <View ref={setNativeRef}
     {...(rest as InnerViewWin32Props)}
+    {...((controlsTarget !== null) ? {accessibilityControls:controlsTarget} : {})}
     {...((labeledByTarget !== null) ? {accessibilityLabeledBy:labeledByTarget} : {})}
     {...((describedByTarget !== null) ? {accessibilityDescribedBy:describedByTarget} : {})}
     />;


### PR DESCRIPTION
Adding the `accessibilityControls` to ViewWin32. This prop acts as [aria-controls ](https://www.w3.org/TR/wai-aria-1.1/#aria-controls). 

This prop is needed for a new Win32 JS Control being developed, Live Persona Picker (People Picker). This JS LPP component is a dropdown list that displays after a user types '@' in a textbox. This will be used for WIn32, and thus, we need to send this prop over the bridge so the Native side can set the ControllerForSource object on both (Textbox+LPP) components. 

This ControllerForSource object is needed because when scrolling through the LPP list, focus isn't actually on the list, it's on the textbox, so how will a screen reader know what to read? This allows the screen reader to subscribe to events on the list. See more about [ControllerFor here. ](https://stackoverflow.microsoft.com/questions/50793)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7796)