### PR TITLE
[0.63] Use V8 by default in desktop (if enabled)

### DIFF
--- a/change/react-native-windows-2021-06-28-15-49-47-0.63-stable.json
+++ b/change/react-native-windows-2021-06-28-15-49-47-0.63-stable.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use V8 by default for desktop (if enabled)",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-06-28T22:49:47.499Z"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.9" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.10" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview2.200713.0" targetFramework="native"/>
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.9" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.10" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -33,7 +33,7 @@
     <HERMES_ARCH Condition="'$(HERMES_ARCH)' == ''">uwp</HERMES_ARCH>
 
     <USE_V8 Condition="('$(USE_V8)' == '') OR ('$(Platform)' == 'ARM')">false</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.63.9</V8_Version>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.63.10</V8_Version>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' == 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' != 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.$(V8_Version)</V8_Package>
 


### PR DESCRIPTION
If USE_V8 is set (desktop), then default to using V8 instead of the pre-JSI Chakra executor.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8127)