### PR TITLE
[0.65] Run Release Promotion Script in 0.65-stable

### DIFF
--- a/change/@office-iss-react-native-win32-580b9157-2960-4c9a-8262-c736d97b7398.json
+++ b/change/@office-iss-react-native-win32-580b9157-2960-4c9a-8262-c736d97b7398.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-2794c12d-1601-47c4-8cec-f458c9aea5b1.json
+++ b/change/@react-native-windows-cli-2794c12d-1601-47c4-8cec-f458c9aea5b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-3f464a40-4fb0-4529-b579-fe0bf7b57cb7.json
+++ b/change/@react-native-windows-codegen-3f464a40-4fb0-4529-b579-fe0bf7b57cb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@react-native-windows/codegen",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-5a66dece-a8ba-4b63-ae8d-c6525888a3a6.json
+++ b/change/@react-native-windows-find-repo-root-5a66dece-a8ba-4b63-ae8d-c6525888a3a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-4af1debf-92b4-4aad-ae47-6c157394f129.json
+++ b/change/@react-native-windows-package-utils-4af1debf-92b4-4aad-ae47-6c157394f129.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-c22a929e-5477-4d8a-b184-c1b2b360cb35.json
+++ b/change/@react-native-windows-telemetry-c22a929e-5477-4d8a-b184-c1b2b360cb35.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-6f55cdcf-4397-4ea6-a3a1-d166456710ea.json
+++ b/change/react-native-windows-6f55cdcf-4397-4ea6-a3a1-d166456710ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Promote 0.65 to preview",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "lage build -- --color",
     "lint": "lage lint --verbose -- --color",
     "lint:fix": "lage lint:fix -- --color",
-    "change": "beachball change",
+    "change": "beachball change --branch 0.65-stable",
     "clean": "lage clean -- --color",
     "doc": "doxysaurus --config vnext/doxysaurus.json",
     "format": "format-files -i -style=file -assume-filename=../.clang-format",

--- a/packages/@office-iss/react-native-win32-tester/package.json
+++ b/packages/@office-iss/react-native-win32-tester/package.json
@@ -14,11 +14,11 @@
     "@react-native/tester": "0.0.1"
   },
   "peerDependencies": {
-    "@office-iss/react-native-win32": "^0.0.0-canary.91",
+    "@office-iss/react-native-win32": "0.65.0-preview.0",
     "react-native": "0.0.0-7e05480cc"
   },
   "devDependencies": {
-    "@office-iss/react-native-win32": "^0.0.0-canary.91",
+    "@office-iss/react-native-win32": "0.65.0-preview.0",
     "@rnw-scripts/eslint-config": "1.1.6",
     "@rnw-scripts/ts-config": "1.1.0",
     "@types/node": "^14.14.22",

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-iss/react-native-win32",
-  "version": "0.0.0-canary.91",
+  "version": "0.65.0-preview.0",
   "description": "Implementation of react native on top of Office's Win32 platform.",
   "license": "MIT",
   "main": "./index.win32.js",
@@ -76,7 +76,7 @@
     "react-native": "0.0.0-7e05480cc"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/cli",
-  "version": "0.0.0-canary.71",
+  "version": "0.65.0-preview.0",
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "repository": {
@@ -17,8 +17,8 @@
     "watch": "rnw-scripts watch"
   },
   "dependencies": {
-    "@react-native-windows/package-utils": "^0.0.0-canary.17",
-    "@react-native-windows/telemetry": "^0.0.0-canary.18",
+    "@react-native-windows/package-utils": "0.65.0-preview.0",
+    "@react-native-windows/telemetry": "0.65.0-preview.0",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",
@@ -65,7 +65,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/codegen",
-  "version": "0.0.0-canary.6",
+  "version": "0.65.0-preview.0",
   "description": "Generators for react-native-codegen targeting react-native-windows",
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-windows",
@@ -43,7 +43,7 @@
     "typescript": "^3.8.3"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/find-repo-root",
-  "version": "0.0.0-canary.20",
+  "version": "0.65.0-preview.0",
   "license": "MIT",
   "scripts": {
     "build": "rnw-scripts build",
@@ -25,7 +25,7 @@
     "typescript": "^3.8.3"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/package-utils",
-  "version": "0.0.0-canary.17",
+  "version": "0.65.0-preview.0",
   "license": "MIT",
   "scripts": {
     "build": "rnw-scripts build",
@@ -11,7 +11,7 @@
   },
   "main": "lib-commonjs/packageUtils.js",
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.0-canary.20",
+    "@react-native-windows/find-repo-root": "0.65.0-preview.0",
     "get-monorepo-packages": "^1.2.0",
     "lodash": "^4.17.15"
   },
@@ -27,7 +27,7 @@
     "typescript": "^3.8.3"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/telemetry",
-  "version": "0.0.0-canary.18",
+  "version": "0.65.0-preview.0",
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "typings": "lib-commonjs/index.d.ts",
@@ -39,7 +39,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "^0.0.0-canary.316"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.1.6",
@@ -25,7 +25,7 @@
     "just-scripts": "^1.3.3",
     "react-native": "0.0.0-7e05480cc",
     "react-native-platform-override": "^1.4.14",
-    "react-native-windows": "^0.0.0-canary.316",
+    "react-native-windows": "0.65.0-preview.0",
     "typescript": "^3.8.3"
   }
 }

--- a/packages/@rnw-bots/coordinator/package.json
+++ b/packages/@rnw-bots/coordinator/package.json
@@ -25,5 +25,6 @@
     "just-scripts": "^1.3.3",
     "prettier": "1.19.1",
     "typescript": "^3.8.3"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/babel-node-config/package.json
+++ b/packages/@rnw-scripts/babel-node-config/package.json
@@ -15,5 +15,6 @@
     "@babel/core": "^7.8.0",
     "@babel/preset-env": "^7.8.0",
     "@babel/preset-typescript": "^7.8.0"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.5.3",
-    "@react-native-windows/find-repo-root": "^0.0.0-canary.20",
+    "@react-native-windows/find-repo-root": "0.65.0-preview.0",
     "chalk": "^4.1.0",
     "glob": "^7.1.6",
     "lodash": "^4.17.15",
@@ -41,5 +41,6 @@
   "files": [
     "bin.js",
     "lib-commonjs"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/doxysaurus/package.json
+++ b/packages/@rnw-scripts/doxysaurus/package.json
@@ -46,5 +46,6 @@
     "bin.js",
     "lib-commonjs",
     "templates"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/eslint-config/package.json
+++ b/packages/@rnw-scripts/eslint-config/package.json
@@ -12,5 +12,6 @@
   },
   "peerDependencies": {
     "eslint": ">=6.7.0"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -31,5 +31,6 @@
   "files": [
     "bin.js",
     "lib-commonjs"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -14,8 +14,8 @@
     "integrate-rn": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.0-canary.20",
-    "@react-native-windows/package-utils": "^0.0.0-canary.17",
+    "@react-native-windows/find-repo-root": "0.65.0-preview.0",
+    "@react-native-windows/package-utils": "0.65.0-preview.0",
     "async": "^3.2.0",
     "lodash": "^4.17.15",
     "ora": "^3.4.0",
@@ -49,5 +49,6 @@
   "files": [
     "bin.js",
     "lib-commonjs"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/jest-debug-config/package.json
+++ b/packages/@rnw-scripts/jest-debug-config/package.json
@@ -18,5 +18,6 @@
   "peerDependencies": {
     "babel-jest": "^26.3.0",
     "jest": "^26.4.0"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/jest-e2e-config/package.json
+++ b/packages/@rnw-scripts/jest-e2e-config/package.json
@@ -18,5 +18,6 @@
   "peerDependencies": {
     "babel-jest": "^26.3.0",
     "jest": "^26.4.0"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/jest-unittest-config/package.json
+++ b/packages/@rnw-scripts/jest-unittest-config/package.json
@@ -18,5 +18,6 @@
   "peerDependencies": {
     "babel-jest": "^26.3.0",
     "jest": "^26.4.0"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/just-task/package.json
+++ b/packages/@rnw-scripts/just-task/package.json
@@ -15,5 +15,6 @@
   },
   "peerDependencies": {
     "just-scripts": "^1.3.3"
-  }
+  },
+  "private": true
 }

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -13,8 +13,8 @@
     "promote-release": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.0-canary.20",
-    "@react-native-windows/package-utils": "^0.0.0-canary.17",
+    "@react-native-windows/find-repo-root": "0.65.0-preview.0",
+    "@react-native-windows/package-utils": "0.65.0-preview.0",
     "chalk": "^4.1.0",
     "simple-git": "^1.131.0",
     "source-map-support": "^0.5.19",
@@ -35,5 +35,6 @@
   "files": [
     "bin.js",
     "lib-commonjs"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -36,5 +36,6 @@
   "files": [
     "bin.js",
     "lib-commonjs"
-  ]
+  ],
+  "private": true
 }

--- a/packages/@rnw-scripts/ts-config/package.json
+++ b/packages/@rnw-scripts/ts-config/package.json
@@ -2,5 +2,6 @@
   "name": "@rnw-scripts/ts-config",
   "version": "1.1.0",
   "license": "MIT",
-  "main": "tsconfig.json"
+  "main": "tsconfig.json",
+  "private": true
 }

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -15,7 +15,7 @@
     "node-rnw-rpc": "^1.0.7-0",
     "react": "17.0.2",
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "^0.0.0-canary.316"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -14,7 +14,7 @@
     "node-rnw-rpc": "^1.0.7-0",
     "react": "17.0.2",
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "^0.0.0-canary.316"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/jest-environment-winappdriver/package.json
+++ b/packages/jest-environment-winappdriver/package.json
@@ -5,7 +5,7 @@
   "main": "lib-commonjs/WinAppDriverEnvironment.js",
   "repository": "https://github.com/microsoft/react-native-windows",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/node-rnw-rpc/package.json
+++ b/packages/node-rnw-rpc/package.json
@@ -15,7 +15,7 @@
     "jsonrpc-lite": "^2.2.0"
   },
   "peerDependencies": {
-    "react-native-windows": ">=0.0.0-canary.316 <0.0.0"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.1.6",
@@ -28,11 +28,12 @@
     "prettier": "1.19.1",
     "react": "17.0.2",
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "^0.0.0-canary.316",
+    "react-native-windows": "0.65.0-preview.0",
     "typescript": "^3.8.3"
   },
   "files": [
     "lib-commonjs",
     "windows"
-  ]
+  ],
+  "private": true
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -13,7 +13,7 @@
     "@react-native-windows/tester": "0.0.1",
     "react": "17.0.2",
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "0.0.0-canary.316"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -22,7 +22,7 @@
     "react-native-platform-override": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/package-utils": "^0.0.0-canary.17",
+    "@react-native-windows/package-utils": "0.65.0-preview.0",
     "async": "^3.2.0",
     "chalk": "^4.1.0",
     "fp-ts": "^2.5.0",
@@ -43,7 +43,7 @@
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-typescript": "^7.8.3",
-    "@react-native-windows/package-utils": "0.0.0-canary.17",
+    "@react-native-windows/package-utils": "0.65.0-preview.0",
     "@rnw-scripts/eslint-config": "1.1.6",
     "@rnw-scripts/jest-unittest-config": "1.2.1",
     "@rnw-scripts/just-task": "2.1.1",
@@ -78,5 +78,6 @@
     "lib-commonjs",
     "!lib-commonjs/e2etest/**",
     "!lib-commonjs/test/**"
-  ]
+  ],
+  "private": true
 }

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/microsoft/react-native-windows",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",
@@ -18,7 +18,7 @@
     "react-native-windows-init": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/telemetry": "^0.0.0-canary.18",
+    "@react-native-windows/telemetry": "0.65.0-preview.0",
     "chalk": "^4.1.0",
     "find-up": "^4.1.0",
     "mustache": "^4.0.1",
@@ -30,7 +30,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@react-native-windows/cli": "0.0.0-canary.71",
+    "@react-native-windows/cli": "0.65.0-preview.0",
     "@rnw-scripts/eslint-config": "1.1.6",
     "@rnw-scripts/jest-unittest-config": "1.2.1",
     "@rnw-scripts/just-task": "2.1.1",

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "react": "17.0.2",
     "react-native": "0.0.0-7e05480cc",
-    "react-native-windows": "0.0.0-canary.316"
+    "react-native-windows": "0.65.0-preview.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
     "@babel/runtime": "^7.8.4",
-    "@react-native-windows/codegen": "0.0.0-canary.6",
+    "@react-native-windows/codegen": "0.65.0-preview.0",
     "@rnw-scripts/eslint-config": "1.1.6",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.0.0-canary.316",
+  "version": "0.65.0-preview.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "@react-native-community/cli": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-android": "^5.0.1-alpha.0",
     "@react-native-community/cli-platform-ios": "^5.0.1-alpha.0",
-    "@react-native-windows/cli": "0.0.0-canary.71",
+    "@react-native-windows/cli": "0.65.0-preview.0",
     "@react-native/assets": "1.0.0",
     "@react-native/normalize-color": "1.0.0",
     "@react-native/polyfills": "1.0.0",
@@ -55,7 +55,7 @@
     "ws": "^6.1.4"
   },
   "devDependencies": {
-    "@react-native-windows/codegen": "0.0.0-canary.6",
+    "@react-native-windows/codegen": "0.65.0-preview.0",
     "@rnw-scripts/eslint-config": "1.1.6",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
@@ -78,7 +78,7 @@
     "react-native": "0.0.0-7e05480cc"
   },
   "beachball": {
-    "defaultNpmTag": "canary",
+    "defaultNpmTag": "preview",
     "gitTags": true,
     "disallowedChangeTypes": [
       "major",


### PR DESCRIPTION
This does not yet integrate a new version of RN or change peerDependency from a nightly build version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7824)