### PR TITLE
Fix CI Break to Specify Playground Certificate Correctly

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -111,7 +111,7 @@ jobs:
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             $(BuildWinUI3Properties)
             /p:BaseIntDir=$(BaseIntDir)
-            /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\playground-Key.pfx
+            /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
         condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
 
       - template: ../templates/cleanup-certificate.yml


### PR DESCRIPTION
**_Why_**
Change in #8015 had a bug which resulted in the CI build failing for Release Playground once the change was merged into main.

**_What_**
Fixed Playground VSBuild source to specify the certificate correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8060)