### PR TITLE
Disable arm64 unit test on desktop builds in CI

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -111,6 +111,7 @@ jobs:
           collectDumpOn: onAbortOnly
           vsTestVersion: latest
           failOnMinTestsNotRun: true
+        condition: and(succeeded(), not(eq(variables['BuildPlatform'], 'arm64')))
 
       - task: PowerShell@2
         displayName: Set up test servers


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8038)