### PR TITLE
Emit `onSubmitEditing` before clearing text

### DIFF
--- a/change/react-native-windows-2021-06-04-11-17-50-textInputEventOrder.json
+++ b/change/react-native-windows-2021-06-04-11-17-50-textInputEventOrder.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Emit `onSubmitEditing` before clearing text",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-04T15:17:50.448Z"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -400,6 +400,9 @@ void TextInputShadowNode::registerPreviewKeyDown() {
                 "text", HstringToDynamic(control.as<xaml::Controls::PasswordBox>().Password()));
           }
 
+          GetViewManager()->GetReactContext().DispatchEvent(
+              tag, "topTextInputSubmitEditing", std::move(eventDataSubmitEditing));
+
           if (m_shouldClearTextOnSubmit) {
             if (m_isTextBox) {
               control.as<xaml::Controls::TextBox>().ClearValue(xaml::Controls::TextBox::TextProperty());
@@ -407,9 +410,6 @@ void TextInputShadowNode::registerPreviewKeyDown() {
               control.as<xaml::Controls::PasswordBox>().ClearValue(xaml::Controls::PasswordBox::PasswordProperty());
             }
           }
-
-          GetViewManager()->GetReactContext().DispatchEvent(
-              tag, "topTextInputSubmitEditing", std::move(eventDataSubmitEditing));
 
           // For multi-line TextInput, we have to mark the PreviewKeyDown event as
           // handled to prevent the TextInput from adding a newline character


### PR DESCRIPTION
When creating logic for submitting editing, apps may wish to use the current state of the text set by the `onChange` event rather than the text passed through by the `onSubmitEditing` event, especially if it's a controlled component where JS may modify the text in the `onChange` event. The recent change to emit `onChange` events in the `TextBox.TextChanging` event rather than the `TextBox.TextChanged` event cause the `onChange` event to fire synchronously when the `TextBox.Text` value is cleared, and the `onChange` event was arriving before `onSubmitEditing`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7949)