### PR TITLE
Remove JavaScriptMainModuleName and DebugHost

### DIFF
--- a/change/react-native-windows-503903d7-2bfe-4626-9861-291a470f0ec5.json
+++ b/change/react-native-windows-503903d7-2bfe-4626-9861-291a470f0ec5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove JavaScriptMainModuleName and DebugHost",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -71,7 +71,13 @@ void MainPage::OnLoadClick(
   host.InstanceSettings().JSIEngineOverride(
       static_cast<Microsoft::ReactNative::JSIEngine>(x_JsEngine().SelectedIndex()));
   if (!m_bundlerHostname.empty()) {
-    host.InstanceSettings().DebugHost(m_bundlerHostname);
+    std::wstring dhost(m_bundlerHostname);
+    auto colonPos = dhost.find(L':');
+    if (colonPos != std::wstring::npos) {
+      host.InstanceSettings().SourceBundleHost(hstring(dhost.substr(0, colonPos)));
+      dhost.erase(0, colonPos + 1);
+      host.InstanceSettings().SourceBundlePort(static_cast<uint16_t>(std::stoi(dhost)));
+    }
   }
 
   host.InstanceSettings().InstanceCreated(

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -85,14 +85,6 @@ void ReactApplication::UseDeveloperSupport(bool value) noexcept {
   InstanceSettings().UseDeveloperSupport(value);
 }
 
-hstring ReactApplication::JavaScriptMainModuleName() noexcept {
-  return InstanceSettings().JavaScriptMainModuleName();
-}
-
-void ReactApplication::JavaScriptMainModuleName(hstring const &value) noexcept {
-  InstanceSettings().JavaScriptMainModuleName(value);
-}
-
 hstring ReactApplication::JavaScriptBundleFile() noexcept {
   return InstanceSettings().JavaScriptBundleFile();
 }

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -86,9 +86,6 @@ struct ReactApplication : NoDefaultCtorReactApplication_base<ReactApplication> {
   bool UseDeveloperSupport() noexcept;
   void UseDeveloperSupport(bool value) noexcept;
 
-  hstring JavaScriptMainModuleName() noexcept;
-  void JavaScriptMainModuleName(hstring const &value) noexcept;
-
   hstring JavaScriptBundleFile() noexcept;
   void JavaScriptBundleFile(hstring const &value) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactApplication.idl
+++ b/vnext/Microsoft.ReactNative/ReactApplication.idl
@@ -39,11 +39,6 @@ namespace Microsoft.ReactNative
       "See @ReactInstanceSettings.UseDeveloperSupport.")
     Boolean UseDeveloperSupport { get; set; };
 
-    // Deprecated - Use JavaScriptBundleFile instead
-    [deprecated("Use @.JavaScriptBundleFile instead", deprecate, 1)]
-    DOC_STRING("See @ReactInstanceSettings.JavaScriptMainModuleName.")
-    String JavaScriptMainModuleName { get; set; };
-
     DOC_STRING("See @ReactInstanceSettings.JavaScriptBundleFile.")
     String JavaScriptBundleFile { get; set; };
   }

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -140,9 +140,6 @@ struct ReactDevOptions {
   //! For direct debugging, specifies a name to associate with the JavaScript runtime instance.
   std::string DebuggerRuntimeName;
 
-  //! URL used for debugging
-  std::string DebugHost;
-
   //! When using web debugging and/or live reload, the source is obtained from the packager.
   //! The source url for the bundle is "http://{HOST}:{PORT}/{NAME}{EXTENSION}?platform=..."
   //! which defaults to:

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -107,23 +107,6 @@ void ReactInstanceSettings::EnableDeveloperMenu(bool value) noexcept {
   UseDeveloperSupport(value);
 }
 
-hstring ReactInstanceSettings::DebugHost() noexcept {
-  std::wstring dhost(SourceBundleHost());
-  dhost.append(L":");
-  dhost.append(std::to_wstring(SourceBundlePort()));
-  return hstring(dhost);
-}
-
-void ReactInstanceSettings::DebugHost(hstring const &value) noexcept {
-  std::wstring dhost(value);
-  auto colonPos = dhost.find(L':');
-  if (colonPos != std::wstring::npos) {
-    SourceBundleHost(hstring(dhost.substr(0, colonPos)));
-    dhost.erase(0, colonPos + 1);
-    SourceBundlePort(static_cast<uint16_t>(std::stoi(dhost)));
-  }
-}
-
 IReactPropertyNamespace InstanceSettingsNamespace() noexcept {
   static IReactPropertyNamespace value = ReactPropertyBagHelper::GetNamespace(L"ReactNative.InstanceSettings");
   return value;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -60,9 +60,6 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   bool UseDeveloperSupport() noexcept;
   void UseDeveloperSupport(bool value) noexcept;
 
-  hstring JavaScriptMainModuleName() noexcept;
-  void JavaScriptMainModuleName(hstring const &value) noexcept;
-
   hstring JavaScriptBundleFile() noexcept;
   void JavaScriptBundleFile(hstring const &value) noexcept;
 
@@ -105,9 +102,6 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
 
   hstring ByteCodeFileUri() noexcept;
   void ByteCodeFileUri(hstring const &value) noexcept;
-
-  hstring DebugHost() noexcept;
-  void DebugHost(hstring const &value) noexcept;
 
   hstring DebugBundlePath() noexcept;
   void DebugBundlePath(hstring const &value) noexcept;
@@ -163,7 +157,6 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   IReactNotificationService m_notifications{ReactNotificationServiceHelper::CreateNotificationService()};
   Windows::Foundation::Collections::IVector<IReactPackageProvider> m_packageProviders{
       single_threaded_vector<IReactPackageProvider>()};
-  hstring m_javaScriptMainModuleName{};
   hstring m_javaScriptBundleFile{};
   bool m_enableJITCompilation{true};
   bool m_enableByteCodeCaching{false};
@@ -209,14 +202,6 @@ inline IReactNotificationService ReactInstanceSettings::Notifications() noexcept
 inline Windows::Foundation::Collections::IVector<IReactPackageProvider>
 ReactInstanceSettings::PackageProviders() noexcept {
   return m_packageProviders;
-}
-
-inline hstring ReactInstanceSettings::JavaScriptMainModuleName() noexcept {
-  return m_javaScriptMainModuleName;
-}
-
-inline void ReactInstanceSettings::JavaScriptMainModuleName(hstring const &value) noexcept {
-  m_javaScriptMainModuleName = value;
 }
 
 inline hstring ReactInstanceSettings::JavaScriptBundleFile() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -82,11 +82,6 @@ namespace Microsoft.ReactNative
       "In particular, it enables the developer menu, the default `RedBox` and `LogBox` experience.")
     Boolean UseDeveloperSupport { get; set; };
 
-    // Deprecated - use JavaScriptBundleFile instead
-    [deprecated("Use @.JavaScriptBundleFile instead. It will be removed in version 0.65.", deprecate, 1)]
-    DOC_STRING("Name of the JavaScript bundle file. If @.JavaScriptBundleFile is specified it is used instead.")
-    String JavaScriptMainModuleName { get; set; };
-
     DOC_STRING(
       "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "
       "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
@@ -155,19 +150,9 @@ namespace Microsoft.ReactNative
       "**Note that currently the byte code generation is not implemented for UWP applications.**")
     String ByteCodeFileUri { get; set; };
 
-    // Deprecated
-    [deprecated(
-      "This has been replaced with @.SourceBundleHost and @.SourceBundlePort and will be removed in version 0.65.",
-      deprecate, 1)]
-    DOC_STRING(
-      "When using a @.UseFastRefresh, @.UseLiveReload or @.UseWebDebugger this is the server that will be "
-      "used to load the bundle from.")
-    DOC_DEFAULT("localhost:8081")
-    String DebugHost { get; set; };
-
     DOC_STRING(
       "When loading from a bundle server (such as metro), this is the path that will be requested from the server. "
-      "If this is not provided the value of @.JavaScriptBundleFile or @.JavaScriptMainModuleName is used.")
+      "If this is not provided the value of @.JavaScriptBundleFile is used.")
     String DebugBundlePath { get; set; };
 
     DOC_STRING("Base path used for the location of the bundle.")

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -152,7 +152,7 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "When loading from a bundle server (such as metro), this is the path that will be requested from the server. "
-      "If this is not provided the value of @.JavaScriptBundleFile is used.")
+      "If this is not provided, the value of @.JavaScriptBundleFile is used.")
     String DebugBundlePath { get; set; };
 
     DOC_STRING("Base path used for the location of the bundle.")

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -113,7 +113,6 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   reactOptions.SetUseFastRefresh(m_instanceSettings.UseFastRefresh());
   reactOptions.SetUseLiveReload(m_instanceSettings.UseLiveReload());
   reactOptions.EnableJITCompilation = m_instanceSettings.EnableJITCompilation();
-  reactOptions.DeveloperSettings.DebugHost = to_string(m_instanceSettings.DebugHost());
   reactOptions.BundleRootPath = to_string(m_instanceSettings.BundleRootPath());
   reactOptions.DeveloperSettings.DebuggerPort = m_instanceSettings.DebuggerPort();
   if (m_instanceSettings.RedBoxHandler()) {
@@ -149,13 +148,8 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   };
 
   std::string jsBundleFile = to_string(m_instanceSettings.JavaScriptBundleFile());
-  std::string jsMainModuleName = to_string(m_instanceSettings.JavaScriptMainModuleName());
   if (jsBundleFile.empty()) {
-    if (!jsMainModuleName.empty()) {
-      jsBundleFile = jsMainModuleName;
-    } else {
-      jsBundleFile = "index.windows";
-    }
+    jsBundleFile = "index.windows";
   }
 
   reactOptions.Identity = jsBundleFile;


### PR DESCRIPTION
These two properties have been marked deprecated for a while, and were in fact documented to be removed in 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8027)