### PR TITLE
Adds timestamp to onKeyUp/Down events

### DIFF
--- a/change/react-native-windows-8cc2d5c9-9a96-49cd-9235-6d0679ed92e4.json
+++ b/change/react-native-windows-8cc2d5c9-9a96-49cd-9235-6d0679ed92e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds timestamp to onKeyUp/Down events",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -56,9 +56,9 @@ std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::React
   return json_type_traits<std::vector<HandledKeyboardEvent>>::parseJson(obj);
 }
 
-static folly::dynamic ToEventData(ReactKeyboardEvent event) {
+static folly::dynamic ToEventData(ReactKeyboardEvent event, double timestamp) {
   return folly::dynamic::object(TARGET, event.target)(ALT_KEY, event.altKey)(CTRL_KEY, event.ctrlKey)(KEY, event.key)(
-      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, GetTickCount64());
+      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, timestamp);
 }
 
 KeyboardEventBaseHandler::KeyboardEventBaseHandler(KeyboardEventCallback &&keyDown, KeyboardEventCallback &&keyUp)
@@ -211,6 +211,8 @@ void UpdateModifiedKeyStatusTo(T &event) {
 void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
     std::string &&eventName,
     xaml::Input::KeyRoutedEventArgs const &args) {
+  const auto timestamp =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count();
   if (auto source = args.OriginalSource().try_as<xaml::FrameworkElement>()) {
     auto reactId = getViewId(*m_context, source);
     if (reactId.isValid) {
@@ -220,7 +222,7 @@ void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
       event.key = KeyboardHelper::FromVirtualKey(args.Key(), event.shiftKey, event.capLocked);
       event.code = KeyboardHelper::CodeFromVirtualKey(args.OriginalKey());
 
-      m_context->DispatchEvent(event.target, std::move(eventName), ToEventData(event));
+      m_context->DispatchEvent(event.target, std::move(eventName), ToEventData(event, timestamp));
     }
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -20,6 +20,7 @@ static constexpr auto EVENT_PHASE = "handledEventPhase";
 static constexpr auto KEY = "key";
 static constexpr auto TARGET = "target";
 static constexpr auto CODE = "code";
+static constexpr auto TIMESTAMP = "timestamp";
 
 template <>
 struct json_type_traits<Microsoft::ReactNative::HandledKeyboardEvent> {
@@ -57,7 +58,7 @@ std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::React
 
 static folly::dynamic ToEventData(ReactKeyboardEvent event) {
   return folly::dynamic::object(TARGET, event.target)(ALT_KEY, event.altKey)(CTRL_KEY, event.ctrlKey)(KEY, event.key)(
-      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code);
+      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, GetTickCount64());
 }
 
 KeyboardEventBaseHandler::KeyboardEventBaseHandler(KeyboardEventCallback &&keyDown, KeyboardEventCallback &&keyUp)

--- a/vnext/proposals/active/keyboard-reconcile-desktop.md
+++ b/vnext/proposals/active/keyboard-reconcile-desktop.md
@@ -15,9 +15,9 @@ Property that determines whether this View, Touchable should be focusable with a
 | boolean | No | Windows, macOS | false |
 
 React Native core introduced `focusable` that does the same thing as acceptsKeyboardFocus in v0.62. In order to align and make this complete, the work here includes the following:
-- **COMPLETED** : Windows has added `focusable` and marked `acceptsKeyboardFocus` as deprecated in 0.62. 
+- **COMPLETED** : Windows has added `focusable` and marked `acceptsKeyboardFocus` as deprecated in 0.62.
 - macOS needs to do add `focusable` and mark `acceptsKeyboardFocus` as deprecated. Tracked by - [Issue#498](https://github.com/microsoft/react-native-macos/issues/498)
-- **COMPLETED** : Add focusable to Pressable ([windows Issue#5512](https://github.com/microsoft/react-native-windows/issues/5512), [macOS Issue#500](https://github.com/microsoft/react-native-macos/issues/500)). 
+- **COMPLETED** : Add focusable to Pressable ([windows Issue#5512](https://github.com/microsoft/react-native-windows/issues/5512), [macOS Issue#500](https://github.com/microsoft/react-native-macos/issues/500)).
 - `focusable` is already supported in Android and exists in core. There is no hard upstreaming requirement, however – it would be good to implement this for iOS/iPadOS for completion.
 
 ## focus, blur, onFocus, onBlur on View
@@ -44,7 +44,7 @@ macOS has implemented an `onScrollKeyDown` callback in ScrollView to scroll the 
 
 ## onKeyXX callbacks
 
-The following callbacks are available on View component (and get passed through to TextInput and Pressable) in Windows to cover the most common use cases where key stroke handling is likely to occur. Other individual components where they may be neeeded can wrap a View around themselves. 
+The following callbacks are available on View component (and get passed through to TextInput and Pressable) in Windows to cover the most common use cases where key stroke handling is likely to occur. Other individual components where they may be neeeded can wrap a View around themselves.
 > Note: The `onKeyDown` event fires repeatedly when a key is held down continuously which is also similar to how native Windows implements KeyDown.
 
 All the below need to be implemented for macOS. Tracked by [Issue#520](https://github.com/microsoft/react-native-macos/issues/520)
@@ -68,6 +68,7 @@ Where `IKeyboardEvent` is a new event type added to `ReactNative.NativeSynthetic
 | shiftKey | boolean | The Shift key. | false |
 | metaKey | boolean | Maps to Windows Logo key and the Apple Command key. | False |
 | repeat | boolean | Flag to represent if a key is being held down/repeated. Tracked by [Windows Issue#5513](https://github.com/microsoft/react-native-windows/issues/5513), [macOS Issue#502](https://github.com/microsoft/react-native-macos/issues/502) | False |
+| timestamp | number | The time, relative to the system boot time, in milliseconds. | undefined |
 | ~~eventPhase~~ | ~~EventPhase~~ | ~~Current phase of routing for the key event.~~ | ~~Bubbling~~ |
 
 ~~Where EventPhase is an enum to detect whether the keystroke is being tunneled/bubbled to the target component that has focus. It has the following fields:~~
@@ -80,7 +81,7 @@ Where `IKeyboardEvent` is a new event type added to `ReactNative.NativeSynthetic
 In the following example, the lastKeyDown prop will contain the key stroke from the end user when keyboard focus is on View.
 ```
   <View onKeyDown={this._onKeyDown} />
-      
+
   private _onKeyDown = (event: IKeyboardEvent) => {
     this.setState({ lastKeyDown: event.nativeEvent.key });
   };
@@ -106,15 +107,15 @@ When the `onKeyXX` events are handled by the app code, the corresponding native 
 In the following example, the app's logic takes precedence when certain keystrokes are encountered at certain event routing phases in the TextInput before the native platform can handle them.
 ```
   <TextInput onKeyUp={this._onKeyUp} keyUpEvents={handledNativeKeyboardEvents} />
-  
+
   const handledNativeKeyboardEvents: IHandledKeyboardEvent[] = [
      { key: 'Enter', eventPhase : EventPhase.Bubbling },
   ];
-  
+
   private _onKeyUp = (event: IKeyboardEvent) => {
     if(event.nativeEvent.key == 'Enter'){
             //do something custom when Enter key is detected when focus is on the TextInput component AFTER the native TextBox has had a chance to handle it (eventPhase = Bubbling)
-    }    
+    }
   };
 ```
 **Behavior details:**
@@ -127,22 +128,22 @@ In the following example, the app's logic takes precedence when certain keystrok
 - It is possible to declare different keystrokes for different event phases on the same component. For example, the following is allowed:
 ```
   <TextInput onKeyUp={this._onKeyUp} keyUpEvents={handledNativeKeyboardEvents} />
-  
+
   const handledNativeKeyboardEvents: IHandledKeyboardEvent[] = [
      { key: 'Esc' },
      { key: 'Enter', ctrlKey : true, eventPhase : EventPhase.Capturing }
   ];
-  
+
   private _onKeyUp = (event: IKeyboardEvent) => {
     if(event.nativeEvent.key == 'Esc'){
-       //do something custom when Escape key is detected when focus is on the TextInput component AFTER 
+       //do something custom when Escape key is detected when focus is on the TextInput component AFTER
        //the native TextBox has had a chance to handle it (default eventPhase = Bubbling)
-    } else if (event.nativeEvent.key == 'Enter' && 
-               event.nativeEvent.eventPhase == EventPhase.Capturing && 
+    } else if (event.nativeEvent.key == 'Enter' &&
+               event.nativeEvent.eventPhase == EventPhase.Capturing &&
                event.nativeEvent.ctrlKey == true)
     {
        //do something custom when user presses Ctrl + Enter when focus is on the TextInput component BEFORE
        //the native TextBox has had a chance to handle it.
-    }      
-  }; 
+    }
+  };
 ```


### PR DESCRIPTION
In order to better support perf testing metrics for events driven by either pointer events or keyboard events (e.g., triggered by Pressable, which can be triggered by either keyboard or pointer), this adds a timestamp property to the native event data for `onKeyDown` and `onKeyUp`.

Ideally this would use a native timestamp from the KeyRoutedEventArgs to get the actual time the key event occurred, but this is a sufficient approximation absent a XAML API to retrive this.

We use `GetTickCount64()` because that matches the behavior for the PointerRoutedEventArgs.

Fixes #8004

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8006)