### PR TITLE
Run WACK validation in PR

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -131,11 +131,11 @@ jobs:
 
       - powershell: $(Build.SourcesDirectory)/.ado/scripts/TestWACK.ps1 $(BuildPlatform) $(BuildConfiguration) $(Build.StagingDirectory)\WACK
         displayName: Test WACK
-        condition: and(succeeded(), eq(variables.TestWACK, true), eq('${{ parameters.BuildEnvironment }}', 'Continuous'))
+        condition: and(succeeded(), eq(variables.TestWACK, true))
 
       - task: PublishBuildArtifacts@1
         displayName: Upload WACK report
-        condition: and(succeededOrFailed(), eq(variables.TestWACK, true), eq('${{ parameters.BuildEnvironment }}', 'Continuous'))
+        condition: and(succeededOrFailed(), eq(variables.TestWACK, true))
         inputs:
           pathtoPublish: '$(Build.StagingDirectory)/WACK'
           artifactName: 'WACK report $(BuildPlatform) $(BuildConfiguration) ($(System.JobAttempt))'


### PR DESCRIPTION
Currently it is easy to break WACK and then we are left to try to figure out which change did it. Running WACK should be fast and this will help us avoid WACK regressions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7944)