### PR TITLE
Fixes bug in BatchingEventEmitter

### DIFF
--- a/change/react-native-windows-e5ae44de-62f6-4114-8c1d-028cf9ca9fd2.json
+++ b/change/react-native-windows-e5ae44de-62f6-4114-8c1d-028cf9ca9fd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes bug in BatchingEventEmitter",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -62,7 +62,7 @@ void BatchingEventEmitter::EmitCoalescingJSEvent(
     isFirstEventInBatch = m_eventQueue.size() == 0;
 
     auto endIter = std::remove_if(m_eventQueue.begin(), m_eventQueue.end(), [&](const auto &evt) noexcept {
-      return evt.eventName == eventName && evt.tag == tag;
+      return evt.eventName == newEvent.eventName && evt.tag == tag;
     });
 
     m_eventQueue.erase(endIter, m_eventQueue.end());


### PR DESCRIPTION
The `eventName` parameter is std::move'd into the BatchedEvent object that gets enqueued. As such, the event removal test `evt.eventName == eventName` was always false because `eventName` had been moved.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7820)