### PR TITLE
Coalesce RN View onLayout events

### DIFF
--- a/change/react-native-windows-d97dc1fe-0a82-4894-9183-bbfeef3d6d65.json
+++ b/change/react-native-windows-d97dc1fe-0a82-4894-9183-bbfeef3d6d65.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Coalesce RN View onLayout events",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -60,7 +60,7 @@ void BatchingEventEmitter::DispatchCoalescingEvent(
       L"receiveEvent",
       std::move(eventName),
       tag,
-      [tag, eventName = std::move(eventName), &eventDataWriter](const IJSValueWriter &paramsWriter) {
+      [tag, eventName, &eventDataWriter](const IJSValueWriter &paramsWriter) {
         paramsWriter.WriteArrayBegin();
         WriteValue(paramsWriter, tag);
         WriteValue(paramsWriter, std::move(eventName));

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -51,8 +51,11 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
       const JSValueArgWriter &params) noexcept;
 
  private:
-  size_t GetCoalescingEventKey(winrt::hstring eventEmitterName, winrt::hstring emitterMethod, winrt::hstring eventName);
-  void AddOrCoalesceEvent(implementation::BatchedEvent event);
+  size_t GetCoalescingEventKey(
+      const winrt::hstring &eventEmitterName,
+      const winrt::hstring &emitterMethod,
+      const winrt::hstring &eventName);
+  void AddOrCoalesceEvent(implementation::BatchedEvent &&event);
   void RegisterFrameCallback() noexcept;
   void OnFrameUI() noexcept;
   void OnFrameJS() noexcept;

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -32,7 +32,7 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
   BatchingEventEmitter(Mso::CntPtr<const Mso::React::IReactContext> &&context) noexcept;
 
   //! Dispatches an event from a view manager.
-  void DispatchEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventData) noexcept;
+  void DispatchEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventDataWriter) noexcept;
   //! Queues an event to be fired.
   void EmitJSEvent(
       winrt::hstring &&eventEmitterName,
@@ -40,7 +40,8 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
       const JSValueArgWriter &params) noexcept;
 
   //! Dispatches an event from a view manager. Existing events in the batch with the same name and tag will be removed.
-  void DispatchCoalescingEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventData) noexcept;
+  void
+  DispatchCoalescingEvent(int64_t tag, winrt::hstring &&eventName, const JSValueArgWriter &eventDataWriter) noexcept;
   //! Queues an event to be fired. Existing events in the batch with the same name and tag will be removed.
   void EmitCoalescingJSEvent(
       winrt::hstring &&eventEmitterName,

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.h
@@ -51,12 +51,16 @@ struct BatchingEventEmitter : public std::enable_shared_from_this<BatchingEventE
       const JSValueArgWriter &params) noexcept;
 
  private:
+  size_t GetCoalescingEventKey(winrt::hstring eventEmitterName, winrt::hstring emitterMethod, winrt::hstring eventName);
+  void AddOrCoalesceEvent(implementation::BatchedEvent event);
   void RegisterFrameCallback() noexcept;
   void OnFrameUI() noexcept;
   void OnFrameJS() noexcept;
 
   Mso::CntPtr<const Mso::React::IReactContext> m_context;
   std::deque<implementation::BatchedEvent> m_eventQueue;
+  std::map<std::tuple<winrt::hstring, winrt::hstring, winrt::hstring>, size_t> m_coalescingEventIds;
+  std::map<std::tuple<int64_t, size_t>, size_t> m_lastEventIndex;
   std::mutex m_eventQueueMutex;
   xaml::Media::CompositionTarget::Rendering_revoker m_renderingRevoker;
   IReactDispatcher m_uiDispatcher;

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -38,7 +38,7 @@ void RefreshControlShadowNode::createView(const winrt::Microsoft::ReactNative::J
         refreshContainer.RefreshRequested(winrt::auto_revoke, [this](auto &&, winrt::RefreshRequestedEventArgs args) {
           m_refreshDeferral = args.GetDeferral();
           winrt::Microsoft::ReactNative::JSValueObject eventData{};
-          GetViewManager()->DispatchEvent(m_tag, L"topOnRefresh", MakeJSValueArgWriter(std::move(eventData)));
+          GetViewManager()->DispatchEvent(m_tag, L"topOnRefresh", MakeJSValueWriter(std::move(eventData)));
         });
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RefreshControlManager.cpp
@@ -37,8 +37,8 @@ void RefreshControlShadowNode::createView(const winrt::Microsoft::ReactNative::J
     m_refreshRequestedRevoker =
         refreshContainer.RefreshRequested(winrt::auto_revoke, [this](auto &&, winrt::RefreshRequestedEventArgs args) {
           m_refreshDeferral = args.GetDeferral();
-          folly::dynamic eventData = folly::dynamic::object();
-          GetViewManager()->DispatchEvent(m_tag, "topOnRefresh", std::move(eventData));
+          winrt::Microsoft::ReactNative::JSValueObject eventData{};
+          GetViewManager()->DispatchEvent(m_tag, L"topOnRefresh", MakeJSValueArgWriter(std::move(eventData)));
         });
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -417,8 +417,7 @@ void ScrollViewShadowNode::UpdateZoomMode(const winrt::ScrollViewer &scrollViewe
                                                                    : winrt::ZoomMode::Disabled);
 }
 
-ScrollViewManager::ScrollViewManager(const Mso::React::IReactContext &context)
-    : Super(context), m_batchingEventEmitter{std::make_shared<BatchingEventEmitter>(Mso::CntPtr(&context))} {}
+ScrollViewManager::ScrollViewManager(const Mso::React::IReactContext &context) : Super(context) {}
 
 const wchar_t *ScrollViewManager::GetName() const {
   return L"RCTScrollView";

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.h
@@ -37,8 +37,6 @@ class ScrollViewManager : public ControlViewManager {
 
  private:
   friend class ScrollViewShadowNode;
-
-  std::shared_ptr<winrt::Microsoft::ReactNative::BatchingEventEmitter> m_batchingEventEmitter;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -80,7 +80,9 @@ YGSize DefaultYogaSelfMeasureFunc(
   return desiredSize;
 }
 
-ViewManagerBase::ViewManagerBase(const Mso::React::IReactContext &context) : m_context(&context) {}
+ViewManagerBase::ViewManagerBase(const Mso::React::IReactContext &context)
+    : m_context(&context),
+      m_batchingEventEmitter{std::make_shared<React::BatchingEventEmitter>(Mso::CntPtr(&context))} {}
 
 void ViewManagerBase::GetExportedViewConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {}
 
@@ -346,11 +348,11 @@ void ViewManagerBase::SetLayoutProps(
   // Fire Events
   if (layoutHasChanged && nodeToUpdate.m_onLayoutRegistered) {
     int64_t tag = GetTag(viewToUpdate);
-    folly::dynamic layout = folly::dynamic::object("x", left)("y", top)("height", height)("width", width);
+    React::JSValueObject layout{{"x", left}, {"y", top}, {"height", height}, {"width", width}};
 
-    folly::dynamic eventData = folly::dynamic::object("target", tag)("layout", std::move(layout));
+    React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
 
-    m_context->DispatchEvent(tag, "topLayout", std::move(eventData));
+    m_batchingEventEmitter->DispatchEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
   }
 }
 
@@ -366,10 +368,11 @@ bool ViewManagerBase::IsNativeControlWithSelfLayout() const {
   return GetYogaCustomMeasureFunc() != nullptr;
 }
 
-void ViewManagerBase::DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData)
-    const noexcept {
-  folly::dynamic params = folly::dynamic::array(viewTag, std::move(eventName), std::move(eventData));
-  m_context->CallJSFunction("RCTEventEmitter", "receiveEvent", std::move(params));
+void ViewManagerBase::DispatchEvent(
+    int64_t viewTag,
+    winrt::hstring &&eventName,
+    const React::JSValueArgWriter &eventDataWriter) const noexcept {
+  m_batchingEventEmitter->DispatchEvent(viewTag, std::move(eventName), eventDataWriter);
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -352,7 +352,7 @@ void ViewManagerBase::SetLayoutProps(
 
     React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
 
-    m_batchingEventEmitter->DispatchEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
+    m_batchingEventEmitter->DispatchCoalescingEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -9,6 +9,7 @@
 #include <XamlView.h>
 #include <folly/dynamic.h>
 #include <yoga/yoga.h>
+#include "Utils/BatchingEventEmitter.h"
 
 namespace Microsoft::ReactNative {
 
@@ -82,7 +83,10 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
     return *m_context;
   }
   std::shared_ptr<ExpressionAnimationStore> GetExpressionAnimationStore() noexcept;
-  void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept;
+  void DispatchEvent(
+      int64_t viewTag,
+      winrt::hstring &&eventName,
+      const winrt::Microsoft::ReactNative::JSValueArgWriter &eventDataWriter) const noexcept;
 
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView);
 
@@ -101,6 +105,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
 
  protected:
   Mso::CntPtr<const Mso::React::IReactContext> m_context;
+  std::shared_ptr<winrt::Microsoft::ReactNative::BatchingEventEmitter> m_batchingEventEmitter;
 };
 #pragma warning(pop)
 


### PR DESCRIPTION
Another view that is apt to fire rapidly (especially in window resizing scenarios) is `onLayout`. This change introduces the batching event emitter for ViewManagerBase for use with onLayout events.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7872)