### PR TITLE
Removed Microsoft.ReactNative.Manager.ReactPackageProvider registration from C# template

### DIFF
--- a/change/react-native-windows-e70a0776-a0e9-4343-a7fc-4afa6ee8df4e.json
+++ b/change/react-native-windows-e70a0776-a0e9-4343-a7fc-4afa6ee8df4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed Microsoft.ReactNative.Manager.ReactPackageProvider registration from C# template",
+  "packageName": "react-native-windows",
+  "email": "matteo.pagani@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/cs-app/src/App.xaml.cs
+++ b/vnext/template/cs-app/src/App.xaml.cs
@@ -32,7 +32,6 @@ namespace {{ namespace }}
 
             Microsoft.ReactNative.Managed.AutolinkedNativeModules.RegisterAutolinkedNativeModulePackages(PackageProviders); // Includes any autolinked modules
 
-            PackageProviders.Add(new Microsoft.ReactNative.Managed.ReactPackageProvider());
             PackageProviders.Add(new ReactPackageProvider());
 
             InitializeComponent();


### PR DESCRIPTION
This PR addresses issue #8108 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8109)