### PR TITLE
Fix GitHub Release Generation for Previews

### DIFF
--- a/change/@rnw-scripts-create-github-releases-fd7dd57a-2910-4fdf-9e9f-a2e271f970eb.json
+++ b/change/@rnw-scripts-create-github-releases-fd7dd57a-2910-4fdf-9e9f-a2e271f970eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix GitHub Release Generation for Previews",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -267,7 +267,7 @@ function mostRecentMajorRelease(
     releaseSemver.prerelease[0] === 'preview'
   ) {
     firstVersion = semver.parse(
-      `${releaseSemver.major}.${releaseSemver.minor}.${releaseSemver.patch}.${releaseSemver.prerelease[0]}.1`,
+      `${releaseSemver.major}.${releaseSemver.minor}.${releaseSemver.patch}-${releaseSemver.prerelease[0]}.1`,
     )!;
   } else {
     return null;


### PR DESCRIPTION
Regression from a previous change. Leads to failure to create automated releases for previews.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7908)