### PR TITLE
[0.63] [Win32] Use text instead of images for LogBox arrows

### DIFF
--- a/change/@office-iss-react-native-win32-2021-06-02-16-38-58-logboximg63win32.json
+++ b/change/@office-iss-react-native-win32-2021-06-02-16-38-58-logboximg63win32.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use text instead of images for LogBox arrows",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-02T23:38:58.846Z"
+}

--- a/packages/react-native-win32/overrides.json
+++ b/packages/react-native-win32/overrides.json
@@ -331,6 +331,14 @@
       "issue": "LEGACY_FIXME"
     },
     {
+      "type": "patch",
+      "file": "src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js",
+      "baseFile": "Libraries/LogBox/UI/LogBoxInspectorHeader.js",
+      "baseVersion": "0.63.2",
+      "baseHash": "a69f43f63a365875af68538ed95080c537597266",
+      "issue": 5886
+    },
+    {
       "type": "derived",
       "file": "src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js",
       "baseFile": "Libraries/LogBox/UI/LogBoxInspectorStackFrame.js",

--- a/packages/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
+++ b/packages/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import Image from '../../Image/Image';
+import Platform from '../../Utilities/Platform';
+import * as React from 'react';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
+import View from '../../Components/View/View';
+import StatusBar from '../../Components/StatusBar/StatusBar';
+import LogBoxButton from './LogBoxButton';
+import * as LogBoxStyle from './LogBoxStyle';
+import type {LogLevel} from '../Data/LogBoxLog';
+type Props = $ReadOnly<{|
+  onSelectIndex: (selectedIndex: number) => void,
+  selectedIndex: number,
+  total: number,
+  level: LogLevel,
+|}>;
+
+function LogBoxInspectorHeader(props: Props): React.Node {
+  if (props.level === 'syntax') {
+    return (
+      <View style={[styles.safeArea, styles[props.level]]}>
+        <View style={styles.header}>
+          <View style={styles.title}>
+            <Text style={styles.titleText}>Failed to compile</Text>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
+  const prevIndex =
+    props.selectedIndex - 1 < 0 ? props.total - 1 : props.selectedIndex - 1;
+  const nextIndex =
+    props.selectedIndex + 1 > props.total - 1 ? 0 : props.selectedIndex + 1;
+
+  const titleText = `Log ${props.selectedIndex + 1} of ${props.total}`;
+
+  return (
+    <View style={[styles.safeArea, styles[props.level]]}>
+      <View style={styles.header}>
+        <LogBoxInspectorHeaderButton
+          disabled={props.total <= 1}
+          level={props.level}
+          image={'←'}
+          onPress={() => props.onSelectIndex(prevIndex)}
+        />
+        <View style={styles.title}>
+          <Text style={styles.titleText}>{titleText}</Text>
+        </View>
+        <LogBoxInspectorHeaderButton
+          disabled={props.total <= 1}
+          focusable={true}
+          level={props.level}
+          image={'→'}
+          onPress={() => props.onSelectIndex(nextIndex)}
+        />
+      </View>
+    </View>
+  );
+}
+
+const backgroundForLevel = (level: LogLevel) =>
+  ({
+    warn: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getWarningDarkColor(),
+    },
+    error: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getErrorDarkColor(),
+    },
+    fatal: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getFatalDarkColor(),
+    },
+    syntax: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getFatalDarkColor(),
+    },
+  }[level]);
+
+function LogBoxInspectorHeaderButton(
+  props: $ReadOnly<{|
+    disabled: boolean,
+    image: string,
+    level: LogLevel,
+    onPress?: ?() => void,
+  |}>,
+): React.Node {
+  return (
+    <LogBoxButton
+      backgroundColor={backgroundForLevel(props.level)}
+      onPress={props.disabled ? null : props.onPress}
+      style={styles.title}>
+      {props.disabled ? null : (
+        <Text style={[styles.titleText, headerStyles.buttonText]}>
+          {props.image}
+        </Text>
+      )}
+    </LogBoxButton>
+  );
+}
+
+const headerStyles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    aspectRatio: 1,
+    justifyContent: 'center',
+    marginTop: 0,
+    marginRight: 6,
+    marginLeft: 6,
+    marginBottom: 0,
+    borderRadius: 3,
+    height: 50,
+    width: 50,
+  },
+  buttonText: {
+    fontSize: 30,
+  },
+  buttonImage: {
+    fontSize: 20,
+    color: LogBoxStyle.getTextColor(),
+  },
+});
+
+const styles = StyleSheet.create({
+  syntax: {
+    backgroundColor: LogBoxStyle.getFatalColor(),
+  },
+  fatal: {
+    backgroundColor: LogBoxStyle.getFatalColor(),
+  },
+  warn: {
+    backgroundColor: LogBoxStyle.getWarningColor(),
+  },
+  error: {
+    backgroundColor: LogBoxStyle.getErrorColor(),
+  },
+  header: {
+    flexDirection: 'row',
+    height: Platform.select({
+      android: 48,
+      ios: 44,
+    }),
+  },
+  title: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  titleText: {
+    color: LogBoxStyle.getTextColor(),
+    fontSize: 16,
+    fontWeight: '600',
+    includeFontPadding: false,
+    lineHeight: 20,
+  },
+  safeArea: {
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 40,
+  },
+});
+
+export default LogBoxInspectorHeader;

--- a/packages/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
+++ b/packages/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import Image from '../../Image/Image';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 import StyleSheet from '../../StyleSheet/StyleSheet';
@@ -61,7 +60,6 @@ function LogBoxInspectorHeader(props: Props): React.Node {
         </View>
         <LogBoxInspectorHeaderButton
           disabled={props.total <= 1}
-          focusable={true}
           level={props.level}
           image={'→'}
           onPress={() => props.onSelectIndex(nextIndex)}


### PR DESCRIPTION
Replace usage of png files in LogBox for arrow keys with simple text components.

Currently having images from react-native internally causes some issues, which means these images do not show up and reduce the functionality of LogBox. -- Plus its silly to ship pngs when a simple unicode character will do.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7930)