### PR TITLE
Fixing inspector with Hermes v0.8

### DIFF
--- a/change/react-native-windows-226e1de5-e19b-44dc-a44a-cd8bc20fd68c.json
+++ b/change/react-native-windows-226e1de5-e19b-44dc-a44a-cd8bc20fd68c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Hermes inspector was broken on Hermes v0.8 package as some changes were not correctly migrated from 0.7 branch.",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/integration-test-app/windows/integrationtest/packages.config
+++ b/packages/integration-test-app/windows/integrationtest/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging2" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native"/>
 </packages>

--- a/packages/playground/packages.config
+++ b/packages/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging2" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging2" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging2" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native"/>
 </packages>

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.UI.Xaml" version="2.5.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging2" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
   <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.64.8" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.8.0-staging2</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.8.0-staging3</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)</HermesPackage>
     <!-- TODO: Can we automatically distinguish between uwp and win32 here? -->
     <HermesArch Condition="'$(HermesArch)' == ''">uwp</HermesArch>


### PR DESCRIPTION
Hermes inspector was broken with Hermes v0.8 package as some changes were not correctly integrated from 0.7 branch. We've fixed it in the latest Hermes 0.8 package. This PR bumps the version of Hermes package used in RNW.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7852)