### PR TITLE
[0.64] Fix regression where E2ETest app no longer uploads tree dump outputs …

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -85,7 +85,7 @@ jobs:
       - task: CopyFiles@2
         displayName: Copy tree dump output files
         inputs:
-          sourceFolder: $(LocalAppData)\Packages\ReactUWPTestApp_cezq6h4ygq1hw\LocalState
+          sourceFolder: $(UserProfile)\Documents\ReactUWPTestApp_cezq6h4ygq1hw!App
           targetFolder: $(Build.StagingDirectory)/ReactUWPTestAppTreeDump
           contents: TreeDump\**
         condition: succeededOrFailed()

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -357,9 +357,9 @@ capabilities are the configuration which appium/WinAppDriver used to identify th
       maxInstances: 1,
       platformName: 'windows',
       'appium:deviceName': 'WindowsPC',
-      'appium:app': 'ReactUWPTestApp_kc2bncckyf4ap!App',
+      'appium:app': 'ReactUWPTestApp_cezq6h4ygq1hw!App',
       'deviceName': 'WindowsPC',
-      'app': 'ReactUWPTestApp_kc2bncckyf4ap!App',
+      'app': 'ReactUWPTestApp_cezq6h4ygq1hw!App',
       'winAppDriver:experimental-w3c': true,
   },
 
@@ -459,7 +459,7 @@ The best way to do this is by letting the CI run and fail, then downloading the 
 When an output doesn't match its master, a file with `.err` extension will be produced under the `TreeDump` folder in the `ReactUWPTestAppTreeDump` artifact. The content of the `.err` file will usually just say:
 
 ```txt
-Tree dump file does not match master at C:\Program Files\WindowsApps\ReactUWPTestApp_1.0.0.0_x64__kc2bncckyf4ap\Assets\TreeDump\masters\ControlStyleRoundBorder.json - See output at C:\Users\VssAdministrator\AppData\Local\Packages\ReactUWPTestApp_kc2bncckyf4ap\LocalState\TreeDump\ControlStyleRoundBorder.json
+Tree dump file does not match master at C:\Program Files\WindowsApps\ReactUWPTestApp_1.0.0.0_x64__cezq6h4ygq1hw\Assets\TreeDump\masters\ControlStyleRoundBorder.json - See output at C:\Users\VssAdministrator\Documents\ReactUWPTestApp_cezq6h4ygq1hw\LocalState\TreeDump\ControlStyleRoundBorder.json
 ```
 
 ![Errors](img/e2e-errors.png)

--- a/packages/E2ETest/windows/ReactUWPTestApp/Package.appxmanifest
+++ b/packages/E2ETest/windows/ReactUWPTestApp/Package.appxmanifest
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
@@ -40,10 +40,22 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.fileTypeAssociation">
+          <uap:FileTypeAssociation Name="e2etest">
+            <uap:Logo>images\icon.png</uap:Logo>
+            <uap:SupportedFileTypes>
+              <uap:FileType>.json</uap:FileType>
+              <uap:FileType>.err</uap:FileType>
+            </uap:SupportedFileTypes>
+          </uap:FileTypeAssociation>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
 
   <Capabilities>
     <Capability Name="internetClient" />
+    <uap:Capability Name="documentsLibrary"/>
   </Capabilities>
 </Package>

--- a/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/E2ETest/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -20,7 +20,6 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
-    <PackageCertificateThumbprint>8FA11EA9E8951B266F245AFE92B3060CECAF4503</PackageCertificateThumbprint>
     <PackageCertificateKeyFile>ReactUWPTestApp_TemporaryKey.pfx</PackageCertificateKeyFile>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>

--- a/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
+++ b/packages/E2ETest/windows/ReactUWPTestApp/TreeDumpControlViewManager.cs
@@ -30,8 +30,9 @@ namespace TreeDumpLibrary
             m_textBlock = new TextBlock();
             m_textBlock.TextWrapping = TextWrapping.Wrap;
             m_textBlock.IsTextSelectionEnabled = false;
-            m_textBlock.LayoutUpdated += (source, e) =>
+            m_textBlock.LayoutUpdated += async (source, e) =>
             {
+                await KnownFolders.DocumentsLibrary.CreateFolderAsync("TreeDump", CreationCollisionOption.OpenIfExists);
                 ApplicationView.GetForCurrentView().TryResizeView(new Size(800, 600));
                 var bounds = ApplicationView.GetForCurrentView().VisibleBounds;
                 if (bounds.Width != 800 || bounds.Height != 600)
@@ -160,7 +161,7 @@ namespace TreeDumpLibrary
         public static async Task<bool> MatchDump(string outputJson, string masterFileRelativePath, string outputFileRelativePath)
         {
             Debug.WriteLine($"master file = {Windows.ApplicationModel.Package.Current.InstalledLocation.Path}\\Assets\\{masterFileRelativePath}");
-            StorageFolder storageFolder = ApplicationData.Current.LocalFolder;
+            StorageFolder storageFolder = KnownFolders.DocumentsLibrary;
             Debug.WriteLine($"output file = {storageFolder.Path + "\\" + outputFileRelativePath}");
 
             StorageFile outFile = await storageFolder.CreateFileAsync(outputFileRelativePath, CreationCollisionOption.ReplaceExisting);
@@ -218,7 +219,7 @@ namespace TreeDumpLibrary
                 var matchSuccessful = await MatchTreeDumpFromLayoutUpdateAsync(m_dumpID, m_uiaID, m_textBlock, m_additionalProperties, DumpTreeMode.Json, m_dumpExpectedText);
                 if (!matchSuccessful)
                 {
-                    StorageFolder storageFolder = ApplicationData.Current.LocalFolder;
+                    StorageFolder storageFolder = KnownFolders.DocumentsLibrary;
                     StorageFile outFile = await storageFolder.GetFileAsync(GetOutputFile(m_dumpID));
                     StorageFile masterFile = await Windows.ApplicationModel.Package.Current.InstalledLocation.GetFileAsync($@"Assets\{GetMasterFile(m_dumpID)}");
 
@@ -310,7 +311,7 @@ namespace TreeDumpLibrary
 
         private async Task WriteErrorFile()
         {
-            StorageFolder storageFolder = ApplicationData.Current.LocalFolder;
+            StorageFolder storageFolder = KnownFolders.DocumentsLibrary;
             string fileNameError = "TreeDump\\" + m_dumpID + ".err";
             try
             {

--- a/packages/E2ETest/windows/ReactUWPTestApp/copyTreeDump.cmd
+++ b/packages/E2ETest/windows/ReactUWPTestApp/copyTreeDump.cmd
@@ -1,1 +1,0 @@
-@copy /d %LocalAppData%\Packages\ReactUWPTestApp_cezq6h4ygq1hw\LocalState\TreeDump\*.json %~dp0%\Assets\TreeDump\masters\*.json


### PR DESCRIPTION
Backport of #6686. This was already partly backported in https://github.com/microsoft/react-native-windows/pull/7399
Fix tree dump snapshots not getting uploaded as build artifacts.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7803)