### PR TITLE
Remove unnecessary line from GetCompositor

### DIFF
--- a/change/react-native-windows-dc38be40-2c3f-4b74-8f0e-98b90d52fe01.json
+++ b/change/react-native-windows-dc38be40-2c3f-4b74-8f0e-98b90d52fe01.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary line from GetCompositor",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -45,7 +45,6 @@ comp::Compositor GetCompositor() {
   if (!IsXamlIsland()) {
     return xaml::Window::Current().Compositor();
   }
-  comp::Compositor compositor;
 #ifndef USE_WINUI3
   assert(tlsCompositor != nullptr);
   return tlsCompositor;


### PR DESCRIPTION
Creating an unnecessary Compositor instance adds significant overhead. We're not doing anything with this instance, so it basically spends time creating a compositor instance then immediately tearing it down. This change reduced time spent in dcomp nearly 100% (overall, we were spending 11% of time on this call in the app scenario and removing this line brings it down to 0%).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8146)