### PR TITLE
[0.64] Backporting AccessibilityControls prop on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-ab588088-9d63-4f25-b0da-123dfa0d64fd.json
+++ b/change/@office-iss-react-native-win32-ab588088-9d63-4f25-b0da-123dfa0d64fd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backporting AccessibilityControls prop to 0.64",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -378,6 +378,7 @@ const ReactNativeViewConfig = {
     accessibilityDescribedBy: true,
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
+    accessibilityControls: true,
     // Windows]
   },
 };

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -168,6 +168,14 @@ export type BasePropsWin32 = {
   */
   accessibilityDescribedBy?: React.RefObject<any>;
   accessibilityLabeledBy?: React.RefObject<any>;
+
+  /**
+  * Identifies the element whose contents or presence are controlled by another element. 
+  * 
+  * This is mainly used for a Textbox with a Dropdown PeoplePicker-type list.  This allows an 
+  * accessibility tool to query those other providers for properties and listen to their events.
+  */
+   accessibilityControls?: React.RefObject<any>;   
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -45,7 +45,9 @@ export const ViewWin32 = React.forwardRef(
 
     const [labeledByTarget, setLabeledByTarget] = React.useState(null);
     const [describedByTarget, setDescribedByTarget] = React.useState(null);
-    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = props;
+    const [controlsTarget, setControlsTarget] = React.useState(null);
+    const {accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls, ...rest} = props;
+
     React.useLayoutEffect(() => {
       if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy.current !== null)
       {
@@ -55,7 +57,9 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
+    }, [accessibilityLabeledBy]);
 
+    React.useLayoutEffect(() => {
       if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy.current !== null)
       {
         setDescribedByTarget(findNodeHandle(accessibilityDescribedBy.current as
@@ -64,7 +68,18 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
-    }, [accessibilityLabeledBy, accessibilityDescribedBy]);
+    }, [accessibilityDescribedBy]);
+
+    React.useLayoutEffect(() => {
+      if(accessibilityControls !== undefined && accessibilityControls.current !== null)
+      {
+        setControlsTarget(findNodeHandle(accessibilityControls.current as
+          | null
+          | number
+          | React.Component<any, any, any>
+          | React.ComponentClass<any, any>));
+      }
+    }, [accessibilityControls]);
 
     /**
      * Set up the forwarding ref to enable adding the focus method.
@@ -94,6 +109,7 @@ export const ViewWin32 = React.forwardRef(
 
     return <View ref={setNativeRef}
     {...(rest as InnerViewWin32Props)}
+    {...((controlsTarget !== null) ? {accessibilityControls:controlsTarget} : {})}
     {...((labeledByTarget !== null) ? {accessibilityLabeledBy:labeledByTarget} : {})}
     {...((describedByTarget !== null) ? {accessibilityDescribedBy:describedByTarget} : {})}
     />;


### PR DESCRIPTION
Backporting changes from [#7796](https://github.com/microsoft/react-native-windows/pull/7796) and [#8126 ](https://github.com/microsoft/react-native-windows/pull/8126). 

These changes add the AccessibilityControls prop on ViewWin32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8154)