### PR TITLE
Allow propagating WinRTWebSocketResource constructor exceptions

### DIFF
--- a/change/react-native-windows-fb507b4a-50b0-480f-bf49-e8ad0ca6f888.json
+++ b/change/react-native-windows-fb507b4a-50b0-480f-bf49-e8ad0ca6f888.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow propagating WinRT WS resource constructor exceptions",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -39,6 +39,18 @@ TEST_CLASS (WebSocketModuleTest) {
     Assert::AreEqual(static_cast<size_t>(0), module->getConstants().size());
   }
 
+  TEST_METHOD(ConnectEmptyUriFails) {
+    auto module = make_unique<WebSocketModule>();
+
+    module->getMethods()
+        .at(WebSocketModule::MethodId::Connect)
+        .func(
+            dynamic::array("" /*url*/, dynamic(), dynamic(), /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+
+    // Test passes by not crashing due to an unhandled exception.
+    Assert::IsTrue(true);
+  }
+
   TEST_METHOD(ConnectSendsEvent) {
     string eventName;
     string moduleName;

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -10,6 +10,9 @@
 #include <cxxreact/JsArgumentHelpers.h>
 #include "Unicode.h"
 
+// Standard Libriary
+#include <iomanip>
+
 using namespace facebook::xplat;
 using namespace folly;
 
@@ -161,7 +164,10 @@ shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id,
     }
     catch (const winrt::hresult_error& e)
     {
-      string message =  string{"[" + e.code()} + "] " + Utf16ToUtf8(e.message());
+      std::wstringstream ss;
+      ss << L"[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << L"] " << e.message().c_str();
+      string message{winrt::to_string(ss.str()).c_str()};
+
       SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(message)));
 
       return nullptr;

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -87,19 +87,7 @@ string HResultToString(hresult &&result) {
 
 namespace Microsoft::React {
 
-WinRTWebSocketResource::WinRTWebSocketResource(
-    IMessageWebSocket &&socket,
-    IDataWriter &&writer,
-    Uri &&uri,
-    vector<ChainValidationResult> &&certExeptions) noexcept
-    : m_uri{std::move(uri)}, m_socket{std::move(socket)}, m_writer{std::move(writer)} {
-  m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
-
-  for (const auto &certException : certExeptions) {
-    m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
-  }
-}
-
+//private
 WinRTWebSocketResource::WinRTWebSocketResource(
     IMessageWebSocket &&socket,
     Uri &&uri,
@@ -111,8 +99,21 @@ WinRTWebSocketResource::WinRTWebSocketResource(
           std::move(certExeptions)) {}
 
 WinRTWebSocketResource::WinRTWebSocketResource(
+    IMessageWebSocket &&socket,
+    IDataWriter &&writer,
+    Uri &&uri,
+    vector<ChainValidationResult> &&certExeptions)
+    : m_uri{std::move(uri)}, m_socket{std::move(socket)}, m_writer{std::move(writer)} {
+  m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
+
+  for (const auto &certException : certExeptions) {
+    m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
+  }
+}
+
+WinRTWebSocketResource::WinRTWebSocketResource(
     const string &urlString,
-    vector<ChainValidationResult> &&certExeptions) noexcept
+    vector<ChainValidationResult> &&certExeptions)
     : WinRTWebSocketResource(MessageWebSocket{}, Uri{winrt::to_hstring(urlString)}, std::move(certExeptions)) {}
 
 WinRTWebSocketResource::~WinRTWebSocketResource() noexcept /*override*/

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -87,7 +87,7 @@ string HResultToString(hresult &&result) {
 
 namespace Microsoft::React {
 
-//private
+// private
 WinRTWebSocketResource::WinRTWebSocketResource(
     IMessageWebSocket &&socket,
     Uri &&uri,
@@ -111,9 +111,7 @@ WinRTWebSocketResource::WinRTWebSocketResource(
   }
 }
 
-WinRTWebSocketResource::WinRTWebSocketResource(
-    const string &urlString,
-    vector<ChainValidationResult> &&certExeptions)
+WinRTWebSocketResource::WinRTWebSocketResource(const string &urlString, vector<ChainValidationResult> &&certExeptions)
     : WinRTWebSocketResource(MessageWebSocket{}, Uri{winrt::to_hstring(urlString)}, std::move(certExeptions)) {}
 
 WinRTWebSocketResource::~WinRTWebSocketResource() noexcept /*override*/

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -64,12 +64,12 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
       winrt::Windows::Foundation::Uri &&uri,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions) noexcept;
+          &&certExeptions);
 
   WinRTWebSocketResource(
       const std::string &urlString,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions) noexcept;
+          &&certExeptions);
 
   ~WinRTWebSocketResource() noexcept override;
 

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -63,13 +63,11 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
 
   WinRTWebSocketResource(
       const std::string &urlString,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
 
   ~WinRTWebSocketResource() noexcept override;
 


### PR DESCRIPTION
Exceptions on member construction (i.e. `m_uri`) were crashing the host process due to public `WinRTWebSocketResource` constructors being marked as `noexcept`.

This change removes the `noexcept` qualifier from those constructors, allowing the eventual `winrt::hresult_error` exceptions to be correctly handled by the owning object (i.e. `WebSocketModule`).

This change is critical to correctly handle corner cases like extraneous or empty strings passed to the WebSocket connection URL so backports down to `0.63-stable` are requested.

**Note** the modified APIs are not exposed to the export layer, so this change should be transparent to any consuming application.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7892)