### PR TITLE
[0.64] Fix msbuild as more cases of *Undefined* are popping up

### DIFF
--- a/change/react-native-windows-c45458c5-46d6-4759-a42d-9c38edb2c0da.json
+++ b/change/react-native-windows-c45458c5-46d6-4759-a42d-9c38edb2c0da.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] More cases of *Undefined* are popping up in MsBuild",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -5,7 +5,7 @@
   <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../')))" Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
+    <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">$(MSBuildThisFileDirectory)</SolutionDir>
 
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>


### PR DESCRIPTION
Mix of Backport of #8055 and forward port of #7918
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8057)