### PR TITLE
Remove Bad Task in Playground Pipeline

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -71,12 +71,6 @@ jobs:
           restoreSolution: packages/playground/windows/$(SolutionFile)
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: CmdLine@2
-        displayName: Check Secret
-        inputs:
-          script: |
-            echo ##vso[task.setvariable variable=BuildWinUI3Properties]/p:AppxPackageSigningEnabled=false /p:UseWinUI3=true
-
       - task: PowerShell@2
         displayName: Set Up Certificate
         inputs:


### PR DESCRIPTION
**_Why_**
Stale task left in playground pipeline during work of #7743. Task is unneeded and causes all builds to use WinUI3, generating errors during WACK test task.

**_What_**
Remove task from pipeline.

Fix #7935

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7941)