### PR TITLE
Add JSI.MemoryMappedScriptStore runtime option to control usage of MemoryMappedBuffer

### DIFF
--- a/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
+++ b/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Condition using memory mapped buffer to runtime option JSI.MemoryMappedScriptStore",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/BaseScriptStoreImpl.cpp
+++ b/vnext/Shared/BaseScriptStoreImpl.cpp
@@ -6,6 +6,8 @@
 #include "BaseScriptStoreImpl.h"
 #include "MemoryMappedBuffer.h"
 
+#include <RuntimeOptions.h>
+
 // C++/WinRT
 #include <winrt/base.h>
 
@@ -144,7 +146,26 @@ std::unique_ptr<const jsi::Buffer> LocalFileSimpleBufferStore::getBuffer(const s
     std::terminate();
   }
 
-  return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+  if (Microsoft::React::GetRuntimeOptionBool("JSI.MemoryMappedScriptStore")) {
+    return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+  } else {
+    // Treat buffer id as the relative path fragment.
+    std::ifstream file(storeDirectory_ + bufferId, std::ios::binary | std::ios::ate);
+
+    if (!file) {
+      return nullptr;
+    }
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    auto buffer = std::make_unique<ByteArrayBuffer>(static_cast<size_t>(size));
+    if (!file.read(reinterpret_cast<char *>(buffer->data()), size)) {
+      return nullptr;
+    }
+
+    return buffer;
+  }
 }
 
 bool LocalFileSimpleBufferStore::persistBuffer(


### PR DESCRIPTION
We have seen unexpected crashes in Office when using the memory map-based JSI Buffer, when trying to create the prepared script file handle:
```C++
  std::unique_ptr<void, decltype(&CloseHandle)> fileHandle{
      CreateFile2(filename, GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING, nullptr /* pCreateExParams */), &CloseHandle};

  if (fileHandle.get() == INVALID_HANDLE_VALUE) {
```

To mitigate this, the feature will be scaled back and require the consumer to set the `JSI.MemoryMappedScriptStore` runtime option to enable it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7943)