### PR TITLE
Have script store return nullptr on facebook::jsi::JSINativeException

### DIFF
--- a/change/react-native-windows-63ea3a71-e181-4a1e-a183-141818f55403.json
+++ b/change/react-native-windows-63ea3a71-e181-4a1e-a183-141818f55403.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Have script store return nullptr on facebook::jsi::JSINativeException",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/BaseScriptStoreImpl.cpp
+++ b/vnext/Shared/BaseScriptStoreImpl.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<const jsi::Buffer> LocalFileSimpleBufferStore::getBuffer(const s
   if (Microsoft::React::GetRuntimeOptionBool("JSI.MemoryMappedScriptStore")) {
     try {
       return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
-    } catch (const facebook::jsi::JSINativeException &e) {
+    } catch (const facebook::jsi::JSINativeException &) {
       return nullptr;
     }
   } else {

--- a/vnext/Shared/BaseScriptStoreImpl.cpp
+++ b/vnext/Shared/BaseScriptStoreImpl.cpp
@@ -147,7 +147,11 @@ std::unique_ptr<const jsi::Buffer> LocalFileSimpleBufferStore::getBuffer(const s
   }
 
   if (Microsoft::React::GetRuntimeOptionBool("JSI.MemoryMappedScriptStore")) {
-    return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+    try {
+      return Microsoft::JSI::MakeMemoryMappedBuffer(winrt::to_hstring(storeDirectory_ + bufferId).c_str());
+    } catch (const facebook::jsi::JSINativeException &e) {
+      return nullptr;
+    }
   } else {
     // Treat buffer id as the relative path fragment.
     std::ifstream file(storeDirectory_ + bufferId, std::ios::binary | std::ios::ate);


### PR DESCRIPTION
Expected error conditions such as prepared script cache not (yet) existing were not handled, crashing the host process.

This change returns `nullptr` on memory-mapped buffer creation for subsequent handling by the JS engine.

Requesting backport to unblock Office feature.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8068)