### PR TITLE
Avoid crash when unsupported facade is given - `react-native-paper` button fix

### DIFF
--- a/change/react-native-windows-cb6f7ebc-0410-4d3e-9840-b160e5f8f554.json
+++ b/change/react-native-windows-cb6f7ebc-0410-4d3e-9840-b160e5f8f554.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FacadeType extended with None to avoid crash for unsupported values",
+  "packageName": "react-native-windows",
+  "email": "Bartosz.Klonowski@callstack.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FacadeType.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FacadeType.h
@@ -16,7 +16,10 @@ enum class FacadeType {
   TranslateX,
   TranslateY,
   Perspective,
-  Progress
+  Progress,
+
+  // Indicates the unrecognized/unsupported facade
+  None
 };
 
 inline FacadeType StringToFacadeType(const std::string &value) noexcept {
@@ -41,6 +44,6 @@ inline FacadeType StringToFacadeType(const std::string &value) noexcept {
   if (value == "perspective")
     return FacadeType::Perspective;
 
-  assert(value == "progress");
-  return FacadeType::Progress;
+  // None of the above facade has been recognized
+  return FacadeType::None;
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FacadeType.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FacadeType.h
@@ -43,6 +43,8 @@ inline FacadeType StringToFacadeType(const std::string &value) noexcept {
     return FacadeType::TranslateY;
   if (value == "perspective")
     return FacadeType::Perspective;
+  if (value == "progress")
+    return FacadeType::Progress;
 
   // None of the above facade has been recognized
   return FacadeType::None;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -90,8 +90,9 @@ void PropsAnimatedNode::UpdateView() {
         }
       } else if (const auto &valueNode = manager->GetValueAnimatedNode(entry.second)) {
         const auto &facade = StringToFacadeType(entry.first);
-        if (facade != FacadeType::None)
+        if (facade != FacadeType::None) {
           MakeAnimation(entry.second, facade);
+        }
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -89,7 +89,9 @@ void PropsAnimatedNode::UpdateView() {
           MakeAnimation(styleEntry.second, styleEntry.first);
         }
       } else if (const auto &valueNode = manager->GetValueAnimatedNode(entry.second)) {
-        MakeAnimation(entry.second, StringToFacadeType(entry.first));
+        const auto &facade = StringToFacadeType(entry.first);
+        if (facade != FacadeType::None)
+          MakeAnimation(entry.second, facade);
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
@@ -29,7 +29,10 @@ std::unordered_map<FacadeType, int64_t> StyleAnimatedNode::GetMapping() {
         break;
       }
     }
-    mapping.insert({StringToFacadeType(prop.first), prop.second});
+
+    const auto &facade = StringToFacadeType(prop.first);
+    if (facade != FacadeType::None)
+      mapping.insert({facade, prop.second});
   }
   return mapping;
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
@@ -31,8 +31,9 @@ std::unordered_map<FacadeType, int64_t> StyleAnimatedNode::GetMapping() {
     }
 
     const auto &facade = StringToFacadeType(prop.first);
-    if (facade != FacadeType::None)
+    if (facade != FacadeType::None) {
       mapping.insert({facade, prop.second});
+    }
   }
   return mapping;
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
@@ -28,7 +28,9 @@ std::unordered_map<FacadeType, int64_t> TransformAnimatedNode::GetMapping() {
   std::unordered_map<FacadeType, int64_t> mapping;
   for (const auto &config : m_transformConfigs) {
     if (config.nodeTag != s_unsetNodeTag) {
-      mapping.insert({StringToFacadeType(config.property), config.nodeTag});
+      const auto &facade = StringToFacadeType(config.property);
+      if (facade != FacadeType::None)
+        mapping.insert({facade, config.nodeTag});
     }
   }
   return mapping;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
@@ -29,8 +29,9 @@ std::unordered_map<FacadeType, int64_t> TransformAnimatedNode::GetMapping() {
   for (const auto &config : m_transformConfigs) {
     if (config.nodeTag != s_unsetNodeTag) {
       const auto &facade = StringToFacadeType(config.property);
-      if (facade != FacadeType::None)
+      if (facade != FacadeType::None) {
         mapping.insert({facade, config.nodeTag});
+      }
     }
   }
   return mapping;


### PR DESCRIPTION
This pull request fixes #6430 

It creates new enumeration value that indicates whether unsupported facade type is specified.

---

This fix delivers new facade type: `FacadeType::None` which indicates that a given type is not supported by the framework. It avoids a crash because if `None` is noticed the animation is just not started and further processing is omitted.

The usage of this type is to first get the result of `StringToFacadeType()` method, and only then check it against the `None` value to see whether an existing and supported value is used.

Another change is to modify the default return value of `FacadeType`, which was previously set to `progress` and now it's `None` instead of throwing an assert.

---

These changes were tested on the real example application given in the original [issue](https://github.com/callstack/react-native-paper/issues/2329).
The button marked as a crashing button now does not crash and animates correctly:
![RNPaperCrashExample](https://user-images.githubusercontent.com/70535775/122059805-498f3f80-cded-11eb-9ae2-0e454dd885c3.gif)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8034)

