### PR TITLE
[DRAFT] Support specifying native module dispatcher

### DIFF
--- a/change/react-native-windows-73005277-12cc-4fd5-bdb6-09efd9f0d44b.json
+++ b/change/react-native-windows-73005277-12cc-4fd5-bdb6-09efd9f0d44b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add dispatcherName to REACT_MODULE attribute",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -47,10 +47,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="Shared">
-    <Import Project="..\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
-    <Import Project="..\Mso\Mso.vcxitems" Label="Shared" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -106,6 +102,10 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <ImportGroup Label="Shared">
+    <Import Project="..\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" Label="Shared" />
+    <Import Project="..\Mso\Mso.vcxitems" Label="Shared" />
+  </ImportGroup>
   <ItemGroup>
     <ClInclude Include="JsonJSValueReader.h" />
     <ClInclude Include="JsonReader.h" />

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NoAttributeNativeModuleTest.cpp
@@ -551,8 +551,14 @@ struct SimpleNativeModule2 {
 
 /*static*/ std::string SimpleNativeModule2::StaticMessage;
 
-void GetReactModuleInfo(SimpleNativeModule2 *, React::ReactModuleBuilder<SimpleNativeModule2> &moduleBuilder) noexcept {
-  moduleBuilder.RegisterModuleName(L"SimpleNativeModule2");
+React::ReactModuleInfo const &GetReactModuleInfo(SimpleNativeModule2 *) {
+  static React::ReactModuleInfo moduleInfo(L"SimpleNativeModule2");
+  return moduleInfo;
+}
+
+void VisitReactModuleMembers(
+    SimpleNativeModule2 *,
+    React::ReactModuleBuilder<SimpleNativeModule2> &moduleBuilder) noexcept {
   moduleBuilder.RegisterInitMethod(&SimpleNativeModule2::Initialize);
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::Add, L"Add");
   moduleBuilder.RegisterMethod(&SimpleNativeModule2::Negate, L"Negate");

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.cpp
@@ -178,4 +178,12 @@ Microsoft::ReactNative::IReactPropertyBag ReactPropertyBagHelper::CreateProperty
   VerifyElseCrashSz(false, "Not implemented");
 }
 
+IReactPropertyName ReactDispatcherHelper::UIDispatcherProperty() {
+  return nullptr;
+}
+
+IReactPropertyName ReactDispatcherHelper::JSDispatcherProperty() {
+  return nullptr;
+}
+
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -1237,16 +1237,16 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 };
 
 TEST_CLASS (TurboModuleTest) {
-  winrt::Microsoft::ReactNative::ReactModuleBuilderMock m_builderMock{};
-  winrt::Microsoft::ReactNative::IReactModuleBuilder m_moduleBuilder;
+  React::ReactModuleBuilderMock m_builderMock{};
+  React::IReactModuleBuilder m_moduleBuilder;
   Windows::Foundation::IInspectable m_moduleObject{nullptr};
   MyTurboModule *m_module;
 
   TurboModuleTest() {
-    m_moduleBuilder = winrt::make<winrt::Microsoft::ReactNative::ReactModuleBuilderImpl>(m_builderMock);
-    auto provider = winrt::Microsoft::ReactNative::MakeTurboModuleProvider<MyTurboModule, MyTurboModuleSpec>();
+    m_moduleBuilder = winrt::make<React::ReactModuleBuilderImpl>(m_builderMock);
+    auto provider = React::MakeTurboModuleProvider<MyTurboModule, MyTurboModuleSpec>();
     m_moduleObject = m_builderMock.CreateModule(provider, m_moduleBuilder);
-    m_module = winrt::Microsoft::ReactNative::ReactNonAbiValue<MyTurboModule>::GetPtrUnsafe(m_moduleObject);
+    m_module = React::ReactNonAbiValue<MyTurboModule>::GetPtrUnsafe(m_moduleObject);
   }
 
   TEST_METHOD(TestMethodCall_Add) {

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/pch.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/pch.h
@@ -10,13 +10,17 @@
 
 #undef GetCurrentTime
 
+#include <CppWinRTIncludes.h>
 #include <winrt/Microsoft.ReactNative.h>
-#include <winrt/Windows.Foundation.Collections.h>
-#include <winrt/Windows.Foundation.h>
 
-#include "gtest/gtest.h"
-#include "motifCpp/gTestAdapter.h"
-#include "motifCpp/testCheck.h"
+#include <future/future.h>
+#include <future/futureWait.h>
+#include <gtest/gtest.h>
+#include <motifCpp/gTestAdapter.h>
+#include <motifCpp/testCheck.h>
+
+#include <mutex>
+#include <stack>
 
 #ifndef CXXUNITTESTS
 #define CXXUNITTESTS

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -99,18 +99,10 @@
       This is because msbuild has to invoke different cl.exe invocations for each
       set of flags and msbuild inside a project is single threaded.
     -->
-    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\LongLivedObject.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModule.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
-    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModuleUtils.cpp">
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-    </ClCompile>
+    <ClCompile Include="$(JSI_SourcePath)\jsi\jsi.cpp" />
+    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\LongLivedObject.cpp" />
+    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModule.cpp" />
+    <ClCompile Include="$(TurboModule_SourcePath)\ReactCommon\TurboModuleUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" />

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
@@ -9,26 +9,36 @@
 
 namespace winrt::Microsoft::ReactNative {
 
-const ModuleRegistration *ModuleRegistration::s_head{nullptr};
+const ReactModuleRegistration *ReactModuleRegistration::s_head{nullptr};
 
-ModuleRegistration::ModuleRegistration(wchar_t const *moduleName) noexcept : m_moduleName{moduleName}, m_next{s_head} {
+ReactModuleRegistration::ReactModuleRegistration(ReactModuleInfo &&moduleInfo) noexcept
+    : m_moduleInfo{std::move(moduleInfo)}, m_next{s_head} {
   s_head = this;
 }
 
-void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept {
-  for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
-    packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
+void AddAttributedModules(ReactPackageBuilder const &packageBuilder) noexcept {
+  for (auto const *reg = ReactModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
+    packageBuilder.AddDispatchedModule(
+        reg->ModuleInfo().ModuleName, reg->MakeModuleProvider(), reg->ModuleInfo().DispatcherName);
   }
 }
 
-bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept {
-  for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
-    if (moduleName == reg->ModuleName()) {
-      packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());
+bool TryAddAttributedModule(ReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept {
+  for (auto const *reg = ReactModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
+    if (moduleName == reg->ModuleInfo().ModuleName) {
+      packageBuilder.AddDispatchedModule(moduleName, reg->MakeModuleProvider(), reg->ModuleInfo().DispatcherName);
       return true;
     }
   }
   return false;
+}
+
+void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept {
+  AddAttributedModules(packageBuilder.as<ReactPackageBuilder>());
+}
+
+bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept {
+  return TryAddAttributedModule(packageBuilder.as<ReactPackageBuilder>(), moduleName);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -3,17 +3,20 @@
 
 #pragma once
 #include "ReactDispatcherHelper.g.h"
+#include <Threading/MessageDispatchQueue.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Microsoft.ReactNative.h>
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IReactDispatcher>> {
+struct ReactDispatcher : implements<ReactDispatcher, default_interface<IReactDispatcher>> {
   ReactDispatcher() = default;
   ReactDispatcher(Mso::DispatchQueue &&queue) noexcept;
 
   bool HasThreadAccess() noexcept;
   void Post(ReactDispatcherCallback const &callback) noexcept;
+
+  std::shared_ptr<facebook::react::MessageQueueThread> GetMessageQueueThread() const noexcept;
 
   static IReactDispatcher CreateSerialDispatcher() noexcept;
 
@@ -28,6 +31,7 @@ struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IR
 
  private:
   Mso::DispatchQueue m_queue;
+  std::shared_ptr<Mso::React::MessageDispatchQueue> m_messageQueue;
 };
 
 struct ReactDispatcherHelper {

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -40,4 +40,24 @@ namespace Microsoft.ReactNative
     DOC_STRING("Adds a custom TurboModule that directly uses the JS Engine API (JSI).")
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
   }
+
+  [webhosthidden]
+  DOC_STRING("Extends the @IReactPackageBuilder interface with the new @.AddDispatchedModule method.")
+  interface IReactPackageBuilder2 requires IReactPackageBuilder
+  {
+    DOC_STRING(
+      "Adds a custom native module with a dispatcher name where to run the module methods. "
+      "The dispatcher name is used to retrieve the @IReactDispatcher from the @IReactContext.Properties. "
+      "See @ReactModuleProvider, @IReactPropertyName.")
+    void AddDispatchedModule(String moduleName, ReactModuleProvider moduleProvider, IReactPropertyName dispatcherName);
+  }
+
+  [webhosthidden]
+  DOC_STRING("Builds ReactNative package with the set of native modules and view managers.")
+  runtimeclass ReactPackageBuilder :
+      [default]IReactPackageBuilder,
+      IReactPackageBuilderExperimental,
+      IReactPackageBuilder2
+  {
+  }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/NativeModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/NativeModulesProvider.h
@@ -15,10 +15,13 @@ class NativeModulesProvider final : public Mso::React::NativeModuleProvider2 {
       std::shared_ptr<facebook::react::MessageQueueThread> const &defaultQueueThread) override;
 
  public:
-  void AddModuleProvider(winrt::hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+  void AddModuleProvider(
+      winrt::hstring const &moduleName,
+      ReactModuleProvider const &moduleProvider,
+      IReactPropertyName const &dispatcherName) noexcept;
 
  private:
-  std::map<std::string, ReactModuleProvider> m_moduleProviders;
+  std::map<std::string, std::pair<ReactModuleProvider, IReactPropertyName>> m_moduleProviders;
   IReactPackageBuilder m_packageBuilder;
 };
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -239,13 +239,13 @@ void ReactInstanceWin::LoadModules(
     const std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> &turboModulesProvider) noexcept {
   auto registerNativeModule = [&nativeModulesProvider](
                                   const wchar_t *name, const ReactModuleProvider &provider) noexcept {
-    nativeModulesProvider->AddModuleProvider(name, provider);
+    nativeModulesProvider->AddModuleProvider(name, provider, nullptr);
   };
 
   auto registerTurboModule = [this, &nativeModulesProvider, &turboModulesProvider](
                                  const wchar_t *name, const ReactModuleProvider &provider) noexcept {
     if (m_options.UseWebDebugger()) {
-      nativeModulesProvider->AddModuleProvider(name, provider);
+      nativeModulesProvider->AddModuleProvider(name, provider, nullptr);
     } else {
       turboModulesProvider->AddModuleProvider(name, provider);
     }
@@ -261,7 +261,7 @@ void ReactInstanceWin::LoadModules(
 
   registerTurboModule(
       L"UIManager",
-      // Spec incorrectly reports commandID as a number, but its actually a number | string.. so dont use the spec for
+      // Spec incorrectly reports commandID as a number, but its actually a number | string. So don't use the spec for
       // now
       // winrt::Microsoft::ReactNative::MakeTurboModuleProvider < ::Microsoft::ReactNative::UIManager,
       //::Microsoft::ReactNativeSpecs::UIManagerSpec>());

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -4,7 +4,7 @@
 #include "pch.h"
 #include "ReactPackageBuilder.h"
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
 //===========================================================================
 // ReactPackageBuilder implementation
@@ -24,7 +24,7 @@ ReactPackageBuilder::ReactPackageBuilder(
 }
 
 void ReactPackageBuilder::AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept {
-  m_modulesProvider->AddModuleProvider(moduleName, moduleProvider);
+  m_modulesProvider->AddModuleProvider(moduleName, moduleProvider, nullptr);
 }
 
 #ifndef CORE_ABI
@@ -41,4 +41,11 @@ void ReactPackageBuilder::AddTurboModule(
   m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider);
 }
 
-} // namespace winrt::Microsoft::ReactNative
+void ReactPackageBuilder::AddDispatchedModule(
+    hstring const &moduleName,
+    ReactModuleProvider const &moduleProvider,
+    IReactPropertyName const &dispatcherName) noexcept {
+  m_modulesProvider->AddModuleProvider(moduleName, moduleProvider, dispatcherName);
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -7,12 +7,11 @@
 #ifndef CORE_ABI
 #include "ViewManagersProvider.h"
 #endif
-#include "winrt/Microsoft.ReactNative.h"
+#include "ReactPackageBuilder.g.h"
 
-namespace winrt::Microsoft::ReactNative {
+namespace winrt::Microsoft::ReactNative::implementation {
 
-struct ReactPackageBuilder
-    : winrt::implements<ReactPackageBuilder, IReactPackageBuilder, IReactPackageBuilderExperimental> {
+struct ReactPackageBuilder : ReactPackageBuilderT<ReactPackageBuilder> {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
 #ifndef CORE_ABI
@@ -20,12 +19,16 @@ struct ReactPackageBuilder
 #endif
       std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept;
 
- public: // IReactPackageBuilder
+ public: // ReactPackageBuilder runtime class API
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 #ifndef CORE_ABI
   void AddViewManager(hstring const &viewManagerName, ReactViewManagerProvider const &viewManagerProvider) noexcept;
 #endif
   void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+  void AddDispatchedModule(
+      hstring const &moduleName,
+      ReactModuleProvider const &moduleProvider,
+      IReactPropertyName const &dispatcherName) noexcept;
 
  private:
   std::shared_ptr<NativeModulesProvider> m_modulesProvider;
@@ -35,4 +38,4 @@ struct ReactPackageBuilder
   std::shared_ptr<TurboModulesProvider> m_turboModulesProvider;
 };
 
-} // namespace winrt::Microsoft::ReactNative
+} // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
This is an initial preview of the change - the goal is to get a general feedback about the approach first.

This PR adds a capability to associate a `IReactDispatcher` with a native module.
When a module is registered, we do not have all dispatchers created yet.
Thus, instead of providing a dispatcher, we provide the `dispatcherName` that then can be used to retrieve the dispatcher from the `ReactContext.Properties`. For example, to associate the UI dispatcher with a module we can write:

```C++
REACT_MODULE(MyModule, dispatcherName = UIDispatcher)
struct MyModule { ... };
```

The dispatcherName has type `winrt::Microsoft::ReactNative::IReactPropertyName` and can be created using `ReactPropertyBagHelper` ABI class or `ReactPropertyBag` wrapper class.

There are two new important features in the `REACT_MODULE` attribute-macro above:
- Its optional arguments can be assigned out-of-order using the named argument syntax. Without it we would have to write: `REACT_MODULE(MyModule, L"MyModule", L"RCTDeviceEventEmitter", UIDispatcher)`. The other named arguments are `moduleName` and `eventEmiterName`.
- Predefined property name aliases `UIDispatcher` and `JSDispatcher` for the well-known dispatchers.

The ABI API is changed to support the new feature:
- Added new interface `ReactPackageBuilder2` with `AddDispatchedModule` method.
- Added new `ReactPackageBuilder` runtime class to support future expansions of the package builder API.

In `Microsoft.ReactNative` to support the native module dispatcher we have added `MessageQueueThread` field inside of the `ReactDispatcher` implementation which is used for the native module registration.

Pending tasks before the PR is ready:
- Add an integration test
- Add support for C# code
- Write docs