### PR TITLE
Add UWP sdk version diagnostics to prepare-env

### DIFF
--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -10,17 +10,18 @@ parameters:
 
 steps:
   - task: PowerShell@2
-    displayName: Display env
+    displayName: Display machine state
     inputs:
       targetType: "inline"
-      script:  gci env:* | sort-object name
-
-  - task: PowerShell@2
-    displayName: Display disksize
-    inputs:
-      targetType: inline # filePath | inline
-      script: |
+      script:  |
+        Write-Host "************** Environment ***********"
+        gci env:* | sort-object name
+        Write-Host "************** Disk Sizes ***********"
         Get-WmiObject Win32_LogicalDisk
+        Write-Host "************** Installed UWP SDK versions ***********"
+        Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.Native.Compiler" | Select-Object FullName
+        Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary" | Select-Object FullName
+        Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk" | Select-Object FullName
 
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
   - task: NuGetToolInstaller@0


### PR DESCRIPTION
Adding the UWP versions to the diagnose machine info, so it will be easier to see find new versions deployed on the vm's.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7861)