### PR TITLE
Rewind SDK version for reunion

### DIFF
--- a/change/react-native-windows-56b9c874-cffa-4b25-8e10-8414939d84c3.json
+++ b/change/react-native-windows-56b9c874-cffa-4b25-8e10-8414939d84c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use older SDK for the purpose of Reunion projection",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.ProjectReunion'">
     <UseWinUI3>true</UseWinUI3>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,8 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.ProjectReunion'">
     <UseWinUI3>true</UseWinUI3>
-    <!-- Ideally WindowsTargetPlatformVersion should be 17763, but we can't do that 
-      until https://github.com/microsoft/ProjectReunion/issues/921 is fixed -->
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,6 +1,8 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.ProjectReunion'">
     <UseWinUI3>true</UseWinUI3>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <!-- Ideally WindowsTargetPlatformVersion should be 17763, but we can't do that 
+      until https://github.com/microsoft/ProjectReunion/issues/921 is fixed -->
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.ProjectReunion'">
     <UseWinUI3>true</UseWinUI3>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>

--- a/vnext/Microsoft.ReactNative.ProjectReunion/Microsoft.ReactNative.ProjectReunion.csproj
+++ b/vnext/Microsoft.ReactNative.ProjectReunion/Microsoft.ReactNative.ProjectReunion.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
+      <!-- Ideally we target 17763, but we can't do that 
+      until https://github.com/microsoft/ProjectReunion/issues/921 is fixed -->
+    <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/vnext/Microsoft.ReactNative.ProjectReunion/Microsoft.ReactNative.ProjectReunion.csproj
+++ b/vnext/Microsoft.ReactNative.ProjectReunion/Microsoft.ReactNative.ProjectReunion.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.17763.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 

--- a/vnext/Scripts/Microsoft.ReactNative.ProjectReunion.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.ProjectReunion.nuspec
@@ -17,9 +17,7 @@
       <group targetFramework=".NETCoreApp3.0" />
       <group targetFramework="UAP10.0" />
       <group targetFramework=".NETFramework4.6" />
-      <group targetFramework="net5.0">
-        <dependency id="Microsoft.Windows.CsWinRT" version="1.3.0" exclude="Build,Analyzers" />
-      </group>
+      <group targetFramework="net5.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
reunion packages are using 18362 as the base SDK version. We recently updated RNW's SDK version to be 19041 (#7779). 
This change special cases the reunion projection project to use the older version so that RNW can be used in reunion apps all the way down to 17763.

Edit: because of a bug, we can't use 17763, see microsoft/ProjectReunion#921 - so I'm using 18362 for now.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8092)