### PR TITLE
[0.63] Backporting AccessibilityControls prop on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-2021-07-03-12-41-38-sammy-0.63_ViewWin32Config_Backport.json
+++ b/change/@office-iss-react-native-win32-2021-07-03-12-41-38-sammy-0.63_ViewWin32Config_Backport.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Backporting AccessibilityControls prop to 0.63",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-07-03T19:41:38.702Z"
+}

--- a/packages/react-native-win32/docs/api/react-native-win32.basepropswin32.md
+++ b/packages/react-native-win32/docs/api/react-native-win32.basepropswin32.md
@@ -13,5 +13,6 @@ export declare type BasePropsWin32 = {
     accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
     accessibilityDescribedBy?: React.RefObject<any>;
     accessibilityLabeledBy?: React.RefObject<any>;
+    accessibilityControls?: React.RefObject<any>;
 };
 ```

--- a/packages/react-native-win32/etc/react-native-win32.api.md
+++ b/packages/react-native-win32/etc/react-native-win32.api.md
@@ -56,6 +56,7 @@ export type BasePropsWin32 = {
     accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
     accessibilityDescribedBy?: React_2.RefObject<any>;
     accessibilityLabeledBy?: React_2.RefObject<any>;
+    accessibilityControls?: React_2.RefObject<any>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "IButtonWin32State" needs to be exported by the entry point typings-index.d.ts

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -378,6 +378,7 @@ const ReactNativeViewConfig = {
     accessibilityDescribedBy: true,
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
+    accessibilityControls: true,
     // Windows]
   },
 };

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -168,6 +168,14 @@ export type BasePropsWin32 = {
   */
   accessibilityDescribedBy?: React.RefObject<any>;
   accessibilityLabeledBy?: React.RefObject<any>;
+
+  /**
+  * Identifies the element whose contents or presence are controlled by another element. 
+  * 
+  * This is mainly used for a Textbox with a Dropdown PeoplePicker-type list.  This allows an 
+  * accessibility tool to query those other providers for properties and listen to their events.
+  */
+   accessibilityControls?: React.RefObject<any>;     
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -45,7 +45,9 @@ export const ViewWin32 = React.forwardRef(
 
     const [labeledByTarget, setLabeledByTarget] = React.useState(null);
     const [describedByTarget, setDescribedByTarget] = React.useState(null);
-    const {accessibilityLabeledBy, accessibilityDescribedBy, ...rest} = props;
+    const [controlsTarget, setControlsTarget] = React.useState(null);
+    const {accessibilityLabeledBy, accessibilityDescribedBy, accessibilityControls, ...rest} = props;
+
     React.useLayoutEffect(() => {
       if (accessibilityLabeledBy !== undefined && accessibilityLabeledBy?.current !== null)
       {
@@ -54,8 +56,10 @@ export const ViewWin32 = React.forwardRef(
           | number
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
-      }
+        }
+      }, [accessibilityLabeledBy]);
 
+    React.useLayoutEffect(() => {
       if (accessibilityDescribedBy !== undefined && accessibilityDescribedBy?.current !== null)
       {
         setDescribedByTarget(findNodeHandle(accessibilityDescribedBy.current as
@@ -64,7 +68,18 @@ export const ViewWin32 = React.forwardRef(
           | React.Component<any, any, any>
           | React.ComponentClass<any, any>));
       }
-    }, [accessibilityLabeledBy, accessibilityDescribedBy]);
+    }, [accessibilityDescribedBy]);
+
+    React.useLayoutEffect(() => {
+      if(accessibilityControls !== undefined && accessibilityControls.current !== null)
+      {
+        setControlsTarget(findNodeHandle(accessibilityControls.current as
+          | null
+          | number
+          | React.Component<any, any, any>
+          | React.ComponentClass<any, any>));
+      }
+    }, [accessibilityControls]);    
 
     /**
      * Set up the forwarding ref to enable adding the focus method.
@@ -94,6 +109,7 @@ export const ViewWin32 = React.forwardRef(
 
     return <View ref={_setNativeRef}
     {...(rest as InnerViewWin32Props)}
+    {...((controlsTarget !== null) ? {accessibilityControls:controlsTarget} : {})}
     {...((labeledByTarget !== null) ? {accessibilityLabeledBy:labeledByTarget} : {})}
     {...((describedByTarget !== null) ? {accessibilityDescribedBy:describedByTarget} : {})}
     />;


### PR DESCRIPTION
Backporting changes from [#7796](https://github.com/microsoft/react-native-windows/pull/7796) and [#8126 ](https://github.com/microsoft/react-native-windows/pull/8126). 

These changes add the AccessibilityControls prop on ViewWin32.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8155)