### PR TITLE
[Fabric] Add support for PlatformColor

### DIFF
--- a/change/react-native-windows-b9691dda-2b02-4670-a043-8ecd90525929.json
+++ b/change/react-native-windows-b9691dda-2b02-4670-a043-8ecd90525929.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add support for PlatformColor",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ActivityIndicatorComponentView.cpp
@@ -46,7 +46,7 @@ void ActivityIndicatorComponentView::updateProps(
   }
 
   if (oldActivityProps.color != newActivityProps.color) {
-    m_element.Foreground(SolidColorBrushFrom(newActivityProps.color));
+    m_element.Foreground(newActivityProps.color.AsWindowsBrush());
   }
 
   m_props = std::static_pointer_cast<facebook::react::ActivityIndicatorViewProps const>(props);

--- a/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
@@ -87,7 +87,7 @@ void ImageComponentView::updateProps(
 
   if (oldImageProps.tintColor != newImageProps.tintColor) {
     if (newImageProps.tintColor) {
-      m_element->TintColor(ColorFromNumber(*(newImageProps.tintColor)));
+      m_element->TintColor(newImageProps.tintColor.AsWindowsColor());
     } else {
       m_element->TintColor(winrt::Colors::Transparent());
     }

--- a/vnext/Microsoft.ReactNative/Fabric/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ParagraphComponentView.cpp
@@ -48,7 +48,7 @@ void ParagraphComponentView::updateProps(
 
   if (oldViewProps.textAttributes.foregroundColor != newViewProps.textAttributes.foregroundColor) {
     if (newViewProps.textAttributes.foregroundColor)
-      m_element.Foreground(SolidColorBrushFrom(newViewProps.textAttributes.foregroundColor));
+      m_element.Foreground(newViewProps.textAttributes.foregroundColor.AsWindowsBrush());
     else
       m_element.ClearValue(::xaml::Controls::TextBlock::ForegroundProperty());
   }

--- a/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ViewComponentView.cpp
@@ -48,7 +48,7 @@ void ViewComponentView::updateProps(
     auto color = *newViewProps.backgroundColor;
 
     if (newViewProps.backgroundColor) {
-      m_panel.ViewBackground(SolidColorBrushFrom(newViewProps.backgroundColor));
+      m_panel.ViewBackground(newViewProps.backgroundColor.AsWindowsBrush());
     } else {
       m_panel.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::ViewBackgroundProperty());
     }
@@ -56,7 +56,7 @@ void ViewComponentView::updateProps(
 
   if (oldViewProps.borderColors != newViewProps.borderColors) {
     if (newViewProps.borderColors.all) {
-      m_panel.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
+      m_panel.BorderBrush(newViewProps.borderColors.all->AsWindowsBrush());
     } else {
       m_panel.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
     }

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "Color.h"
+#include <Utils/ValueUtils.h>
+
+namespace facebook
+{
+namespace react
+{
+
+xaml::Media::Brush SharedColor::AsWindowsBrush() const {
+  if (!m_color)
+    return nullptr;
+  if (!m_color->m_platformColor.empty()) {
+    return Microsoft::ReactNative::BrushFromColorObject(winrt::to_hstring(m_color->m_platformColor));
+  }
+  return xaml::Media::SolidColorBrush(m_color->m_color);
+}
+
+SharedColor colorFromComponents(ColorComponents components) {
+  float ratio = 255;
+  return SharedColor(ui::ColorHelper::FromArgb((int)round(components.alpha * ratio) & 0xff, (int)round(components.red * ratio) & 0xff, (int)round(components.green * ratio) & 0xff, (int)round(components.blue * ratio) & 0xff));
+}
+
+ColorComponents colorComponentsFromColor(SharedColor sharedColor) {
+  float ratio = 255;
+  auto color = sharedColor.AsWindowsColor();
+  return ColorComponents {
+      (float)color.R / ratio,
+      (float)color.G / ratio,
+      (float)color.B / ratio,
+      (float)color.A / ratio };
+}
+
+SharedColor clearColor() {
+  static SharedColor color = colorFromComponents(ColorComponents { 0, 0, 0, 0 });
+  return color;
+}
+
+SharedColor blackColor() {
+  static SharedColor color = colorFromComponents(ColorComponents { 0, 0, 0, 1 });
+  return color;
+}
+
+SharedColor whiteColor() {
+  static SharedColor color = colorFromComponents(ColorComponents { 1, 1, 1, 1 });
+  return color;
+}
+
+} // namespace react
+} // namespace facebook

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -4,10 +4,8 @@
 #include "Color.h"
 #include <Utils/ValueUtils.h>
 
-namespace facebook
-{
-namespace react
-{
+namespace facebook {
+namespace react {
 
 xaml::Media::Brush SharedColor::AsWindowsBrush() const {
   if (!m_color)
@@ -20,31 +18,32 @@ xaml::Media::Brush SharedColor::AsWindowsBrush() const {
 
 SharedColor colorFromComponents(ColorComponents components) {
   float ratio = 255;
-  return SharedColor(ui::ColorHelper::FromArgb((int)round(components.alpha * ratio) & 0xff, (int)round(components.red * ratio) & 0xff, (int)round(components.green * ratio) & 0xff, (int)round(components.blue * ratio) & 0xff));
+  return SharedColor(ui::ColorHelper::FromArgb(
+      (int)round(components.alpha * ratio) & 0xff,
+      (int)round(components.red * ratio) & 0xff,
+      (int)round(components.green * ratio) & 0xff,
+      (int)round(components.blue * ratio) & 0xff));
 }
 
 ColorComponents colorComponentsFromColor(SharedColor sharedColor) {
   float ratio = 255;
   auto color = sharedColor.AsWindowsColor();
-  return ColorComponents {
-      (float)color.R / ratio,
-      (float)color.G / ratio,
-      (float)color.B / ratio,
-      (float)color.A / ratio };
+  return ColorComponents{
+      (float)color.R / ratio, (float)color.G / ratio, (float)color.B / ratio, (float)color.A / ratio};
 }
 
 SharedColor clearColor() {
-  static SharedColor color = colorFromComponents(ColorComponents { 0, 0, 0, 0 });
+  static SharedColor color = colorFromComponents(ColorComponents{0, 0, 0, 0});
   return color;
 }
 
 SharedColor blackColor() {
-  static SharedColor color = colorFromComponents(ColorComponents { 0, 0, 0, 1 });
+  static SharedColor color = colorFromComponents(ColorComponents{0, 0, 0, 1});
   return color;
 }
 
 SharedColor whiteColor() {
-  static SharedColor color = colorFromComponents(ColorComponents { 1, 1, 1, 1 });
+  static SharedColor color = colorFromComponents(ColorComponents{1, 1, 1, 1});
   return color;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.h
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// RN has some weird include directory redirections..this forwards the include to the right place
+#include <react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h>

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Float.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Float.h
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// RN has some weird include directory redirections..this forwards the include to the right place
+#include <react/renderer/graphics/platform/cxx/react/renderer/graphics/Float.h>

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h
@@ -41,10 +41,10 @@ inline void fromRawValue(const RawValue &value, SharedColor &result) {
     green = items.at(1);
     blue = items.at(2);
     alpha = length == 4 ? items.at(3) : 1.0f;
-// [Windows - Add support for windowsBrush colors (PlatformColor)
+    // [Windows - Add support for windowsBrush colors (PlatformColor)
   } else if (value.hasType<better::map<std::string, std::string>>()) {
     auto map = (better::map<std::string, std::string>)value;
-    for (const auto& pair : map) {
+    for (const auto &pair : map) {
       if (pair.first == "windowsbrush") {
         result = SharedColor(std::string(pair.second));
         return;
@@ -62,20 +62,16 @@ inline folly::dynamic toDynamic(const SharedColor &color) {
   ColorComponents components = colorComponentsFromColor(color);
   auto ratio = 255.f;
   return (
-      ((int)round(components.alpha * ratio) & 0xff) << 24 |
-      ((int)round(components.red * ratio) & 0xff) << 16 |
-      ((int)round(components.green * ratio) & 0xff) << 8 |
-      ((int)round(components.blue * ratio) & 0xff));
+      ((int)round(components.alpha * ratio) & 0xff) << 24 | ((int)round(components.red * ratio) & 0xff) << 16 |
+      ((int)round(components.green * ratio) & 0xff) << 8 | ((int)round(components.blue * ratio) & 0xff));
 }
 
 inline int toMapBuffer(const SharedColor &color) {
   ColorComponents components = colorComponentsFromColor(color);
   auto ratio = 255.f;
   return (
-      ((int)round(components.alpha * ratio) & 0xff) << 24 |
-      ((int)round(components.red * ratio) & 0xff) << 16 |
-      ((int)round(components.green * ratio) & 0xff) << 8 |
-      ((int)round(components.blue * ratio) & 0xff));
+      ((int)round(components.alpha * ratio) & 0xff) << 24 | ((int)round(components.red * ratio) & 0xff) << 16 |
+      ((int)round(components.green * ratio) & 0xff) << 8 | ((int)round(components.blue * ratio) & 0xff));
 }
 
 #endif
@@ -83,8 +79,8 @@ inline int toMapBuffer(const SharedColor &color) {
 inline std::string toString(const SharedColor &value) {
   ColorComponents components = colorComponentsFromColor(value);
   auto ratio = 255.f;
-  return "rgba(" + folly::to<std::string>(round(components.red * ratio)) +
-      ", " + folly::to<std::string>(round(components.green * ratio)) + ", " +
+  return "rgba(" + folly::to<std::string>(round(components.red * ratio)) + ", " +
+      folly::to<std::string>(round(components.green * ratio)) + ", " +
       folly::to<std::string>(round(components.blue * ratio)) + ", " +
       folly::to<std::string>(round(components.alpha * ratio)) + ")";
 }
@@ -234,13 +230,11 @@ inline void fromRawValue(const RawValue &value, CornerInsets &result) {
 }
 
 inline std::string toString(const Point &point) {
-  return "{" + folly::to<std::string>(point.x) + ", " +
-      folly::to<std::string>(point.y) + "}";
+  return "{" + folly::to<std::string>(point.x) + ", " + folly::to<std::string>(point.y) + "}";
 }
 
 inline std::string toString(const Size &size) {
-  return "{" + folly::to<std::string>(size.width) + ", " +
-      folly::to<std::string>(size.height) + "}";
+  return "{" + folly::to<std::string>(size.width) + ", " + folly::to<std::string>(size.height) + "}";
 }
 
 inline std::string toString(const Rect &rect) {
@@ -248,17 +242,14 @@ inline std::string toString(const Rect &rect) {
 }
 
 inline std::string toString(const EdgeInsets &edgeInsets) {
-  return "{" + folly::to<std::string>(edgeInsets.left) + ", " +
-      folly::to<std::string>(edgeInsets.top) + ", " +
-      folly::to<std::string>(edgeInsets.right) + ", " +
-      folly::to<std::string>(edgeInsets.bottom) + "}";
+  return "{" + folly::to<std::string>(edgeInsets.left) + ", " + folly::to<std::string>(edgeInsets.top) + ", " +
+      folly::to<std::string>(edgeInsets.right) + ", " + folly::to<std::string>(edgeInsets.bottom) + "}";
 }
 
 inline std::string toString(const CornerInsets &cornerInsets) {
-  return "{" + folly::to<std::string>(cornerInsets.topLeft) + ", " +
-      folly::to<std::string>(cornerInsets.topRight) + ", " +
-      folly::to<std::string>(cornerInsets.bottomLeft) + ", " +
-      folly::to<std::string>(cornerInsets.bottomRight) + "}";
+  return "{" + folly::to<std::string>(cornerInsets.topLeft) + ", " + folly::to<std::string>(cornerInsets.topRight) +
+      ", " + folly::to<std::string>(cornerInsets.bottomLeft) + ", " + folly::to<std::string>(cornerInsets.bottomRight) +
+      "}";
 }
 
 } // namespace react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <better/map.h>
+#include <folly/dynamic.h>
+#include <glog/logging.h>
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/Geometry.h>
+
+namespace facebook {
+namespace react {
+
+#pragma mark - Color
+
+inline void fromRawValue(const RawValue &value, SharedColor &result) {
+  float red = 0;
+  float green = 0;
+  float blue = 0;
+  float alpha = 0;
+
+  if (value.hasType<int>()) {
+    auto argb = (int64_t)value;
+    auto ratio = 255.f;
+    alpha = ((argb >> 24) & 0xFF) / ratio;
+    red = ((argb >> 16) & 0xFF) / ratio;
+    green = ((argb >> 8) & 0xFF) / ratio;
+    blue = (argb & 0xFF) / ratio;
+  } else if (value.hasType<std::vector<float>>()) {
+    auto items = (std::vector<float>)value;
+    auto length = items.size();
+    react_native_assert(length == 3 || length == 4);
+    red = items.at(0);
+    green = items.at(1);
+    blue = items.at(2);
+    alpha = length == 4 ? items.at(3) : 1.0f;
+// [Windows - Add support for windowsBrush colors (PlatformColor)
+  } else if (value.hasType<better::map<std::string, std::string>>()) {
+    auto map = (better::map<std::string, std::string>)value;
+    for (const auto& pair : map) {
+      if (pair.first == "windowsbrush") {
+        result = SharedColor(std::string(pair.second));
+        return;
+      }
+    }
+  }
+  // Windows]
+
+  result = colorFromComponents({red, green, blue, alpha});
+}
+
+#ifdef ANDROID
+
+inline folly::dynamic toDynamic(const SharedColor &color) {
+  ColorComponents components = colorComponentsFromColor(color);
+  auto ratio = 255.f;
+  return (
+      ((int)round(components.alpha * ratio) & 0xff) << 24 |
+      ((int)round(components.red * ratio) & 0xff) << 16 |
+      ((int)round(components.green * ratio) & 0xff) << 8 |
+      ((int)round(components.blue * ratio) & 0xff));
+}
+
+inline int toMapBuffer(const SharedColor &color) {
+  ColorComponents components = colorComponentsFromColor(color);
+  auto ratio = 255.f;
+  return (
+      ((int)round(components.alpha * ratio) & 0xff) << 24 |
+      ((int)round(components.red * ratio) & 0xff) << 16 |
+      ((int)round(components.green * ratio) & 0xff) << 8 |
+      ((int)round(components.blue * ratio) & 0xff));
+}
+
+#endif
+
+inline std::string toString(const SharedColor &value) {
+  ColorComponents components = colorComponentsFromColor(value);
+  auto ratio = 255.f;
+  return "rgba(" + folly::to<std::string>(round(components.red * ratio)) +
+      ", " + folly::to<std::string>(round(components.green * ratio)) + ", " +
+      folly::to<std::string>(round(components.blue * ratio)) + ", " +
+      folly::to<std::string>(round(components.alpha * ratio)) + ")";
+}
+
+#pragma mark - Geometry
+
+inline void fromRawValue(const RawValue &value, Point &result) {
+  if (value.hasType<better::map<std::string, Float>>()) {
+    auto map = (better::map<std::string, Float>)value;
+    for (const auto &pair : map) {
+      if (pair.first == "x") {
+        result.x = pair.second;
+      } else if (pair.first == "y") {
+        result.y = pair.second;
+      }
+    }
+    return;
+  }
+
+  react_native_assert(value.hasType<std::vector<Float>>());
+  if (value.hasType<std::vector<Float>>()) {
+    auto array = (std::vector<Float>)value;
+    react_native_assert(array.size() == 2);
+    if (array.size() >= 2) {
+      result = {array.at(0), array.at(1)};
+    } else {
+      result = {0, 0};
+      LOG(ERROR) << "Unsupported Point vector size: " << array.size();
+    }
+  } else {
+    LOG(ERROR) << "Unsupported Point type";
+  }
+}
+
+inline void fromRawValue(const RawValue &value, Size &result) {
+  if (value.hasType<better::map<std::string, Float>>()) {
+    auto map = (better::map<std::string, Float>)value;
+    for (const auto &pair : map) {
+      if (pair.first == "width") {
+        result.width = pair.second;
+      } else if (pair.first == "height") {
+        result.height = pair.second;
+      } else {
+        LOG(ERROR) << "Unsupported Size map key: " << pair.first;
+        react_native_assert(false);
+      }
+    }
+    return;
+  }
+
+  react_native_assert(value.hasType<std::vector<Float>>());
+  if (value.hasType<std::vector<Float>>()) {
+    auto array = (std::vector<Float>)value;
+    react_native_assert(array.size() == 2);
+    if (array.size() >= 2) {
+      result = {array.at(0), array.at(1)};
+    } else {
+      result = {0, 0};
+      LOG(ERROR) << "Unsupported Size vector size: " << array.size();
+    }
+  } else {
+    LOG(ERROR) << "Unsupported Size type";
+  }
+}
+
+inline void fromRawValue(const RawValue &value, EdgeInsets &result) {
+  if (value.hasType<Float>()) {
+    auto number = (Float)value;
+    result = {number, number, number, number};
+  }
+
+  if (value.hasType<better::map<std::string, Float>>()) {
+    auto map = (better::map<std::string, Float>)value;
+    for (const auto &pair : map) {
+      if (pair.first == "top") {
+        result.top = pair.second;
+      } else if (pair.first == "left") {
+        result.left = pair.second;
+      } else if (pair.first == "bottom") {
+        result.bottom = pair.second;
+      } else if (pair.first == "right") {
+        result.right = pair.second;
+      } else {
+        LOG(ERROR) << "Unsupported EdgeInsets map key: " << pair.first;
+        react_native_assert(false);
+      }
+    }
+    return;
+  }
+
+  react_native_assert(value.hasType<std::vector<Float>>());
+  if (value.hasType<std::vector<Float>>()) {
+    auto array = (std::vector<Float>)value;
+    react_native_assert(array.size() == 4);
+    if (array.size() >= 4) {
+      result = {array.at(0), array.at(1), array.at(2), array.at(3)};
+    } else {
+      result = {0, 0, 0, 0};
+      LOG(ERROR) << "Unsupported EdgeInsets vector size: " << array.size();
+    }
+  } else {
+    LOG(ERROR) << "Unsupported EdgeInsets type";
+  }
+}
+
+inline void fromRawValue(const RawValue &value, CornerInsets &result) {
+  if (value.hasType<Float>()) {
+    auto number = (Float)value;
+    result = {number, number, number, number};
+    return;
+  }
+
+  if (value.hasType<better::map<std::string, Float>>()) {
+    auto map = (better::map<std::string, Float>)value;
+    for (const auto &pair : map) {
+      if (pair.first == "topLeft") {
+        result.topLeft = pair.second;
+      } else if (pair.first == "topRight") {
+        result.topRight = pair.second;
+      } else if (pair.first == "bottomLeft") {
+        result.bottomLeft = pair.second;
+      } else if (pair.first == "bottomRight") {
+        result.bottomRight = pair.second;
+      } else {
+        LOG(ERROR) << "Unsupported CornerInsets map key: " << pair.first;
+        react_native_assert(false);
+      }
+    }
+    return;
+  }
+
+  react_native_assert(value.hasType<std::vector<Float>>());
+  if (value.hasType<std::vector<Float>>()) {
+    auto array = (std::vector<Float>)value;
+    react_native_assert(array.size() == 4);
+    if (array.size() >= 4) {
+      result = {array.at(0), array.at(1), array.at(2), array.at(3)};
+    } else {
+      LOG(ERROR) << "Unsupported CornerInsets vector size: " << array.size();
+    }
+  }
+
+  // Error case - we should only here if all other supported cases fail
+  // In dev we would crash on assert before this point
+  result = {0, 0, 0, 0};
+  LOG(ERROR) << "Unsupported CornerInsets type";
+}
+
+inline std::string toString(const Point &point) {
+  return "{" + folly::to<std::string>(point.x) + ", " +
+      folly::to<std::string>(point.y) + "}";
+}
+
+inline std::string toString(const Size &size) {
+  return "{" + folly::to<std::string>(size.width) + ", " +
+      folly::to<std::string>(size.height) + "}";
+}
+
+inline std::string toString(const Rect &rect) {
+  return "{" + toString(rect.origin) + ", " + toString(rect.size) + "}";
+}
+
+inline std::string toString(const EdgeInsets &edgeInsets) {
+  return "{" + folly::to<std::string>(edgeInsets.left) + ", " +
+      folly::to<std::string>(edgeInsets.top) + ", " +
+      folly::to<std::string>(edgeInsets.right) + ", " +
+      folly::to<std::string>(edgeInsets.bottom) + "}";
+}
+
+inline std::string toString(const CornerInsets &cornerInsets) {
+  return "{" + folly::to<std::string>(cornerInsets.topLeft) + ", " +
+      folly::to<std::string>(cornerInsets.topRight) + ", " +
+      folly::to<std::string>(cornerInsets.bottomLeft) + ", " +
+      folly::to<std::string>(cornerInsets.bottomRight) + "}";
+}
+
+} // namespace react
+} // namespace facebook

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cmath>
+#include <functional>
+#include <limits>
+
+#include <better/optional.h>
+#include <react/renderer/graphics/ColorComponents.h>
+#include <CppWinRTIncludes.h>
+
+namespace facebook
+{
+namespace react
+{
+
+struct Color {
+  bool operator==(const Color& otherColor) const {
+    return m_color == otherColor.m_color && m_platformColor == otherColor.m_platformColor;
+  }
+  bool operator!=(const Color& otherColor) const {
+    return m_color != otherColor.m_color || m_platformColor != otherColor.m_platformColor;
+  }
+
+  ui::Color m_color;
+  std::string m_platformColor;
+};
+
+/*
+ * On Android, a color can be represented as 32 bits integer, so there is no
+ * need to instantiate complex color objects and then pass them as shared
+ * pointers. Hense instead of using shared_ptr, we use a simple wrapper class
+ * which provides a pointer-like interface.
+ */
+class SharedColor {
+  friend std::hash<SharedColor>;
+
+public:
+  SharedColor() : m_color(nullptr) {}
+
+  SharedColor(const SharedColor& sharedColor) : m_color(sharedColor.m_color) {}
+
+  SharedColor(ui::Color color) {
+    m_color = std::make_shared<Color>();
+    m_color->m_color = color;
+  }
+
+  SharedColor(std::string&& windowsBrush) {
+    m_color = std::make_shared<Color>();
+    m_color->m_platformColor = std::move(windowsBrush);
+  }
+
+
+  SharedColor& operator=(const SharedColor& sharedColor) {
+    m_color = sharedColor.m_color;
+    return *this;
+  }
+
+  Color operator*() const {
+    return *m_color;
+  }
+
+  bool operator==(const SharedColor& otherColor) const {
+    if (!m_color && !otherColor.m_color)
+      return true;
+    if (!m_color || !otherColor.m_color)
+      return false;
+    return *m_color == *otherColor.m_color;
+  }
+
+  bool operator!=(const SharedColor& otherColor) const {
+    if (!m_color && !otherColor.m_color)
+      return false;
+    if (!m_color || !otherColor.m_color)
+      return true;
+    return *m_color != *otherColor.m_color;
+  }
+
+  operator bool() const {
+    return m_color != nullptr;
+  }
+
+  ui::Color AsWindowsColor() const {
+    return m_color->m_color;
+  }
+
+  xaml::Media::Brush AsWindowsBrush() const;
+
+private:
+  std::shared_ptr<Color> m_color;
+};
+
+SharedColor colorFromComponents(ColorComponents components);
+ColorComponents colorComponentsFromColor(SharedColor color);
+
+SharedColor clearColor();
+SharedColor blackColor();
+SharedColor whiteColor();
+
+} // namespace react
+} // namespace facebook
+
+namespace std
+{
+template <>
+struct hash<facebook::react::SharedColor> {
+  size_t operator()(const facebook::react::SharedColor& sharedColor) const {
+    size_t h = sharedColor.m_color->m_color.A + (sharedColor.m_color->m_color.B << 8) + (sharedColor.m_color->m_color.G << 16) + (sharedColor.m_color->m_color.R << 24);
+    return h ^ hash<decltype(sharedColor.m_color->m_platformColor)>{}(sharedColor.m_color->m_platformColor);
+  }
+};
+} // namespace std

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
@@ -26,7 +26,7 @@ struct Color {
     return m_color != otherColor.m_color || m_platformColor != otherColor.m_platformColor;
   }
 
-  ui::Color m_color;
+  winrt::Windows::UI::Color m_color;
   std::string m_platformColor;
 };
 
@@ -44,7 +44,7 @@ class SharedColor {
 
   SharedColor(const SharedColor &sharedColor) : m_color(sharedColor.m_color) {}
 
-  SharedColor(ui::Color color) {
+  SharedColor(winrt::Windows::UI::Color color) {
     m_color = std::make_shared<Color>();
     m_color->m_color = color;
   }
@@ -83,7 +83,7 @@ class SharedColor {
     return m_color != nullptr;
   }
 
-  ui::Color AsWindowsColor() const {
+  winrt::Windows::UI::Color AsWindowsColor() const {
     return m_color->m_color;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h
@@ -11,20 +11,18 @@
 #include <functional>
 #include <limits>
 
+#include <CppWinRTIncludes.h>
 #include <better/optional.h>
 #include <react/renderer/graphics/ColorComponents.h>
-#include <CppWinRTIncludes.h>
 
-namespace facebook
-{
-namespace react
-{
+namespace facebook {
+namespace react {
 
 struct Color {
-  bool operator==(const Color& otherColor) const {
+  bool operator==(const Color &otherColor) const {
     return m_color == otherColor.m_color && m_platformColor == otherColor.m_platformColor;
   }
-  bool operator!=(const Color& otherColor) const {
+  bool operator!=(const Color &otherColor) const {
     return m_color != otherColor.m_color || m_platformColor != otherColor.m_platformColor;
   }
 
@@ -41,23 +39,22 @@ struct Color {
 class SharedColor {
   friend std::hash<SharedColor>;
 
-public:
+ public:
   SharedColor() : m_color(nullptr) {}
 
-  SharedColor(const SharedColor& sharedColor) : m_color(sharedColor.m_color) {}
+  SharedColor(const SharedColor &sharedColor) : m_color(sharedColor.m_color) {}
 
   SharedColor(ui::Color color) {
     m_color = std::make_shared<Color>();
     m_color->m_color = color;
   }
 
-  SharedColor(std::string&& windowsBrush) {
+  SharedColor(std::string &&windowsBrush) {
     m_color = std::make_shared<Color>();
     m_color->m_platformColor = std::move(windowsBrush);
   }
 
-
-  SharedColor& operator=(const SharedColor& sharedColor) {
+  SharedColor &operator=(const SharedColor &sharedColor) {
     m_color = sharedColor.m_color;
     return *this;
   }
@@ -66,7 +63,7 @@ public:
     return *m_color;
   }
 
-  bool operator==(const SharedColor& otherColor) const {
+  bool operator==(const SharedColor &otherColor) const {
     if (!m_color && !otherColor.m_color)
       return true;
     if (!m_color || !otherColor.m_color)
@@ -74,7 +71,7 @@ public:
     return *m_color == *otherColor.m_color;
   }
 
-  bool operator!=(const SharedColor& otherColor) const {
+  bool operator!=(const SharedColor &otherColor) const {
     if (!m_color && !otherColor.m_color)
       return false;
     if (!m_color || !otherColor.m_color)
@@ -92,7 +89,7 @@ public:
 
   xaml::Media::Brush AsWindowsBrush() const;
 
-private:
+ private:
   std::shared_ptr<Color> m_color;
 };
 
@@ -106,12 +103,12 @@ SharedColor whiteColor();
 } // namespace react
 } // namespace facebook
 
-namespace std
-{
+namespace std {
 template <>
 struct hash<facebook::react::SharedColor> {
-  size_t operator()(const facebook::react::SharedColor& sharedColor) const {
-    size_t h = sharedColor.m_color->m_color.A + (sharedColor.m_color->m_color.B << 8) + (sharedColor.m_color->m_color.G << 16) + (sharedColor.m_color->m_color.R << 24);
+  size_t operator()(const facebook::react::SharedColor &sharedColor) const {
+    size_t h = sharedColor.m_color->m_color.A + (sharedColor.m_color->m_color.B << 8) +
+        (sharedColor.m_color->m_color.G << 16) + (sharedColor.m_color->m_color.R << 24);
     return h ^ hash<decltype(sharedColor.m_color->m_platformColor)>{}(sharedColor.m_color->m_platformColor);
   }
 };

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -110,7 +110,6 @@
         $(ReactNativeWindowsDir)Shared;
         $(ReactNativeWindowsDir)Shared\tracing;
         $(ReactNativeWindowsDir)include\Shared;
-        $(ReactNativeDir)\ReactCommon\react\renderer\graphics\platform\cxx;
         $(YogaDir);
         $(GeneratedFilesDir);
         %(AdditionalIncludeDirectories)
@@ -441,7 +440,6 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\core\UnbatchedEventQueue.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\debug\DebugStringConvertible.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\debug\DebugStringConvertibleItem.cpp" />
-    <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\graphics\platform\cxx\react\renderer\graphics\Color.cpp" DisableSpecificWarnings="4305;%(DisableSpecificWarnings)" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\graphics\Transform.cpp" DisableSpecificWarnings="4018;%(DisableSpecificWarnings)" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\leakchecker\LeakChecker.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\leakchecker\WeakFamilyRegistry.cpp" />
@@ -481,6 +479,7 @@
     <ClCompile Include="Fabric\ImageRequest.cpp" />
     <ClCompile Include="Fabric\ParagraphComponentView.cpp" />
     <ClCompile Include="Fabric\platform\react\renderer\textlayoutmanager\TextLayoutManager.cpp" />
+    <ClCompile Include="Fabric\platform\react\renderer\graphics\Color.cpp" />
     <ClCompile Include="Fabric\ReactNativeConfigProperties.cpp" />
     <ClCompile Include="Fabric\ScrollViewComponentView.cpp" />
     <ClCompile Include="Fabric\TextComponentView.cpp" />

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -197,15 +197,6 @@ SolidColorBrushFrom(const winrt::Microsoft::ReactNative::JSValue &v) {
   return SolidBrushFromColor(ColorFrom(v));
 }
 
-xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::Color argb) noexcept {
-  return SolidBrushFromColor(
-      winrt::ColorHelper::FromArgb(GetAFromArgb(argb), GetRFromArgb(argb), GetGFromArgb(argb), GetBFromArgb(argb)));
-}
-
-xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::SharedColor color) noexcept {
-  return SolidColorBrushFrom(*color);
-}
-
 REACTWINDOWS_API_(xaml::Media::SolidColorBrush)
 SolidColorBrushFrom(const folly::dynamic &d) {
   if (d.isObject()) {

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -20,6 +20,7 @@ struct JSValue;
 
 namespace Microsoft::ReactNative {
 
+xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName);
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v);
 xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);
@@ -59,6 +60,4 @@ TimeSpanFromMs(double ms);
 winrt::Uri UriTryCreate(winrt::param::hstring const &uri);
 
 winrt::Windows::UI::Color ColorFromNumber(DWORD argb) noexcept;
-xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::Color) noexcept;
-xaml::Media::SolidColorBrush SolidColorBrushFrom(facebook::react::SharedColor) noexcept;
 } // namespace Microsoft::ReactNative

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -16,6 +16,24 @@
     },
     {
       "type": "patch",
+      "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp",
+      "baseFile": "ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.cpp",
+      "baseHash": "72f43acae8d5d34ed0607636008ff2618b5c734f"
+    },
+    {
+      "type": "patch",
+      "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h",
+      "baseFile": "ReactCommon/react/renderer/graphics/conversions.h",
+      "baseHash": "a77dfb26acdaeaf0b7cd1df893843cd176364b17"
+    },
+    {
+      "type": "patch",
+      "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h",
+      "baseFile": "ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h",
+      "baseHash": "93c4d57329747bec83201898ba807d0a23700570"
+    },
+    {
+      "type": "patch",
       "file": "ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/leakchecker/LeakChecker.cpp",
       "baseFile": "ReactCommon/react/renderer/leakchecker/LeakChecker.cpp",
       "baseHash": "71e63e48a41f515954445737b6b09540b8416113",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -18,19 +18,22 @@
       "type": "patch",
       "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp",
       "baseFile": "ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.cpp",
-      "baseHash": "72f43acae8d5d34ed0607636008ff2618b5c734f"
+      "baseHash": "72f43acae8d5d34ed0607636008ff2618b5c734f",
+      "issue": 7821
     },
     {
       "type": "patch",
       "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/conversions.h",
       "baseFile": "ReactCommon/react/renderer/graphics/conversions.h",
-      "baseHash": "a77dfb26acdaeaf0b7cd1df893843cd176364b17"
+      "baseHash": "a77dfb26acdaeaf0b7cd1df893843cd176364b17",
+      "issue": 7821
     },
     {
       "type": "patch",
       "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h",
       "baseFile": "ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.h",
-      "baseHash": "93c4d57329747bec83201898ba807d0a23700570"
+      "baseHash": "93c4d57329747bec83201898ba807d0a23700570",
+      "issue": 7821
     },
     {
       "type": "patch",


### PR DESCRIPTION
This overrides the implementation of the native fabric Color object to add support for PlatformColor.

The Color object is already platform specific with a different implementation on ios than on android.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7801)