### PR TITLE
Make Fabric a per RootView setting

### DIFF
--- a/change/react-native-windows-01520e78-9cae-47fe-b603-eea26db815fa.json
+++ b/change/react-native-windows-01520e78-9cae-47fe-b603-eea26db815fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make Fabric a per RootView setting",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -51,10 +51,6 @@ void MainPage::OnLoadClick(
   }
   host.InstanceSettings().JavaScriptBundleFile(bundleFile);
 
-  winrt::Microsoft::ReactNative::QuirkSettings::SetEnableFabric(
-      host.InstanceSettings(), x_UseFabric().IsChecked().GetBoolean());
-  ReactRootView().ExperimentalUseFabric(x_UseFabric().IsChecked().GetBoolean());
-
   auto item = x_rootComponentNameCombo().SelectedItem();
   winrt::hstring mainComponentName;
   if (auto selected = item.try_as<ComboBoxItem>()) {
@@ -63,6 +59,7 @@ void MainPage::OnLoadClick(
     mainComponentName = unbox_value<hstring>(item);
   }
   ReactRootView().ComponentName(mainComponentName);
+  ReactRootView().ExperimentalUseFabric(x_UseFabric().IsChecked().GetBoolean());
   ReactRootView().ReactNativeHost(host);
 
   host.InstanceSettings().UseDeveloperSupport(true);

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -51,6 +51,10 @@ void MainPage::OnLoadClick(
   }
   host.InstanceSettings().JavaScriptBundleFile(bundleFile);
 
+  winrt::Microsoft::ReactNative::QuirkSettings::SetEnableFabric(
+      host.InstanceSettings(), x_UseFabric().IsChecked().GetBoolean());
+  ReactRootView().ExperimentalUseFabric(x_UseFabric().IsChecked().GetBoolean());
+
   auto item = x_rootComponentNameCombo().SelectedItem();
   winrt::hstring mainComponentName;
   if (auto selected = item.try_as<ComboBoxItem>()) {
@@ -72,9 +76,6 @@ void MainPage::OnLoadClick(
   if (!m_bundlerHostname.empty()) {
     host.InstanceSettings().DebugHost(m_bundlerHostname);
   }
-
-  winrt::Microsoft::ReactNative::QuirkSettings::SetEnableFabric(
-      host.InstanceSettings(), x_UseFabric().IsChecked().GetBoolean());
 
   host.InstanceSettings().InstanceCreated(
       [wkThis = get_weak()](auto sender, winrt::Microsoft::ReactNative::InstanceCreatedEventArgs args) {

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -48,9 +48,6 @@ FabicUIManagerProperty() noexcept {
 
 /*static*/ std::shared_ptr<FabricUIManager> FabricUIManager::FromProperties(
     const winrt::Microsoft::ReactNative::ReactPropertyBag &props) {
-  if (!Mso::React::ReactOptions::EnableFabric(props.Handle()))
-    return nullptr;
-
   return props.Get(FabicUIManagerProperty()).Value();
 }
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -46,12 +46,6 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
   ReactPropertyBag(settings.Properties()).Set(AcceptSelfSignedCertsProperty(), value);
 }
 
-/*static*/ void QuirkSettings::SetEnableFabric(
-    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
-    bool value) noexcept {
-  Mso::React::ReactOptions::SetEnableFabric(settings.Properties(), value);
-}
-
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
@@ -60,10 +54,6 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
 
 /*static*/ bool QuirkSettings::GetAcceptSelfSigned(ReactPropertyBag properties) noexcept {
   return properties.Get(AcceptSelfSignedCertsProperty()).value_or(false);
-}
-
-/*static*/ bool QuirkSettings::GetEnableFabric(ReactPropertyBag properties) noexcept {
-  return Mso::React::ReactOptions::EnableFabric(properties.Handle());
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -30,8 +30,6 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       bool value) noexcept;
 
   static void SetAcceptSelfSigned(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
-
-  static void SetEnableFabric(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
 #pragma endregion Public API - part of IDL interface
 };
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -25,8 +25,5 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.")
     static void SetAcceptSelfSigned(ReactInstanceSettings settings, Boolean value);
-
-    // Enable ability to use new Fabric UIManager within this instance.
-    static void SetEnableFabric(ReactInstanceSettings settings, Boolean value);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -86,8 +86,9 @@ struct IReactInstance : IUnknown {
 
   virtual void AttachMeasuredRootView(
       facebook::react::IReactRootView *rootView,
-      folly::dynamic &&initialProps) noexcept = 0;
-  virtual void DetachRootView(facebook::react::IReactRootView *rootView) noexcept = 0;
+      folly::dynamic &&initialProps,
+      bool useFabric) noexcept = 0;
+  virtual void DetachRootView(facebook::react::IReactRootView *rootView, bool useFabric) noexcept = 0;
 };
 
 MSO_GUID(IReactSettingsSnapshot, "6652bb2e-4c5e-49f7-b642-e817b0fef4de")
@@ -127,6 +128,9 @@ struct ReactViewOptions {
 
   //! Set of initial component properties. It is a JSON string.
   folly::dynamic InitialProps;
+
+  //! Use Fabric for this ReactView
+  bool UseFabric;
 };
 
 struct ReactDevOptions {

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -130,7 +130,7 @@ struct ReactViewOptions {
   folly::dynamic InitialProps;
 
   //! Use Fabric for this ReactView
-  bool UseFabric;
+  bool UseFabric{false};
 };
 
 struct ReactDevOptions {
@@ -286,12 +286,6 @@ struct ReactOptions {
       winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
       bool value) noexcept;
   static bool UseWebDebugger(winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept;
-
-  //! Should the instance enable the Fabric UI architecture
-  void SetEnableFabric(bool enabled) noexcept;
-  bool EnableFabric() const noexcept;
-  static void SetEnableFabric(winrt::Microsoft::ReactNative::IReactPropertyBag const &properties, bool value) noexcept;
-  static bool EnableFabric(winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept;
 
   //! For direct debugging, whether to break on the next line of JavaScript that is executed.
   void SetDebuggerBreakOnNextLine(bool enable) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -161,30 +161,6 @@ bool ReactOptions::UseWebDebugger() const noexcept {
   return winrt::unbox_value_or<bool>(properties.Get(UseWebDebuggerProperty()), false);
 }
 
-void ReactOptions::SetEnableFabric(bool enabled) noexcept {
-  SetEnableFabric(Properties, enabled);
-}
-
-bool ReactOptions::EnableFabric() const noexcept {
-  return EnableFabric(Properties);
-}
-
-/*static*/ void ReactOptions::SetEnableFabric(
-    winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
-    bool value) noexcept {
-  properties.Set(EnableFabricProperty(), winrt::box_value(value));
-
-  if (value) {
-    // Fabric is incompatible with WebDebugging
-    SetUseWebDebugger(properties, false);
-  }
-}
-
-/*static*/ bool ReactOptions::EnableFabric(
-    winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept {
-  return winrt::unbox_value_or<bool>(properties.Get(EnableFabricProperty()), false);
-}
-
 bool ReactOptions::UseLiveReload() const noexcept {
   return UseLiveReload(Properties);
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -868,14 +868,15 @@ bool ReactInstanceWin::IsLoaded() const noexcept {
 
 void ReactInstanceWin::AttachMeasuredRootView(
     facebook::react::IReactRootView *rootView,
-    folly::dynamic &&initialProps) noexcept {
+    folly::dynamic &&initialProps,
+    bool useFabric) noexcept {
   if (State() == ReactInstanceState::HasError)
     return;
 
   int64_t rootTag = -1;
 
 #ifdef USE_FABRIC
-  if (m_options.EnableFabric()) {
+  if (useFabric) {
     auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
         winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()));
 
@@ -901,7 +902,7 @@ void ReactInstanceWin::AttachMeasuredRootView(
   }
 }
 
-void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView) noexcept {
+void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView, bool useFabric) noexcept {
   if (State() == ReactInstanceState::HasError)
     return;
 
@@ -909,7 +910,7 @@ void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView)
   folly::dynamic params = folly::dynamic::array(rootTag);
 
 #ifdef USE_FABRIC
-  if (m_options.EnableFabric()) {
+  if (useFabric) {
     auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
         winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()));
     uiManager->stopSurface(static_cast<facebook::react::SurfaceId>(rootTag));

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -252,7 +252,7 @@ void ReactInstanceWin::LoadModules(
   };
 
 #ifdef USE_FABRIC
-  if (m_options.EnableFabric()) {
+  if (!m_options.UseWebDebugger()) {
     registerTurboModule(
         L"FabricUIManagerBinding",
         winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::FabricUIManager>());
@@ -446,7 +446,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
 #ifdef USE_FABRIC
         // Eagerly init the FabricUI binding
-        if (m_options.EnableFabric()) {
+        if (!m_options.UseWebDebugger()) {
           Microsoft::ReactNative::SchedulerSettings::SetRuntimeExecutor(
               winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()),
               m_instanceWrapper.Load()->GetInstance()->getRuntimeExecutor(false /*shouldFlush*/));
@@ -876,7 +876,7 @@ void ReactInstanceWin::AttachMeasuredRootView(
   int64_t rootTag = -1;
 
 #ifdef USE_FABRIC
-  if (useFabric) {
+  if (useFabric && !m_useWebDebugger) {
     auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
         winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()));
 
@@ -910,7 +910,7 @@ void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView,
   folly::dynamic params = folly::dynamic::array(rootTag);
 
 #ifdef USE_FABRIC
-  if (useFabric) {
+  if (useFabric && !m_useWebDebugger) {
     auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
         winrt::Microsoft::ReactNative::ReactPropertyBag(m_reactContext->Properties()));
     uiManager->stopSurface(static_cast<facebook::react::SurfaceId>(rootTag));

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -52,9 +52,11 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   const ReactOptions &Options() const noexcept override;
   ReactInstanceState State() const noexcept override;
   Mso::React::IReactContext &GetReactContext() const noexcept override;
-  void AttachMeasuredRootView(facebook::react::IReactRootView *rootView, folly::dynamic &&initialProps) noexcept
-      override;
-  void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
+  void AttachMeasuredRootView(
+      facebook::react::IReactRootView *rootView,
+      folly::dynamic &&initialProps,
+      bool useFabric) noexcept override;
+  void DetachRootView(facebook::react::IReactRootView *rootView, bool useFabric) noexcept override;
 
  public: // IReactInstanceInternal
   Mso::Future<void> Destroy() noexcept override;

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -434,7 +434,8 @@ Windows::Foundation::Size ReactRootView::MeasureOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) &&
+      m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;
@@ -471,7 +472,8 @@ Windows::Foundation::Size ReactRootView::ArrangeOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) &&
+      m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -69,11 +69,22 @@ void ReactRootView::InitialProps(ReactNative::JSValueArgWriter const &value) noe
   }
 }
 
+bool ReactRootView::ExperimentalUseFabric() const noexcept {
+  return m_useFabric;
+}
+void ReactRootView::ExperimentalUseFabric(bool value) noexcept {
+  if (m_useFabric != value) {
+    m_useFabric = value;
+    ReloadView();
+  }
+}
+
 void ReactRootView::ReloadView() noexcept {
   if (m_reactNativeHost && !m_componentName.empty()) {
     Mso::React::ReactViewOptions viewOptions{};
     viewOptions.ComponentName = to_string(m_componentName);
     viewOptions.InitialProps = m_initialProps;
+    viewOptions.UseFabric = m_useFabric;
     if (auto reactViewHost = ReactViewHost()) {
       reactViewHost->ReloadViewInstanceWithOptions(std::move(viewOptions));
     } else {
@@ -200,7 +211,7 @@ void ReactRootView::UninitRootView() noexcept {
 
   if (m_isJSViewAttached) {
     if (auto reactInstance = m_weakReactInstance.GetStrongPtr()) {
-      reactInstance->DetachRootView(this);
+      reactInstance->DetachRootView(this, m_reactViewHost->Options().UseFabric);
     }
   }
 
@@ -269,7 +280,8 @@ void ReactRootView::ShowInstanceLoaded() noexcept {
     ClearLoadingUI();
 
     if (auto reactInstance = m_weakReactInstance.GetStrongPtr()) {
-      reactInstance->AttachMeasuredRootView(this, Mso::Copy(m_reactViewOptions->InitialProps));
+      reactInstance->AttachMeasuredRootView(
+          this, Mso::Copy(m_reactViewOptions->InitialProps), m_reactViewOptions->UseFabric);
     }
     m_isJSViewAttached = true;
   }
@@ -422,7 +434,7 @@ Windows::Foundation::Size ReactRootView::MeasureOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_reactOptions->EnableFabric() && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;
@@ -459,7 +471,7 @@ Windows::Foundation::Size ReactRootView::ArrangeOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_reactOptions->EnableFabric() && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -434,7 +434,7 @@ Windows::Foundation::Size ReactRootView::MeasureOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_useFabric && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;
@@ -471,7 +471,7 @@ Windows::Foundation::Size ReactRootView::ArrangeOverride(Windows::Foundation::Si
   }
 
 #ifdef USE_FABRIC
-  if (m_isInitialized && m_useFabric && m_rootTag != -1) {
+  if (m_isInitialized && m_useFabric && !Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
       facebook::react::LayoutContext context;

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -162,7 +162,8 @@ void ReactRootView::InitRootView(
   m_context = &reactInstance->GetReactContext();
   m_reactViewOptions = std::make_unique<Mso::React::ReactViewOptions>(std::move(reactViewOptions));
 
-  m_touchEventHandler = std::make_shared<::Microsoft::ReactNative::TouchEventHandler>(*m_context);
+  m_touchEventHandler = std::make_shared<::Microsoft::ReactNative::TouchEventHandler>(
+      *m_context, m_reactViewOptions->UseFabric && !reactInstance->Options().UseWebDebugger());
   m_SIPEventHandler = std::make_shared<::Microsoft::ReactNative::SIPEventHandler>(*m_context);
   m_previewKeyboardEventHandlerOnRoot =
       std::make_shared<::Microsoft::ReactNative::PreviewKeyboardEventHandlerOnRoot>(*m_context);

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -36,6 +36,10 @@ struct ReactRootView : ReactRootViewT<ReactRootView>, ::Microsoft::ReactNative::
     UpdatePerspective();
   }
 
+  // property ExperimentalUseFabric
+  bool ExperimentalUseFabric() const noexcept;
+  void ExperimentalUseFabric(bool value) noexcept;
+
   void ReloadView() noexcept;
 
  public: // IXamlRootView
@@ -68,6 +72,7 @@ struct ReactRootView : ReactRootViewT<ReactRootView>, ::Microsoft::ReactNative::
   bool m_isPerspectiveEnabled{true};
   bool m_isInitialized{false};
   bool m_isJSViewAttached{false};
+  bool m_useFabric{false};
   Mso::DispatchQueue m_uiQueue;
   int64_t m_rootTag{-1};
   std::unique_ptr<Mso::React::ReactOptions> m_reactOptions;

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -8,10 +8,18 @@ import "ReactNativeHost.idl";
 
 namespace Microsoft.ReactNative
 {
+  [experimental]
+  DOC_STRING("Experimental properties for ReactRootView")
+  interface IReactRootViewExperimental
+  {
+    DOC_STRING("Use Fabric for this ReactRootView")
+    Boolean ExperimentalUseFabric { get; set; };
+  }
+
   [default_interface]
   [webhosthidden]
   DOC_STRING("A XAML component that hosts React Native UI elements.")
-  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid
+  runtimeclass ReactRootView : XAML_NAMESPACE.Controls.Grid, IReactRootViewExperimental
   {
     DOC_STRING("Creates a new instance of @ReactRootView.")
     ReactRootView();
@@ -36,8 +44,5 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Reloads the current @ReactRootView UI components.")
     void ReloadView();
-
-    DOC_STRING("Use Fabric for this ReactRootView")
-    Boolean ExperimentalUseFabric { get; set; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactRootView.idl
+++ b/vnext/Microsoft.ReactNative/ReactRootView.idl
@@ -36,5 +36,8 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Reloads the current @ReactRootView UI components.")
     void ReloadView();
+
+    DOC_STRING("Use Fabric for this ReactRootView")
+    Boolean ExperimentalUseFabric { get; set; };
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -158,7 +158,8 @@ void FlyoutShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueOb
   if (m_isFlyoutShowOptionsSupported)
     m_showOptions = winrt::FlyoutShowOptions();
 
-  m_touchEventHanadler = std::make_unique<TouchEventHandler>(GetViewManager()->GetReactContext());
+  m_touchEventHanadler = std::make_unique<TouchEventHandler>(
+      GetViewManager()->GetReactContext(), false /*Flyout not supported in fabric currently*/);
   m_previewKeyboardEventHandlerOnRoot =
       std::make_unique<PreviewKeyboardEventHandlerOnRoot>(GetViewManager()->GetReactContext());
 

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -78,7 +78,8 @@ void PopupShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObj
 
   auto popup = GetView().as<winrt::Popup>();
   auto control = GetControl();
-  m_touchEventHandler = std::make_unique<TouchEventHandler>(GetViewManager()->GetReactContext());
+  m_touchEventHandler = std::make_unique<TouchEventHandler>(
+      GetViewManager()->GetReactContext(), false /*Popup not supported in fabric currently*/);
   m_previewKeyboardEventHandlerOnRoot =
       std::make_unique<PreviewKeyboardEventHandlerOnRoot>(GetViewManager()->GetReactContext());
 

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -34,8 +34,8 @@ namespace Microsoft::ReactNative {
 
 std::vector<int64_t> GetTagsForBranch(INativeUIManagerHost *host, int64_t tag);
 
-TouchEventHandler::TouchEventHandler(const Mso::React::IReactContext &context)
-    : m_xamlView(nullptr), m_context(&context) {}
+TouchEventHandler::TouchEventHandler(const Mso::React::IReactContext &context, bool fabric)
+    : m_xamlView(nullptr), m_context(&context), m_fabric(fabric) {}
 
 TouchEventHandler::~TouchEventHandler() {
   RemoveTouchHandlers();
@@ -384,8 +384,10 @@ void TouchEventHandler::DispatchTouchEvent(TouchEventType eventType, size_t poin
   changedIndices.push_back(pointerIndex);
 
 #ifdef USE_FABRIC
-  if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  std::shared_ptr<FabricUIManager> fabricuiManager;
+  if (m_fabric &&
+      !!(fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
+             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties())))) {
     std::unordered_set<facebook::react::SharedTouchEventEmitter> uniqueEventEmitters = {};
     std::vector<facebook::react::SharedTouchEventEmitter> emittersForIndex;
 

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -28,7 +28,7 @@ namespace Microsoft::ReactNative {
 
 class TouchEventHandler {
  public:
-  TouchEventHandler(const Mso::React::IReactContext &context);
+  TouchEventHandler(const Mso::React::IReactContext &context, bool fabric);
   virtual ~TouchEventHandler();
 
   void AddTouchHandlers(XamlView xamlView);
@@ -105,6 +105,7 @@ class TouchEventHandler {
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;
+  bool m_fabric;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
Make Fabric a per RootView setting.  This is how core works, and enables apps to more incrementally opt into Fabric in more complex brownfield apps.

This also fixes some issues where in playground you'd hit crashes switching back and forth between fabric and paper.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7843)