### PR TITLE
Disable project/dependency config when not running on windows

### DIFF
--- a/change/@react-native-windows-cli-85ae69ed-4113-468c-85b6-9e610f051b75.json
+++ b/change/@react-native-windows-cli-85ae69ed-4113-468c-85b6-9e610f051b75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable project/dependency config when not running on windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -9,7 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
-import { platform } from 'os';
+import {platform} from 'os';
 import path from 'path';
 
 import * as configUtils from './configUtils';

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -9,6 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
+import { platform } from 'os';
 import path from 'path';
 
 import * as configUtils from './configUtils';
@@ -117,6 +118,10 @@ export function dependencyConfigWindows(
   folder: string,
   userConfig: Partial<WindowsDependencyConfig> | null = {},
 ): WindowsDependencyConfig | null {
+  if (platform() !== 'win32') {
+    return null;
+  }
+
   if (userConfig === null) {
     return null;
   }

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -9,7 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
-import { platform } from 'os';
+import {platform} from 'os';
 import path from 'path';
 
 import * as configUtils from './configUtils';

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -9,6 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
+import { platform } from 'os';
 import path from 'path';
 
 import * as configUtils from './configUtils';
@@ -84,6 +85,10 @@ export function projectConfigWindows(
   folder: string,
   userConfig: Partial<WindowsProjectConfig> | null = {},
 ): WindowsProjectConfig | null {
+  if (platform() !== 'win32') {
+    return null;
+  }
+
   if (userConfig === null) {
     return null;
   }


### PR DESCRIPTION
This PR adds a check to project and dependency config to bail when not
running on windows, since we assume non-windows machines don't need the
windows config information.

Closes #7979

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7980)