### PR TITLE
TurboModules might be kept alive by RNH when instance is shutdown

### DIFF
--- a/change/react-native-windows-b0a5a498-4f12-447c-97cd-82b3d28ccb4e.json
+++ b/change/react-native-windows-b0a5a498-4f12-447c-97cd-82b3d28ccb4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "TurboModules might be kept alive by RNH when instance is shutdown",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -37,6 +37,12 @@ MainPage::MainPage() {
   x_JsEngine().SelectedIndex(1);
 }
 
+void MainPage::OnUnloadClick(
+    Windows::Foundation::IInspectable const & /*sender*/,
+    xaml::RoutedEventArgs const & /*args*/) {
+  Host().UnloadInstance();
+}
+
 void MainPage::OnLoadClick(
     Windows::Foundation::IInspectable const & /*sender*/,
     xaml::RoutedEventArgs const & /*args*/) {

--- a/packages/playground/windows/playground/MainPage.h
+++ b/packages/playground/windows/playground/MainPage.h
@@ -7,6 +7,7 @@ struct MainPage : MainPageT<MainPage> {
   MainPage();
 
   void OnLoadClick(Windows::Foundation::IInspectable const & /*sender*/, xaml::RoutedEventArgs const & /*args*/);
+  void OnUnloadClick(Windows::Foundation::IInspectable const & /*sender*/, xaml::RoutedEventArgs const & /*args*/);
 
  private:
   Microsoft::ReactNative::ReactNativeHost Host() noexcept;

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -16,6 +16,7 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="auto"/>
+            <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
 
@@ -27,13 +28,25 @@
             VerticalAlignment="Center"
             Grid.Column="0"
             Grid.RowSpan="2"
+            IsCompact="false"
             Click="OnLoadClick"
-            Margin="4"
+        />
+
+        <AppBarButton
+            x:Name="x_UnloadButton"
+            Label="Unload"
+            Icon="Stop"
+            Style="{ThemeResource AppBarButtonRevealStyle}"
+            VerticalAlignment="Center"
+            Grid.Column="1"
+            Grid.RowSpan="2"
+            IsCompact="false"
+            Click="OnUnloadClick"
         />
 
         <Grid
             Grid.Row="0"
-            Grid.Column="1"
+            Grid.Column="2"
             BorderThickness="1,0,0,0"
             BorderBrush="{ThemeResource SystemBaseMediumColor}">
             <Grid.ColumnDefinitions>
@@ -101,7 +114,7 @@
 
         <StackPanel
             Grid.Row="1"
-            Grid.Column="1"
+            Grid.Column="2"
             Orientation="Horizontal"
             BorderThickness="1,0,0,0"
             BorderBrush="{ThemeResource SystemBaseMediumColor}">
@@ -166,7 +179,7 @@
             BorderThickness="0,1,0,0"
             BorderBrush="{ThemeResource SystemBaseMediumColor}"
             Grid.Row="3"
-            Grid.ColumnSpan="2"
+            Grid.ColumnSpan="3"
             />
     </Grid>
 </Page>

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -310,22 +310,13 @@ class TurboModuleImpl : public facebook::react::TurboModule {
 TurboModulesProvider::TurboModulePtr TurboModulesProvider::getModule(
     const std::string &moduleName,
     const CallInvokerPtr &callInvoker) noexcept {
-  // see if the expected turbo module has been cached
-  auto pair = std::make_pair(moduleName, callInvoker);
-  auto itCached = m_cachedModules.find(pair);
-  if (itCached != m_cachedModules.end()) {
-    return itCached->second;
-  }
-
   // fail if the expected turbo module has not been registered
   auto it = m_moduleProviders.find(moduleName);
   if (it == m_moduleProviders.end()) {
     return nullptr;
   }
 
-  // cache and return the turbo module
   auto tm = std::make_shared<TurboModuleImpl>(m_reactContext, moduleName, callInvoker, it->second);
-  m_cachedModules.insert({pair, tm});
   return tm;
 }
 
@@ -351,8 +342,6 @@ void TurboModulesProvider::AddModuleProvider(
     m_moduleProviders.insert({key, moduleProvider});
   } else {
     // turbo modules should be replaceable before the first time it is requested
-    // if a turbo module has been requested, it will be cached in m_cachedModules
-    // in this case, changing m_moduleProviders affects nothing
     it->second = moduleProvider;
   }
 }

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -30,7 +30,6 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
 
  private:
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;
-  std::unordered_map<std::pair<std::string, CallInvokerPtr>, TurboModulePtr> m_cachedModules;
   IReactContext m_reactContext;
 };
 


### PR DESCRIPTION
`TurboModulesProvider` was caching `TurboModules`, but since it is an object on `ReactOptions` not tied directly to an instance, these `TurboModules` could stick around after an instance is shutdown.  An easy repo would be to hit the unload button in the playground app and see that none of the `TurboModules` destructors run until you hit load again.

This would also happen when reloading the instance through metro, where the same `ReactOptions` object was used for the reload.

There is no need for `TurboModulesProvider` to cache the TurboModules, since they are cached internal to the instance in `TurboModuleManager`.  So this was an unnecesary caching.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8035)