### PR TITLE
Block creating C# apps with Hermes

### DIFF
--- a/change/react-native-windows-init-9d0bb145-b388-4dbb-a904-d1723ccf6382.json
+++ b/change/react-native-windows-init-9d0bb145-b388-4dbb-a904-d1723ccf6382.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hermes cannot currently be used in C# apps, so blocking it in the CLI",
+  "packageName": "react-native-windows-init",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -91,7 +91,7 @@ const argv = yargs
     useHermes: {
       type: 'boolean',
       describe:
-        'Use Hermes instead of Chakra as the JS engine (supported on 0.64+)',
+        '[Experimental] Use Hermes instead of Chakra as the JS engine (supported on 0.64+ for C++ projects)',
       default: false,
     },
     useWinUI3: {
@@ -432,6 +432,14 @@ function isProjectUsingYarn(cwd: string): boolean {
         'IncompatibleOptions',
         "Error: Incompatible options specified. Options '--useHermes' and '--experimentalNuGetDependency' are incompatible",
         {detail: 'useHermes and experimentalNuGetDependency'},
+      );
+    }
+
+    if (argv.useHermes && argv.language === 'cs') {
+      throw new CodedError(
+        'IncompatibleOptions',
+        "Error: Incompatible options specified. Options '--useHermes' and '--language cs' are incompatible",
+        {detail: 'useHermes and C#'},
       );
     }
 


### PR DESCRIPTION
Currently Hermes is not supported for C# apps, so we should block it in the CLI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8075)