### PR TITLE
Autolink best effort

### DIFF
--- a/change/@react-native-windows-cli-bb7e2de4-5a44-4dc8-9eda-d4528ae003da.json
+++ b/change/@react-native-windows-cli-bb7e2de4-5a44-4dc8-9eda-d4528ae003da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Best-effort autolinking - if a module was built without the standard module project template, use it for autolinking anyway",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -140,7 +140,15 @@ export function findDependencyProjectFiles(winFolder: string): string[] {
 
   // Try to find any project file that appears to be a dependency project
   for (const projectFile of allProjects) {
-    if (isRnwDependencyProject(path.join(winFolder, projectFile))) {
+    // A project is marked as a RNW dependency iff either:
+    // - If the project has the standard native module imports, or
+    // - If we only have a single project (and it doesn't have the standard native module imports),
+    // pick it and hope for the best. This enables autolinking for modules that were written
+    // before the standard native module template existed.
+    if (
+      allProjects.length === 1 ||
+      isRnwDependencyProject(path.join(winFolder, projectFile))
+    ) {
       dependencyProjectFiles.push(path.normalize(projectFile));
     }
   }

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -425,6 +425,16 @@ export class AutolinkWindows {
             'projects' in windowsDependency &&
             Array.isArray(windowsDependency.projects)
           ) {
+            if (
+              windowsDependency.projects.length === 0 &&
+              dependencyName.includes('react-native')
+            ) {
+              // the dependency is probably a react native module, but we didn't find a module project
+              throw new CodedError(
+                'Autolinking',
+                `Found a Windows solution for ${dependencyName} but no React Native for Windows native module projects`,
+              );
+            }
             windowsDependency.projects.forEach(project => {
               const itemsToCheck: Array<keyof ProjectDependency> = [
                 'projectFile',


### PR DESCRIPTION
Best-effort autolinking - if a module was built without the standard module project template, use it for autolinking anyway

Fixes #8047 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8053)