### PR TITLE
Reduce string conversions when reporting hresult_error

### DIFF
--- a/change/react-native-windows-f41aeaf8-aa9a-469b-89a5-c1eeaf7ce92a.json
+++ b/change/react-native-windows-f41aeaf8-aa9a-469b-89a5-c1eeaf7ce92a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reduce string conversions when reporting hresult_error",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -164,11 +164,11 @@ shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id,
     }
     catch (const winrt::hresult_error& e)
     {
-      std::wstringstream ss;
-      ss << L"[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << L"] " << e.message().c_str();
-      string message{winrt::to_string(ss.str()).c_str()};
+      std::stringstream ss;
+      ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << "] " <<
+        winrt::to_string(e.message());
 
-      SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(message)));
+      SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(ss.str())));
 
       return nullptr;
     }


### PR DESCRIPTION
Minor optimization.

Minimizes conversions when catching/reporting an instance of `winrt::hresult_error` as `std::string`.

Instead of assembling a `wstringstream` and converting it to `std::string`, this change only converts `winrt::hresult_error::message()` to `std::string`, and assembles the rest of the message using `std::stringstream`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8016)