### PR TITLE
Better reporting of failures to load the bundle file

### DIFF
--- a/change/react-native-windows-846102b7-d6a2-4c67-a0d1-a9f6cb4daee3.json
+++ b/change/react-native-windows-846102b7-d6a2-4c67-a0d1-a9f6cb4daee3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Better reporting of failures to load the bundle file",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -733,9 +733,7 @@ void ReactInstanceWin::OnError(const Mso::ErrorCode &errorCode) noexcept {
     m_redboxHandler->showNewError(std::move(errorInfo), ErrorType::Native);
   }
 
-  InvokeInQueue([this, errorCode]() noexcept {
-    m_options.OnError(errorCode);
-   });
+  InvokeInQueue([this, errorCode]() noexcept { m_options.OnError(errorCode); });
 
   m_updateUI();
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -541,6 +541,7 @@ void ReactInstanceWin::OnReactInstanceLoaded(const Mso::ErrorCode &errorCode) no
     } else {
       m_state = ReactInstanceState::HasError;
       m_whenLoaded.SetError(errorCode);
+      OnError(errorCode);
       AbandonJSCallQueue();
     }
   }
@@ -719,22 +720,25 @@ std::function<void(std::string)> ReactInstanceWin::GetErrorCallback() noexcept {
 }
 
 void ReactInstanceWin::OnErrorWithMessage(const std::string &errorMessage) noexcept {
+  OnError(Mso::React::ReactErrorProvider().MakeErrorCode(Mso::React::ReactError{errorMessage.c_str()}));
+}
+
+void ReactInstanceWin::OnError(const Mso::ErrorCode &errorCode) noexcept {
   m_state = ReactInstanceState::HasError;
   AbandonJSCallQueue();
 
   if (m_redboxHandler && m_redboxHandler->isDevSupportEnabled()) {
     ErrorInfo errorInfo;
-    errorInfo.Message = errorMessage;
+    errorInfo.Message = errorCode.ToString();
     errorInfo.Id = 0;
     m_redboxHandler->showNewError(std::move(errorInfo), ErrorType::Native);
   }
 
-  OnError(Mso::React::ReactErrorProvider().MakeErrorCode(Mso::React::ReactError{errorMessage.c_str()}));
-  m_updateUI();
-}
+  InvokeInQueue([this, errorCode]() noexcept {
+    m_options.OnError(errorCode);
+   });
 
-void ReactInstanceWin::OnError(const Mso::ErrorCode &errorCode) noexcept {
-  InvokeInQueue([this, errorCode]() noexcept { m_options.OnError(errorCode); });
+  m_updateUI();
 }
 
 void ReactInstanceWin::OnLiveReload() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -542,7 +542,6 @@ void ReactInstanceWin::OnReactInstanceLoaded(const Mso::ErrorCode &errorCode) no
       m_state = ReactInstanceState::HasError;
       m_whenLoaded.SetError(errorCode);
       OnError(errorCode);
-      AbandonJSCallQueue();
     }
   }
 }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -495,6 +495,13 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
   } catch (std::exception &e) {
     m_devSettings->errorCallback(e.what());
   }
+  catch (winrt::hresult_error& hrerr) {
+    std::stringstream ss;
+    ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(hrerr.code()) << "] " <<
+      winrt::to_string(hrerr.message());
+
+    m_devSettings->errorCallback(std::move(ss.str()));
+  }
 }
 
 InstanceImpl::~InstanceImpl() {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -494,11 +494,10 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 #endif
   } catch (std::exception &e) {
     m_devSettings->errorCallback(e.what());
-  }
-  catch (winrt::hresult_error& hrerr) {
+  } catch (winrt::hresult_error &hrerr) {
     std::stringstream ss;
-    ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(hrerr.code()) << "] " <<
-      winrt::to_string(hrerr.message());
+    ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(hrerr.code()) << "] "
+       << winrt::to_string(hrerr.message());
 
     m_devSettings->errorCallback(std::move(ss.str()));
   }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -492,9 +492,9 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
   } catch (const facebook::react::ChakraJSException &e) {
     m_devSettings->errorCallback(std::string{e.what()} + "\r\n" + e.getStack());
 #endif
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     m_devSettings->errorCallback(e.what());
-  } catch (winrt::hresult_error &hrerr) {
+  } catch (const winrt::hresult_error &hrerr) {
     std::stringstream ss;
     ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(hrerr.code()) << "] "
        << winrt::to_string(hrerr.message());


### PR DESCRIPTION
Currently when the bundle file doesn't exist, the instance just ends up in a blank state.

Several changes:

- handle winrt exceptions on bundle load to our error handler, where it was previously only handling std::exceptions.
- Forward instance load errors to the standard error handler which will display a redbox.
- Also one of the error handling methods in ReactInstance was not calling into redbox and some other error handling logic, these errors would be suppressed from users, and the instance wouldn't be put into an error state.

Now loading attempting to load an instance with a missing bundle will display redbox / call the users redbox callbacks.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8018)