### PR TITLE
Update Button Hover Color 

### DIFF
--- a/change/react-native-windows-4b3e136e-d3d6-42fc-9751-a22cff274ac5.json
+++ b/change/react-native-windows-4b3e136e-d3d6-42fc-9751-a22cff274ac5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Button Hover",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -27,113 +27,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-    Text to display inside the button. On Android the given title will be
-    converted to the uppercased form.
-   */
+     Text to display inside the button. On Android the given title will be
+     converted to the uppercased form.
+    */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
-    argument is an event in form of [PressEvent](pressevent).
-   */
+     Handler to be called when the user taps the button. The first function
+     argument is an event in form of [PressEvent](pressevent).
+    */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-    If `true`, doesn't play system sound on touch.
-
-    @platform android
-
-    @default false
-   */
+     If `true`, doesn't play system sound on touch.
+ 
+     @platform android
+ 
+     @default false
+    */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
-
-    @default {@platform android} '#2196F3'
-    @default {@platform ios} '#007AFF'
-   */
+     Color of the text (iOS), or background color of the button (Android).
+ 
+     @default {@platform android} '#2196F3'
+     @default {@platform ios} '#007AFF'
+    */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
-
-    @platform tv
-
-    @default false
-   */
+     TV preferred focus.
+ 
+     @platform tv
+ 
+     @default false
+    */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
-    the [Android documentation][android:nextFocusDown].
-
-    [android:nextFocusDown]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
-
-    @platform android, tv
-   */
+     Designates the next view to receive focus when the user navigates down. See
+     the [Android documentation][android:nextFocusDown].
+ 
+     [android:nextFocusDown]:
+     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
+ 
+     @platform android, tv
+    */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
-    See the [Android documentation][android:nextFocusForward].
-
-    [android:nextFocusForward]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
-
-    @platform android, tv
-   */
+     Designates the next view to receive focus when the user navigates forward.
+     See the [Android documentation][android:nextFocusForward].
+ 
+     [android:nextFocusForward]:
+     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
+ 
+     @platform android, tv
+    */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
-    the [Android documentation][android:nextFocusLeft].
-
-    [android:nextFocusLeft]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
-
-    @platform android, tv
-   */
+     Designates the next view to receive focus when the user navigates left. See
+     the [Android documentation][android:nextFocusLeft].
+ 
+     [android:nextFocusLeft]:
+     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
+ 
+     @platform android, tv
+    */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
-    the [Android documentation][android:nextFocusRight].
-
-    [android:nextFocusRight]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
-
-    @platform android, tv
-   */
+     Designates the next view to receive focus when the user navigates right. See
+     the [Android documentation][android:nextFocusRight].
+ 
+     [android:nextFocusRight]:
+     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
+ 
+     @platform android, tv
+    */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
-    the [Android documentation][android:nextFocusUp].
-
-    [android:nextFocusUp]:
-    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
-
-    @platform android, tv
-   */
+     Designates the next view to receive focus when the user navigates up. See
+     the [Android documentation][android:nextFocusUp].
+ 
+     [android:nextFocusUp]:
+     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
+ 
+     @platform android, tv
+    */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
-   */
+     Text to display for blindness accessibility features.
+    */
   accessibilityLabel?: ?string,
 
   /**
-    If `true`, disable all interactions for this component.
-
-    @default false
-   */
+     If `true`, disable all interactions for this component.
+ 
+     @default false
+    */
   disabled?: ?boolean,
 
   /**
-    Used to locate this view in end-to-end tests.
-   */
+     Used to locate this view in end-to-end tests.
+    */
   testID?: ?string,
 
   /**
@@ -143,122 +143,122 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-   */
+     Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+    */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
-  A basic button component that should render nicely on any platform. Supports a
-  minimal level of customization.
-
-  If this button doesn't look right for your app, you can build your own button
-  using [TouchableOpacity](touchableopacity) or
-  [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
-  the [source code for this button component][button:source]. Or, take a look at
-  the [wide variety of button components built by the community]
-  [button:examples].
-
-  [button:source]:
-  https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js
-
-  [button:examples]:
-  https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button
-
-  ```jsx
-  <Button
-    onPress={onPressLearnMore}
-    title="Learn More"
-    color="#841584"
-    accessibilityLabel="Learn more about this purple button"
-  />
-  ```
-
-  ```SnackPlayer name=Button%20Example
-  import React from 'react';
-  import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
-
-  const Separator = () => (
-    <View style={styles.separator} />
-  );
-
-  const App = () => (
-    <SafeAreaView style={styles.container}>
-      <View>
-        <Text style={styles.title}>
-          The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
-        </Text>
-        <Button
-          title="Press me"
-          onPress={() => Alert.alert('Simple Button pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
-        </Text>
-        <Button
-          title="Press me"
-          color="#f194ff"
-          onPress={() => Alert.alert('Button with adjusted color pressed')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          All interaction for the component are disabled.
-        </Text>
-        <Button
-          title="Press me"
-          disabled
-          onPress={() => Alert.alert('Cannot press this one')}
-        />
-      </View>
-      <Separator />
-      <View>
-        <Text style={styles.title}>
-          This layout strategy lets the title define the width of the button.
-        </Text>
-        <View style={styles.fixToText}>
-          <Button
-            title="Left button"
-            onPress={() => Alert.alert('Left button pressed')}
-          />
-          <Button
-            title="Right button"
-            onPress={() => Alert.alert('Right button pressed')}
-          />
-        </View>
-      </View>
-    </SafeAreaView>
-  );
-
-  const styles = StyleSheet.create({
-    container: {
-      flex: 1,
-      justifyContent: 'center',
-      marginHorizontal: 16,
-    },
-    title: {
-      textAlign: 'center',
-      marginVertical: 8,
-    },
-    fixToText: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-    },
-    separator: {
-      marginVertical: 8,
-      borderBottomColor: '#737373',
-      borderBottomWidth: StyleSheet.hairlineWidth,
-    },
-  });
-
-  export default App;
-  ```
- */
+   A basic button component that should render nicely on any platform. Supports a
+   minimal level of customization.
+ 
+   If this button doesn't look right for your app, you can build your own button
+   using [TouchableOpacity](touchableopacity) or
+   [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
+   the [source code for this button component][button:source]. Or, take a look at
+   the [wide variety of button components built by the community]
+   [button:examples].
+ 
+   [button:source]:
+   https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js
+ 
+   [button:examples]:
+   https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button
+ 
+   ```jsx
+   <Button
+     onPress={onPressLearnMore}
+     title="Learn More"
+     color="#841584"
+     accessibilityLabel="Learn more about this purple button"
+   />
+   ```
+ 
+   ```SnackPlayer name=Button%20Example
+   import React from 'react';
+   import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
+ 
+   const Separator = () => (
+     <View style={styles.separator} />
+   );
+ 
+   const App = () => (
+     <SafeAreaView style={styles.container}>
+       <View>
+         <Text style={styles.title}>
+           The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
+         </Text>
+         <Button
+           title="Press me"
+           onPress={() => Alert.alert('Simple Button pressed')}
+         />
+       </View>
+       <Separator />
+       <View>
+         <Text style={styles.title}>
+           Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
+         </Text>
+         <Button
+           title="Press me"
+           color="#f194ff"
+           onPress={() => Alert.alert('Button with adjusted color pressed')}
+         />
+       </View>
+       <Separator />
+       <View>
+         <Text style={styles.title}>
+           All interaction for the component are disabled.
+         </Text>
+         <Button
+           title="Press me"
+           disabled
+           onPress={() => Alert.alert('Cannot press this one')}
+         />
+       </View>
+       <Separator />
+       <View>
+         <Text style={styles.title}>
+           This layout strategy lets the title define the width of the button.
+         </Text>
+         <View style={styles.fixToText}>
+           <Button
+             title="Left button"
+             onPress={() => Alert.alert('Left button pressed')}
+           />
+           <Button
+             title="Right button"
+             onPress={() => Alert.alert('Right button pressed')}
+           />
+         </View>
+       </View>
+     </SafeAreaView>
+   );
+ 
+   const styles = StyleSheet.create({
+     container: {
+       flex: 1,
+       justifyContent: 'center',
+       marginHorizontal: 16,
+     },
+     title: {
+       textAlign: 'center',
+       marginVertical: 8,
+     },
+     fixToText: {
+       flexDirection: 'row',
+       justifyContent: 'space-between',
+     },
+     separator: {
+       marginVertical: 8,
+       borderBottomColor: '#737373',
+       borderBottomWidth: StyleSheet.hairlineWidth,
+     },
+   });
+ 
+   export default App;
+   ```
+  */
 
 class Button extends React.Component<ButtonProps, {hover: boolean}> {
   // [Windows
@@ -266,6 +266,9 @@ class Button extends React.Component<ButtonProps, {hover: boolean}> {
     super(props);
     this.state = {
       hover: false,
+      // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+      // https://github.com/microsoft/react-native-windows/issues/7425
+      pressed: false,
     };
   }
   // Windows]
@@ -338,15 +341,26 @@ class Button extends React.Component<ButtonProps, {hover: boolean}> {
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
+          // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+          // https://github.com/microsoft/react-native-windows/issues/7425
           underlayColor={PlatformColor('ButtonBackgroundPressed')}
+          onShowUnderlay={() => {
+            this.setState({pressed: true});
+          }}
+          onHideUnderlay={() => {
+            this.setState({pressed: false});
+          }}
           style={
-            this.state.hover
+            this.state.hover && !this.state.pressed
               ? [
                   buttonStyles,
                   {
                     backgroundColor: PlatformColor(
                       'ButtonBackgroundPointerOver',
                     ),
+                    // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+                    // https://github.com/microsoft/react-native-windows/issues/7425
+                    opacity: 0.1,
                   },
                 ]
               : buttonStyles

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -27,113 +27,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-     Text to display inside the button. On Android the given title will be
-     converted to the uppercased form.
-    */
+    Text to display inside the button. On Android the given title will be
+    converted to the uppercased form.
+   */
   title: string,
 
   /**
-     Handler to be called when the user taps the button. The first function
-     argument is an event in form of [PressEvent](pressevent).
-    */
+    Handler to be called when the user taps the button. The first function
+    argument is an event in form of [PressEvent](pressevent).
+   */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-     If `true`, doesn't play system sound on touch.
- 
-     @platform android
- 
-     @default false
-    */
+    If `true`, doesn't play system sound on touch.
+
+    @platform android
+
+    @default false
+   */
   touchSoundDisabled?: ?boolean,
 
   /**
-     Color of the text (iOS), or background color of the button (Android).
- 
-     @default {@platform android} '#2196F3'
-     @default {@platform ios} '#007AFF'
-    */
+    Color of the text (iOS), or background color of the button (Android).
+
+    @default {@platform android} '#2196F3'
+    @default {@platform ios} '#007AFF'
+   */
   color?: ?ColorValue,
 
   /**
-     TV preferred focus.
- 
-     @platform tv
- 
-     @default false
-    */
+    TV preferred focus.
+
+    @platform tv
+
+    @default false
+   */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-     Designates the next view to receive focus when the user navigates down. See
-     the [Android documentation][android:nextFocusDown].
- 
-     [android:nextFocusDown]:
-     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
- 
-     @platform android, tv
-    */
+    Designates the next view to receive focus when the user navigates down. See
+    the [Android documentation][android:nextFocusDown].
+
+    [android:nextFocusDown]:
+    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
+
+    @platform android, tv
+   */
   nextFocusDown?: ?number,
 
   /**
-     Designates the next view to receive focus when the user navigates forward.
-     See the [Android documentation][android:nextFocusForward].
- 
-     [android:nextFocusForward]:
-     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
- 
-     @platform android, tv
-    */
+    Designates the next view to receive focus when the user navigates forward.
+    See the [Android documentation][android:nextFocusForward].
+
+    [android:nextFocusForward]:
+    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
+
+    @platform android, tv
+   */
   nextFocusForward?: ?number,
 
   /**
-     Designates the next view to receive focus when the user navigates left. See
-     the [Android documentation][android:nextFocusLeft].
- 
-     [android:nextFocusLeft]:
-     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
- 
-     @platform android, tv
-    */
+    Designates the next view to receive focus when the user navigates left. See
+    the [Android documentation][android:nextFocusLeft].
+
+    [android:nextFocusLeft]:
+    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
+
+    @platform android, tv
+   */
   nextFocusLeft?: ?number,
 
   /**
-     Designates the next view to receive focus when the user navigates right. See
-     the [Android documentation][android:nextFocusRight].
- 
-     [android:nextFocusRight]:
-     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
- 
-     @platform android, tv
-    */
+    Designates the next view to receive focus when the user navigates right. See
+    the [Android documentation][android:nextFocusRight].
+
+    [android:nextFocusRight]:
+    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
+
+    @platform android, tv
+   */
   nextFocusRight?: ?number,
 
   /**
-     Designates the next view to receive focus when the user navigates up. See
-     the [Android documentation][android:nextFocusUp].
- 
-     [android:nextFocusUp]:
-     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
- 
-     @platform android, tv
-    */
+    Designates the next view to receive focus when the user navigates up. See
+    the [Android documentation][android:nextFocusUp].
+
+    [android:nextFocusUp]:
+    https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
+
+    @platform android, tv
+   */
   nextFocusUp?: ?number,
 
   /**
-     Text to display for blindness accessibility features.
-    */
+    Text to display for blindness accessibility features.
+   */
   accessibilityLabel?: ?string,
 
   /**
-     If `true`, disable all interactions for this component.
- 
-     @default false
-    */
+    If `true`, disable all interactions for this component.
+
+    @default false
+   */
   disabled?: ?boolean,
 
   /**
-     Used to locate this view in end-to-end tests.
-    */
+    Used to locate this view in end-to-end tests.
+   */
   testID?: ?string,
 
   /**
@@ -143,124 +143,127 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-     Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-    */
+    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+   */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
-   A basic button component that should render nicely on any platform. Supports a
-   minimal level of customization.
- 
-   If this button doesn't look right for your app, you can build your own button
-   using [TouchableOpacity](touchableopacity) or
-   [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
-   the [source code for this button component][button:source]. Or, take a look at
-   the [wide variety of button components built by the community]
-   [button:examples].
- 
-   [button:source]:
-   https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js
- 
-   [button:examples]:
-   https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button
- 
-   ```jsx
-   <Button
-     onPress={onPressLearnMore}
-     title="Learn More"
-     color="#841584"
-     accessibilityLabel="Learn more about this purple button"
-   />
-   ```
- 
-   ```SnackPlayer name=Button%20Example
-   import React from 'react';
-   import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
- 
-   const Separator = () => (
-     <View style={styles.separator} />
-   );
- 
-   const App = () => (
-     <SafeAreaView style={styles.container}>
-       <View>
-         <Text style={styles.title}>
-           The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
-         </Text>
-         <Button
-           title="Press me"
-           onPress={() => Alert.alert('Simple Button pressed')}
-         />
-       </View>
-       <Separator />
-       <View>
-         <Text style={styles.title}>
-           Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
-         </Text>
-         <Button
-           title="Press me"
-           color="#f194ff"
-           onPress={() => Alert.alert('Button with adjusted color pressed')}
-         />
-       </View>
-       <Separator />
-       <View>
-         <Text style={styles.title}>
-           All interaction for the component are disabled.
-         </Text>
-         <Button
-           title="Press me"
-           disabled
-           onPress={() => Alert.alert('Cannot press this one')}
-         />
-       </View>
-       <Separator />
-       <View>
-         <Text style={styles.title}>
-           This layout strategy lets the title define the width of the button.
-         </Text>
-         <View style={styles.fixToText}>
-           <Button
-             title="Left button"
-             onPress={() => Alert.alert('Left button pressed')}
-           />
-           <Button
-             title="Right button"
-             onPress={() => Alert.alert('Right button pressed')}
-           />
-         </View>
-       </View>
-     </SafeAreaView>
-   );
- 
-   const styles = StyleSheet.create({
-     container: {
-       flex: 1,
-       justifyContent: 'center',
-       marginHorizontal: 16,
-     },
-     title: {
-       textAlign: 'center',
-       marginVertical: 8,
-     },
-     fixToText: {
-       flexDirection: 'row',
-       justifyContent: 'space-between',
-     },
-     separator: {
-       marginVertical: 8,
-       borderBottomColor: '#737373',
-       borderBottomWidth: StyleSheet.hairlineWidth,
-     },
-   });
- 
-   export default App;
-   ```
-  */
+  A basic button component that should render nicely on any platform. Supports a
+  minimal level of customization.
 
-class Button extends React.Component<ButtonProps, {hover: boolean}> {
+  If this button doesn't look right for your app, you can build your own button
+  using [TouchableOpacity](touchableopacity) or
+  [TouchableWithoutFeedback](touchablewithoutfeedback). For inspiration, look at
+  the [source code for this button component][button:source]. Or, take a look at
+  the [wide variety of button components built by the community]
+  [button:examples].
+
+  [button:source]:
+  https://github.com/facebook/react-native/blob/master/Libraries/Components/Button.js
+
+  [button:examples]:
+  https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button
+
+  ```jsx
+  <Button
+    onPress={onPressLearnMore}
+    title="Learn More"
+    color="#841584"
+    accessibilityLabel="Learn more about this purple button"
+  />
+  ```
+
+  ```SnackPlayer name=Button%20Example
+  import React from 'react';
+  import { StyleSheet, Button, View, SafeAreaView, Text, Alert } from 'react-native';
+
+  const Separator = () => (
+    <View style={styles.separator} />
+  );
+
+  const App = () => (
+    <SafeAreaView style={styles.container}>
+      <View>
+        <Text style={styles.title}>
+          The title and onPress handler are required. It is recommended to set accessibilityLabel to help make your app usable by everyone.
+        </Text>
+        <Button
+          title="Press me"
+          onPress={() => Alert.alert('Simple Button pressed')}
+        />
+      </View>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          Adjust the color in a way that looks standard on each platform. On  iOS, the color prop controls the color of the text. On Android, the color adjusts the background color of the button.
+        </Text>
+        <Button
+          title="Press me"
+          color="#f194ff"
+          onPress={() => Alert.alert('Button with adjusted color pressed')}
+        />
+      </View>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          All interaction for the component are disabled.
+        </Text>
+        <Button
+          title="Press me"
+          disabled
+          onPress={() => Alert.alert('Cannot press this one')}
+        />
+      </View>
+      <Separator />
+      <View>
+        <Text style={styles.title}>
+          This layout strategy lets the title define the width of the button.
+        </Text>
+        <View style={styles.fixToText}>
+          <Button
+            title="Left button"
+            onPress={() => Alert.alert('Left button pressed')}
+          />
+          <Button
+            title="Right button"
+            onPress={() => Alert.alert('Right button pressed')}
+          />
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+
+  const styles = StyleSheet.create({
+    container: {
+      flex: 1,
+      justifyContent: 'center',
+      marginHorizontal: 16,
+    },
+    title: {
+      textAlign: 'center',
+      marginVertical: 8,
+    },
+    fixToText: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    separator: {
+      marginVertical: 8,
+      borderBottomColor: '#737373',
+      borderBottomWidth: StyleSheet.hairlineWidth,
+    },
+  });
+
+  export default App;
+  ```
+ */
+
+class Button extends React.Component<
+  ButtonProps,
+  {hover: boolean, pressed: boolean},
+> {
   // [Windows
   constructor(props: Object) {
     super(props);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2188,9 +2188,9 @@
     "@types/node" "*"
 
 "@types/react-native@^0.64.4":
-  version "0.64.7"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.7.tgz#feffa6ec1504f28807eaf6e487e2edede8685b9a"
-  integrity sha512-YMkzol/Ii0UxlRjkjCU9ukWzJIHsNu5rON2jpDsIA9CJntrE4FxUjvzK3GsKTxGfhxazVZdR0Jlkf18Er1ynrA==
+  version "0.64.10"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.10.tgz#5eb6a72c77ce0f7e6e14b19c61a6bc585975eef5"
+  integrity sha512-3Kb9QM5/WZ6p58yZ7VPbvjvi6Wc/ZkESgJhKso1gKkNuHBe/4WL6586R2JRDiz9Tsxal9lMnbj3fligBVGl8PA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
**_Why_**
Color extracted from Windows brush ButtonBackgroundPointerOver from MUX fails to only collects the color value and not the opacity value. This is because the ButtonBackgroundPointerOver brush uses "color" and "opacity" keys to define itself rather than a "ResourceKey". See [here](https://github.com/microsoft/microsoft-ui-xaml/blob/f06843042e7c3f29ae7bee8e941c93ad15030bad/dev/CommonStyles/Button_themeresources_v1.xaml#L23) for source. This results in the wrong color displayed during a button's hover state for apps using MUX. 

**_What_**
Add logic to specify opacity of View during hover state. Note this produces a Button that does not perfectly match the Windows styling, as it fades the button title as well as the button background. However, this code change is temporary, as it won't be needed when RNW moves to MUX2.6. See [here](https://github.com/microsoft/microsoft-ui-xaml/blob/f06843042e7c3f29ae7bee8e941c93ad15030bad/dev/CommonStyles/Button_themeresources.xaml#L26) for MUX2.6 source showing that the ButtonBackgroundPointerOver brush for 2.6 defines itself using a "ResourceKey".

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7938)