### PR TITLE
[0.65] Allow propagating WinRTWebSocketResource constructor exceptions

### DIFF
--- a/change/react-native-windows-528a6d68-44a6-40ab-8e25-63b25356b527.json
+++ b/change/react-native-windows-528a6d68-44a6-40ab-8e25-63b25356b527.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Allow propagating WinRT WS resource constructor exceptions",
+  "comment": "Allow propagating WinRTWebSocketResource constructor exceptions (#7892)",
   "packageName": "react-native-windows",
   "email": "julio.rocha@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-fb507b4a-50b0-480f-bf49-e8ad0ca6f888.json
+++ b/change/react-native-windows-fb507b4a-50b0-480f-bf49-e8ad0ca6f888.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow propagating WinRT WS resource constructor exceptions",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -39,6 +39,18 @@ TEST_CLASS (WebSocketModuleTest) {
     Assert::AreEqual(static_cast<size_t>(0), module->getConstants().size());
   }
 
+  TEST_METHOD(ConnectEmptyUriFails) {
+    auto module = make_unique<WebSocketModule>();
+
+    module->getMethods()
+        .at(WebSocketModule::MethodId::Connect)
+        .func(
+            dynamic::array("" /*url*/, dynamic(), dynamic(), /*id*/ 0), [](vector<dynamic>) {}, [](vector<dynamic>) {});
+
+    // Test passes by not crashing due to an unhandled exception.
+    Assert::IsTrue(true);
+  }
+
   TEST_METHOD(ConnectSendsEvent) {
     string eventName;
     string moduleName;

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -10,6 +10,9 @@
 #include <cxxreact/JsArgumentHelpers.h>
 #include "Unicode.h"
 
+// Standard Libriary
+#include <iomanip>
+
 using namespace facebook::xplat;
 using namespace folly;
 
@@ -161,7 +164,10 @@ shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id,
     }
     catch (const winrt::hresult_error& e)
     {
-      string message =  string{"[" + e.code()} + "] " + Utf16ToUtf8(e.message());
+      std::wstringstream ss;
+      ss << L"[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << L"] " << e.message().c_str();
+      string message{winrt::to_string(ss.str()).c_str()};
+
       SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(message)));
 
       return nullptr;

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -91,28 +91,28 @@ namespace Microsoft::React {
 WinRTWebSocketResource::WinRTWebSocketResource(
     IMessageWebSocket &&socket,
     Uri &&uri,
-    vector<ChainValidationResult> certExeptions) noexcept
+    vector<ChainValidationResult> &&certExceptions)
     : WinRTWebSocketResource(
           std::move(socket),
           DataWriter{socket.OutputStream()},
           std::move(uri),
-          std::move(certExeptions)) {}
+          std::move(certExceptions)) {}
 
 WinRTWebSocketResource::WinRTWebSocketResource(
     IMessageWebSocket &&socket,
     IDataWriter &&writer,
     Uri &&uri,
-    vector<ChainValidationResult> &&certExeptions)
+    vector<ChainValidationResult> &&certExceptions)
     : m_uri{std::move(uri)}, m_socket{std::move(socket)}, m_writer{std::move(writer)} {
   m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
 
-  for (const auto &certException : certExeptions) {
+  for (const auto &certException : certExceptions) {
     m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
   }
 }
 
-WinRTWebSocketResource::WinRTWebSocketResource(const string &urlString, vector<ChainValidationResult> &&certExeptions)
-    : WinRTWebSocketResource(MessageWebSocket{}, Uri{winrt::to_hstring(urlString)}, std::move(certExeptions)) {}
+WinRTWebSocketResource::WinRTWebSocketResource(const string &urlString, vector<ChainValidationResult> &&certExceptions)
+    : WinRTWebSocketResource(MessageWebSocket{}, Uri{winrt::to_hstring(urlString)}, std::move(certExceptions)) {}
 
 WinRTWebSocketResource::~WinRTWebSocketResource() noexcept /*override*/
 {

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -87,19 +87,7 @@ string HResultToString(hresult &&result) {
 
 namespace Microsoft::React {
 
-WinRTWebSocketResource::WinRTWebSocketResource(
-    IMessageWebSocket &&socket,
-    IDataWriter &&writer,
-    Uri &&uri,
-    vector<ChainValidationResult> &&certExeptions) noexcept
-    : m_uri{std::move(uri)}, m_socket{std::move(socket)}, m_writer{std::move(writer)} {
-  m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
-
-  for (const auto &certException : certExeptions) {
-    m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
-  }
-}
-
+// private
 WinRTWebSocketResource::WinRTWebSocketResource(
     IMessageWebSocket &&socket,
     Uri &&uri,
@@ -111,8 +99,19 @@ WinRTWebSocketResource::WinRTWebSocketResource(
           std::move(certExeptions)) {}
 
 WinRTWebSocketResource::WinRTWebSocketResource(
-    const string &urlString,
-    vector<ChainValidationResult> &&certExeptions) noexcept
+    IMessageWebSocket &&socket,
+    IDataWriter &&writer,
+    Uri &&uri,
+    vector<ChainValidationResult> &&certExeptions)
+    : m_uri{std::move(uri)}, m_socket{std::move(socket)}, m_writer{std::move(writer)} {
+  m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
+
+  for (const auto &certException : certExeptions) {
+    m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
+  }
+}
+
+WinRTWebSocketResource::WinRTWebSocketResource(const string &urlString, vector<ChainValidationResult> &&certExeptions)
     : WinRTWebSocketResource(MessageWebSocket{}, Uri{winrt::to_hstring(urlString)}, std::move(certExeptions)) {}
 
 WinRTWebSocketResource::~WinRTWebSocketResource() noexcept /*override*/

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -46,7 +46,7 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   WinRTWebSocketResource(
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExeptions) noexcept;
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
   winrt::Windows::Foundation::IAsyncAction PerformConnect() noexcept;
   winrt::fire_and_forget PerformPing() noexcept;
@@ -63,11 +63,11 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
   WinRTWebSocketResource(
       const std::string &urlString,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
   ~WinRTWebSocketResource() noexcept override;
 

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -63,13 +63,11 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
       winrt::Windows::Foundation::Uri &&uri,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions) noexcept;
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
 
   WinRTWebSocketResource(
       const std::string &urlString,
-      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult>
-          &&certExeptions) noexcept;
+      std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExeptions);
 
   ~WinRTWebSocketResource() noexcept override;
 


### PR DESCRIPTION
Backport of #7892.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7896)