### PR TITLE
[0.64] Fix XAML Visibility for `display:none`

### DIFF
--- a/change/react-native-windows-c609b529-2e4e-4b5a-8b30-1d3567f739f6.json
+++ b/change/react-native-windows-c609b529-2e4e-4b5a-8b30-1d3567f739f6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix XAML Visibility for `display:none`",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-c609b529-2e4e-4b5a-8b30-1d3567f739f6.json
+++ b/change/react-native-windows-c609b529-2e4e-4b5a-8b30-1d3567f739f6.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix XAML Visibility for `display:none`",
+  "comment": "[0.64]Fix XAML Visibility for `display:none`",
   "packageName": "react-native-windows",
   "email": "agnel@microsoft.com",
   "dependentChangeType": "patch"

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -535,6 +535,17 @@ bool FrameworkElementViewManager::UpdateProperty(
     } else if (propertyName == "accessibilityActions") {
       auto value = json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>>::parseJson(propertyValue);
       DynamicAutomationProperties::SetAccessibilityActions(element, value);
+    } else if (propertyName == "display") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+        auto value = propertyValue.AsString();
+        if (value == "none") {
+          element.Visibility(xaml::Visibility::Collapsed);
+        } else {
+          element.Visibility(xaml::Visibility::Visible);
+        }
+      } else if (propertyValue.IsNull()) {
+        element.ClearValue(xaml::UIElement::VisibilityProperty());
+      }
     } else {
       return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
     }


### PR DESCRIPTION
Backporting #7363 by request. Expected to fix react-navigation's issue [#9109](https://github.com/react-navigation/react-navigation/issues/9109) for a team currently on 0.63 (in the process of upgrading to 0.64).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8044)