### PR TITLE
[0.65] Adjust Button Styling Following Upgrade to WinUI2.6

### DIFF
--- a/change/react-native-windows-fe3d1400-2d6f-4ccd-9a42-7e56656d6f10.json
+++ b/change/react-native-windows-fe3d1400-2d6f-4ccd-9a42-7e56656d6f10.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Backport WinUI2.6 Button Changes",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -133,7 +133,7 @@ type ButtonProps = $ReadOnly<{|
 
   /**
     Used to locate this view in end-to-end tests.
-  */
+   */
   testID?: ?string,
 
   /**

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -133,7 +133,7 @@ type ButtonProps = $ReadOnly<{|
 
   /**
     Used to locate this view in end-to-end tests.
-   */
+  */
   testID?: ?string,
 
   /**
@@ -269,8 +269,6 @@ class Button extends React.Component<
     super(props);
     this.state = {
       hover: false,
-      // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-      // https://github.com/microsoft/react-native-windows/issues/7425
       pressed: false,
     };
   }
@@ -289,6 +287,9 @@ class Button extends React.Component<
       nextFocusRight,
       nextFocusUp,
       testID,
+      accessible,
+      accessibilityActions,
+      onAccessibilityAction,
       tabIndex,
     } = this.props;
     const buttonStyles = [styles.button];
@@ -344,8 +345,6 @@ class Button extends React.Component<
           onPress={onPress}
           tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}
-          // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-          // https://github.com/microsoft/react-native-windows/issues/7425
           underlayColor={PlatformColor('ButtonBackgroundPressed')}
           onShowUnderlay={() => {
             this.setState({pressed: true});
@@ -354,16 +353,22 @@ class Button extends React.Component<
             this.setState({pressed: false});
           }}
           style={
-            this.state.hover && !this.state.pressed
+            this.state.pressed
+              ? [
+                  buttonStyles,
+                  {
+                    borderColor: PlatformColor('ButtonBorderBrushPressed'),
+                    borderBottomWidth: 1,
+                  },
+                ]
+              : this.state.hover
               ? [
                   buttonStyles,
                   {
                     backgroundColor: PlatformColor(
                       'ButtonBackgroundPointerOver',
                     ),
-                    // Workaround for MUX2.5; remove after update to MUX2.6 is completed.
-                    // https://github.com/microsoft/react-native-windows/issues/7425
-                    opacity: 0.1,
+                    borderColor: PlatformColor('ButtonBorderBrushPointerOver'),
                   },
                 ]
               : buttonStyles
@@ -374,7 +379,25 @@ class Button extends React.Component<
           onMouseLeave={() => {
             if (!disabled) this.setState({hover: false});
           }}>
-          <Text style={textStyles} disabled={disabled}>
+          <Text
+            style={
+              this.state.pressed
+                ? [
+                    textStyles,
+                    {
+                      color: PlatformColor('ButtonForegroundPressed'),
+                    },
+                  ]
+                : this.state.hover
+                ? [
+                    textStyles,
+                    {
+                      color: PlatformColor('ButtonForegroundPointerOver'),
+                    },
+                  ]
+                : textStyles
+            }
+            disabled={disabled}>
             {formattedTitle}
           </Text>
         </Touchable>
@@ -382,6 +405,9 @@ class Button extends React.Component<
     } else {
       return (
         <Touchable
+          accessible={accessible}
+          accessibilityActions={accessibilityActions}
+          onAccessibilityAction={onAccessibilityAction}
           accessibilityLabel={accessibilityLabel}
           accessibilityRole="button"
           accessibilityState={accessibilityState}
@@ -394,7 +420,6 @@ class Button extends React.Component<
           testID={testID}
           disabled={disabled}
           onPress={onPress}
-          tabIndex={tabIndex}
           touchSoundDisabled={touchSoundDisabled}>
           <View style={buttonStyles}>
             <Text style={textStyles} disabled={disabled}>
@@ -421,6 +446,9 @@ const styles = StyleSheet.create({
     windows: {
       backgroundColor: PlatformColor('ButtonBackground'),
       borderRadius: 3,
+      borderColor: PlatformColor('ButtonBorderBrush'),
+      borderWidth: 1,
+      borderBottomWidth: 1.5,
     },
     // Windows]
   }),
@@ -454,6 +482,7 @@ const styles = StyleSheet.create({
     },
     windows: {
       backgroundColor: PlatformColor('ButtonBackgroundDisabled'),
+      borderColor: PlatformColor('ButtonBorderBrushDisabled'),
     },
   }),
   textDisabled: Platform.select({

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -287,9 +287,6 @@ class Button extends React.Component<
       nextFocusRight,
       nextFocusUp,
       testID,
-      accessible,
-      accessibilityActions,
-      onAccessibilityAction,
       tabIndex,
     } = this.props;
     const buttonStyles = [styles.button];
@@ -405,9 +402,6 @@ class Button extends React.Component<
     } else {
       return (
         <Touchable
-          accessible={accessible}
-          accessibilityActions={accessibilityActions}
-          onAccessibilityAction={onAccessibilityAction}
           accessibilityLabel={accessibilityLabel}
           accessibilityRole="button"
           accessibilityState={accessibilityState}


### PR DESCRIPTION
**_Why_**
Recent upgrade of RNW to MUX2.6 caused a second shift in button styling. A couple of small tweaks were needed here to match the styling of the XAML button.

**_What_**
Added border color and width to Button.
Removed workaround in place for WinUI2.5 ButtonBackgroundPointerOver brush.
Added button title color change with change in states.

Backport #8148 to 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8169)