### PR TITLE
[0.62] Fix JSValue memory leak in move constructor (#7859)

### DIFF
--- a/change/react-native-windows-01974fdb-aa04-49a7-ad88-8715629563e1.json
+++ b/change/react-native-windows-01974fdb-aa04-49a7-ad88-8715629563e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix JSValue memory leak in move constructor",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValue.cpp
@@ -432,13 +432,13 @@ void JSValueArray::WriteTo(IJSValueWriter const &writer) const noexcept {
 JSValue::JSValue(JSValue &&other) noexcept : m_type{other.m_type} {
   switch (m_type) {
     case JSValueType::Object:
-      new (&m_object) JSValueObject(std::move(other.m_object));
+      new (std::addressof(m_object)) JSValueObject(std::move(other.m_object));
       break;
     case JSValueType::Array:
-      new (&m_array) JSValueArray(std::move(other.m_array));
+      new (std::addressof(m_array)) JSValueArray(std::move(other.m_array));
       break;
     case JSValueType::String:
-      new (&m_string) std::string(std::move(other.m_string));
+      new (std::addressof(m_string)) std::string(std::move(other.m_string));
       break;
     case JSValueType::Boolean:
       m_bool = other.m_bool;
@@ -451,8 +451,7 @@ JSValue::JSValue(JSValue &&other) noexcept : m_type{other.m_type} {
       break;
   }
 
-  other.m_type = JSValueType::Null;
-  other.m_int64 = 0;
+  other.~JSValue();
 }
 #pragma warning(pop)
 


### PR DESCRIPTION
Cherry pick PR #7859

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7870)