### PR TITLE
Provide error message when an unhandled exception occurs in a native method (in Debug)

### DIFF
--- a/change/react-native-windows-c8eca782-653c-40b7-9973-879c1529aa43.json
+++ b/change/react-native-windows-c8eca782-653c-40b7-9973-879c1529aa43.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add error message when an exception happens in a native module (in Debug)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -29,10 +29,10 @@ void ReactModuleBuilder::AddConstantProvider(ConstantProviderDelegate const &con
 // Modules will usually call Windows APIs, and those APIs might expect to be called in the UI thread.
 // Developers can dispatch work to the UI thread via reactContext.UIDispatcher().Post(). When they fail to do so,
 // cppwinrt will grab the failure HRESULT (RPC_E_WRONG_THREAD), convert it to a C++ exception, and throw it.
-// However, native module methods are noexcept, meaning the CRT will call std::terminate and not propagate exceptions up the stack.
-// Developers are then left with a crashing app and no good way to debug it.
-// To improve developers' experience, we can replace the terminate handler temporarily while we call out to the native method.
-// In the terminate handler, we can inspect the exception that was thrown and give an error message before going down.
+// However, native module methods are noexcept, meaning the CRT will call std::terminate and not propagate exceptions up
+// the stack. Developers are then left with a crashing app and no good way to debug it. To improve developers'
+// experience, we can replace the terminate handler temporarily while we call out to the native method. In the terminate
+// handler, we can inspect the exception that was thrown and give an error message before going down.
 struct Terminator final {
   Terminator() {
     m_oldHandler = std::get_terminate();

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -47,7 +47,8 @@ struct Terminator final {
           StringCchPrintf(
               buf,
               ARRAYSIZE(buf),
-              L"An unhandled exception (0x%x) occurred in a native module. The exception message was:\n\n%s",
+              L"An unhandled exception (0x%x) occurred in a native module. "
+              L"The exception message was:\n\n%s",
               hr.code(),
               hr.message().c_str());
           auto messageBox = reinterpret_cast<decltype(&MessageBoxW)>(
@@ -56,7 +57,8 @@ struct Terminator final {
             StringCchCat(
                 buf,
                 ARRAYSIZE(buf),
-                L"\n\nIt's likely that the native module called a Windows API that needs to be called from the UI thread. For more information, see https://aka.ms/RNW-UIAPI");
+                L"\n\nIt's likely that the native module called a Windows API that needs to be called from the UI thread. "
+                L"For more information, see https://aka.ms/RNW-UIAPI");
           }
           messageBox(nullptr, buf, L"Unhandled exception in native module", MB_ICONERROR | MB_OK);
         } catch (...) {

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -11,6 +11,59 @@ using namespace facebook::xplat::module;
 
 namespace winrt::Microsoft::ReactNative {
 
+#ifdef DEBUG
+// Starting with RNW 0.64, native modules are called on the JS thread.
+// Modules will usually call Windows APIs, and those APIs might expect to be called in the UI thread.
+// Developers can dispatch work to the UI thread via reactContext.UIDispatcher().Post(). When they fail to do so,
+// cppwinrt will grab the failure HRESULT (RPC_E_WRONG_THREAD), convert it to a C++ exception, and throw it.
+// However, native module methods are noexcept, meaning the CRT will call std::terminate and not propagate exceptions up
+// the stack. Developers are then left with a crashing app and no good way to debug it. To improve developers'
+// experience, we can replace the terminate handler temporarily while we call out to the native method. In the terminate
+// handler, we can inspect the exception that was thrown and give an error message before going down.
+struct TerminateExceptionGuard final {
+  TerminateExceptionGuard() {
+    m_oldHandler = std::get_terminate();
+    std::set_terminate([]() {
+      auto ex = std::current_exception();
+      if (ex) {
+        try {
+          std::rethrow_exception(ex);
+        } catch (const winrt::hresult_error &hr) {
+          wchar_t buf[1024] = {};
+          StringCchPrintf(
+              buf,
+              std::size(buf),
+              L"An unhandled exception (0x%x) occurred in a native module. "
+              L"The exception message was:\n\n%s",
+              hr.code(),
+              hr.message().c_str());
+          auto messageBox = reinterpret_cast<decltype(&MessageBoxW)>(
+              GetProcAddress(GetModuleHandle(L"ext-ms-win-ntuser-dialogbox-l1-1-0.dll"), "MessageBoxW"));
+          if (hr.code() == RPC_E_WRONG_THREAD) {
+            StringCchCat(
+                buf,
+                std::size(buf),
+                L"\n\nIt's likely that the native module called a Windows API that needs to be called from the UI thread. "
+                L"For more information, see https://aka.ms/RNW-UIAPI");
+          }
+          messageBox(nullptr, buf, L"Unhandled exception in native module", MB_ICONERROR | MB_OK);
+        } catch (...) {
+        }
+      }
+    });
+  }
+  ~TerminateExceptionGuard() {
+    std::set_terminate(m_oldHandler);
+  }
+
+ private:
+  std::terminate_handler m_oldHandler;
+};
+#define REACT_TERMINATE_GUARD(x) TerminateExceptionGuard x
+#else
+#define REACT_TERMINATE_GUARD(x)
+#endif
+
 //===========================================================================
 // ReactModuleBuilder implementation
 //===========================================================================
@@ -25,56 +78,6 @@ void ReactModuleBuilder::AddConstantProvider(ConstantProviderDelegate const &con
   m_constantProviders.push_back(constantProvider);
 }
 
-#ifdef DEBUG
-// Starting with RNW 0.64, native modules are called on the JS thread.
-// Modules will usually call Windows APIs, and those APIs might expect to be called in the UI thread.
-// Developers can dispatch work to the UI thread via reactContext.UIDispatcher().Post(). When they fail to do so,
-// cppwinrt will grab the failure HRESULT (RPC_E_WRONG_THREAD), convert it to a C++ exception, and throw it.
-// However, native module methods are noexcept, meaning the CRT will call std::terminate and not propagate exceptions up
-// the stack. Developers are then left with a crashing app and no good way to debug it. To improve developers'
-// experience, we can replace the terminate handler temporarily while we call out to the native method. In the terminate
-// handler, we can inspect the exception that was thrown and give an error message before going down.
-struct Terminator final {
-  Terminator() {
-    m_oldHandler = std::get_terminate();
-    std::set_terminate([]() {
-      auto ex = std::current_exception();
-      if (ex) {
-        try {
-          std::rethrow_exception(ex);
-        } catch (const winrt::hresult_error &hr) {
-          wchar_t buf[1024] = {};
-          StringCchPrintf(
-              buf,
-              ARRAYSIZE(buf),
-              L"An unhandled exception (0x%x) occurred in a native module. "
-              L"The exception message was:\n\n%s",
-              hr.code(),
-              hr.message().c_str());
-          auto messageBox = reinterpret_cast<decltype(&MessageBoxW)>(
-              GetProcAddress(GetModuleHandle(L"ext-ms-win-ntuser-dialogbox-l1-1-0.dll"), "MessageBoxW"));
-          if (hr.code() == RPC_E_WRONG_THREAD) {
-            StringCchCat(
-                buf,
-                ARRAYSIZE(buf),
-                L"\n\nIt's likely that the native module called a Windows API that needs to be called from the UI thread. "
-                L"For more information, see https://aka.ms/RNW-UIAPI");
-          }
-          messageBox(nullptr, buf, L"Unhandled exception in native module", MB_ICONERROR | MB_OK);
-        } catch (...) {
-        }
-      }
-    });
-  }
-  ~Terminator() {
-    std::set_terminate(m_oldHandler);
-  }
-
- private:
-  std::terminate_handler m_oldHandler;
-};
-#endif
-
 void ReactModuleBuilder::AddMethod(
     hstring const &name,
     MethodReturnType returnType,
@@ -86,9 +89,8 @@ void ReactModuleBuilder::AddMethod(
         auto resolveCallback = MakeMethodResultCallback(std::move(resolve));
         auto rejectCallback = MakeMethodResultCallback(std::move(reject));
 
-#ifdef DEBUG
-        Terminator term;
-#endif
+        REACT_TERMINATE_GUARD(term);
+
         method(argReader, resultWriter, resolveCallback, rejectCallback);
       });
 

--- a/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/IReactModuleBuilder.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "IReactModuleBuilder.h"
+#include <strsafe.h>
 #include "DynamicWriter.h"
 #include "ReactHost/MsoUtils.h"
 


### PR DESCRIPTION
Fixes #7871 

Today when a native module calls an API that expects to be called on the UI thread, from the JS thread, an exception is raised and the app is forcefully terminated. This is because native module methods are `noexcept`.

This change adds some guardrails for developers to indicate what the issue was, and points them to our new documentation about posting work to the UI dispatcher. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7889)