### PR TITLE
Tie visitAllPages Test to RNTesterList

### DIFF
--- a/packages/e2e-test-app/jest-resolver.js
+++ b/packages/e2e-test-app/jest-resolver.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const resolveSync = require('resolve').sync;
+
+module.exports = (request, options) => {
+  return resolveSync(request, {
+    ...options,
+    preserveSymlinks: false,
+    pathFilter: (pkg, _path, relativePath) => {
+      if (pkg.name === 'react-native') {
+        const basePath = path.dirname(require.resolve(`${pkg.name}/package.json`));
+        const rnwPath = path.dirname(require.resolve('react-native-windows/package.json'));
+        return path.relative(basePath, path.join(rnwPath, relativePath));
+      } else {
+        return relativePath;
+      }
+    } 
+  });
+}

--- a/packages/e2e-test-app/jest.config.js
+++ b/packages/e2e-test-app/jest.config.js
@@ -22,10 +22,25 @@ module.exports = {
   // Default timeout of a test in milliseconds
   testTimeout: 70000,
 
+  // This option allows the use of a custom resolver
+  resolver: './jest-resolver.js',
+
+  // This will be used to configure the behavior of jest-haste-map, Jest's internal file crawler/cache system
+  haste: {
+    defaultPlatform: 'windows',
+    platforms: ['windows'],
+  },
+
   // A map from regular expressions to paths to transformers
   transform: {
-    '^.+\\.[jt]sx?$': ['babel-jest', require('@rnw-scripts/babel-node-config')],
+    '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$':
+      'react-native-windows/jest/assetFileTransformer.js',
+    '.*': 'react-native-windows/jest/preprocessor.js',
   },
+
+  // An array of regexp pattern strings that are matched against all source file paths before transformation.
+  // If the file path matches any of the patterns, it will not be transformed.
+  transformIgnorePatterns: [],
 
   // Specifies the maximum number of workers the worker-pool will spawn for running tests.
   maxWorkers: 1,
@@ -35,7 +50,7 @@ module.exports = {
 
   // A list of paths to modules that run some code to configure or set up the testing framework
   // before each test file in the suite is executed
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  setupFilesAfterEnv: ['react-native-windows/jest/setup', './jest.setup.js'],
 
   testEnvironmentOptions: {
     app: 'ReactUWPTestApp_8wekyb3d8bbwe!App',

--- a/packages/e2e-test-app/jest.setup.js
+++ b/packages/e2e-test-app/jest.setup.js
@@ -9,6 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const sanitizeFilename = require('sanitize-filename');
+const {LogBox} = require('react-native');
 
 const screenshotDir = './errorShots';
 fs.mkdirSync(screenshotDir, {recursive: true});
@@ -26,3 +27,5 @@ global.jasmine.getEnv().addReporter({
     }
   },
 });
+
+LogBox.ignoreAllLogs(true);

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -39,6 +39,7 @@
     "metro-react-native-babel-preset": "^0.56.0",
     "prettier": "1.19.1",
     "react-test-renderer": "17.0.2",
+    "resolve": "^1.14.2",
     "sanitize-filename": "^1.6.3",
     "typescript": "^3.8.3"
   }

--- a/packages/e2e-test-app/test/framework/Navigation.ts
+++ b/packages/e2e-test-app/test/framework/Navigation.ts
@@ -26,7 +26,7 @@ export async function goToApiExample(example: string) {
 async function goToExample(example: string) {
   // Filter the list down to the one test, to improve the stability of selectors
   const searchBox = await $('~explorer_search');
-  await searchBox.setValue(example);
+  await searchBox.setValue(regexEscape(example));
 
   const exampleButton = await $(`~${example}`);
   await exampleButton.click();
@@ -37,4 +37,8 @@ async function goToExample(example: string) {
   await browser.waitUntil(async () => !(await exampleButton.isDisplayed()));
   const componentsTab = await $('~components-tab');
   expect(await componentsTab.isDisplayed()).toBe(true);
+}
+
+function regexEscape(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/e2e-test-app/test/visitAllPages.test.ts
+++ b/packages/e2e-test-app/test/visitAllPages.test.ts
@@ -9,16 +9,12 @@ import {goToComponentExample, goToApiExample} from './framework';
 
 type RNTesterExampleModule = {
   title: string;
-  testTitle?: string | null;
   description: string;
-  displayName?: string | null;
 };
 
 type RNTesterExample = {
   key: string;
   module: RNTesterExampleModule;
-  category?: string;
-  exampleType?: 'components' | 'apis';
 };
 
 type RNTesterList = {

--- a/packages/e2e-test-app/test/visitAllPages.test.ts
+++ b/packages/e2e-test-app/test/visitAllPages.test.ts
@@ -14,7 +14,7 @@ type RNTesterExampleModule = {
   displayName?: string | null;
 };
 
-export type RNTesterExample = {
+type RNTesterExample = {
   key: string;
   module: RNTesterExampleModule;
   category?: string;

--- a/packages/e2e-test-app/test/visitAllPages.test.ts
+++ b/packages/e2e-test-app/test/visitAllPages.test.ts
@@ -7,70 +7,31 @@
 
 import {goToComponentExample, goToApiExample} from './framework';
 
+type RNTesterExampleModule = {
+  title: string;
+  testTitle?: string | null;
+  description: string;
+  displayName?: string | null;
+};
+
+export type RNTesterExample = {
+  key: string;
+  module: RNTesterExampleModule;
+  category?: string;
+  exampleType?: 'components' | 'apis';
+};
+
+type RNTesterList = {
+  APIExamples: RNTesterExample[];
+  ComponentExamples: RNTesterExample[];
+};
+
+const testerList: RNTesterList = require('@react-native-windows/tester/js/utils/RNTesterList');
+
+const apiExamples = testerList.APIExamples.map(e => e.module.title);
+const componentExamples = testerList.ComponentExamples.map(e => e.module.title);
+
 describe('visitAllPages', () => {
-  const componentExamples = [
-    'ActivityIndicator',
-    'Button',
-    'DatePicker',
-    'Fast Path Texts',
-    'FlatList',
-    'FlatList with Separators',
-    'FlatList onViewableItemsChanged',
-    'FlatList onEndReached',
-    'Flyout',
-    'Glyph UWP',
-    'Image',
-    //  'FlatList - MultiColumn',
-    'New App Screen',
-    'PickerWindows',
-    'Pressable',
-    'Popup',
-    'ScrollViewSimpleExample',
-    //  'SectionList',
-    'Switch',
-    'Text',
-    'TextInput',
-    //'Touchable* and onPress',
-    'TransferProperties',
-    'TransparentHitTestExample',
-    'View',
-    //  'LegacyControlStyleTest',
-    //  'LegacyTextInputTest',
-    //  'LegacyLoginTest',
-    //  'LegacyImageTest',
-  ];
-
-  const apiExamples = [
-    'Keyboard Focus Example',
-    'Accessibility',
-    'AccessibilityInfo',
-    'Accessibility Windows',
-    'AsyncStorage Windows',
-    'Alerts',
-    'Animated - Examples',
-    'Animated - Gratuitous App',
-    'Appearance',
-    'AppState',
-    'Border',
-    'Crash',
-    'DevSettings',
-    'Dimensions',
-    'Keyboard',
-    'Layout Events',
-    'Linking',
-    'Layout - Flexbox',
-    'Mouse Events',
-    'Native Animated Example',
-    'PanResponder Sample',
-    'PlatformColor',
-    'Pointer Events',
-    'RTLExample',
-    'Share',
-    'Timers',
-    'WebSocket',
-    'Transforms',
-  ];
-
   for (const component of componentExamples) {
     test(component, async () => await goToComponentExample(component));
   }


### PR DESCRIPTION
Fixes #7726

We have a UIA-based test which navigates back and forward from each RNTester example. The list of examples cannot be populated by the UI, and is currently hardcoded. The source of truth, RNTesterList in RNTester, loads quite a bit of RN with it.

A previously discussed approach was to relay loaded data from the RN application process to the test runner. This change goes with a simpler approach, of making the test runner act more like RN. That includes Metro's Babel transformations, Windows platform resolution logic, and global setup. We can mostly rely on existing react-native UT infrastructure to automate most of this.

This loads enough of the environment to allow successfully loading all RNTester example modules, letting us poke at its data.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8071)