### PR TITLE
[0.65] Require Triage Starting 6/4

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
-# Global Catch-All
-* @microsoft/react-native-windows-write
-
-# API Review for DEF/IDL file changes
-/vnext/**/*.def @microsoft/react-native-windows-api-review @microsoft/react-native-windows-write
-/vnext/**/*.idl @microsoft/react-native-windows-api-review @microsoft/react-native-windows-write
+# Enforce changes going into a stable branch are triaged
+* @microsoft/react-native-windows-backport-triage


### PR DESCRIPTION
Setting GitHub to require triage two weeks after we cut the branch and sent out reminders.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7911)