### PR TITLE
 Normalize paths provided by react-native.config.js

### DIFF
--- a/change/@react-native-windows-cli-35e87e87-c745-44ad-8f4c-2b38f9b46108.json
+++ b/change/@react-native-windows-cli-35e87e87-c745-44ad-8f4c-2b38f9b46108.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Normalize paths provided by react-native.config.js",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -226,6 +226,8 @@ export function dependencyConfigWindows(
 
       const projectContents = configUtils.readProjectFile(projectFile);
 
+      project.projectFile = path.relative(sourceDir, projectFile);
+
       // Calculating (auto) items
       project.projectName = configUtils.getProjectName(
         projectFile,


### PR DESCRIPTION
This PR makes sure that raw paths specified in a react-native.config.js
are normalized when config is run, before the result is passed up to
whichever CLI command called for it.

Closes #7979

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7982)