### PR TITLE
Use DispatcherTimer unless animation frame needed

### DIFF
--- a/change/react-native-windows-97eb0bc5-471b-4848-bdf8-edd943238c00.json
+++ b/change/react-native-windows-97eb0bc5-471b-4848-bdf8-edd943238c00.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use DispatcherTimer unless animation frame needed",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -83,7 +83,6 @@ std::weak_ptr<facebook::react::Instance> Timing::getInstance() noexcept {
   return m_parent->getInstance();
 }
 
-
 winrt::DispatcherQueueTimer Timing::EnsureDispatcherTimer() {
   if (!m_dispatcherQueueTimer) {
     winrt::DispatcherQueue queue = winrt::DispatcherQueue::GetForCurrentThread();
@@ -149,6 +148,7 @@ void Timing::StartRendering() {
     m_dispatcherQueueTimer.Stop();
   }
 
+  m_usingRendering = true;
   m_rendering.revoke();
   m_rendering = xaml::Media::CompositionTarget::Rendering(
       winrt::auto_revoke,
@@ -213,9 +213,7 @@ void Timing::deleteTimer(int64_t id) {
   m_timerQueue.Remove(id);
 
   if (m_timerQueue.IsEmpty()) {
-    m_usingRendering = false;
-    m_rendering.revoke();
-    EnsureDispatcherTimer().Stop();
+    StopTicks();
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -21,7 +21,6 @@ using namespace facebook::xplat;
 using namespace folly;
 namespace winrt {
 using namespace Windows::Foundation;
-using namespace Windows::System;
 using namespace xaml::Media;
 } // namespace winrt
 using namespace std;
@@ -131,9 +130,9 @@ void Timing::OnTick() {
   }
 }
 
-winrt::DispatcherQueueTimer Timing::EnsureDispatcherTimer() {
+winrt::system::DispatcherQueueTimer Timing::EnsureDispatcherTimer() {
   if (!m_dispatcherQueueTimer) {
-    winrt::DispatcherQueue queue = winrt::DispatcherQueue::GetForCurrentThread();
+    const auto queue = winrt::system::DispatcherQueue::GetForCurrentThread();
     m_dispatcherQueueTimer = queue.CreateTimer();
     m_dispatcherQueueTimer.Tick([wkThis = std::weak_ptr(this->shared_from_this())](auto &&...) {
       if (auto pThis = wkThis.lock()) {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -78,7 +78,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
   winrt::system::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
-  bool m_usingRendering;
+  bool m_usingRendering{false};
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -78,7 +78,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
   winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
-  int64_t m_animationFrameRequests{0};
+  bool m_usingRendering;
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -68,17 +68,18 @@ class Timing : public std::enable_shared_from_this<Timing> {
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
   void OnTick();
-  void UpdateScheduler();
-  void UpdateScheduler(TTimeSpan period, TDateTime targetTime);
   winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherQueueTimer();
-  void EnsureRenderingCallback();
+  void StartRendering();
+  void StopTicks();
+  void UpdateTimer(TDateTime targetTime);
 
  private:
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
   winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer;
-  bool m_usingRendering;
+  bool m_usingRendering{false};
+  TDateTime m_nextDueTime{TDateTime::max()};
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <CppWinRTIncludes.h>
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/MessageQueueThread.h>
 
@@ -11,7 +12,6 @@
 #include <vector>
 
 #include <winrt/Windows.Foundation.h>
-#include <winrt/Windows.System.h>
 namespace Microsoft::ReactNative {
 
 typedef winrt::Windows::Foundation::DateTime TDateTime;
@@ -68,7 +68,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
   void OnTick();
-  winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherTimer();
+  winrt::system::DispatcherQueueTimer EnsureDispatcherTimer();
   void StartRendering();
   void StartDispatcherTimer();
   void StopTicks();
@@ -77,7 +77,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
-  winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
+  winrt::system::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
   bool m_usingRendering;
 };
 

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -77,7 +77,7 @@ class Timing : public std::enable_shared_from_this<Timing> {
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
-  winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer;
+  winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
   bool m_usingRendering{false};
   TDateTime m_nextDueTime{TDateTime::max()};
 };

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -70,16 +70,15 @@ class Timing : public std::enable_shared_from_this<Timing> {
   void OnTick();
   winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherTimer();
   void StartRendering();
+  void StartDispatcherTimer();
   void StopTicks();
-  void UpdateDispatcherTimer(TDateTime targetTime);
 
  private:
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
   winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
-  bool m_usingRendering{false};
-  TDateTime m_nextDueTime{TDateTime::max()};
+  int64_t m_animationFrameRequests{0};
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.System.h>
 namespace Microsoft::ReactNative {
 
 typedef winrt::Windows::Foundation::DateTime TDateTime;
@@ -66,12 +67,18 @@ class Timing : public std::enable_shared_from_this<Timing> {
 
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
-  void OnRendering();
+  void OnTick();
+  void UpdateScheduler();
+  void UpdateScheduler(TTimeSpan period, TDateTime targetTime);
+  winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherQueueTimer();
+  void EnsureRenderingCallback();
 
  private:
   TimingModule *m_parent;
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
+  winrt::Windows::System::DispatcherQueueTimer m_dispatcherQueueTimer;
+  bool m_usingRendering;
 };
 
 class TimingModule : public facebook::xplat::module::CxxModule {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -68,10 +68,10 @@ class Timing : public std::enable_shared_from_this<Timing> {
  private:
   std::weak_ptr<facebook::react::Instance> getInstance() noexcept;
   void OnTick();
-  winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherQueueTimer();
+  winrt::Windows::System::DispatcherQueueTimer EnsureDispatcherTimer();
   void StartRendering();
   void StopTicks();
-  void UpdateTimer(TDateTime targetTime);
+  void UpdateDispatcherTimer(TDateTime targetTime);
 
  private:
   TimingModule *m_parent;


### PR DESCRIPTION
The CompositionTarget::Rendering event burns a lot of CPU. For long running interval timers that fire infrequently, using this event for the timer implementation is overkill. This change checks the period of the timer, and uses the CompositionTarget::Rendering callback for period == 1ms (which is typical of requestAnimationFrame requests) and for everything else, uses a dispatcher timer that updates it's tick to the next due time each time a timer fires.

Fixes #6032

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8039)