### PR TITLE
Native build logic shouldn't delete PCH on build for all CI machines

### DIFF
--- a/change/react-native-windows-51bbc131-2b1c-465c-b2a8-b06ce1e6b002.json
+++ b/change/react-native-windows-51bbc131-2b1c-465c-b2a8-b06ce1e6b002.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Native build logic shouldn't delete PCH's on all CI machines",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -56,27 +56,4 @@
     <Message Text="=> MSBuildExtensionsPath64 [$(MSBuildExtensionsPath64)]" />
     <Message Text="=> VCTargetsPath           [$(VCTargetsPath)]" />
   </Target>
-
-  <Target Name="_ComputePrecompToCleanUp">
-    <ItemGroup>
-      <PCHFileToClean Include="$(IntDir)\**\*.pch" />
-      <_PCHFileToCleanWithTimestamp Include="@(PCHFileToClean)" Condition="'%(Identity)' != ''">
-        <LastWriteTime>$([System.IO.File]::GetLastWriteTime('%(Identity)'))</LastWriteTime>
-      </_PCHFileToCleanWithTimestamp>
-    </ItemGroup>
-  </Target>
-  <!--
-    As a C++/WinRT project, .pch is very big, and delete it in pipeline after build
-    Instead of outright deleting the PCHs, we want to trick the "project freshness detector" by
-    emitting empty files that look suspiciously like the PCHs it's expecting.
-    It's of utmost importance that their timestamps match up. -->
-  <Target Name="CleanUpPrecompHeaders"
-          DependsOnTargets="_ComputePrecompToCleanUp"
-          AfterTargets="AfterBuild"
-          Condition="'$(AGENT_ID)' != ''">
-    <!-- We just need to keep *ReactNativeWindows*'s PCHs because they get rebuilt more often. -->
-    <Delete Files="@(_PCHFileToCleanWithTimestamp)"/>
-    <Touch Files="@(_PCHFileToCleanWithTimestamp)" Time="%(LastWriteTime)" AlwaysCreate="true" />
-    <Message Text="PCH and Precomp object @(_PCHFileToCleanWithTimestamp) has been deleted for $(ProjectName)." />
-  </Target>
 </Project>


### PR DESCRIPTION
Fixes #7866

Discovered this logic, which paves our PCH's after build, specifically when running on CI machines (`Condition="'$(AGENT_ID)' != ''"`)

This was added when our specific infra was running into file-size issues with E2ETest, and a second VS toolset. It is really specific to what our environment was seeing, and really shouldn't be run on every user build.

We've since then alleviated our own CI setup issues, and reduced our disk footprint on PCHs and other binaries. Removing this logic unless we see new disk space issues.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7874)