### PR TITLE
Fix Error in CI Pipeline for Playground Set Up Certificate Task

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -79,7 +79,7 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            $PfxBytes = [System.Convert]::FromBase64String($(playgroundEncodedKey))
+            $PfxBytes = [System.Convert]::FromBase64String("$(playgroundEncodedKey)")
             $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath playground-Key.pfx) )
             [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
         condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')


### PR DESCRIPTION
**_What_**
Fix Error in CI Pipeline for Playground "Set Up Certificate Task". Change in #7743 did not contain quotes around secret leading to syntax error when Continuous pipeline was run. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7881)