### PR TITLE
Add Templates for Certificate Retrieval in Pipeline

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -18,9 +18,14 @@ jobs:
           #   BuildPlatform: ARM64
           x64:
             BuildPlatform: x64
+            DeployOption:
+          x86:
+            BuildPlatform: x86
         # End Continuous only
-        x86:
-          BuildPlatform: x86
+        ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+          x86:
+            BuildPlatform: x86
+            DeployOption: --deploy-from-layout
 
     variables:
       - template: ../variables/vs2019.yml
@@ -55,39 +60,15 @@ jobs:
           workingDirectory: $(Build.SourcesDirectory)
         condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
 
-      - task: PowerShell@2
-        displayName: Set Up Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxBytes = [System.Convert]::FromBase64String("$(reactUWPTestAppEncodedKey)")
-            $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath reactUWPTestApp-Key.pfx) )
-            [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
-
-      - task: CmdLine@2
-        displayName: run-windows - PR
-        inputs:
-          script: yarn windows --no-launch --no-packager --arch $(BuildPlatform) --deploy-from-layout --release --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      - template: ../templates/run-windows-with-certificates.yml
+        parameters:
+          buildEnvironment: ${{ parameters.BuildEnvironment }}
+          encodedKey: reactUWPTestAppEncodedKey
+          buildConfiguration: Release
+          buildPlatform: $(BuildPlatform)
+          deployOption: $(DeployOption)
+          buildLogDirectory: $(BuildLogDirectory)
           workingDirectory: packages/e2e-test-app
-        condition: eq('${{ parameters.BuildEnvironment }}', 'PullRequest')
-
-      - task: CmdLine@2
-        displayName: run-windows - CI
-        inputs:
-          script: yarn windows --no-launch --no-packager --arch $(BuildPlatform) --release --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir),PackageCertificateKeyFile=$(Build.SourcesDirectory)\reactUWPTestApp-Key.pfx
-          workingDirectory: packages/e2e-test-app
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
-
-      - task: PowerShell@2
-        displayName: Remove Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxPath = Join-Path -Path $(Build.SourcesDirectory) -ChildPath reactUWPTestApp-Key.pfx
-            Write-Host $PfxPath
-            Remove-Item -path $PfxPath
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
 
       - script: |
           echo ##vso[task.setvariable variable=StartedTests]true

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -71,15 +71,10 @@ jobs:
           restoreSolution: packages/playground/windows/$(SolutionFile)
           verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-      - task: PowerShell@2
-        displayName: Set Up Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxBytes = [System.Convert]::FromBase64String("$(playgroundEncodedKey)")
-            $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath playground-Key.pfx) )
-            [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
+      - template: ../templates/setup-certificate.yml
+        parameters:
+          buildEnvironment: ${{ parameters.BuildEnvironment }}
+          encodedKey: playgroundEncodedKey
 
       - task: VSBuild@1
         displayName: VSBuild - Playground PR
@@ -119,15 +114,9 @@ jobs:
             /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\playground-Key.pfx
         condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
 
-      - task: PowerShell@2
-        displayName: Remove Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxPath = Join-Path -Path $(Build.SourcesDirectory) -ChildPath playground-Key.pfx
-            Write-Host $PfxPath
-            Remove-Item -path $PfxPath
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
+      - template: ../templates/cleanup-certificate.yml
+        parameters:
+          buildEnvironment: ${{ parameters.BuildEnvironment }}
 
       - powershell: $(Build.SourcesDirectory)/.ado/scripts/TestWACK.ps1 $(BuildPlatform) $(BuildConfiguration) $(Build.StagingDirectory)\WACK
         displayName: Test WACK

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -43,7 +43,7 @@ jobs:
           X86Release:
             BuildConfiguration: Release
             BuildPlatform: x86
-            NoDeployOption:
+            DeployOption:
         # End Continuous only
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
@@ -64,46 +64,16 @@ jobs:
           verbosityRestore: Detailed # Options: quiet, normal, detailed
         condition: succeeded()
 
-      - task: PowerShell@2
-        displayName: Set Up Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxBytes = [System.Convert]::FromBase64String("$(sampleAppCPPEncodedKey)")
-            $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath sampleAppCPP-Key.pfx) )
-            [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
-
-      - task: CmdLine@2
-        displayName: run-windows (Debug)
-        inputs:
-          script: yarn windows --no-packager --no-launch $(DeployOption) --arch $(BuildPlatform) --logging --buildLogDirectory $(BuildLogDirectory) --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      - template: ../templates/run-windows-with-certificates.yml
+        parameters:
+          buildEnvironment: ${{ parameters.BuildEnvironment }}
+          encodedKey: sampleAppCPPEncodedKey
+          ${{ if eq(variables.BuildConfiguration, 'Release') }}:
+            buildConfiguration: Release
+          buildPlatform: $(BuildPlatform)
+          deployOption: $(DeployOption)
+          buildLogDirectory: $(BuildLogDirectory)
           workingDirectory: packages/sample-apps
-        condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Debug'))
-
-      - task: CmdLine@2
-        displayName: run-windows (Release) - PR
-        inputs:
-          script: yarn windows --no-packager --no-launch $(DeployOption) --arch $(BuildPlatform) --logging --buildLogDirectory $(BuildLogDirectory) --release --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
-          workingDirectory: packages/sample-apps
-        condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.BuildEnvironment }}', 'PullRequest'))
-
-      - task: CmdLine@2
-        displayName: run-windows (Release) - CI
-        inputs:
-          script: yarn windows --no-packager --no-launch $(DeployOption) --arch $(BuildPlatform) --logging --buildLogDirectory $(BuildLogDirectory) --release --msbuildprops BaseIntDir=$(BaseIntDir),PackageCertificateKeyFile=$(Build.SourcesDirectory)\sampleAppCPP-Key.pfx
-          workingDirectory: packages/sample-apps
-        condition: and(succeeded(), eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.BuildEnvironment }}', 'Continuous'))
-
-      - task: PowerShell@2
-        displayName: Remove Certificate
-        inputs:
-          targetType: 'inline'
-          script: |
-            $PfxPath = Join-Path -Path $(Build.SourcesDirectory) -ChildPath sampleAppCPP-Key.pfx
-            Write-Host $PfxPath
-            Remove-Item -path $PfxPath
-        condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
 
       - task: CmdLine@2
         displayName: Create SampleApp bundle

--- a/.ado/templates/cleanup-certificate.yml
+++ b/.ado/templates/cleanup-certificate.yml
@@ -1,0 +1,18 @@
+parameters:
+  - name: buildEnvironment
+    type: string
+    default: PullRequest
+    values: 
+     - PullRequest 
+     - Continuous
+
+steps:
+  - task: PowerShell@2
+    displayName: Remove Certificate
+    inputs:
+      targetType: 'inline'
+      script: |
+        $PfxPath = Join-Path -Path $(Build.SourcesDirectory) -ChildPath EncodedKey.pfx
+        Write-Host $PfxPath
+        Remove-Item -path $PfxPath
+    condition: eq('${{ parameters.buildEnvironment }}', 'Continuous')

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -1,0 +1,54 @@
+parameters:
+  - name: buildEnvironment
+    type: string
+    default: PullRequest
+    values: 
+     - PullRequest 
+     - Continuous
+  - name: encodedKey
+    type: string
+  - name: buildConfiguration
+    type: string
+    default: 'Debug'
+    values:
+    - Debug
+    - Release
+  - name: buildPlatform
+    type: string
+  - name: deployOption
+    type: string
+  - name: buildLogDirectory
+    type: string
+  - name: workingDirectory
+    type: string
+
+steps:
+  - template: ../templates/setup-certificate.yml
+    parameters:
+      buildEnvironment: ${{ parameters.BuildEnvironment }}
+      encodedKey: ${{ parameters.encodedKey }}
+
+  - task: CmdLine@2
+    displayName: run-windows (Debug)
+    inputs:
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      workingDirectory: ${{ parameters.workingDirectory }}
+    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Debug'))
+
+  - task: CmdLine@2
+    displayName: run-windows (Release) - PR
+    inputs:
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      workingDirectory: ${{ parameters.workingDirectory }}
+    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'PullRequest'))
+
+  - task: CmdLine@2
+    displayName: run-windows (Release) - CI
+    inputs:
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops BaseIntDir=$(BaseIntDir),PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+      workingDirectory: ${{ parameters.workingDirectory }}
+    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'Continuous'))
+
+  - template: ../templates/cleanup-certificate.yml
+    parameters:
+      buildEnvironment: ${{ parameters.BuildEnvironment }}

--- a/.ado/templates/setup-certificate.yml
+++ b/.ado/templates/setup-certificate.yml
@@ -1,0 +1,32 @@
+parameters:
+  - name: buildEnvironment
+    type: string
+    default: PullRequest
+    values: 
+     - PullRequest 
+     - Continuous
+  - name: encodedKey
+    type: string
+
+steps:
+  - script: echo '##vso[task.setvariable variable=EncodedKey]$(sampleAppCPPEncodedKey)'
+    displayName: "Specify Certificate"
+    condition: and(eq('${{ parameters.buildEnvironment }}', 'Continuous'), eq('${{ parameters.encodedKey}}' , 'sampleAppCPPEncodedKey'))
+  
+  - script: echo '##vso[task.setvariable variable=EncodedKey]$(reactUWPTestAppEncodedKey)'
+    displayName: "Specify Certificate"
+    condition: and(eq('${{ parameters.buildEnvironment }}', 'Continuous'), eq('${{ parameters.encodedKey}}' , 'reactUWPTestAppEncodedKey'))
+
+  - script: echo '##vso[task.setvariable variable=EncodedKey]$(playgroundEncodedKey)'
+    displayName: "Specify Certificate"
+    condition: and(eq('${{ parameters.buildEnvironment }}', 'Continuous'), eq('${{ parameters.encodedKey}}' , 'playgroundEncodedKey'))
+
+  - task: PowerShell@2
+    displayName: Set Up Certificate
+    inputs:
+      targetType: 'inline'
+      script: |
+        $PfxBytes = [System.Convert]::FromBase64String("$(EncodedKey)")
+        $PfxPath = [System.IO.Path]::GetFullPath( (Join-Path -Path $(Build.SourcesDirectory) -ChildPath EncodedKey.pfx) )
+        [System.IO.File]::WriteAllBytes("$PfxPath", $PfxBytes)
+    condition: eq('${{ parameters.buildEnvironment }}', 'Continuous')


### PR DESCRIPTION
**_Why_**
Request in #7743 to extract certificate setup to a template file to reduce code repetition. 

**_What_**
Added three template files, one for executing the run-windows command under the new pipeline conditions which contains the logic for check which buildEnvironment it is to know if certificates can be accessed, one for setting up a certificate, and one for remove the certificate. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8015)