### PR TITLE
 Mark QuirkSettings as Experimental

### DIFF
--- a/change/react-native-windows-f28c18d4-b45b-47e2-95d9-3cd9b7154fb8.json
+++ b/change/react-native-windows-f28c18d4-b45b-47e2-95d9-3cd9b7154fb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Mark QuirkSettings as Experimental",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -9,6 +9,7 @@ namespace Microsoft.ReactNative
 {
   [webhosthidden]
   [default_interface]
+  [experimental]
   DOC_STRING(
     "This can be used to add settings that allow react-native-windows behavior to be maintained across version updates "
     "to facilitate upgrades. Settings in this class are likely to be removed in future releases, so apps should try "


### PR DESCRIPTION
`QuirkSettings` is going to have on going breaking changes in it.  So we should just mark the whole thing as experimental.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7950)