### PR TITLE
Reorder RNTester multicolumn example to be inside the group of flatlist examples

### DIFF
--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -36,6 +36,12 @@ const ComponentExamples: Array<RNTesterExample> = [
     category: 'ListView',
   },
   {
+    // shows up as <FlatList> - MultiColumn
+    key: 'MultiColumnExample',
+    category: 'ListView',
+    module: require('../examples/MultiColumn/MultiColumnExample'),
+  },
+  {
     key: 'FlatList-onViewableItemsChanged',
     module: require('../examples/FlatList/FlatList-onViewableItemsChanged'),
     category: 'ListView',
@@ -75,11 +81,6 @@ const ComponentExamples: Array<RNTesterExample> = [
   //   category: 'UI',
   //   module: require('../examples/Modal/ModalExample'),
   // },
-  {
-    key: 'MultiColumnExample',
-    category: 'ListView',
-    module: require('../examples/MultiColumn/MultiColumnExample'),
-  },
   {
     key: 'NewAppScreenExample',
     module: require('../examples/NewAppScreen/NewAppScreenExample'),


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8061)