### PR TITLE
[0.65] Remove rule that CG must pass for code signing

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -78,15 +78,6 @@ jobs:
       - script: yarn build
         displayName: yarn build
 
-      # Ensure EnableCodesign is set properly so CG fails appropriately
-      - script: |
-          echo ##vso[task.setvariable variable=EnableCodesign]true
-        displayName: Set EnableCodesign
-        condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
-      
-      # Running CG here as a sanity check to fail the job before any beachball bump
-      - template: templates/component-governance.yml
-
       - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public --no-git-tags
         displayName: Beachball Publish (Master Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
@@ -202,17 +193,6 @@ jobs:
           contents: |
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
-
-      # Ensure EnableCodesign is set properly so CG fails appropriately
-      - script: |
-          echo ##vso[task.setvariable variable=EnableCodesign]true
-        displayName: Set EnableCodesign
-        condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
-
-      # We are not codesigning Desktop at this time, so turning it off. Remove this script task if we do start signing Desktop
-      - script: |
-          echo ##vso[task.setvariable variable=EnableCodesign]false
-        displayName: Set EnableCodesign to false for Desktop
       
       - template: templates/component-governance.yml
 
@@ -262,12 +242,6 @@ jobs:
             Microsoft.ReactNative\**
             Microsoft.ReactNative.Managed\**
             Microsoft.ReactNative.Managed.CodeGen\**
-      
-      # Ensure EnableCodesign is set properly so CG fails appropriately
-      - script: |
-          echo ##vso[task.setvariable variable=EnableCodesign]true
-        displayName: Set EnableCodesign
-        condition: or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(${{ parameters.skipStableCodesign }})))
       
       - template: templates/component-governance.yml
 

--- a/.ado/templates/component-governance.yml
+++ b/.ado/templates/component-governance.yml
@@ -1,10 +1,4 @@
 steps:
-  # Alerts must always fail the run if EnableCodesign == true, to prevent codesigning
-  - script: |
-      echo ##vso[task.setvariable variable=FailCGOnAlert]true
-    displayName: Set FailCGOnAlert
-    condition: or(eq(variables['FailCGOnAlert'], 'true'), eq(variables['EnableCodesign'], 'true'))
-
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection'
     inputs:


### PR DESCRIPTION
This PR backports #8028 to 0.65.

We are working internally to better clarify our policies and improve our tooling around Component Governance and code signing of native binaries.

In the meantime, we are removing the restriction that CG must be strictly "completely clean" in order to codesign our native nuget packages.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8097)