### PR TITLE
[0.64] Autolinking doesn't add a project marked as a non-direct dependency

### DIFF
--- a/change/@react-native-windows-cli-e170057f-76da-4c14-a1d2-01671454ed72.json
+++ b/change/@react-native-windows-cli-e170057f-76da-4c14-a1d2-01671454ed72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Typo in Autolinking Source",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -267,7 +267,7 @@ async function updateAutoLink(
               dependencyIsValid = !!(
                 dependencyIsValid &&
                 item in project &&
-                project[item] != '' &&
+                project[item] !== '' &&
                 !project[item]!.toString().startsWith('Error: ')
               );
             });


### PR DESCRIPTION
Fixes #7793

Port #7437 to 0.64. Fixes typo from #7447.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7814)