### PR TITLE
Fix activation of xaml islands app in 18362

### DIFF
--- a/packages/playground/windows/playground-win32/Application.manifest
+++ b/packages/playground/windows/playground-win32/Application.manifest
@@ -5,7 +5,11 @@
     <application> 
       <!--This Id value indicates the application supports Windows 10 functionality -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
-      <maxversiontested Id="10.0.19041.0"/>
+      <!-- 
+        WARNING - DO NOT CHANGE THE maxversiontested VALUE 
+        Microsoft internal - see https://task.ms/33672605
+      -->
+      <maxversiontested Id="10.0.18362.0"/>
     </application>
   </compatibility>
 


### PR DESCRIPTION
Recently the SDK version was updated to 19041, with it we updated the win32 app's maxversiontested. However there is a bug in the OS app activation will fail if maxversiontested > current, so keeping 18362 so this app can run on 19h1. 

Fixes #7976 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7978)