### PR TITLE
[0.63] Add JSI.MemoryMappedScriptStore runtime option to control usage of MemoryMappedBuffer

### DIFF
--- a/change/react-native-windows-2021-06-04-13-24-10-fg-mmap-63.json
+++ b/change/react-native-windows-2021-06-04-13-24-10-fg-mmap-63.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add JSI.MemoryMappedScriptStore runtime option to control usage of MemoryMappedBuffer (#7943)",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-04T20:24:10.727Z"
+}

--- a/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
+++ b/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Condition using memory mapped buffer to runtime option JSI.MemoryMappedScriptStore",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
+++ b/change/react-native-windows-9566a736-184e-4f8f-bb18-95eefbad34a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Condition using memory mapped buffer to runtime option JSI.MemoryMappedScriptStore",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/BaseScriptStoreImpl.cpp
+++ b/vnext/Shared/BaseScriptStoreImpl.cpp
@@ -6,6 +6,8 @@
 #include "BaseScriptStoreImpl.h"
 #include "MemoryMappedBuffer.h"
 
+#include <RuntimeOptions.h>
+
 // C++/WinRT
 #include <winrt/base.h>
 
@@ -144,7 +146,26 @@ std::unique_ptr<const jsi::Buffer> LocalFileSimpleBufferStore::getBuffer(const s
     std::terminate();
   }
 
-  return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+  if (Microsoft::React::GetRuntimeOptionBool("JSI.MemoryMappedScriptStore")) {
+    return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+  } else {
+    // Treat buffer id as the relative path fragment.
+    std::ifstream file(storeDirectory_ + bufferId, std::ios::binary | std::ios::ate);
+
+    if (!file) {
+      return nullptr;
+    }
+
+    std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    auto buffer = std::make_unique<ByteArrayBuffer>(static_cast<size_t>(size));
+    if (!file.read(reinterpret_cast<char *>(buffer->data()), size)) {
+      return nullptr;
+    }
+
+    return buffer;
+  }
 }
 
 bool LocalFileSimpleBufferStore::persistBuffer(


### PR DESCRIPTION
Backport of #7943 has been approved.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7958)