### PR TITLE
I18n.AllowRTL should default to true

### DIFF
--- a/change/react-native-windows-802e1a1f-0feb-43da-ac1c-e81018aa3e62.json
+++ b/change/react-native-windows-802e1a1f-0feb-43da-ac1c-e81018aa3e62.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "I18n.AllowRTL should default to true",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
@@ -43,7 +43,7 @@ void I18nManager::InitI18nInfo(const winrt::Microsoft::ReactNative::ReactPropert
   if (propertyBag.Get(ForceRTLPropertyId()).value_or(false))
     return true;
 
-  if (!propertyBag.Get(AllowRTLPropertyId()).value_or(false))
+  if (!propertyBag.Get(AllowRTLPropertyId()).value_or(true))
     return false;
 
   return propertyBag.Get(SystemIsRTLPropertyId()).value_or(false);


### PR DESCRIPTION
The default value of this is true in core -- we should align.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7840)