### PR TITLE
Do not mark instance as IsProfiling when using fastrefresh

### DIFF
--- a/change/react-native-windows-fbd04605-ccd9-4478-80a6-f7040fa55702.json
+++ b/change/react-native-windows-fbd04605-ccd9-4478-80a6-f7040fa55702.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not mark instance as IsProfiling when using fastrefresh",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -279,9 +279,11 @@ std::pair<std::string, bool> GetJavaScriptFromServer(
     const uint16_t sourceBundlePort,
     const std::string &jsBundleName,
     const std::string &platform,
+    bool dev,
+    bool hot,
     bool inlineSourceMap) {
   auto bundleUrl = facebook::react::DevServerHelper::get_BundleUrl(
-      sourceBundleHost, sourceBundlePort, jsBundleName, platform, true /*dev*/, false /*hot*/, inlineSourceMap);
+      sourceBundleHost, sourceBundlePort, jsBundleName, platform, dev, hot, inlineSourceMap);
   try {
     return GetJavaScriptFromServerAsync(bundleUrl).get();
   } catch (winrt::hresult_error const &e) {

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -31,6 +31,8 @@ std::pair<std::string, bool> GetJavaScriptFromServer(
     const uint16_t sourceBundlePort,
     const std::string &jsBundleName,
     const std::string &platform,
+    bool dev,
+    bool hot,
     bool inlineSourceMap);
 
 class DevSupportManager final : public facebook::react::IDevSupportManager {

--- a/vnext/Shared/tracing/tracing.cpp
+++ b/vnext/Shared/tracing/tracing.cpp
@@ -174,11 +174,11 @@ void counterJSHook(uint64_t tag, const std::string &profile_name, int value) {
       TraceLoggingInt64(value, "value"));
 }
 
-void initializeJSHooks(jsi::Runtime &runtime) {
+void initializeJSHooks(jsi::Runtime &runtime, bool isProfiling) {
   // TODO:: Assess the performance impact of hooking up the JS trace events. Especially when the tracing is not enabled.
   // If significant, this should be put under flag based on devsettings
 
-  runtime.global().setProperty(runtime, "__RCTProfileIsProfiling", true);
+  runtime.global().setProperty(runtime, "__RCTProfileIsProfiling", isProfiling);
 
   runtime.global().setProperty(
       runtime,

--- a/vnext/Shared/tracing/tracing.h
+++ b/vnext/Shared/tracing/tracing.h
@@ -11,7 +11,7 @@ namespace facebook {
 namespace react {
 namespace tracing {
 void initializeETW();
-void initializeJSHooks(facebook::jsi::Runtime &runtime);
+void initializeJSHooks(facebook::jsi::Runtime &runtime, bool isProfiling);
 
 void log(const char *msg);
 void error(const char *msg);


### PR DESCRIPTION
Currently any non-web debugging instance will set the JS variable `__RCTProfileIsProfiling` to true, which disables a bunch of logic on the JS side, including some debug checks and enabling hot reload. (Fast refresh)

Fixes #7845 

The important RN code that uses the variable for enabling/disabling fastrefresh:
https://github.com/facebook/react-native/blob/70da64094608f5f2e3c554ed719e9aad624e3459/Libraries/Core/setUpBatchedBridge.js#L43

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7924)