### PR TITLE
fix pipeline casing of x64/x86 as yaml string compare is case sensitive

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -12,11 +12,11 @@
           Matrix:
             - Name: X64ReleaseFast
               BuildConfiguration: Release
-              BuildPlatform: X64
+              BuildPlatform: x64
               FastBuild: true
             - Name: X86DebugFast
               BuildConfiguration: Debug
-              BuildPlatform: X86
+              BuildPlatform: x86
               LayoutHeaders: true
               FastBuild: true
         - BuildEnvironment: Continuous
@@ -31,28 +31,28 @@
               FastBuild: false
             - Name: X64Debug
               BuildConfiguration: Debug
-              BuildPlatform: X64
+              BuildPlatform: x64
               FastBuild: false
             - Name: X64Release
               BuildConfiguration: Release
-              BuildPlatform: X64
+              BuildPlatform: x64
               FastBuild: false
             - Name: X86Debug
               BuildConfiguration: Debug
-              BuildPlatform: X86
+              BuildPlatform: x86
               LayoutHeaders: true
               FastBuild: false
             - Name: X86Release
               BuildConfiguration: Release
-              BuildPlatform: X86
+              BuildPlatform: x86
               FastBuild: false
             - Name: X64ReleaseFast
               BuildConfiguration: Release
-              BuildPlatform: X64
+              BuildPlatform: x64
               FastBuild: true
             - Name: X86DebugFast
               BuildConfiguration: Debug
-              BuildPlatform: X86
+              BuildPlatform: x86
               LayoutHeaders: true
               FastBuild: true
 
@@ -175,7 +175,7 @@
                     publishRunAttachments: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
-                  condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
+                  condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))
 
                 - task: VSTest@2
                   displayName: Run Universal Unit Tests (UWP)
@@ -192,7 +192,7 @@
                     codeCoverageEnabled: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
-                  condition: and(succeeded(), not(startsWith(variables.BuildPlatform, 'arm')))
+                  condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))
 
                 - task: VSTest@2
                   displayName: Run Universal Unit Tests (NetCore)
@@ -209,7 +209,7 @@
                     codeCoverageEnabled: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
-                  condition: and(succeeded(), eq(variables.BuildPlatform, 'x64'))
+                  condition: and(succeeded(), eq('${{ matrix.BuildPlatform }}', 'x64'))
 
     # This job is the one that accumulates the spread out build tasks into one dependency
     - job: UniversalBuild

--- a/change/react-native-windows-701bd979-0064-4bf6-821a-188c704345a3.json
+++ b/change/react-native-windows-701bd979-0064-4bf6-821a-188c704345a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix pipeline casing of x64/x86 as yaml string compare is case sensitive",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
@vmoroz Discovered that we were not running the unittests for the C# CodeGen tool in Pr or CI.
After investigation it seems I made a mistake when factoring the yaml and use 'X64' instead of 'x64' for the build platform. Yaml string compare is case sensitive by default, so the condition to run the tests was never met.

After this we should also report code coverage reports again for the netcore code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/7983)