### PR TITLE
Adds event coalescing to TouchEventHandler

### DIFF
--- a/change/react-native-windows-7120ebe6-957e-4ec9-84db-a461cf12802b.json
+++ b/change/react-native-windows-7120ebe6-957e-4ec9-84db-a461cf12802b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds event coalescing to TouchEventHandler",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native/tester/js/examples/PanResponder/PanResponderExample.js
+++ b/packages/@react-native/tester/js/examples/PanResponder/PanResponderExample.js
@@ -112,13 +112,9 @@ class PanResponderExample extends React.Component<Props, State> {
               styles.circle,
               // $FlowFixMe[incompatible-type]
               {
-                transform: [
-                  {
-                    translateX: this.state.left,
-                    translateY: this.state.top,
-                    backgroundColor: this.state.pressed ? 'blue' : 'green',
-                  },
-                ],
+                translateX: this.state.left,
+                translateY: this.state.top,
+                backgroundColor: this.state.pressed ? 'blue' : 'green',
               },
             ]}
             {...this._panResponder.panHandlers}

--- a/packages/@react-native/tester/js/examples/PanResponder/PanResponderExample.js
+++ b/packages/@react-native/tester/js/examples/PanResponder/PanResponderExample.js
@@ -112,9 +112,13 @@ class PanResponderExample extends React.Component<Props, State> {
               styles.circle,
               // $FlowFixMe[incompatible-type]
               {
-                translateX: this.state.left,
-                translateY: this.state.top,
-                backgroundColor: this.state.pressed ? 'blue' : 'green',
+                transform: [
+                  {
+                    translateX: this.state.left,
+                    translateY: this.state.top,
+                    backgroundColor: this.state.pressed ? 'blue' : 'green',
+                  },
+                ],
               },
             ]}
             {...this._panResponder.panHandlers}

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -17,9 +17,7 @@ void BatchingEventEmitter::EmitJSEvent(JSValueArgWriter &&paramsWriter) noexcept
   return EmitJSEvent(L"receiveEvent", std::move(paramsWriter));
 }
 
-void BatchingEventEmitter::EmitJSEvent(
-    winrt::hstring &&emitterMethod,
-    JSValueArgWriter &&paramsWriter) noexcept {
+void BatchingEventEmitter::EmitJSEvent(winrt::hstring &&emitterMethod, JSValueArgWriter &&paramsWriter) noexcept {
   VerifyElseCrash(m_uiDispatcher.HasThreadAccess());
 
   implementation::BatchedEvent newEvent{std::move(emitterMethod), L"", std::move(paramsWriter)};
@@ -106,7 +104,7 @@ void BatchingEventEmitter::OnFrameJS() noexcept {
   while (!currentBatch.empty()) {
     auto &evt = currentBatch.front();
     m_context->CallJSFunction(
-            "RCTEventEmitter", winrt::to_string(evt.emitterMethod), DynamicWriter::ToDynamic(evt.paramsWriter));
+        "RCTEventEmitter", winrt::to_string(evt.emitterMethod), DynamicWriter::ToDynamic(evt.paramsWriter));
     currentBatch.pop_front();
   }
 }

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -20,7 +20,7 @@ void BatchingEventEmitter::DispatchEvent(
   return EmitJSEvent(
       L"RCTEventEmitter",
       L"receiveEvent",
-      [tag, eventName = std::move(eventName), &eventDataWriter](const IJSValueWriter &paramsWriter) {
+      [tag, eventName = std::move(eventName), eventDataWriter](const IJSValueWriter &paramsWriter) mutable {
         paramsWriter.WriteArrayBegin();
         WriteValue(paramsWriter, tag);
         WriteValue(paramsWriter, std::move(eventName));
@@ -49,7 +49,7 @@ void BatchingEventEmitter::EmitJSEvent(
   if (isFirstEventInBatch) {
     RegisterFrameCallback();
   }
-} // namespace winrt::Microsoft::ReactNative
+}
 
 void BatchingEventEmitter::DispatchCoalescingEvent(
     int64_t tag,

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -31,9 +31,7 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
 
   //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default.
   void EmitJSEvent(JSValueArgWriter &&paramsWriter) noexcept;
-  void EmitJSEvent(
-      winrt::hstring &&emitterMethod,
-      JSValueArgWriter &&paramsWriter) noexcept;
+  void EmitJSEvent(winrt::hstring &&emitterMethod, JSValueArgWriter &&paramsWriter) noexcept;
 
   //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default. Existing events in the batch
   //! with the same name and tag will be removed.

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -13,9 +13,9 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 struct BatchedEvent {
-  std::string eventEmitterName;
-  std::string emitterMethod;
-  std::string eventName;
+  winrt::hstring eventEmitterName;
+  winrt::hstring emitterMethod;
+  winrt::hstring eventName;
   int64_t coalescingKey;
   folly::dynamic params;
 };
@@ -32,20 +32,22 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
   BatchingEventEmitter(Mso::CntPtr<const Mso::React::IReactContext> &&context) noexcept;
 
   //! Dispatches an event from a view manager.
-  void DispatchEvent(int64_t tag, const std::string &eventName, folly::dynamic &&eventData) noexcept;
+  void DispatchEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventData) noexcept;
   //! Queues an event to be fired.
-  void
-  EmitJSEvent(const std::string &eventEmitterName, const std::string &emitterMethod, folly::dynamic &&params) noexcept;
+  void EmitJSEvent(
+      winrt::hstring &&eventEmitterName,
+      winrt::hstring &&emitterMethod,
+      const JSValueArgWriter &params) noexcept;
 
   //! Dispatches an event from a view manager. Existing events in the batch with the same name and tag will be removed.
-  void DispatchCoalescingEvent(int64_t tag, const std::string &eventName, folly::dynamic &&eventData) noexcept;
+  void DispatchCoalescingEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventData) noexcept;
   //! Queues an event to be fired. Existing events in the batch with the same name and tag will be removed.
   void EmitCoalescingJSEvent(
-      const std::string &eventEmitterName,
-      const std::string &emitterMethod,
-      const std::string &eventName,
+      winrt::hstring &&eventEmitterName,
+      winrt::hstring &&emitterMethod,
+      winrt::hstring &&eventName,
       int64_t coalescingKey,
-      folly::dynamic &&params) noexcept;
+      const JSValueArgWriter &params) noexcept;
 
  private:
   void RegisterFrameCallback() noexcept;

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -14,9 +14,8 @@
 namespace winrt::Microsoft::ReactNative::implementation {
 struct BatchedEvent {
   winrt::hstring emitterMethod;
-  int64_t tag{};
-  winrt::hstring eventName;
-  JSValue eventObject;
+  winrt::hstring coalescingKey;
+  JSValueArgWriter paramsWriter;
 };
 } // namespace winrt::Microsoft::ReactNative::implementation
 
@@ -31,18 +30,18 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
   BatchingEventEmitter(Mso::CntPtr<const Mso::React::IReactContext> &&context) noexcept;
 
   //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default.
-  void EmitJSEvent(int64_t tag, winrt::hstring &&eventName, JSValue &&eventObject) noexcept;
-  void
-  EmitJSEvent(winrt::hstring &&emitterMethod, int64_t tag, winrt::hstring &&eventName, JSValue &&eventObject) noexcept;
+  void EmitJSEvent(JSValueArgWriter &&paramsWriter) noexcept;
+  void EmitJSEvent(
+      winrt::hstring &&emitterMethod,
+      JSValueArgWriter &&paramsWriter) noexcept;
 
   //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default. Existing events in the batch
   //! with the same name and tag will be removed.
-  void EmitCoalescingJSEvent(int64_t tag, winrt::hstring &&eventName, JSValue &&eventObject) noexcept;
+  void EmitCoalescingJSEvent(winrt::hstring &&coalescingKey, JSValueArgWriter &&paramsWriter) noexcept;
   void EmitCoalescingJSEvent(
       winrt::hstring &&emitterMethod,
-      int64_t tag,
-      winrt::hstring &&eventName,
-      JSValue &&eventObject) noexcept;
+      winrt::hstring &&coalescingKey,
+      JSValueArgWriter &&paramsWriter) noexcept;
 
  private:
   void RegisterFrameCallback() noexcept;

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -13,9 +13,11 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 struct BatchedEvent {
-  winrt::hstring emitterMethod;
-  winrt::hstring coalescingKey;
-  JSValueArgWriter paramsWriter;
+  std::string eventEmitterName;
+  std::string emitterMethod;
+  std::string eventName;
+  int64_t coalescingKey;
+  folly::dynamic params;
 };
 } // namespace winrt::Microsoft::ReactNative::implementation
 
@@ -29,17 +31,21 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
  public:
   BatchingEventEmitter(Mso::CntPtr<const Mso::React::IReactContext> &&context) noexcept;
 
-  //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default.
-  void EmitJSEvent(JSValueArgWriter &&paramsWriter) noexcept;
-  void EmitJSEvent(winrt::hstring &&emitterMethod, JSValueArgWriter &&paramsWriter) noexcept;
+  //! Dispatches an event from a view manager.
+  void DispatchEvent(int64_t tag, const std::string &eventName, folly::dynamic &&eventData) noexcept;
+  //! Queues an event to be fired.
+  void
+  EmitJSEvent(const std::string &eventEmitterName, const std::string &emitterMethod, folly::dynamic &&params) noexcept;
 
-  //! Queues an event to be fired via RCTEventEmitter, calling receiveEvent() by default. Existing events in the batch
-  //! with the same name and tag will be removed.
-  void EmitCoalescingJSEvent(winrt::hstring &&coalescingKey, JSValueArgWriter &&paramsWriter) noexcept;
+  //! Dispatches an event from a view manager. Existing events in the batch with the same name and tag will be removed.
+  void DispatchCoalescingEvent(int64_t tag, const std::string &eventName, folly::dynamic &&eventData) noexcept;
+  //! Queues an event to be fired. Existing events in the batch with the same name and tag will be removed.
   void EmitCoalescingJSEvent(
-      winrt::hstring &&emitterMethod,
-      winrt::hstring &&coalescingKey,
-      JSValueArgWriter &&paramsWriter) noexcept;
+      const std::string &eventEmitterName,
+      const std::string &emitterMethod,
+      const std::string &eventName,
+      int64_t coalescingKey,
+      folly::dynamic &&params) noexcept;
 
  private:
   void RegisterFrameCallback() noexcept;

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -360,14 +360,9 @@ void ScrollViewShadowNode::EmitScrollEvent(
 
   if (coalesceType == CoalesceType::CoalesceByTag) {
     viewManager->BatchingEmitter().DispatchCoalescingEvent(
-        tag, std::move(eventName), [eventJson = std::move(eventJson)](const IJSValueWriter &paramsWriter) {
-          WriteValue(paramsWriter, eventJson);
-        });
+        tag, std::move(eventName), MakeJSValueWriter(std::move(eventJson)));
   } else {
-    viewManager->BatchingEmitter().DispatchEvent(
-        tag, std::move(eventName), [eventJson = std::move(eventJson)](const IJSValueWriter &paramsWriter) {
-          WriteValue(paramsWriter, eventJson);
-        });
+    viewManager->BatchingEmitter().DispatchEvent(tag, std::move(eventName), MakeJSValueWriter(std::move(eventJson)));
   }
 } // namespace Microsoft::ReactNative
 

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -369,7 +369,7 @@ void ScrollViewShadowNode::EmitScrollEvent(
           WriteValue(paramsWriter, tag);
           WriteValue(paramsWriter, eventName);
           WriteValue(paramsWriter, std::move(eventJson));
-          paramsWriter.WriteArrayEnd();          
+          paramsWriter.WriteArrayEnd();
         });
   } else {
     viewManager->BatchingEmitter().EmitJSEvent(

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -41,7 +41,7 @@ class ScrollViewShadowNode : public ShadowNodeBase {
   void EmitScrollEvent(
       const winrt::ScrollViewer &scrollViewer,
       int64_t tag,
-      const char *eventName,
+      winrt::hstring &&eventName,
       double x,
       double y,
       double zoom,
@@ -248,7 +248,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
           EmitScrollEvent(
               scrollViewerNotNull,
               m_tag,
-              "topScrollEndDrag",
+              L"topScrollEndDrag",
               args.NextView().HorizontalOffset(),
               args.NextView().VerticalOffset(),
               args.NextView().ZoomFactor(),
@@ -257,7 +257,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
           EmitScrollEvent(
               scrollViewerNotNull,
               m_tag,
-              "topScrollBeginMomentum",
+              L"topScrollBeginMomentum",
               args.NextView().HorizontalOffset(),
               args.NextView().VerticalOffset(),
               args.NextView().ZoomFactor(),
@@ -267,7 +267,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
         EmitScrollEvent(
             scrollViewerNotNull,
             m_tag,
-            "topScroll",
+            L"topScroll",
             args.NextView().HorizontalOffset(),
             args.NextView().VerticalOffset(),
             args.NextView().ZoomFactor(),
@@ -286,7 +286,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
         EmitScrollEvent(
             scrollViewer,
             m_tag,
-            "topScrollBeginDrag",
+            L"topScrollBeginDrag",
             scrollViewer.HorizontalOffset(),
             scrollViewer.VerticalOffset(),
             scrollViewer.ZoomFactor(),
@@ -300,7 +300,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
           EmitScrollEvent(
               scrollViewer,
               m_tag,
-              "topScrollEndMomentum",
+              L"topScrollEndMomentum",
               scrollViewer.HorizontalOffset(),
               scrollViewer.VerticalOffset(),
               scrollViewer.ZoomFactor(),
@@ -309,7 +309,7 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
           EmitScrollEvent(
               scrollViewer,
               m_tag,
-              "topScrollEndDrag",
+              L"topScrollEndDrag",
               scrollViewer.HorizontalOffset(),
               scrollViewer.VerticalOffset(),
               scrollViewer.ZoomFactor(),
@@ -331,33 +331,43 @@ void ScrollViewShadowNode::AddHandlers(const winrt::ScrollViewer &scrollViewer) 
 void ScrollViewShadowNode::EmitScrollEvent(
     const winrt::ScrollViewer &scrollViewer,
     int64_t tag,
-    const char *eventName,
+    winrt::hstring &&eventName,
     double x,
     double y,
     double zoom,
     CoalesceType coalesceType) {
   const auto scrollViewerNotNull = scrollViewer;
 
-  folly::dynamic offset = folly::dynamic::object("x", x)("y", y);
+  JSValueObject contentOffset{{"x", x}, {"y", y}};
+  JSValueObject contentInset{{"left", 0}, {"top", 0}, {"right", 0}, {"bottom", 0}};
 
-  folly::dynamic contentInset = folly::dynamic::object("left", 0)("top", 0)("right", 0)("bottom", 0);
+  JSValueObject contentSize{
+      {"width", scrollViewerNotNull.ExtentWidth()}, {"height", scrollViewerNotNull.ExtentHeight()}};
 
-  folly::dynamic contentSize =
-      folly::dynamic::object("width", scrollViewerNotNull.ExtentWidth())("height", scrollViewerNotNull.ExtentHeight());
+  JSValueObject layoutMeasurement{
+      {"width", scrollViewerNotNull.ActualWidth()}, {"height", scrollViewerNotNull.ActualHeight()}};
 
-  folly::dynamic layoutSize =
-      folly::dynamic::object("width", scrollViewerNotNull.ActualWidth())("height", scrollViewerNotNull.ActualHeight());
-
-  folly::dynamic eventJson =
-      folly::dynamic::object("target", tag)("responderIgnoreScroll", true)("contentOffset", offset)(
-          "contentInset", contentInset)("contentSize", contentSize)("layoutMeasurement", layoutSize)("zoomScale", zoom);
+  JSValueObject eventJson{
+      {"target", tag},
+      {"responderIgnoreScroll", true},
+      {"contentOffset", std::move(contentOffset)},
+      {"contentInset", std::move(contentInset)},
+      {"contentSize", std::move(contentSize)},
+      {"layoutMeasurement", std::move(layoutMeasurement)},
+      {"zoomScale", zoom}};
 
   auto *viewManager = static_cast<ScrollViewManager *>(GetViewManager());
 
   if (coalesceType == CoalesceType::CoalesceByTag) {
-    viewManager->BatchingEmitter().DispatchCoalescingEvent(tag, eventName, std::move(eventJson));
+    viewManager->BatchingEmitter().DispatchCoalescingEvent(
+        tag, std::move(eventName), [eventJson = std::move(eventJson)](const IJSValueWriter &paramsWriter) {
+          WriteValue(paramsWriter, eventJson);
+        });
   } else {
-    viewManager->BatchingEmitter().DispatchEvent(tag, eventName, std::move(eventJson));
+    viewManager->BatchingEmitter().DispatchEvent(
+        tag, std::move(eventName), [eventJson = std::move(eventJson)](const IJSValueWriter &paramsWriter) {
+          WriteValue(paramsWriter, eventJson);
+        });
   }
 } // namespace Microsoft::ReactNative
 

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -37,7 +37,8 @@ std::vector<int64_t> GetTagsForBranch(INativeUIManagerHost *host, int64_t tag);
 TouchEventHandler::TouchEventHandler(const Mso::React::IReactContext &context)
     : m_xamlView(nullptr),
       m_context(&context),
-      m_batchingEventEmitter{std::make_shared<winrt::Microsoft::ReactNative::BatchingEventEmitter>(Mso::CntPtr(&context))} {}
+      m_batchingEventEmitter{
+          std::make_shared<winrt::Microsoft::ReactNative::BatchingEventEmitter>(Mso::CntPtr(&context))} {}
 
 TouchEventHandler::~TouchEventHandler() {
   RemoveTouchHandlers();
@@ -346,29 +347,29 @@ void TouchEventHandler::UpdatePointersInViews(
   }
 }
 
-winrt::Microsoft::ReactNative::JSValue TouchEventHandler::GetPointerJson(const ReactPointer &pointer, int64_t target){
+winrt::Microsoft::ReactNative::JSValue TouchEventHandler::GetPointerJson(const ReactPointer &pointer, int64_t target) {
   winrt::Microsoft::ReactNative::JSValueObject json{
-    {"target", target},
-    {"identifier", pointer.identifier},
-    {"pageX", pointer.positionRoot.X},
-    {"pageY", pointer.positionRoot.Y},
-    {"locationX", pointer.positionView.X},
-    {"locationY", pointer.positionView.Y},
-    {"timestamp", pointer.timestamp},
-    {
-        "pointerType",
-        GetPointerDeviceTypeName(pointer.deviceType),
-    },
-    {"force", pointer.pressure},
-    {"isLeftButton", pointer.isLeftButton},
-    {"isRightButton", pointer.isRightButton},
-    {"isMiddleButton", pointer.isMiddleButton},
-    {"isBarrelButtonPressed", pointer.isBarrelButton},
-    {"isHorizontalScrollWheel", pointer.isHorizontalScrollWheel},
-    {"isEraser", pointer.isEraser},
-    {"shiftKey", pointer.shiftKey},
-    {"ctrlKey", pointer.ctrlKey},
-    {"altKey", pointer.altKey}};
+      {"target", target},
+      {"identifier", pointer.identifier},
+      {"pageX", pointer.positionRoot.X},
+      {"pageY", pointer.positionRoot.Y},
+      {"locationX", pointer.positionView.X},
+      {"locationY", pointer.positionView.Y},
+      {"timestamp", pointer.timestamp},
+      {
+          "pointerType",
+          GetPointerDeviceTypeName(pointer.deviceType),
+      },
+      {"force", pointer.pressure},
+      {"isLeftButton", pointer.isLeftButton},
+      {"isRightButton", pointer.isRightButton},
+      {"isMiddleButton", pointer.isMiddleButton},
+      {"isBarrelButtonPressed", pointer.isBarrelButton},
+      {"isHorizontalScrollWheel", pointer.isHorizontalScrollWheel},
+      {"isEraser", pointer.isEraser},
+      {"shiftKey", pointer.shiftKey},
+      {"ctrlKey", pointer.ctrlKey},
+      {"altKey", pointer.altKey}};
   return json;
 }
 
@@ -475,8 +476,7 @@ void TouchEventHandler::DispatchTouchEvent(TouchEventType eventType, size_t poin
     const char *eventName = GetTouchEventTypeName(eventType);
     if (eventName == nullptr)
       return;
-    winrt::Microsoft::ReactNative::JSValueArray params {
-      eventName, std::move(touches), std::move(changedIndices)};
+    winrt::Microsoft::ReactNative::JSValueArray params{eventName, std::move(touches), std::move(changedIndices)};
 
     if (eventType == TouchEventType::Move || eventType == TouchEventType::PointerMove) {
       std::wostringstream coalescingKeyStream;
@@ -484,15 +484,13 @@ void TouchEventHandler::DispatchTouchEvent(TouchEventType eventType, size_t poin
       BatchingEmitter().EmitCoalescingJSEvent(
           L"receiveTouches",
           winrt::hstring{coalescingKeyStream.str()},
-          [params = std::move(params)](
-              winrt::Microsoft::ReactNative::IJSValueWriter const &paramsWriter) noexcept {
+          [params = std::move(params)](winrt::Microsoft::ReactNative::IJSValueWriter const &paramsWriter) noexcept {
             WriteValue(paramsWriter, std::move(params));
           });
     } else {
       BatchingEmitter().EmitJSEvent(
           L"receiveTouches",
-          [params = std::move(params)](
-              winrt::Microsoft::ReactNative::IJSValueWriter const &paramsWriter) noexcept {
+          [params = std::move(params)](winrt::Microsoft::ReactNative::IJSValueWriter const &paramsWriter) noexcept {
             WriteValue(paramsWriter, std::move(params));
           });
     }

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -3,8 +3,8 @@
 
 #pragma once
 #include <IReactInstance.h>
+#include <JSValue.h>
 #include <UI.Xaml.Documents.h>
-#include <folly/dynamic.h>
 #include <winrt/Windows.Devices.Input.h>
 #include <optional>
 #include <set>
@@ -85,10 +85,10 @@ class TouchEventHandler {
   void DispatchTouchEvent(TouchEventType eventType, size_t pointerIndex);
   bool DispatchBackEvent();
   const char *GetPointerDeviceTypeName(winrt::Windows::Devices::Input::PointerDeviceType deviceType) noexcept;
-  const char *GetTouchEventTypeName(TouchEventType eventType) noexcept;
+  const wchar_t *GetTouchEventTypeName(TouchEventType eventType) noexcept;
 
   std::optional<size_t> IndexOfPointerWithId(uint32_t pointerId);
-  folly::dynamic GetPointerJson(const ReactPointer &pointer, int64_t target);
+  winrt::Microsoft::ReactNative::JSValue GetPointerJson(const ReactPointer &pointer, int64_t target);
 
   struct TagSet {
     std::unordered_set<int64_t> tags;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -3,8 +3,8 @@
 
 #pragma once
 #include <IReactInstance.h>
-#include <JSValueWriter.h>
 #include <UI.Xaml.Documents.h>
+#include <folly/dynamic.h>
 #include <winrt/Windows.Devices.Input.h>
 #include <optional>
 #include <set>
@@ -88,7 +88,7 @@ class TouchEventHandler {
   const char *GetTouchEventTypeName(TouchEventType eventType) noexcept;
 
   std::optional<size_t> IndexOfPointerWithId(uint32_t pointerId);
-  winrt::Microsoft::ReactNative::JSValue GetPointerJson(const ReactPointer &pointer, int64_t target);
+  folly::dynamic GetPointerJson(const ReactPointer &pointer, int64_t target);
 
   struct TagSet {
     std::unordered_set<int64_t> tags;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -3,11 +3,12 @@
 
 #pragma once
 #include <IReactInstance.h>
+#include <JSValueWriter.h>
 #include <UI.Xaml.Documents.h>
-#include <folly/dynamic.h>
 #include <winrt/Windows.Devices.Input.h>
 #include <optional>
 #include <set>
+#include "Utils/BatchingEventEmitter.h"
 #include "XamlView.h"
 
 #ifdef USE_FABRIC
@@ -33,6 +34,7 @@ class TouchEventHandler {
 
   void AddTouchHandlers(XamlView xamlView);
   void RemoveTouchHandlers();
+  winrt::Microsoft::ReactNative::BatchingEventEmitter &BatchingEmitter() noexcept;
 
  private:
   void OnPointerPressed(const winrt::IInspectable &, const winrt::PointerRoutedEventArgs &args);
@@ -86,7 +88,7 @@ class TouchEventHandler {
   const char *GetTouchEventTypeName(TouchEventType eventType) noexcept;
 
   std::optional<size_t> IndexOfPointerWithId(uint32_t pointerId);
-  folly::dynamic GetPointerJson(const ReactPointer &pointer, int64_t target);
+  winrt::Microsoft::ReactNative::JSValue GetPointerJson(const ReactPointer &pointer, int64_t target);
 
   struct TagSet {
     std::unordered_set<int64_t> tags;
@@ -105,6 +107,7 @@ class TouchEventHandler {
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;
+  std::shared_ptr<winrt::Microsoft::ReactNative::BatchingEventEmitter> m_batchingEventEmitter;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
This change adds event coalescing to onTouchMove events. The previous implementation of BatchingEventEmitter expected a view tag and event name to perform coalescing. This change generalizes the batching event emitter to accept a coalescing key instead, which simply concatenates the event name and the view tag in the case of ScrollViewViewManager and the event name and the pointer ID in the case of TouchEventHandler. This change also modified the signature of Emit(Coalescing)JsEvent to accept a folly::dynamic rather than a JSValue, as the arguments sent to the `RCTEventEmitter.receiveTouches` JS function do not exactly match the arguments sent to `RCTEventEmitter.receiveEvent`.

Fixes #7276

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7837)