### PR TITLE
Ensure VsTest will fail when it can't find any tests...

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -110,6 +110,7 @@ jobs:
           publishRunAttachments: true
           collectDumpOn: onAbortOnly
           vsTestVersion: latest
+          failOnMinTestsNotRun: true
 
       - task: PowerShell@2
         displayName: Set up test servers
@@ -139,6 +140,7 @@ jobs:
           publishRunAttachments: true
           collectDumpOn: onAbortOnly
           vsTestVersion: latest
+          failOnMinTestsNotRun: true
           otherConsoleOptions: '/blame -- RunConfiguration.TestSessionTimeout=300000'
         # Suspected debug assert in TestRunner hanging tests randomly. Run only on Release for now.
         condition: and(succeeded(), ne(variables['BuildConfiguration'], 'Debug'))

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -171,6 +171,7 @@
                     publishRunAttachments: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
+                    failOnMinTestsNotRun: true
                   # Issue #8003 Tracks restoring this test whose condition should be resotred disabled as it times out on releasex64...
                   # condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))
                   condition: and(succeeded(), eq('${{ matrix.BuildPlatform }}', 'x86'))
@@ -190,6 +191,7 @@
                     codeCoverageEnabled: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
+                    failOnMinTestsNotRun: true
                   condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))
 
                 - task: VSTest@2
@@ -207,6 +209,7 @@
                     codeCoverageEnabled: true
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
+                    failOnMinTestsNotRun: true
                   condition: and(succeeded(), eq('${{ matrix.BuildPlatform }}', 'x64'))
 
     # This job is the one that accumulates the spread out build tasks into one dependency


### PR DESCRIPTION
This should prevent us from accidentally doing somethign that causes 0 tests to be selected...

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8017)