### PR TITLE
Adding AccessibilityControls prop to ViewWin32 config

### DIFF
--- a/change/@office-iss-react-native-win32-dae076bd-42e8-4b4c-a2ff-5a92e477bc03.json
+++ b/change/@office-iss-react-native-win32-dae076bd-42e8-4b4c-a2ff-5a92e477bc03.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding AccessibilityControls to ViewWin32 config",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -380,6 +380,7 @@ const ReactNativeViewConfig: ViewConfig = {
     accessibilityDescribedBy: true,
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
+    accessibilityControls: true,
     // Windows]
   },
 };


### PR DESCRIPTION
When I added the AccessibilityControls prop in a PR last month to ViewWin32, I did not add it to the config file. This caused a logbox error on the Native side for RN SDXs using the View because the properties didn't match up.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8126)