### PR TITLE
[0.63] Fix XAML Visibility for `display:none`

### DIFF
--- a/change/react-native-windows-af57ea20-4d70-48cb-99f9-559acce12fa6.json
+++ b/change/react-native-windows-af57ea20-4d70-48cb-99f9-559acce12fa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.63]Fix XAML Visibility for display:none",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -500,14 +500,14 @@ bool FrameworkElementViewManager::UpdateProperty(
       auto value = json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>>::parseJson(propertyValue);
       DynamicAutomationProperties::SetAccessibilityActions(element, value);
     } else if (propertyName == "display") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        auto value = propertyValue.AsString();
+      if (propertyValue.isString()) {
+        auto value = react::uwp::asHstring(propertyValue);
         if (value == "none") {
           element.Visibility(xaml::Visibility::Collapsed);
         } else {
           element.Visibility(xaml::Visibility::Visible);
         }
-      } else if (propertyValue.IsNull()) {
+      } else if (propertyValue.isNull()) {
         element.ClearValue(xaml::UIElement::VisibilityProperty());
       }
     } else {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -499,6 +499,17 @@ bool FrameworkElementViewManager::UpdateProperty(
     } else if (propertyName == "accessibilityActions") {
       auto value = json_type_traits<winrt::IVector<winrt::react::uwp::AccessibilityAction>>::parseJson(propertyValue);
       DynamicAutomationProperties::SetAccessibilityActions(element, value);
+    } else if (propertyName == "display") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+        auto value = propertyValue.AsString();
+        if (value == "none") {
+          element.Visibility(xaml::Visibility::Collapsed);
+        } else {
+          element.Visibility(xaml::Visibility::Visible);
+        }
+      } else if (propertyValue.IsNull()) {
+        element.ClearValue(xaml::UIElement::VisibilityProperty());
+      }
     } else {
       return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
     }

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -501,7 +501,7 @@ bool FrameworkElementViewManager::UpdateProperty(
       DynamicAutomationProperties::SetAccessibilityActions(element, value);
     } else if (propertyName == "display") {
       if (propertyValue.isString()) {
-        auto value = react::uwp::asHstring(propertyValue);
+        auto value = propertyValue.getString();
         if (value == "none") {
           element.Visibility(xaml::Visibility::Collapsed);
         } else {


### PR DESCRIPTION
Backporting #7363 by request. Expected to fix react-navigation's issue [#9109](https://github.com/react-navigation/react-navigation/issues/9109) for a team currently on 0.63 (in the process of upgrading to 0.64).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8044)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8046)