### PR TITLE
Specify Upload Appx Conditions for Playground Pipeline

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -18,11 +18,13 @@ jobs:
           BuildPlatform: x86
           SolutionFile: Playground.sln
           TestWACK: true
+          UploadAppx: true
         X64ReleaseUniversal:
           BuildConfiguration: Release
           BuildPlatform: x64
           SolutionFile: Playground.sln
           TestWACK: true
+          UploadAppx: true
         X86DebugWin32:
           BuildConfiguration: Debug
           BuildPlatform: x86
@@ -36,6 +38,7 @@ jobs:
           BuildPlatform: x86
           SolutionFile: Playground.sln
           BuildWinUI3: true
+          UploadAppx: true
     pool: $(AgentPool.Medium)
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
@@ -145,7 +148,7 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         displayName: Upload App Package
-        condition: and(succeededOrFailed(), eq('${{ parameters.BuildEnvironment }}', 'Continuous'))
+        condition: and(succeededOrFailed(), eq(variables.UploadAppx, true), eq('${{ parameters.BuildEnvironment }}', 'Continuous'))
         inputs:
           pathtoPublish: 'packages/playground/windows/AppPackages/playground'
           artifactName: 'App Packages $(BuildPlatform) $(BuildConfiguration) ($(System.JobAttempt))'


### PR DESCRIPTION
**_Why_**
CI Pipeline is failing for playground Win32 build with error "appx cannot be uploaded because package cannot be found". 

**_What_**
VS build for playground Win32 configuration does not produce an Appx package. Added a new variable to playground pipeline to specify which builds should run the task to upload their Appx. All Universal configurations will upload. All Win32 configurations will not. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7913)

Fixes #7907 