### PR TITLE
Adjust Button Styling Following Upgrade to WinUI2.6

### DIFF
--- a/change/react-native-windows-2dfe1a4c-812a-4651-9c97-bf5a4522ae0c.json
+++ b/change/react-native-windows-2dfe1a4c-812a-4651-9c97-bf5a4522ae0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Button Styling for 2.6",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -31,113 +31,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-   Text to display inside the button. On Android the given title will be
+    Text to display inside the button. On Android the given title will be
     converted to the uppercased form.
-  */
+   */
   title: string,
 
   /**
-   Handler to be called when the user taps the button. The first function
+    Handler to be called when the user taps the button. The first function
     argument is an event in form of [PressEvent](pressevent).
-  */
+   */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-   If `true`, doesn't play system sound on touch.
+    If `true`, doesn't play system sound on touch.
 
     @platform android
 
     @default false
-  */
+   */
   touchSoundDisabled?: ?boolean,
 
   /**
-   Color of the text (iOS), or background color of the button (Android).
+    Color of the text (iOS), or background color of the button (Android).
 
     @default {@platform android} '#2196F3'
     @default {@platform ios} '#007AFF'
-  */
+   */
   color?: ?ColorValue,
 
   /**
-   TV preferred focus.
+    TV preferred focus.
 
     @platform tv
 
     @default false
-  */
+   */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-   Designates the next view to receive focus when the user navigates down. See
+    Designates the next view to receive focus when the user navigates down. See
     the [Android documentation][android:nextFocusDown].
 
     [android:nextFocusDown]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
 
     @platform android, tv
-  */
+   */
   nextFocusDown?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates forward.
+    Designates the next view to receive focus when the user navigates forward.
     See the [Android documentation][android:nextFocusForward].
 
     [android:nextFocusForward]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
 
     @platform android, tv
-  */
+   */
   nextFocusForward?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates left. See
+    Designates the next view to receive focus when the user navigates left. See
     the [Android documentation][android:nextFocusLeft].
 
     [android:nextFocusLeft]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
 
     @platform android, tv
-  */
+   */
   nextFocusLeft?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates right. See
+    Designates the next view to receive focus when the user navigates right. See
     the [Android documentation][android:nextFocusRight].
 
     [android:nextFocusRight]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
 
     @platform android, tv
-  */
+   */
   nextFocusRight?: ?number,
 
   /**
-   Designates the next view to receive focus when the user navigates up. See
+    Designates the next view to receive focus when the user navigates up. See
     the [Android documentation][android:nextFocusUp].
 
     [android:nextFocusUp]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
 
     @platform android, tv
-  */
+   */
   nextFocusUp?: ?number,
 
   /**
-   Text to display for blindness accessibility features.
-  */
+    Text to display for blindness accessibility features.
+   */
   accessibilityLabel?: ?string,
 
   /**
-   If `true`, disable all interactions for this component.
+    If `true`, disable all interactions for this component.
 
     @default false
-  */
+   */
   disabled?: ?boolean,
 
   /**
-   Used to locate this view in end-to-end tests.
-  */
+    Used to locate this view in end-to-end tests.
+   */
   testID?: ?string,
 
   /**
@@ -150,14 +150,14 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-   Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-  */
+    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+   */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
- A basic button component that should render nicely on any platform. Supports a
+  A basic button component that should render nicely on any platform. Supports a
   minimal level of customization.
 
   If this button doesn't look right for your app, you can build your own button
@@ -265,7 +265,7 @@ type ButtonProps = $ReadOnly<{|
 
   export default App;
   ```
-*/
+ */
 
 class Button extends React.Component<
   ButtonProps,

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -31,113 +31,113 @@ import type {PressEvent} from '../Types/CoreEventTypes';
 
 type ButtonProps = $ReadOnly<{|
   /**
-    Text to display inside the button. On Android the given title will be
+   Text to display inside the button. On Android the given title will be
     converted to the uppercased form.
-   */
+  */
   title: string,
 
   /**
-    Handler to be called when the user taps the button. The first function
+   Handler to be called when the user taps the button. The first function
     argument is an event in form of [PressEvent](pressevent).
-   */
+  */
   onPress: (event?: PressEvent) => mixed,
 
   /**
-    If `true`, doesn't play system sound on touch.
+   If `true`, doesn't play system sound on touch.
 
     @platform android
 
     @default false
-   */
+  */
   touchSoundDisabled?: ?boolean,
 
   /**
-    Color of the text (iOS), or background color of the button (Android).
+   Color of the text (iOS), or background color of the button (Android).
 
     @default {@platform android} '#2196F3'
     @default {@platform ios} '#007AFF'
-   */
+  */
   color?: ?ColorValue,
 
   /**
-    TV preferred focus.
+   TV preferred focus.
 
     @platform tv
 
     @default false
-   */
+  */
   hasTVPreferredFocus?: ?boolean,
 
   /**
-    Designates the next view to receive focus when the user navigates down. See
+   Designates the next view to receive focus when the user navigates down. See
     the [Android documentation][android:nextFocusDown].
 
     [android:nextFocusDown]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusDown
 
     @platform android, tv
-   */
+  */
   nextFocusDown?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates forward.
+   Designates the next view to receive focus when the user navigates forward.
     See the [Android documentation][android:nextFocusForward].
 
     [android:nextFocusForward]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusForward
 
     @platform android, tv
-   */
+  */
   nextFocusForward?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates left. See
+   Designates the next view to receive focus when the user navigates left. See
     the [Android documentation][android:nextFocusLeft].
 
     [android:nextFocusLeft]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusLeft
 
     @platform android, tv
-   */
+  */
   nextFocusLeft?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates right. See
+   Designates the next view to receive focus when the user navigates right. See
     the [Android documentation][android:nextFocusRight].
 
     [android:nextFocusRight]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusRight
 
     @platform android, tv
-   */
+  */
   nextFocusRight?: ?number,
 
   /**
-    Designates the next view to receive focus when the user navigates up. See
+   Designates the next view to receive focus when the user navigates up. See
     the [Android documentation][android:nextFocusUp].
 
     [android:nextFocusUp]:
     https://developer.android.com/reference/android/view/View.html#attr_android:nextFocusUp
 
     @platform android, tv
-   */
+  */
   nextFocusUp?: ?number,
 
   /**
-    Text to display for blindness accessibility features.
-   */
+   Text to display for blindness accessibility features.
+  */
   accessibilityLabel?: ?string,
 
   /**
-    If `true`, disable all interactions for this component.
+   If `true`, disable all interactions for this component.
 
     @default false
-   */
+  */
   disabled?: ?boolean,
 
   /**
-    Used to locate this view in end-to-end tests.
-   */
+   Used to locate this view in end-to-end tests.
+  */
   testID?: ?string,
 
   /**
@@ -150,14 +150,14 @@ type ButtonProps = $ReadOnly<{|
 
   // [Windows
   /**
-    Set the order in which elements receive focus when the user navigates through them by pressing Tab.
-   */
+   Set the order in which elements receive focus when the user navigates through them by pressing Tab.
+  */
   tabIndex?: ?number,
   // Windows]
 |}>;
 
 /**
-  A basic button component that should render nicely on any platform. Supports a
+ A basic button component that should render nicely on any platform. Supports a
   minimal level of customization.
 
   If this button doesn't look right for your app, you can build your own button
@@ -265,7 +265,7 @@ type ButtonProps = $ReadOnly<{|
 
   export default App;
   ```
- */
+*/
 
 class Button extends React.Component<
   ButtonProps,
@@ -276,8 +276,6 @@ class Button extends React.Component<
     super(props);
     this.state = {
       hover: false,
-      // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-      // https://github.com/microsoft/react-native-windows/issues/7425
       pressed: false,
     };
   }
@@ -354,8 +352,6 @@ class Button extends React.Component<
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
-          // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-          // https://github.com/microsoft/react-native-windows/issues/7425
           underlayColor={PlatformColor('ButtonBackgroundPressed')}
           onShowUnderlay={() => {
             this.setState({pressed: true});
@@ -364,16 +360,22 @@ class Button extends React.Component<
             this.setState({pressed: false});
           }}
           style={
-            this.state.hover && !this.state.pressed
+            this.state.pressed
+              ? [
+                  buttonStyles,
+                  {
+                    borderColor: PlatformColor('ButtonBorderBrushPressed'),
+                    borderBottomWidth: 1,
+                  },
+                ]
+              : this.state.hover
               ? [
                   buttonStyles,
                   {
                     backgroundColor: PlatformColor(
                       'ButtonBackgroundPointerOver',
                     ),
-                    // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-                    // https://github.com/microsoft/react-native-windows/issues/7425
-                    opacity: 0.1,
+                    borderColor: PlatformColor('ButtonBorderBrushPointerOver'),
                   },
                 ]
               : buttonStyles
@@ -384,7 +386,25 @@ class Button extends React.Component<
           onMouseLeave={() => {
             if (!disabled) this.setState({hover: false});
           }}>
-          <Text style={textStyles} disabled={disabled}>
+          <Text
+            style={
+              this.state.pressed
+                ? [
+                    textStyles,
+                    {
+                      color: PlatformColor('ButtonForegroundPressed'),
+                    },
+                  ]
+                : this.state.hover
+                ? [
+                    textStyles,
+                    {
+                      color: PlatformColor('ButtonForegroundPointerOver'),
+                    },
+                  ]
+                : textStyles
+            }
+            disabled={disabled}>
             {formattedTitle}
           </Text>
         </Touchable>
@@ -407,6 +427,7 @@ class Button extends React.Component<
           testID={testID}
           disabled={disabled}
           onPress={onPress}
+          tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}>
           <View style={buttonStyles}>
             <Text style={textStyles} disabled={disabled}>
@@ -433,6 +454,9 @@ const styles = StyleSheet.create({
     windows: {
       backgroundColor: PlatformColor('ButtonBackground'),
       borderRadius: 3,
+      borderColor: PlatformColor('ButtonBorderBrush'),
+      borderWidth: 1,
+      borderBottomWidth: 1.5,
     },
     // Windows]
   }),
@@ -466,6 +490,7 @@ const styles = StyleSheet.create({
     },
     windows: {
       backgroundColor: PlatformColor('ButtonBackgroundDisabled'),
+      borderColor: PlatformColor('ButtonBorderBrushDisabled'),
     },
   }),
   textDisabled: Platform.select({

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -427,7 +427,6 @@ class Button extends React.Component<
           testID={testID}
           disabled={disabled}
           onPress={onPress}
-          tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}>
           <View style={buttonStyles}>
             <Text style={textStyles} disabled={disabled}>


### PR DESCRIPTION
**_Why_**
Recent upgrade of RNW to MUX2.6 caused a second shift in button styling. A couple of small tweaks were needed here to match the styling of the XAML button.

**_What_**

- Added border color and width to Button.
- Removed workaround in place for WinUI2.5 ButtonBackgroundPointerOver brush.
- Added button title color change with change in states. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8148)