### PR TITLE
[0.65] Update Button Hover Color

### DIFF
--- a/change/react-native-windows-08e7832e-1f46-4a9b-9666-19f820b7d2cd.json
+++ b/change/react-native-windows-08e7832e-1f46-4a9b-9666-19f820b7d2cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Button Hover",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -27,113 +27,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-    Text to display inside the button. On Android the given title will be
+   Text to display inside the button. On Android the given title will be
     converted to the uppercased form.
-   */
+  */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
+   Handler to be called when the user taps the button. The first function
     argument is an event in form of [PressEvent](pressevent).
-   */
+  */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-    If `true`, doesn't play system sound on touch.
+   If `true`, doesn't play system sound on touch.
 
     @platform android
 
     @default false
-   */
+  */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
+   Color of the text (iOS), or background color of the button (Android).
 
     @default {@platform android} '#2196F3'
     @default {@platform ios} '#007AFF'
-   */
+  */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
+   TV preferred focus.
 
     @platform tv
 
     @default false
-   */
+  */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
+   Designates the next view to receive focus when the user navigates down. See
     the [Android documentation][android:nextFocusDown].
 
     [android:nextFocusDown]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
 
     @platform android, tv
-   */
+  */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
+   Designates the next view to receive focus when the user navigates forward.
     See the [Android documentation][android:nextFocusForward].
 
     [android:nextFocusForward]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
 
     @platform android, tv
-   */
+  */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
+   Designates the next view to receive focus when the user navigates left. See
     the [Android documentation][android:nextFocusLeft].
 
     [android:nextFocusLeft]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
 
     @platform android, tv
-   */
+  */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
+   Designates the next view to receive focus when the user navigates right. See
     the [Android documentation][android:nextFocusRight].
 
     [android:nextFocusRight]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
 
     @platform android, tv
-   */
+  */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
+   Designates the next view to receive focus when the user navigates up. See
     the [Android documentation][android:nextFocusUp].
 
     [android:nextFocusUp]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
 
     @platform android, tv
-   */
+  */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
-   */
+   Text to display for blindness accessibility features.
+  */
   accessibilityLabel?: ?string,
 
   /**
-    If `true`, disable all interactions for this component.
+   If `true`, disable all interactions for this component.
 
     @default false
-   */
+  */
   disabled?: ?boolean,
 
   /**
-    Used to locate this view in end-to-end tests.
-   */
+   Used to locate this view in end-to-end tests.
+  */
   testID?: ?string,
 
   /**
@@ -143,14 +143,14 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-   */
+   Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+  */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
-  A basic button component that should render nicely on any platform. Supports a
+ A basic button component that should render nicely on any platform. Supports a
   minimal level of customization.
 
   If this button doesn't look right for your app, you can build your own button
@@ -258,7 +258,7 @@ type ButtonProps = $ReadOnly<{|
 
   export default App;
   ```
- */
+*/
 
 class Button extends React.Component<ButtonProps, {hover: boolean}> {
   // [Windows

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -27,113 +27,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-   Text to display inside the button. On Android the given title will be
+    Text to display inside the button. On Android the given title will be
     converted to the uppercased form.
-  */
+   */
   title: string,
 
   /**
-   Handler to be called when the user taps the button. The first function
+    Handler to be called when the user taps the button. The first function
     argument is an event in form of [PressEvent](pressevent).
-  */
+   */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-   If `true`, doesn't play system sound on touch.
+    If `true`, doesn't play system sound on touch.
 
     @platform android
 
     @default false
-  */
+   */
   touchSoundDisabled?: ?boolean,
 
   /**
-   Color of the text (iOS), or background color of the button (Android).
+    Color of the text (iOS), or background color of the button (Android).
 
     @default {@platform android} '#2196F3'
     @default {@platform ios} '#007AFF'
-  */
+   */
   color?: ?ColorValue,
 
   /**
-   TV preferred focus.
+    TV preferred focus.
 
     @platform tv
 
     @default false
-  */
+   */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-   Designates the next view to receive focus when the user navigates down. See
+    Designates the next view to receive focus when the user navigates down. See
     the [Android documentation][android:nextFocusDown].
 
     [android:nextFocusDown]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
 
     @platform android, tv
-  */
+   */
   nextFocusDown?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates forward.
+    Designates the next view to receive focus when the user navigates forward.
     See the [Android documentation][android:nextFocusForward].
 
     [android:nextFocusForward]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
 
     @platform android, tv
-  */
+   */
   nextFocusForward?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates left. See
+    Designates the next view to receive focus when the user navigates left. See
     the [Android documentation][android:nextFocusLeft].
 
     [android:nextFocusLeft]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
 
     @platform android, tv
-  */
+   */
   nextFocusLeft?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates right. See
+    Designates the next view to receive focus when the user navigates right. See
     the [Android documentation][android:nextFocusRight].
 
     [android:nextFocusRight]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
 
     @platform android, tv
-  */
+   */
   nextFocusRight?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates up. See
+    Designates the next view to receive focus when the user navigates up. See
     the [Android documentation][android:nextFocusUp].
 
     [android:nextFocusUp]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
 
     @platform android, tv
-  */
+   */
   nextFocusUp?: ?number,
 
   /**
-   Text to display for blindness accessibility features.
-  */
+    Text to display for blindness accessibility features.
+   */
   accessibilityLabel?: ?string,
 
   /**
-   If `true`, disable all interactions for this component.
+    If `true`, disable all interactions for this component.
 
     @default false
-  */
+   */
   disabled?: ?boolean,
 
   /**
-   Used to locate this view in end-to-end tests.
-  */
+    Used to locate this view in end-to-end tests.
+   */
   testID?: ?string,
 
   /**
@@ -143,14 +143,14 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-   Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-  */
+    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+   */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
- A basic button component that should render nicely on any platform. Supports a
+  A basic button component that should render nicely on any platform. Supports a
   minimal level of customization.
 
   If this button doesn't look right for your app, you can build your own button
@@ -258,14 +258,20 @@ type ButtonProps = $ReadOnly<{|
 
   export default App;
   ```
-*/
+ */
 
-class Button extends React.Component<ButtonProps, {hover: boolean}> {
+class Button extends React.Component<
+  ButtonProps,
+  {hover: boolean, pressed: boolean},
+> {
   // [Windows
   constructor(props: Object) {
     super(props);
     this.state = {
       hover: false,
+      // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+      // https://github.com/microsoft/react-native-windows/issues/7425
+      pressed: false,
     };
   }
   // Windows]
@@ -338,15 +344,26 @@ class Button extends React.Component<ButtonProps, {hover: boolean}> {
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
+          // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+          // https://github.com/microsoft/react-native-windows/issues/7425
           underlayColor={PlatformColor('ButtonBackgroundPressed')}
+          onShowUnderlay={() => {
+            this.setState({pressed: true});
+          }}
+          onHideUnderlay={() => {
+            this.setState({pressed: false});
+          }}
           style={
-            this.state.hover
+            this.state.hover && !this.state.pressed
               ? [
                   buttonStyles,
                   {
                     backgroundColor: PlatformColor(
                       'ButtonBackgroundPointerOver',
                     ),
+                    // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
+                    // https://github.com/microsoft/react-native-windows/issues/7425
+                    opacity: 0.1,
                   },
                 ]
               : buttonStyles


### PR DESCRIPTION
**_Why_**
Color extracted from Windows brush ButtonBackgroundPointerOver from MUX fails to only collects the color value and not the opacity value. This is because the ButtonBackgroundPointerOver brush uses "color" and "opacity" keys to define itself rather than a "ResourceKey". 

**_What_**
Add logic to specify opacity of View during hover state. Note this produces a Button that does not perfectly match the Windows styling, as it fades the button title as well as the button background. However, this code change is temporary, as it won't be needed when RNW moves to MUX2.6. 

Port #7938 to 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7953)