### PR TITLE
Add hooks to allow instance to be usable with pluggable UI platforms

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -154,6 +154,7 @@ jobs:
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |
+            React.Windows.Desktop\**
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
 

--- a/change/@office-iss-react-native-win32-e08e70eb-e50d-452b-9414-a3980e22a905.json
+++ b/change/@office-iss-react-native-win32-e08e70eb-e50d-452b-9414-a3980e22a905.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support running UIManager as a TurboModule",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-26a7dc77-a8eb-4dcf-9963-5acdcc5e06d3.json
+++ b/change/react-native-windows-26a7dc77-a8eb-4dcf-9963-5acdcc5e06d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add hooks to allow instance to be usable with pluggable UI platform",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -394,7 +394,7 @@
     },
     {
       "type": "patch",
-      "file": "src/Libraries/ReactNative/PaperUIManager.windows.js",
+      "file": "src/Libraries/ReactNative/PaperUIManager.win32.js",
       "baseFile": "Libraries/ReactNative/PaperUIManager.js",
       "baseHash": "1a47d1e4a1026573cabdda0fa6374ca64bd41b81"
     },

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -393,6 +393,12 @@
       "file": "src/Libraries/QuirkSettings/QuirkSettings.js"
     },
     {
+      "type": "patch",
+      "file": "src/Libraries/ReactNative/PaperUIManager.windows.js",
+      "baseFile": "Libraries/ReactNative/PaperUIManager.js",
+      "baseHash": "1a47d1e4a1026573cabdda0fa6374ca64bd41b81"
+    },
+    {
       "type": "derived",
       "file": "src/Libraries/Settings/Settings.win32.js",
       "baseFile": "Libraries/Settings/Settings.android.js",

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.tsx
@@ -26,10 +26,10 @@
 import React from 'react'
 import {
   findNodeHandle,
-  NativeModules,
   requireNativeComponent,
   TextInputProps,
   NativeMethods,
+  UIManager
 } from 'react-native';
 import {
   IBlurEvent,
@@ -49,7 +49,7 @@ const RCTTextInput = requireNativeComponent<RCTTextInputProps>('RCTTextInput');
 
 // Adding typings on ViewManagers is problematic as available functionality is not known until
 // registration at runtime and would require native and js to always be in sync.
-const TextInputViewManager: any = NativeModules.UIManager.getViewManagerConfig('RCTTextInput');
+const TextInputViewManager: any = UIManager.getViewManagerConfig('RCTTextInput');
 
 class TextInput extends React.Component<TextInputProps, {}> {
   // TODO: Once the native side begins supporting programmatic selection
@@ -152,7 +152,7 @@ class TextInput extends React.Component<TextInputProps, {}> {
    */
   public focus = (): void => {
     TextInputState.setFocusedTextInput(this);
-    NativeModules.UIManager.
+    UIManager.
       dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.focus, null);
   }
 
@@ -161,7 +161,7 @@ class TextInput extends React.Component<TextInputProps, {}> {
    */
   public blur = (): void => {
     TextInputState.blurTextInput(this);
-    NativeModules.UIManager.
+    UIManager.
       dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.blur, null);
   }
 
@@ -173,16 +173,16 @@ class TextInput extends React.Component<TextInputProps, {}> {
   }
 
   private readonly setEventCount = (): void => {
-    NativeModules.UIManager.
+    UIManager.
       dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.setEventCount,
-        { eventCount: this._eventCount });
+        [ this._eventCount ]);
   }
 
   private readonly setNativeText = (val: string): void => {
     if (this._lastNativeText !== val) {
-      NativeModules.UIManager.
+      UIManager.
         dispatchViewManagerCommand(findNodeHandle(this), TextInputViewManager.Commands.setNativeText,
-          { text: val });
+          [ val ]);
     }
   }
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react'
 import RN = require('react-native');
-import { View, findNodeHandle, NativeModules } from 'react-native';
+import { View, findNodeHandle, UIManager } from 'react-native';
 import { IViewWin32Props, UseFrom } from './ViewWin32.Props';
 const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 
@@ -96,9 +96,9 @@ export const ViewWin32 = React.forwardRef(
         if (localRef)
         {
           localRef.focus = () => {
-            NativeModules.UIManager.dispatchViewManagerCommand(
+            UIManager.dispatchViewManagerCommand(
               findNodeHandle(localRef),
-              NativeModules.UIManager.getViewManagerConfig('RCTView').Commands.focus,
+              UIManager.getViewManagerConfig('RCTView').Commands.focus,
               null
               );
           };

--- a/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+const NativeModules = require('../BatchedBridge/NativeModules');
+const Platform = require('../Utilities/Platform');
+const UIManagerProperties = require('./UIManagerProperties');
+
+const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
+
+import NativeUIManager from './NativeUIManager';
+// import type {RootTag} from 'react-native/Libraries/Types/RootTagTypes'; [Windows]
+
+const viewManagerConfigs = {};
+
+const triedLoadingConfig = new Set();
+
+let NativeUIManagerConstants = {};
+let isNativeUIManagerConstantsSet = false;
+function getConstants(): Object {
+  if (!isNativeUIManagerConstantsSet) {
+    NativeUIManagerConstants = NativeUIManager.getConstants();
+    isNativeUIManagerConstantsSet = true;
+  }
+  return NativeUIManagerConstants;
+}
+
+function getViewManagerConfig(viewManagerName: string): any {
+  if (
+    viewManagerConfigs[viewManagerName] === undefined &&
+    global.nativeCallSyncHook && // [Windows] getConstantsForViewManager doesn't work while web debugging. So skip calling it since all constants will have been provided ahead of time.
+    NativeUIManager.getConstantsForViewManager
+  ) {
+    try {
+      viewManagerConfigs[
+        viewManagerName
+      ] = NativeUIManager.getConstantsForViewManager(viewManagerName);
+    } catch (e) {
+      console.error(
+        "NativeUIManager.getConstantsForViewManager('" +
+          viewManagerName +
+          "') threw an exception.",
+        e,
+      );
+      viewManagerConfigs[viewManagerName] = null;
+    }
+  }
+
+  const config = viewManagerConfigs[viewManagerName];
+  if (config) {
+    return config;
+  }
+
+  // If we're in the Chrome Debugger, let's not even try calling the sync
+  // method.
+  if (!global.nativeCallSyncHook) {
+    return config;
+  }
+
+  if (
+    NativeUIManager.lazilyLoadView &&
+    !triedLoadingConfig.has(viewManagerName)
+  ) {
+    const result = NativeUIManager.lazilyLoadView(viewManagerName);
+    triedLoadingConfig.add(viewManagerName);
+    if (result != null && result.viewConfig != null) {
+      getConstants()[viewManagerName] = result.viewConfig;
+      lazifyViewManagerConfig(viewManagerName);
+    }
+  }
+
+  return viewManagerConfigs[viewManagerName];
+}
+
+// $FlowFixMe
+const UIManagerJS = {};
+
+// [Windows The spread operator doesn't work on JSI turbomodules, so use this instead
+for (const propName of Object.getOwnPropertyNames(NativeUIManager)) {
+  // $FlowFixMe
+  UIManagerJS[propName] = NativeUIManager[propName];
+}
+// Windows]
+
+/* $FlowFixMe(>=0.123.0 site=react_native_fb) This comment suppresses an error
+ * found when Flow v0.123.0 was deployed. To see the error, delete this comment
+ * and run Flow. */
+//const UIManagerJS = {
+//  ...NativeUIManager,
+// $FlowFixMe
+UIManagerJS.getConstants = getConstants;
+//  },
+// $FlowFixMe
+UIManagerJS.getViewManagerConfig = getViewManagerConfig;
+
+UIManagerJS.hasViewManagerConfig = (viewManagerName: string) =>
+  getViewManagerConfig(viewManagerName) != null;
+
+//};
+
+// TODO (T45220498): Remove this.
+// 3rd party libs may be calling `NativeModules.UIManager.getViewManagerConfig()`
+// instead of `UIManager.getViewManagerConfig()` off UIManager.js.
+// This is a workaround for now.
+// [Windows - This is incompatible with running UIManager as a JSI object.
+//            getViewManagerConfig is implemented on the JSI object, so we dont
+//            need to hook this unless we are runnign in webdebugger
+if (!global.nativeCallSyncHook)
+  // $FlowFixMe
+  NativeUIManager.getViewManagerConfig = UIManagerJS.getViewManagerConfig;
+
+function lazifyViewManagerConfig(viewName) {
+  const viewConfig = getConstants()[viewName];
+  viewManagerConfigs[viewName] = viewConfig;
+  if (viewConfig.Manager) {
+    defineLazyObjectProperty(viewConfig, 'Constants', {
+      get: () => {
+        const viewManager = NativeModules[viewConfig.Manager];
+        const constants = {};
+        viewManager &&
+          Object.keys(viewManager).forEach(key => {
+            const value = viewManager[key];
+            if (typeof value !== 'function') {
+              constants[key] = value;
+            }
+          });
+        return constants;
+      },
+    });
+    defineLazyObjectProperty(viewConfig, 'Commands', {
+      get: () => {
+        const viewManager = NativeModules[viewConfig.Manager];
+        const commands = {};
+        let index = 0;
+        viewManager &&
+          Object.keys(viewManager).forEach(key => {
+            const value = viewManager[key];
+            if (typeof value === 'function') {
+              commands[key] = index++;
+            }
+          });
+        return commands;
+      },
+    });
+  }
+}
+
+/**
+ * Copies the ViewManager constants and commands into UIManager. This is
+ * only needed for iOS, which puts the constants in the ViewManager
+ * namespace instead of UIManager, unlike Android.
+ */
+if (Platform.OS === 'ios') {
+  Object.keys(getConstants()).forEach(viewName => {
+    lazifyViewManagerConfig(viewName);
+  });
+} else if (getConstants().ViewManagerNames) {
+  NativeUIManager.getConstants().ViewManagerNames.forEach(viewManagerName => {
+    defineLazyObjectProperty(NativeUIManager, viewManagerName, {
+      get: () => NativeUIManager.getConstantsForViewManager(viewManagerName),
+    });
+  });
+}
+
+if (!global.nativeCallSyncHook) {
+  Object.keys(getConstants()).forEach(viewManagerName => {
+    if (!UIManagerProperties.includes(viewManagerName)) {
+      if (!viewManagerConfigs[viewManagerName]) {
+        viewManagerConfigs[viewManagerName] = getConstants()[viewManagerName];
+      }
+      defineLazyObjectProperty(NativeUIManager, viewManagerName, {
+        get: () => {
+          console.warn(
+            `Accessing view manager configs directly off UIManager via UIManager['${viewManagerName}'] ` +
+              `is no longer supported. Use UIManager.getViewManagerConfig('${viewManagerName}') instead.`,
+          );
+
+          return UIManagerJS.getViewManagerConfig(viewManagerName);
+        },
+      });
+    }
+  });
+}
+
+module.exports = UIManagerJS;

--- a/packages/@office-iss/react-native-win32/src/Libraries/Utilities/FocusManager.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Utilities/FocusManager.win32.js
@@ -9,7 +9,7 @@
 'use strict';
 
 import * as React from 'react';
-import {findNodeHandle, NativeModules} from 'react-native';
+import {findNodeHandle, UIManager} from 'react-native';
 
 /*
  ** This is a helper class intended to allow usage of Polite/Aggressive Focus for win32.
@@ -21,17 +21,15 @@ class FocusManager {
   static focus(ref: React.Ref<any>, setWindowFocus: boolean) {
     if (ref) {
       if (setWindowFocus) {
-        NativeModules.UIManager.dispatchViewManagerCommand(
+        UIManager.dispatchViewManagerCommand(
           findNodeHandle(ref),
-          NativeModules.UIManager.getViewManagerConfig('RCTView').Commands
-            .aggressivefocus,
+          UIManager.getViewManagerConfig('RCTView').Commands.aggressivefocus,
           null,
         );
       } else {
-        NativeModules.UIManager.dispatchViewManagerCommand(
+        UIManager.dispatchViewManagerCommand(
           findNodeHandle(ref),
-          NativeModules.UIManager.getViewManagerConfig('RCTView').Commands
-            .politefocus,
+          UIManager.getViewManagerConfig('RCTView').Commands.politefocus,
           null,
         );
       }

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -133,6 +133,7 @@
     <Midl Include="ABI\NativeLogging.idl" />
     <Midl Include="ABI\NativeTracing.idl" />
     <Midl Include="ABI\TestController.idl" />
+    <Midl Include="..\Microsoft.ReactNative\ReactCoreInjection.idl" />
     <Midl Include="..\Microsoft.ReactNative\ReactNativeHost.idl" />
     <Midl Include="..\Microsoft.ReactNative\IReactPackageProvider.idl" />
     <Midl Include="..\Microsoft.ReactNative\ReactInstanceSettings.idl" />
@@ -148,6 +149,7 @@
     <Midl Include="..\Microsoft.ReactNative\IReactPropertyBag.idl" />
     <Midl Include="..\Microsoft.ReactNative\JsiApi.idl" />
     <Midl Include="..\Microsoft.ReactNative\RedBoxHandler.idl" />
+    <Midl Include="..\Microsoft.ReactNative\QuirkSettings.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Microsoft.ReactNative\IReactDispatcher.cpp">
@@ -203,12 +205,16 @@
     <ClCompile Include="..\Microsoft.ReactNative\JsiWriter.cpp">
       <DependentUpon>..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\DevSettingsModule.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle_Win32.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSCallInvokerScheduler.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\MsoUtils.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactContext.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactErrorProvider.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactInstanceWin.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\ReactHost.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactNativeHost.cpp">
       <DependentUpon>..\Microsoft.ReactNative\ReactNativeHost.idl</DependentUpon>
@@ -216,10 +222,18 @@
     <ClCompile Include="..\Microsoft.ReactNative\ReactPackageBuilder.cpp">
       <DependentUpon>..\Microsoft.ReactNative\IReactPackageBuilder.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\ReactCoreInjection.cpp">
+      <DependentUpon>..\Microsoft.ReactNative\ReactCoreInjection.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="..\Microsoft.ReactNative\RedBox.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\RedBoxHandler.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\RedBoxErrorFrameInfo.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\RedBoxErrorInfo.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\TurboModulesProvider.cpp" />
+        <ClCompile Include="..\Microsoft.ReactNative\QuirkSettings.cpp">
+      <DependentUpon>..\Microsoft.ReactNative\QuirkSettings.idl</DependentUpon>
+    </ClCompile>
+
     <ClCompile Include="CxxReactWin32\JSBigString.cpp" />
     <ClCompile Include="JSI\ChakraJsiRuntime_core.cpp" />
     <ClCompile Include="ShadowNode.cpp" />

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -6,11 +6,15 @@
 #include "pch.h"
 #include "winrt/base.h"
 void* winrt_make_Microsoft_Internal_TestController();
+void* winrt_make_Microsoft_ReactNative_JsiRuntime();
+void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
 void* winrt_make_Microsoft_ReactNative_ReactDispatcherHelper();
 void* winrt_make_Microsoft_ReactNative_ReactInstanceSettings();
 void* winrt_make_Microsoft_ReactNative_ReactNativeHost();
 void* winrt_make_Microsoft_ReactNative_ReactNotificationServiceHelper();
 void* winrt_make_Microsoft_ReactNative_ReactPropertyBagHelper();
+void* winrt_make_Microsoft_ReactNative_ReactViewOptions();
+void* winrt_make_Microsoft_ReactNative_RedBoxHelper();
 void* winrt_make_facebook_react_MemoryTracker();
 void* winrt_make_facebook_react_NativeLogEventSource();
 void* winrt_make_facebook_react_NativeTraceEventSource();
@@ -38,6 +42,16 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
         return winrt_make_Microsoft_Internal_TestController();
     }
 
+    if (requal(name, L"Microsoft.ReactNative.JsiRuntime"))
+    {
+        return winrt_make_Microsoft_ReactNative_JsiRuntime();
+    }
+
+    if (requal(name, L"Microsoft.ReactNative.ReactCoreInjection"))
+    {
+        return winrt_make_Microsoft_ReactNative_ReactCoreInjection();
+    }
+
     if (requal(name, L"Microsoft.ReactNative.ReactDispatcherHelper"))
     {
         return winrt_make_Microsoft_ReactNative_ReactDispatcherHelper();
@@ -61,6 +75,16 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     if (requal(name, L"Microsoft.ReactNative.ReactPropertyBagHelper"))
     {
         return winrt_make_Microsoft_ReactNative_ReactPropertyBagHelper();
+    }
+
+    if (requal(name, L"Microsoft.ReactNative.ReactViewOptions"))
+    {
+        return winrt_make_Microsoft_ReactNative_ReactViewOptions();
+    }
+
+    if (requal(name, L"Microsoft.ReactNative.RedBoxHelper"))
+    {
+        return winrt_make_Microsoft_ReactNative_RedBoxHelper();
     }
 
     if (requal(name, L"facebook.react.MemoryTracker"))

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -14,7 +14,6 @@ namespace winrt::Microsoft::ReactNative::implementation {
 // ReactSettingsSnapshot implementation
 //=============================================================================
 
-#ifndef CORE_ABI
 ReactSettingsSnapshot::ReactSettingsSnapshot(Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> &&settings) noexcept
     : m_settings{std::move(settings)} {}
 
@@ -62,27 +61,16 @@ Mso::React::IReactSettingsSnapshot const &ReactSettingsSnapshot::GetInner() cons
   return *m_settings;
 }
 
-#endif
-
 //=============================================================================
 // ReactContext implementation
 //=============================================================================
 
-ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context {
-  std::move(context)
-}
-#ifndef CORE_ABI
-, m_settings {
-  winrt::make<ReactSettingsSnapshot>(&m_context->SettingsSnapshot())
-}
-#endif
-{}
+ReactContext::ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept
+    : m_context{std::move(context)}, m_settings{winrt::make<ReactSettingsSnapshot>(&m_context->SettingsSnapshot())} {}
 
-#ifndef CORE_ABI
 IReactSettingsSnapshot ReactContext::SettingsSnapshot() noexcept {
   return m_settings;
 }
-#endif
 
 IReactPropertyBag ReactContext::Properties() noexcept {
   return m_context->Properties();

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -8,7 +8,6 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-#ifndef CORE_ABI
 struct ReactSettingsSnapshot : winrt::implements<ReactSettingsSnapshot, IReactSettingsSnapshot> {
   ReactSettingsSnapshot(Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> &&settings) noexcept;
 
@@ -31,15 +30,12 @@ struct ReactSettingsSnapshot : winrt::implements<ReactSettingsSnapshot, IReactSe
  private:
   Mso::CntPtr<const Mso::React::IReactSettingsSnapshot> m_settings;
 };
-#endif
 
 struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   ReactContext(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
 
  public: // IReactContext
-#ifndef CORE_ABI
   IReactSettingsSnapshot SettingsSnapshot() noexcept;
-#endif
   IReactPropertyBag Properties() noexcept;
   IReactNotificationService Notifications() noexcept;
   IReactDispatcher UIDispatcher() noexcept;
@@ -67,9 +63,7 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
 
  private:
   Mso::CntPtr<Mso::React::IReactContext> m_context;
-#ifndef CORE_ABI
   ReactNative::IReactSettingsSnapshot m_settings{nullptr};
-#endif
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -13,7 +13,6 @@ import "IReactPropertyBag.idl";
 
 namespace Microsoft.ReactNative
 {
-#ifndef CORE_ABI
   [webhosthidden]
   DOC_STRING("An immutable snapshot of the @ReactInstanceSettings used to create the current React instance.")
   interface IReactSettingsSnapshot
@@ -92,7 +91,6 @@ namespace Microsoft.ReactNative
       "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
     String JavaScriptBundleFile { get; };
   }
-#endif
 
   [webhosthidden]
   DOC_STRING(
@@ -109,10 +107,8 @@ namespace Microsoft.ReactNative
     "- Use @.JSDispatcher to post asynchronous work in the JavaScript engine thread.")
   interface IReactContext
   {
-#ifndef CORE_ABI
     DOC_STRING("Gets the settings snapshot that was used to start the React instance.")
     IReactSettingsSnapshot SettingsSnapshot { get; };
-#endif
 
     DOC_STRING(
       "Gets @IReactPropertyBag shared with the @ReactInstanceSettings.Properties.\n"

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -279,6 +279,10 @@
     <ClInclude Include="ReactHost\ReactInstanceWin.h" />
     <ClInclude Include="ReactHost\ReactNativeHeaders.h" />
     <ClInclude Include="ReactHost\React_Win.h" />
+    <ClInclude Include="ReactCoreInjection.h">
+      <DependentUpon>ReactCoreInjection.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="ReactInstanceSettings.h">
       <DependentUpon>ReactInstanceSettings.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -586,6 +590,10 @@
     <ClCompile Include="ReactHost\ReactErrorProvider.cpp" />
     <ClCompile Include="ReactHost\ReactHost.cpp" />
     <ClCompile Include="ReactHost\ReactInstanceWin.cpp" />
+    <ClCompile Include="ReactCoreInjection.cpp">
+      <DependentUpon>ReactCoreInjection.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="ReactInstanceSettings.cpp">
       <DependentUpon>ReactInstanceSettings.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -697,6 +705,9 @@
     <Midl Include="JsiApi.idl" />
     <Midl Include="ReactApplication.idl" />
     <Midl Include="IReactContext.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+    <Midl Include="ReactCoreInjection.idl">
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="ReactInstanceSettings.idl">

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -134,8 +134,7 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
   winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 
-  inline Mso::Future<void> PostInUIQueue(
-      winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
+  inline Mso::Future<void> PostInUIQueue(winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
 
     // ReactViewInstance has shorter lifetime than ReactRootControl. Thus, we capture this WeakPtr.

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "ReactCoreInjection.h"
+#include "ReactCoreInjection.g.cpp"
+#include "ReactViewOptions.g.cpp"
+#include "ReactInstanceWin.h"
+#include "ReactContext.h"
+#include "IReactContext.h"
+
+#include "ReactNativeHost.h"
+#include "DynamicWriter.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+  ReactViewOptions::ReactViewOptions() noexcept {}
+
+  winrt::hstring ReactViewOptions::ComponentName() noexcept {
+    return m_componentName;
+  }
+
+  void ReactViewOptions::ComponentName(winrt::hstring value) noexcept {
+    m_componentName = value;
+      }
+
+  ReactNative::JSValueArgWriter ReactViewOptions::InitialProps() noexcept {
+    return m_initalProps;
+  }
+
+  void ReactViewOptions::InitialProps(ReactNative::JSValueArgWriter value) noexcept {
+    m_initalProps = value;
+  }
+
+  Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
+    Mso::React::ReactViewOptions viewOptions;
+    viewOptions.ComponentName = winrt::to_string(m_componentName);
+    viewOptions.InitialProps = DynamicWriter::ToDynamic(m_initalProps);
+    return std::move(viewOptions);
+  }
+
+
+ReactCoreInjection::ReactCoreInjection() noexcept {}
+
+/*static*/ ReactPropertyId<IReactCoreInjection> ReactCoreInjection::ReactCoreInjectionProperty() noexcept {
+  static ReactPropertyId<IReactCoreInjection> prop{L"ReactNative.Injection", L"Injection"};
+  return prop;
+}
+
+/*static*/ ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
+    ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
+  static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<
+      std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
+      prop{
+      L"ReactNative.Injection", L"PostToUIBatchingQueue"};
+  return prop;
+}
+
+/*static*/ void ReactCoreInjection::SetReactCoreInjection(
+    IReactPropertyBag const &properties,
+    IReactCoreInjection const &reactCoreInjection) noexcept {
+  ReactNative::ReactPropertyBag(properties).Set(ReactCoreInjectionProperty(), reactCoreInjection);
+}
+
+/*static*/ ReactNative::IReactViewHost ReactCoreInjection::MakeViewHost(ReactNative::ReactNativeHost host, ReactNative::ReactViewOptions viewOptions) noexcept {
+  auto rnhost = host.as<ReactNativeHost>()->ReactHost();
+  auto uiDispatcher = host.InstanceSettings().Properties().Get(winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIDispatcherProperty()).as<winrt::Microsoft::ReactNative::IReactDispatcher>();
+  auto viewHost = rnhost->MakeViewHost(viewOptions.as<ReactViewOptions>()->CreateViewOptions());
+  return winrt::make<ReactViewHost>(*viewHost, uiDispatcher);
+}
+
+/*static*/ void ReactCoreInjection::PostToUIBatchingQueue(
+  ReactNative::IReactContext context,
+  ReactNative::ReactDispatcherCallback callback) noexcept {
+  auto postFn = *ReactNative::ReactPropertyBag(context.Properties()).Get(PostToUIBatchingQueueProperty());
+  postFn(callback);
+}
+
+ReactViewHost::ReactViewHost(
+    Mso::React::IReactViewHost &viewHost,
+    const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher)
+    : m_viewHost(&viewHost), m_uiDispatcher(uiDispatcher) {}
+
+//ReactViewOptions ReactViewHost::Options() noexcept;
+//ReactNative::ReactNativeHost ReactViewHost::ReactHost() noexcept {}
+void ReactViewHost::ReloadViewInstance() noexcept {
+  m_viewHost->ReloadViewInstance();
+}
+
+void ReactViewHost::ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept {
+  m_viewHost->ReloadViewInstanceWithOptions(options.as<ReactViewOptions>()->CreateViewOptions());
+}
+
+void ReactViewHost::UnloadViewInstance() noexcept {
+  m_viewHost->UnloadViewInstance();
+}
+
+//! This class ensures that we access ReactRootView from UI thread.
+struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, Mso::React::IReactViewInstance> {
+  ReactViewInstance(
+      const ReactNative::IReactViewInstance& rootControl,
+      const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher) noexcept
+      : m_rootControl{rootControl}, m_uiDispatcher{uiDispatcher} {}
+
+  Mso::Future<void> InitRootView(
+    Mso::CntPtr<Mso::React::IReactInstance>&& reactInstance,
+    Mso::React::ReactViewOptions&& viewOptions) noexcept override {
+
+    return PostInUIQueue([reactInstance{ std::move(reactInstance) },
+      viewOptions{ std::move(viewOptions) }](ReactNative::IReactViewInstance rootControl) mutable noexcept {
+
+      auto pinstanceWin = static_cast<Mso::React::ReactInstanceWin*>(reactInstance.Get());
+      Mso::CntPtr<Mso::React::IReactContext> context = &(pinstanceWin->GetReactContext());
+
+      ReactNative::ReactViewOptions options;
+      options.ComponentName(winrt::to_hstring(viewOptions.ComponentName));
+      // TODO add a value writer to ViewOptions, to allow the writer to pass through
+
+      rootControl.InitRootView(winrt::make<ReactContext>(std::move(context)), options);
+    });
+  }
+  Mso::Future<void> UpdateRootView() noexcept override {
+    return PostInUIQueue([](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UpdateRootView(); });
+  }
+  Mso::Future<void> UninitRootView() noexcept override {
+    return PostInUIQueue([](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UninitRootView(); });
+  }
+
+private:
+ winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
+ winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
+
+  //using TAction = Mso::FunctorRef<void(ReactNative::IReactViewInstance&)>;
+
+  inline Mso::Future<void> ReactViewInstance::PostInUIQueue(
+     winrt::delegate<ReactNative::IReactViewInstance> const& action) noexcept {
+    Mso::Promise<void> promise;
+
+    // ReactViewInstance has shorter lifetime than ReactRootControl. Thus, we capture this WeakPtr.
+    m_uiDispatcher.Post(
+        [weakThis = Mso::WeakPtr{this}, promise, action{std::move(action)}]() mutable noexcept {
+      if (auto strongThis = weakThis.GetStrongPtr()) {
+          action(strongThis->m_rootControl);
+          promise.SetValue();
+      }
+
+      promise.TryCancel();
+    });
+    return promise.AsFuture();
+  }
+};
+
+void ReactViewHost::AttachViewInstance(ReactNative::IReactViewInstance viewInstance) noexcept {
+
+  m_viewHost->AttachViewInstance(*Mso::Make<ReactViewInstance>(viewInstance, m_uiDispatcher));
+}
+
+void ReactViewHost::DetachViewInstance() noexcept {
+}
+
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -134,8 +134,6 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
   winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 
-  // using TAction = Mso::FunctorRef<void(ReactNative::IReactViewInstance&)>;
-
   inline Mso::Future<void> ReactViewInstance::PostInUIQueue(
       winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
@@ -145,9 +143,9 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
       if (auto strongThis = weakThis.GetStrongPtr()) {
         action(strongThis->m_rootControl);
         promise.SetValue();
+      } else {
+        promise.TryCancel();
       }
-
-      promise.TryCancel();
     });
     return promise.AsFuture();
   }

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -134,7 +134,7 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
   winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 
-  inline Mso::Future<void> ReactViewInstance::PostInUIQueue(
+  inline Mso::Future<void> PostInUIQueue(
       winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
 

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -5,40 +5,39 @@
 #include "ReactCoreInjection.h"
 #include "ReactCoreInjection.g.cpp"
 #include "ReactViewOptions.g.cpp"
-#include "ReactInstanceWin.h"
-#include "ReactContext.h"
 #include "IReactContext.h"
+#include "ReactContext.h"
+#include "ReactInstanceWin.h"
 
-#include "ReactNativeHost.h"
 #include "DynamicWriter.h"
+#include "ReactNativeHost.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-  ReactViewOptions::ReactViewOptions() noexcept {}
+ReactViewOptions::ReactViewOptions() noexcept {}
 
-  winrt::hstring ReactViewOptions::ComponentName() noexcept {
-    return m_componentName;
-  }
+winrt::hstring ReactViewOptions::ComponentName() noexcept {
+  return m_componentName;
+}
 
-  void ReactViewOptions::ComponentName(winrt::hstring value) noexcept {
-    m_componentName = value;
-      }
+void ReactViewOptions::ComponentName(winrt::hstring value) noexcept {
+  m_componentName = value;
+}
 
-  ReactNative::JSValueArgWriter ReactViewOptions::InitialProps() noexcept {
-    return m_initalProps;
-  }
+ReactNative::JSValueArgWriter ReactViewOptions::InitialProps() noexcept {
+  return m_initalProps;
+}
 
-  void ReactViewOptions::InitialProps(ReactNative::JSValueArgWriter value) noexcept {
-    m_initalProps = value;
-  }
+void ReactViewOptions::InitialProps(ReactNative::JSValueArgWriter value) noexcept {
+  m_initalProps = value;
+}
 
-  Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
-    Mso::React::ReactViewOptions viewOptions;
-    viewOptions.ComponentName = winrt::to_string(m_componentName);
-    viewOptions.InitialProps = DynamicWriter::ToDynamic(m_initalProps);
-    return std::move(viewOptions);
-  }
-
+Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
+  Mso::React::ReactViewOptions viewOptions;
+  viewOptions.ComponentName = winrt::to_string(m_componentName);
+  viewOptions.InitialProps = DynamicWriter::ToDynamic(m_initalProps);
+  return std::move(viewOptions);
+}
 
 ReactCoreInjection::ReactCoreInjection() noexcept {}
 
@@ -49,11 +48,10 @@ ReactCoreInjection::ReactCoreInjection() noexcept {}
 
 /*static*/ ReactPropertyId<
     winrt::Microsoft::ReactNative::ReactNonAbiValue<std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
-    ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
+ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
   static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<
       std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
-      prop{
-      L"ReactNative.Injection", L"PostToUIBatchingQueue"};
+      prop{L"ReactNative.Injection", L"PostToUIBatchingQueue"};
   return prop;
 }
 
@@ -63,16 +61,21 @@ ReactCoreInjection::ReactCoreInjection() noexcept {}
   ReactNative::ReactPropertyBag(properties).Set(ReactCoreInjectionProperty(), reactCoreInjection);
 }
 
-/*static*/ ReactNative::IReactViewHost ReactCoreInjection::MakeViewHost(ReactNative::ReactNativeHost host, ReactNative::ReactViewOptions viewOptions) noexcept {
+/*static*/ ReactNative::IReactViewHost ReactCoreInjection::MakeViewHost(
+    ReactNative::ReactNativeHost host,
+    ReactNative::ReactViewOptions viewOptions) noexcept {
   auto rnhost = host.as<ReactNativeHost>()->ReactHost();
-  auto uiDispatcher = host.InstanceSettings().Properties().Get(winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIDispatcherProperty()).as<winrt::Microsoft::ReactNative::IReactDispatcher>();
+  auto uiDispatcher = host.InstanceSettings()
+                          .Properties()
+                          .Get(winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIDispatcherProperty())
+                          .as<winrt::Microsoft::ReactNative::IReactDispatcher>();
   auto viewHost = rnhost->MakeViewHost(viewOptions.as<ReactViewOptions>()->CreateViewOptions());
   return winrt::make<ReactViewHost>(*viewHost, uiDispatcher);
 }
 
 /*static*/ void ReactCoreInjection::PostToUIBatchingQueue(
-  ReactNative::IReactContext context,
-  ReactNative::ReactDispatcherCallback callback) noexcept {
+    ReactNative::IReactContext context,
+    ReactNative::ReactDispatcherCallback callback) noexcept {
   auto postFn = *ReactNative::ReactPropertyBag(context.Properties()).Get(PostToUIBatchingQueueProperty());
   postFn(callback);
 }
@@ -82,8 +85,8 @@ ReactViewHost::ReactViewHost(
     const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher)
     : m_viewHost(&viewHost), m_uiDispatcher(uiDispatcher) {}
 
-//ReactViewOptions ReactViewHost::Options() noexcept;
-//ReactNative::ReactNativeHost ReactViewHost::ReactHost() noexcept {}
+// ReactViewOptions ReactViewHost::Options() noexcept;
+// ReactNative::ReactNativeHost ReactViewHost::ReactHost() noexcept {}
 void ReactViewHost::ReloadViewInstance() noexcept {
   m_viewHost->ReloadViewInstance();
 }
@@ -99,18 +102,16 @@ void ReactViewHost::UnloadViewInstance() noexcept {
 //! This class ensures that we access ReactRootView from UI thread.
 struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::WeakRef, Mso::React::IReactViewInstance> {
   ReactViewInstance(
-      const ReactNative::IReactViewInstance& rootControl,
+      const ReactNative::IReactViewInstance &rootControl,
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher) noexcept
       : m_rootControl{rootControl}, m_uiDispatcher{uiDispatcher} {}
 
   Mso::Future<void> InitRootView(
-    Mso::CntPtr<Mso::React::IReactInstance>&& reactInstance,
-    Mso::React::ReactViewOptions&& viewOptions) noexcept override {
-
-    return PostInUIQueue([reactInstance{ std::move(reactInstance) },
-      viewOptions{ std::move(viewOptions) }](ReactNative::IReactViewInstance rootControl) mutable noexcept {
-
-      auto pinstanceWin = static_cast<Mso::React::ReactInstanceWin*>(reactInstance.Get());
+      Mso::CntPtr<Mso::React::IReactInstance> &&reactInstance,
+      Mso::React::ReactViewOptions &&viewOptions) noexcept override {
+    return PostInUIQueue([reactInstance{std::move(reactInstance)}, viewOptions{std::move(viewOptions)}](
+                             ReactNative::IReactViewInstance rootControl) mutable noexcept {
+      auto pinstanceWin = static_cast<Mso::React::ReactInstanceWin *>(reactInstance.Get());
       Mso::CntPtr<Mso::React::IReactContext> context = &(pinstanceWin->GetReactContext());
 
       ReactNative::ReactViewOptions options;
@@ -121,28 +122,29 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
     });
   }
   Mso::Future<void> UpdateRootView() noexcept override {
-    return PostInUIQueue([](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UpdateRootView(); });
+    return PostInUIQueue(
+        [](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UpdateRootView(); });
   }
   Mso::Future<void> UninitRootView() noexcept override {
-    return PostInUIQueue([](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UninitRootView(); });
+    return PostInUIQueue(
+        [](ReactNative::IReactViewInstance rootControl) mutable noexcept { rootControl.UninitRootView(); });
   }
 
-private:
- winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
- winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
+ private:
+  winrt::Microsoft::ReactNative::IReactViewInstance m_rootControl;
+  winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 
-  //using TAction = Mso::FunctorRef<void(ReactNative::IReactViewInstance&)>;
+  // using TAction = Mso::FunctorRef<void(ReactNative::IReactViewInstance&)>;
 
   inline Mso::Future<void> ReactViewInstance::PostInUIQueue(
-     winrt::delegate<ReactNative::IReactViewInstance> const& action) noexcept {
+      winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
 
     // ReactViewInstance has shorter lifetime than ReactRootControl. Thus, we capture this WeakPtr.
-    m_uiDispatcher.Post(
-        [weakThis = Mso::WeakPtr{this}, promise, action{std::move(action)}]() mutable noexcept {
+    m_uiDispatcher.Post([weakThis = Mso::WeakPtr{this}, promise, action{std::move(action)}]() mutable noexcept {
       if (auto strongThis = weakThis.GetStrongPtr()) {
-          action(strongThis->m_rootControl);
-          promise.SetValue();
+        action(strongThis->m_rootControl);
+        promise.SetValue();
       }
 
       promise.TryCancel();
@@ -152,12 +154,9 @@ private:
 };
 
 void ReactViewHost::AttachViewInstance(ReactNative::IReactViewInstance viewInstance) noexcept {
-
   m_viewHost->AttachViewInstance(*Mso::Make<ReactViewInstance>(viewInstance, m_uiDispatcher));
 }
 
-void ReactViewHost::DetachViewInstance() noexcept {
-}
-
+void ReactViewHost::DetachViewInstance() noexcept {}
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -41,8 +41,8 @@ Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
 
 ReactCoreInjection::ReactCoreInjection() noexcept {}
 
-/*static*/ ReactPropertyId<IReactCoreInjection> ReactCoreInjection::ReactCoreInjectionProperty() noexcept {
-  static ReactPropertyId<IReactCoreInjection> prop{L"ReactNative.Injection", L"Injection"};
+/*static*/ ReactPropertyId<UIBatchCompleteCallback> ReactCoreInjection::UIBatchCompleteCallbackProperty() noexcept {
+  static ReactPropertyId<UIBatchCompleteCallback> prop{L"ReactNative.Injection", L"UIBatchCompleteCallback"};
   return prop;
 }
 
@@ -55,10 +55,10 @@ ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
   return prop;
 }
 
-/*static*/ void ReactCoreInjection::SetReactCoreInjection(
+/*static*/ void ReactCoreInjection::SetUIBatchCompleteCallback(
     IReactPropertyBag const &properties,
-    IReactCoreInjection const &reactCoreInjection) noexcept {
-  ReactNative::ReactPropertyBag(properties).Set(ReactCoreInjectionProperty(), reactCoreInjection);
+    UIBatchCompleteCallback const &callback) noexcept {
+  ReactNative::ReactPropertyBag(properties).Set(UIBatchCompleteCallbackProperty(), callback);
 }
 
 /*static*/ ReactNative::IReactViewHost ReactCoreInjection::MakeViewHost(

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -28,8 +28,6 @@ struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions> {
  private:
   winrt::hstring m_componentName;
   JSValueArgWriter m_initalProps;
-
-  // Mso::React::ReactViewOptions m_viewOptions;
 };
 
 struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
@@ -55,8 +53,6 @@ struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
       Mso::React::IReactViewHost &viewHost,
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
-  // ReactViewOptions Options() noexcept;
-  // ReactNativeHost ReactHost() noexcept;
   /*Windows::Foundation::IAsyncAction */ void ReloadViewInstance() noexcept;
   /*Windows::Foundation::IAsyncAction */ void ReloadViewInstanceWithOptions(
       ReactNative::ReactViewOptions options) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -7,55 +7,64 @@
 #include "ReactViewOptions.g.h"
 
 #include "INativeUIManager.h"
+#include "React.h"
 #include "ReactHost/React.h"
 #include "ReactPropertyBag.h"
 #include "winrt/Microsoft.ReactNative.h"
-#include "React.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-  struct ReactViewOptions : ReactViewOptionsT< ReactViewOptions> {
-    ReactViewOptions() noexcept;
+struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions> {
+  ReactViewOptions() noexcept;
 
-    winrt::hstring ComponentName() noexcept;
-    void ComponentName(winrt::hstring value) noexcept;
+  winrt::hstring ComponentName() noexcept;
+  void ComponentName(winrt::hstring value) noexcept;
 
-    JSValueArgWriter InitialProps() noexcept;
-    void InitialProps(JSValueArgWriter value) noexcept;
+  JSValueArgWriter InitialProps() noexcept;
+  void InitialProps(JSValueArgWriter value) noexcept;
 
-    Mso::React::ReactViewOptions CreateViewOptions() noexcept;
+  Mso::React::ReactViewOptions CreateViewOptions() noexcept;
 
-  private:
-    winrt::hstring m_componentName;
-    JSValueArgWriter m_initalProps;
+ private:
+  winrt::hstring m_componentName;
+  JSValueArgWriter m_initalProps;
 
-    //Mso::React::ReactViewOptions m_viewOptions;
+  // Mso::React::ReactViewOptions m_viewOptions;
 };
 
 struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
   ReactCoreInjection() noexcept;
   static ReactPropertyId<IReactCoreInjection> ReactCoreInjectionProperty() noexcept;
-  static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<std::function<void(ReactNative::ReactDispatcherCallback const&)>>>
-    PostToUIBatchingQueueProperty() noexcept;
-  static void SetReactCoreInjection(IReactPropertyBag const &properties, IReactCoreInjection const& reactCoreInjection) noexcept;
+  static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<
+      std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
+  PostToUIBatchingQueueProperty() noexcept;
+  static void SetReactCoreInjection(
+      IReactPropertyBag const &properties,
+      IReactCoreInjection const &reactCoreInjection) noexcept;
 
-  static IReactViewHost MakeViewHost(ReactNative::ReactNativeHost host, ReactNative::ReactViewOptions viewOptions) noexcept;
-  static void PostToUIBatchingQueue(ReactNative::IReactContext context, ReactNative::ReactDispatcherCallback callback) noexcept;
+  static IReactViewHost MakeViewHost(
+      ReactNative::ReactNativeHost host,
+      ReactNative::ReactViewOptions viewOptions) noexcept;
+  static void PostToUIBatchingQueue(
+      ReactNative::IReactContext context,
+      ReactNative::ReactDispatcherCallback callback) noexcept;
 };
 
 struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
   ReactViewHost(
-      Mso::React::IReactViewHost &viewHost, const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
+      Mso::React::IReactViewHost &viewHost,
+      const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
-  //ReactViewOptions Options() noexcept;
-  //ReactNativeHost ReactHost() noexcept;
+  // ReactViewOptions Options() noexcept;
+  // ReactNativeHost ReactHost() noexcept;
   /*Windows::Foundation::IAsyncAction */ void ReloadViewInstance() noexcept;
-  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
+  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstanceWithOptions(
+      ReactNative::ReactViewOptions options) noexcept;
   /*Windows::Foundation::IAsyncAction */ void UnloadViewInstance() noexcept;
   /*Windows::Foundation::IAsyncAction */ void AttachViewInstance(IReactViewInstance viewInstance) noexcept;
   /*Windows::Foundation::IAsyncAction */ void DetachViewInstance() noexcept;
 
-private:
+ private:
   Mso::CntPtr<Mso::React::IReactViewHost> m_viewHost;
   winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 };
@@ -63,6 +72,6 @@ private:
 } // namespace winrt::Microsoft::ReactNative::implementation
 
 namespace winrt::Microsoft::ReactNative::factory_implementation {
-  struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection, implementation::ReactCoreInjection> {};
-  struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions, implementation::ReactViewOptions> {};
+struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection, implementation::ReactCoreInjection> {};
+struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions, implementation::ReactViewOptions> {};
 } // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "ReactCoreInjection.g.h"
+#include "ReactViewOptions.g.h"
+
+#include "INativeUIManager.h"
+#include "ReactHost/React.h"
+#include "ReactPropertyBag.h"
+#include "winrt/Microsoft.ReactNative.h"
+#include "React.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+  struct ReactViewOptions : ReactViewOptionsT< ReactViewOptions> {
+    ReactViewOptions() noexcept;
+
+    winrt::hstring ComponentName() noexcept;
+    void ComponentName(winrt::hstring value) noexcept;
+
+    JSValueArgWriter InitialProps() noexcept;
+    void InitialProps(JSValueArgWriter value) noexcept;
+
+    Mso::React::ReactViewOptions CreateViewOptions() noexcept;
+
+  private:
+    winrt::hstring m_componentName;
+    JSValueArgWriter m_initalProps;
+
+    //Mso::React::ReactViewOptions m_viewOptions;
+};
+
+struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
+  ReactCoreInjection() noexcept;
+  static ReactPropertyId<IReactCoreInjection> ReactCoreInjectionProperty() noexcept;
+  static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<std::function<void(ReactNative::ReactDispatcherCallback const&)>>>
+    PostToUIBatchingQueueProperty() noexcept;
+  static void SetReactCoreInjection(IReactPropertyBag const &properties, IReactCoreInjection const& reactCoreInjection) noexcept;
+
+  static IReactViewHost MakeViewHost(ReactNative::ReactNativeHost host, ReactNative::ReactViewOptions viewOptions) noexcept;
+  static void PostToUIBatchingQueue(ReactNative::IReactContext context, ReactNative::ReactDispatcherCallback callback) noexcept;
+};
+
+struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
+  ReactViewHost(
+      Mso::React::IReactViewHost &viewHost, const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
+
+  //ReactViewOptions Options() noexcept;
+  //ReactNativeHost ReactHost() noexcept;
+  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstance() noexcept;
+  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
+  /*Windows::Foundation::IAsyncAction */ void UnloadViewInstance() noexcept;
+  /*Windows::Foundation::IAsyncAction */ void AttachViewInstance(IReactViewInstance viewInstance) noexcept;
+  /*Windows::Foundation::IAsyncAction */ void DetachViewInstance() noexcept;
+
+private:
+  Mso::CntPtr<Mso::React::IReactViewHost> m_viewHost;
+  winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+  struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection, implementation::ReactCoreInjection> {};
+  struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions, implementation::ReactViewOptions> {};
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -32,13 +32,13 @@ struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions> {
 
 struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
   ReactCoreInjection() noexcept;
-  static ReactPropertyId<IReactCoreInjection> ReactCoreInjectionProperty() noexcept;
+  static ReactPropertyId<UIBatchCompleteCallback> UIBatchCompleteCallbackProperty() noexcept;
   static ReactPropertyId<winrt::Microsoft::ReactNative::ReactNonAbiValue<
       std::function<void(ReactNative::ReactDispatcherCallback const &)>>>
   PostToUIBatchingQueueProperty() noexcept;
-  static void SetReactCoreInjection(
+  static void SetUIBatchCompleteCallback(
       IReactPropertyBag const &properties,
-      IReactCoreInjection const &reactCoreInjection) noexcept;
+      UIBatchCompleteCallback const &callback) noexcept;
 
   static IReactViewHost MakeViewHost(
       ReactNative::ReactNativeHost host,

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -9,15 +9,6 @@ import "IJSValueReader.idl";
 
 namespace Microsoft.ReactNative
 {
-  [experimental]
-  [webhosthidden]
-  DOC_STRING(
-    "Used to inject platform specific implementations to create react-native targets targeting non-XAML platforms.")
-  interface IReactCoreInjection
-  {
-    DOC_STRING("Called when the UI batch is completed")
-    void OnBatchComplete(IReactPropertyBag properties);
-  }
 
 [experimental]
 [default_interface]
@@ -75,16 +66,19 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
   }
 
   [experimental]
+  [webhosthidden]
+  DOC_STRING("The delegate is called when a UI batch is completed.")
+  delegate void UIBatchCompleteCallback(IReactPropertyBag properties);
+
+  [experimental]
   [default_interface]
   [webhosthidden]
   DOC_STRING(
     "Used to inject platform specific implementations to create react-native targets targeting non-XAML platforms.")
   runtimeclass ReactCoreInjection
   {
-    DOC_STRING(
-      "Sets the @IReactCoreInjection for the instance. "
-      "This must be manually provided to the @ReactInstanceSettings object when using non-XAML ui platforms")
-    static void SetReactCoreInjection(IReactPropertyBag properties, IReactCoreInjection xamlRoot);
+    DOC_STRING("Sets the Callback to call when a UI batch is completed. ")
+    static void SetUIBatchCompleteCallback(IReactPropertyBag properties, UIBatchCompleteCallback xamlRoot);
 
     DOC_STRING(
       "Custom ReactViewInstances use this to create a host to connect to.")

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -58,16 +58,6 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
     "Used to implement a non-XAML platform ReactRootView.")
     interface IReactViewHost
   {
-    //DOC_STRING("Returns a copy of current react view options.")
-//      ReactViewOptions Options {
-      //get;
-    //};
-
-    //DOC_STRING("Returns IReactHost associated with this IReactViewHost.")
-//      ReactNativeHost ReactHost {
-      //get;
-    //};
-
     DOC_STRING("Reloads the IReactViewInstance if it is attached.")
       /*Windows.Foundation.IAsyncAction*/ void ReloadViewInstance();
 

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "IReactContext.idl";
+import "ReactNativeHost.idl";
+import "IJSValueReader.idl";
+
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+  [experimental]
+  [webhosthidden]
+  DOC_STRING(
+    "Used to inject platform specific implementations to create react-native targets targeting non-XAML platforms.")
+  interface IReactCoreInjection
+  {
+    DOC_STRING("Called when the UI batch is completed")
+    void OnBatchComplete(IReactPropertyBag properties);
+  }
+
+[experimental]
+[default_interface]
+[webhosthidden]
+DOC_STRING("Settings per each IReactViewHost associated with an IReactHost instance.")
+  runtimeclass ReactViewOptions {
+    DOC_STRING("Creates a new instance of @ReactViewOptions")
+    ReactViewOptions();
+
+    DOC_STRING("Name of a component registered in JavaScript via AppRegistry.registerComponent('ModuleName', () => ModuleName);")
+    String ComponentName;
+
+    DOC_STRING("Set of initial component properties. It is a JSON string.")
+      JSValueArgWriter InitialProps {
+      get; set;
+    };
+  };
+
+  [experimental]
+  [webhosthidden]
+  DOC_STRING(
+    "Used to implement a non-XAML platform ReactRootView.")
+    interface IReactViewInstance
+  {
+    DOC_STRING("Initialize ReactRootView with the reactInstance and view-specific settings")
+      void InitRootView(IReactContext context, ReactViewOptions viewOptions);
+
+    DOC_STRING("Update ReactRootView with changes in ReactInstance")
+      void UpdateRootView();
+
+    DOC_STRING("Uninitialize ReactRootView and destroy UI tree")
+      void UninitRootView();
+  }
+
+  [experimental]
+  [webhosthidden]
+  DOC_STRING(
+    "Used to implement a non-XAML platform ReactRootView.")
+    interface IReactViewHost
+  {
+    //DOC_STRING("Returns a copy of current react view options.")
+//      ReactViewOptions Options {
+      //get;
+    //};
+
+    //DOC_STRING("Returns IReactHost associated with this IReactViewHost.")
+//      ReactNativeHost ReactHost {
+      //get;
+    //};
+
+    DOC_STRING("Reloads the IReactViewInstance if it is attached.")
+      /*Windows.Foundation.IAsyncAction*/ void ReloadViewInstance();
+
+    DOC_STRING("Reloads IReactViewInstance if it is attached with a new set of options.")
+      /*Windows.Foundation.IAsyncAction*/ void ReloadViewInstanceWithOptions(ReactViewOptions options);
+
+    DOC_STRING("Unloads the attached IReactViewInstance.")
+      /*Windows.Foundation.IAsyncAction*/ void UnloadViewInstance();
+
+    DOC_STRING("Attaches IReactViewInstance to the IReactViewHost.")
+      /*Windows.Foundation.IAsyncAction*/ void AttachViewInstance(IReactViewInstance viewInstance);
+
+    DOC_STRING("Detaches IReactViewInstance from the IReactViewHost.")
+      /*Windows.Foundation.IAsyncAction*/ void DetachViewInstance();
+  }
+
+  [experimental]
+  [default_interface]
+  [webhosthidden]
+  DOC_STRING(
+    "Used to inject platform specific implementations to create react-native targets targeting non-XAML platforms.")
+  runtimeclass ReactCoreInjection
+  {
+    DOC_STRING(
+      "Sets the @IReactCoreInjection for the instance. "
+      "This must be manually provided to the @ReactInstanceSettings object when using non-XAML ui platforms")
+    static void SetReactCoreInjection(IReactPropertyBag properties, IReactCoreInjection xamlRoot);
+
+    DOC_STRING(
+      "Custom ReactViewInstances use this to create a host to connect to.")
+    static IReactViewHost MakeViewHost(ReactNativeHost host, ReactViewOptions viewOptions);
+
+    DOC_STRING("Post something to the main UI dispatcher using the batching queue")
+    static void PostToUIBatchingQueue(IReactContext context, ReactDispatcherCallback callback);
+  }
+
+
+} // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/JSCallInvokerScheduler.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/JSCallInvokerScheduler.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <dispatchQueue/dispatchQueue.h>
+#include "future/future.h"
 
 namespace facebook::react {
 class CallInvoker;

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -113,12 +113,10 @@ struct IReactContext : IUnknown {
   virtual void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept = 0;
   virtual void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept = 0;
   virtual winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept = 0;
-#ifndef CORE_ABI
   virtual ReactInstanceState State() const noexcept = 0;
   virtual bool IsLoaded() const noexcept = 0;
   virtual std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept = 0;
   virtual IReactSettingsSnapshot const &SettingsSnapshot() const noexcept = 0;
-#endif
 };
 
 //! Settings per each IReactViewHost associated with an IReactHost instance.

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -13,8 +13,6 @@ namespace Mso::React {
 // ReactSettingsSnapshot implementation
 //=============================================================================================
 
-#ifndef CORE_ABI // requires instance
-
 ReactSettingsSnapshot::ReactSettingsSnapshot(Mso::WeakPtr<ReactInstanceWin> &&reactInstance) noexcept
     : m_reactInstance{std::move(reactInstance)} {}
 
@@ -95,8 +93,6 @@ bool ReactSettingsSnapshot::UseDeveloperSupport() const noexcept {
   return false;
 }
 
-#endif
-
 //=============================================================================================
 // ReactContext implementation
 //=============================================================================================
@@ -106,12 +102,9 @@ ReactContext::ReactContext(
     winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
     winrt::Microsoft::ReactNative::IReactNotificationService const &notifications) noexcept
     : m_reactInstance{std::move(reactInstance)},
-#ifndef CORE_ABI
       m_settings{Mso::Make<ReactSettingsSnapshot>(Mso::Copy(m_reactInstance))},
-#endif
       m_properties{properties},
-      m_notifications{notifications} {
-}
+      m_notifications{notifications} {}
 
 void ReactContext::Destroy() noexcept {
   if (auto notificationService =
@@ -129,11 +122,9 @@ winrt::Microsoft::ReactNative::IReactNotificationService ReactContext::Notificat
 }
 
 void ReactContext::CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept {
-#ifndef CORE_ABI // requires instance
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     instance->CallJsFunction(std::move(module), std::move(method), std::move(params));
   }
-#endif
 }
 
 void ReactContext::DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept {
@@ -145,18 +136,13 @@ void ReactContext::DispatchEvent(int64_t viewTag, std::string &&eventName, folly
 }
 
 winrt::Microsoft::ReactNative::JsiRuntime ReactContext::JsiRuntime() const noexcept {
-#ifndef CORE_ABI // requires instance
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->JsiRuntime();
   } else {
     return nullptr;
   }
-#else
-  return nullptr;
-#endif
 }
 
-#ifndef CORE_ABI
 ReactInstanceState ReactContext::State() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->State();
@@ -184,7 +170,5 @@ std::shared_ptr<facebook::react::Instance> ReactContext::GetInnerInstance() cons
 IReactSettingsSnapshot const &ReactContext::SettingsSnapshot() const noexcept {
   return *m_settings;
 }
-
-#endif
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -13,7 +13,6 @@ namespace Mso::React {
 
 class ReactInstanceWin;
 
-#ifndef CORE_ABI
 class ReactSettingsSnapshot final : public Mso::UnknownObject<IReactSettingsSnapshot> {
  public:
   ReactSettingsSnapshot(Mso::WeakPtr<ReactInstanceWin> &&reactInstance) noexcept;
@@ -34,7 +33,6 @@ class ReactSettingsSnapshot final : public Mso::UnknownObject<IReactSettingsSnap
  private:
   Mso::WeakPtr<ReactInstanceWin> m_reactInstance;
 };
-#endif
 
 class ReactContext final : public Mso::UnknownObject<IReactContext> {
  public:
@@ -54,18 +52,14 @@ class ReactContext final : public Mso::UnknownObject<IReactContext> {
   void CallJSFunction(std::string &&module, std::string &&method, folly::dynamic &&params) const noexcept override;
   void DispatchEvent(int64_t viewTag, std::string &&eventName, folly::dynamic &&eventData) const noexcept override;
   winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() const noexcept override;
-#ifndef CORE_ABI
   ReactInstanceState State() const noexcept override;
   bool IsLoaded() const noexcept override;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() const noexcept override;
   IReactSettingsSnapshot const &SettingsSnapshot() const noexcept override;
-#endif
 
  private:
   Mso::WeakPtr<ReactInstanceWin> m_reactInstance;
-#ifndef CORE_ABI
   Mso::CntPtr<ReactSettingsSnapshot> m_settings;
-#endif
   winrt::Microsoft::ReactNative::IReactPropertyBag m_properties;
   winrt::Microsoft::ReactNative::IReactNotificationService m_notifications;
 };

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -337,7 +337,6 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
   Mso::Promise<void> whenCreated;
   Mso::Promise<void> whenLoaded;
 
-#ifndef CORE_ABI
   // Requires MakeReactInstance which incurs platform-specific dependencies.
   m_reactInstance.Exchange(
       MakeReactInstance(*this, std::move(options), Mso::Copy(whenCreated), Mso::Copy(whenLoaded), [this]() noexcept {
@@ -345,9 +344,6 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
           ForEachViewHost([](auto &viewHost) noexcept { viewHost.UpdateViewInstanceInQueue(); });
         });
       }));
-#else
-  assert(false);
-#endif
 
   return whenCreated.AsFuture().Then(Mso::Executors::Inline{}, [this, whenLoaded]() noexcept {
     std::vector<Mso::Future<void>> initCompletionList;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -140,9 +140,9 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
               instance->m_batchingUIThread->runOnQueue([wkInstance]() {
                 if (auto instance = wkInstance.GetStrongPtr()) {
                   auto propBag = ReactPropertyBag(instance->m_reactContext->Properties());
-                  if (auto coreInjection = propBag.Get(winrt::Microsoft::ReactNative::implementation::
-                                                           ReactCoreInjection::ReactCoreInjectionProperty())) {
-                    coreInjection.OnBatchComplete(instance->m_reactContext->Properties());
+                  if (auto callback = propBag.Get(winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::
+                                                      UIBatchCompleteCallbackProperty())) {
+                    (*callback)(instance->m_reactContext->Properties());
                   }
 #ifndef CORE_ABI
                   if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
@@ -165,9 +165,9 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
           instance->m_batchingUIThread->runOnQueue([wkInstance = m_wkInstance]() {
             if (auto instance = wkInstance.GetStrongPtr()) {
               auto propBag = ReactPropertyBag(instance->m_reactContext->Properties());
-              if (auto coreInjection = propBag.Get(winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::
-                                                       ReactCoreInjectionProperty())) {
-                coreInjection.OnBatchComplete(instance->m_reactContext->Properties());
+              if (auto callback = propBag.Get(winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::
+                                                  UIBatchCompleteCallbackProperty())) {
+                (*callback)(instance->m_reactContext->Properties());
               }
 #ifndef CORE_ABI
               if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -10,7 +10,9 @@
 #include <Threading/MessageQueueThreadFactory.h>
 #include <comUtil/qiCast.h>
 
+#ifndef CORE_ABI
 #include <XamlUIService.h>
+#endif
 #include "ReactErrorProvider.h"
 
 #include "Microsoft.ReactNative/IReactNotificationService.h"
@@ -37,24 +39,32 @@
 #include <Views/ViewManager.h>
 #include <base/CoreNativeModules.h>
 #include <dispatchQueue/dispatchQueue.h>
+#ifndef CORE_ABI
 #include "ConfigureBundlerDlg.h"
 #include "DevMenu.h"
+#endif
 #include "IReactContext.h"
 #include "IReactDispatcher.h"
+#ifndef CORE_ABI
 #include "Modules/AccessibilityInfoModule.h"
 #include "Modules/AlertModule.h"
 #include "Modules/AppStateModule.h"
 #include "Modules/ClipboardModule.h"
+#endif
 #include "Modules/DevSettingsModule.h"
+#ifndef CORE_ABI
 #include "Modules/DeviceInfoModule.h"
 #include "Modules/I18nManagerModule.h"
 #include "Modules/LogBoxModule.h"
 #include "Modules/NativeUIManager.h"
 #include "Modules/PaperUIManagerModule.h"
+#endif
 #include "Modules/ReactRootViewTagGenerator.h"
 
+#ifndef CORE_ABI
 #include <Utils/UwpPreparedScriptStore.h>
 #include <Utils/UwpScriptStore.h>
+#endif
 
 #if defined(USE_HERMES)
 #include "HermesRuntimeHolder.h"
@@ -72,6 +82,7 @@
 #include "ChakraRuntimeHolder.h"
 
 #include "JsiApi.h"
+#include "ReactCoreInjection.h"
 
 namespace Microsoft::ReactNative {
 
@@ -128,13 +139,19 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
             if (auto instance = wkInstance.GetStrongPtr()) {
               instance->m_batchingUIThread->runOnQueue([wkInstance]() {
                 if (auto instance = wkInstance.GetStrongPtr()) {
+                  auto propBag = ReactPropertyBag(instance->m_reactContext->Properties());
+                  if (auto coreInjection = propBag.Get(winrt::Microsoft::ReactNative::implementation::
+                                                           ReactCoreInjection::ReactCoreInjectionProperty())) {
+                    coreInjection.OnBatchComplete(instance->m_reactContext->Properties());
+                  }
+#ifndef CORE_ABI
                   if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
                     uiManager->onBatchComplete();
                   }
+#endif
                 }
               });
 
-#ifdef WINRT
               // For UWP we use a batching message queue to optimize the usage
               // of the CoreDispatcher.  Win32 already has an optimized queue.
               facebook::react::BatchingMessageQueueThread *batchingUIThread =
@@ -142,18 +159,23 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
               if (batchingUIThread != nullptr) {
                 batchingUIThread->onBatchComplete();
               }
-#endif
             }
           });
         } else {
           instance->m_batchingUIThread->runOnQueue([wkInstance = m_wkInstance]() {
             if (auto instance = wkInstance.GetStrongPtr()) {
+              auto propBag = ReactPropertyBag(instance->m_reactContext->Properties());
+              if (auto coreInjection = propBag.Get(winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::
+                                                       ReactCoreInjectionProperty())) {
+                coreInjection.OnBatchComplete(instance->m_reactContext->Properties());
+              }
+#ifndef CORE_ABI
               if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*instance->m_reactContext).lock()) {
                 uiManager->onBatchComplete();
               }
+#endif
             }
           });
-#ifdef WINRT
           // For UWP we use a batching message queue to optimize the usage
           // of the CoreDispatcher.  Win32 already has an optimized queue.
           facebook::react::BatchingMessageQueueThread *batchingUIThread =
@@ -161,7 +183,6 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
           if (batchingUIThread != nullptr) {
             batchingUIThread->onBatchComplete();
           }
-#endif
         }
       }
     }
@@ -259,6 +280,7 @@ void ReactInstanceWin::LoadModules(
   }
 #endif
 
+#ifndef CORE_ABI
   registerTurboModule(
       L"UIManager",
       // Spec incorrectly reports commandID as a number, but its actually a number | string.. so dont use the spec for
@@ -295,6 +317,7 @@ void ReactInstanceWin::LoadModules(
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
           ::Microsoft::ReactNative::DeviceInfo,
           ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
+#endif
 
   registerTurboModule(
       L"DevSettings",
@@ -302,11 +325,13 @@ void ReactInstanceWin::LoadModules(
           ::Microsoft::ReactNative::DevSettings,
           ::Microsoft::ReactNativeSpecs::DevSettingsSpec>());
 
+#ifndef CORE_ABI
   registerTurboModule(
       L"I18nManager",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
           ::Microsoft::ReactNative::I18nManager,
           ::Microsoft::ReactNativeSpecs::I18nManagerSpec>());
+#endif
 }
 
 //! Initialize() is called from the native queue.
@@ -315,14 +340,17 @@ void ReactInstanceWin::Initialize() noexcept {
   InitNativeMessageThread();
   InitUIMessageThread();
 
+#ifndef CORE_ABI
   // InitUIManager uses m_legacyReactInstance
   InitUIManager();
 
   Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext, [weakReactHost = m_weakReactHost]() noexcept {
     Microsoft::ReactNative::ShowConfigureBundlerDialog(weakReactHost);
   });
+#endif
 
   Mso::PostFuture(m_uiQueue, [weakThis = Mso::WeakPtr{this}]() noexcept {
+#ifndef CORE_ABI
     // Objects that must be created on the UI thread
     if (auto strongThis = weakThis.GetStrongPtr()) {
       strongThis->m_appTheme = std::make_shared<Microsoft::ReactNative::AppTheme>(
@@ -334,6 +362,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
       Microsoft::ReactNative::DeviceInfoHolder::InitDeviceInfoHolder(strongThis->GetReactContext());
     }
+#endif
   }).Then(Queue(), [this, weakThis = Mso::WeakPtr{this}]() noexcept {
     if (auto strongThis = weakThis.GetStrongPtr()) {
       // auto cxxModulesProviders = GetCxxModuleProviders();
@@ -358,6 +387,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
       devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
       devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
+#ifndef CORE_ABI
       devSettings->showDevMenuCallback = [weakThis]() noexcept {
         if (auto strongThis = weakThis.GetStrongPtr()) {
           strongThis->m_uiQueue.Post([context = strongThis->m_reactContext]() {
@@ -365,6 +395,7 @@ void ReactInstanceWin::Initialize() noexcept {
           });
         }
       };
+#endif
 
       // Now that ReactNativeWindows is building outside devmain, it is missing
       // fix given by PR https://github.com/microsoft/react-native-windows/pull/2624 causing
@@ -372,6 +403,9 @@ void ReactInstanceWin::Initialize() noexcept {
       // Bug https://office.visualstudio.com/DefaultCollection/OC/_workitems/edit/3441551 is tracking this
       devSettings->debuggerConsoleRedirection = false; // JSHost::ChangeGate::ChakraCoreDebuggerConsoleRedirection();
 
+#ifdef CORE_ABI
+      std::vector<facebook::react::NativeModuleDescription> cxxModules;
+#else
       // Acquire default modules and then populate with custom modules.
       // Note that some of these have custom thread affinity.
       std::vector<facebook::react::NativeModuleDescription> cxxModules = Microsoft::ReactNative::GetCoreModules(
@@ -380,6 +414,7 @@ void ReactInstanceWin::Initialize() noexcept {
           std::move(m_appTheme),
           std::move(m_appearanceListener),
           m_reactContext);
+#endif
 
       auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();
 
@@ -408,19 +443,22 @@ void ReactInstanceWin::Initialize() noexcept {
 #endif
         case JSIEngine::V8:
 #if defined(USE_V8)
+#ifndef CORE_ABI
           preparedScriptStore =
               std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
-
+#endif // CORE_ABI
           devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
               devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
           break;
-#endif
+#endif // USE_V8
         case JSIEngine::Chakra:
+#ifndef CORE_ABI
           if (m_options.EnableByteCodeCaching || !m_options.ByteCodeFileUri.empty()) {
             scriptStore = std::make_unique<Microsoft::ReactNative::UwpScriptStore>();
             preparedScriptStore = std::make_unique<Microsoft::ReactNative::UwpPreparedScriptStore>(
                 winrt::to_hstring(m_options.ByteCodeFileUri));
           }
+#endif
           devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
               devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
           break;
@@ -432,9 +470,10 @@ void ReactInstanceWin::Initialize() noexcept {
         // We need to keep the instance wrapper alive as its destruction shuts down the native queue.
         m_options.TurboModuleProvider->SetReactContext(
             winrt::make<implementation::ReactContext>(Mso::Copy(m_reactContext)));
+        auto bundleRootPath = devSettings->bundleRootPath;
         auto instanceWrapper = facebook::react::CreateReactInstance(
             std::shared_ptr<facebook::react::Instance>(strongThis->m_instance.Load()),
-            std::string(), // bundleRootPath
+            std::move(bundleRootPath), // bundleRootPath
             std::move(cxxModules),
             m_options.TurboModuleProvider,
             std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
@@ -624,12 +663,23 @@ void ReactInstanceWin::InitUIMessageThread() noexcept {
   auto batchingUIThread = Microsoft::ReactNative::MakeBatchingQueueThread(m_uiMessageThread.Load());
   m_batchingUIThread = batchingUIThread;
 
+  ReactPropertyBag(m_reactContext->Properties())
+      .Set(
+          winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::PostToUIBatchingQueueProperty(),
+          [wkBatchingUIThread = std::weak_ptr<facebook::react::BatchingMessageQueueThread>(batchingUIThread)](
+              winrt::Microsoft::ReactNative::ReactDispatcherCallback const &callback) {
+            if (auto batchingUIThread = wkBatchingUIThread.lock()) {
+              batchingUIThread->runOnQueue(callback);
+            }
+          });
+
   m_jsDispatchQueue.Load().Post(
       [batchingUIThread, instance = std::weak_ptr<facebook::react::Instance>(m_instance.Load())]() noexcept {
         batchingUIThread->decoratedNativeCallInvokerReady(instance);
       });
 }
 
+#ifndef CORE_ABI
 void ReactInstanceWin::InitUIManager() noexcept {
   std::vector<std::unique_ptr<Microsoft::ReactNative::IViewManager>> viewManagers;
 
@@ -648,6 +698,7 @@ void ReactInstanceWin::InitUIManager() noexcept {
       implementation::XamlUIService::XamlUIServiceProperty().Handle(),
       winrt::make<implementation::XamlUIService>(m_reactContext));
 }
+#endif
 
 facebook::react::NativeLoggingHook ReactInstanceWin::GetLoggingCallback() noexcept {
   if (m_options.OnLogging) {
@@ -689,9 +740,11 @@ facebook::react::NativeLoggingHook ReactInstanceWin::GetLoggingCallback() noexce
 std::shared_ptr<IRedBoxHandler> ReactInstanceWin::GetRedBoxHandler() noexcept {
   if (m_options.RedBoxHandler) {
     return m_options.RedBoxHandler;
+#ifndef CORE_ABI
   } else if (UseDeveloperSupport()) {
     auto localWkReactHost = m_weakReactHost;
     return CreateDefaultRedBoxHandler(std::move(localWkReactHost), Mso::Copy(m_uiQueue));
+#endif
   } else {
     return {};
   }
@@ -871,6 +924,7 @@ void ReactInstanceWin::AttachMeasuredRootView(
     facebook::react::IReactRootView *rootView,
     folly::dynamic &&initialProps,
     bool useFabric) noexcept {
+#ifndef CORE_ABI
   if (State() == ReactInstanceState::HasError)
     return;
 
@@ -901,6 +955,7 @@ void ReactInstanceWin::AttachMeasuredRootView(
         folly::dynamic::object("initialProps", std::move(initialProps))("rootTag", rootTag)("fabric", false));
     CallJsFunction("AppRegistry", "runApplication", std::move(params));
   }
+#endif
 }
 
 void ReactInstanceWin::DetachRootView(facebook::react::IReactRootView *rootView, bool useFabric) noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -67,7 +67,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   winrt::Microsoft::ReactNative::JsiRuntime JsiRuntime() noexcept;
   std::shared_ptr<facebook::react::Instance> GetInnerInstance() noexcept;
   bool IsLoaded() const noexcept;
-#ifndef CORE_ABI
 
   bool UseWebDebugger() const noexcept;
   bool UseFastRefresh() const noexcept;
@@ -80,7 +79,6 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   uint16_t SourceBundlePort() const noexcept;
   std::string JavaScriptBundleFile() const noexcept;
   bool UseDeveloperSupport() const noexcept;
-#endif
 
  private:
   friend MakePolicy;
@@ -101,7 +99,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   void InitJSMessageThread() noexcept;
   void InitNativeMessageThread() noexcept;
   void InitUIMessageThread() noexcept;
+#ifndef CORE_ABI
   void InitUIManager() noexcept;
+#endif
   std::string GetBytecodeFileName() noexcept;
   std::function<void()> GetLiveReloadCallback() noexcept;
   std::function<void(std::string)> GetErrorCallback() noexcept;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -573,12 +573,14 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
   return std::make_shared<RedBoxHandler>(redBoxHandler);
 }
 
-#ifndef CORE_ABI
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
     Mso::DispatchQueue &&uiQueue) noexcept {
+#ifndef CORE_ABI
   return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), std::move(uiQueue));
-}
+#else
+  return nullptr;
 #endif
+}
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBox.h
+++ b/vnext/Microsoft.ReactNative/RedBox.h
@@ -10,9 +10,7 @@ namespace Mso::React {
 std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
     winrt::Microsoft::ReactNative::IRedBoxHandler const &redBoxHandler) noexcept;
 
-#ifndef CORE_ABI
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
     Mso::DispatchQueue &&uiQueue) noexcept;
-#endif
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
@@ -59,7 +59,11 @@ struct DefaultRedBoxHandler : winrt::implements<DefaultRedBoxHandler, IRedBoxHan
 };
 
 IRedBoxHandler RedBoxHelper::CreateDefaultHandler(winrt::Microsoft::ReactNative::ReactNativeHost const &host) noexcept {
+#ifndef CORE_ABI
   return winrt::make<DefaultRedBoxHandler>(host);
+#else
+  return nullptr;
+#endif
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -21,6 +21,12 @@
     <file src="$nugetroot$\x86\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\x86"     exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\x64\Release\React.Windows.Desktop.DLL\react-native-win32.*"    target="lib\ship\x64"     exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\ARM64\Release\React.Windows.Desktop.DLL\react-native-win32.*"  target="lib\ship\ARM64"   exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
+    <file src="$nugetroot$\x86\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\debug\x86"/>
+    <file src="$nugetroot$\x64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\debug\x64"/>
+    <file src="$nugetroot$\ARM64\Debug\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\debug\ARM64"/>
+    <file src="$nugetroot$\x86\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\x86"/>
+    <file src="$nugetroot$\x64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\x64"/>
+    <file src="$nugetroot$\ARM64\Release\React.Windows.Desktop\Microsoft.ReactNative.winmd" target="lib\ship\ARM64"/>
 
     <file src="$nugetroot$\x86\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"    target="lib\debug\x86"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
     <file src="$nugetroot$\x64\Debug\React.Windows.Desktop.Test.DLL\React.Windows.Desktop.Test.**"    target="lib\debug\x64"  exclude="**\*.iobj;**\*.ipdb;**\*.exp;**\*.ilk" />
@@ -66,7 +72,6 @@
     <file src="$nugetroot$\inc\ReactWin32\JSBigStringResourceDll.h" target="inc"/>
     <file src="$nugetroot$\inc\react-native-win32.x64.def" target="inc"/>
     <file src="$nugetroot$\inc\react-native-win32.x86.def" target="inc"/>
-    <file src="$nugetroot$\inc\ReactWin32\Microsoft.ReactNative.winmd" target="inc"/>
 
     <file src="$nugetroot$\inc\include\**\*.*" target="inc\include" />
 

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -66,6 +66,7 @@
     <file src="$nugetroot$\inc\ReactWin32\JSBigStringResourceDll.h" target="inc"/>
     <file src="$nugetroot$\inc\react-native-win32.x64.def" target="inc"/>
     <file src="$nugetroot$\inc\react-native-win32.x86.def" target="inc"/>
+    <file src="$nugetroot$\inc\ReactWin32\Microsoft.ReactNative.winmd" target="inc"/>
 
     <file src="$nugetroot$\inc\include\**\*.*" target="inc\include" />
 

--- a/vnext/Scripts/Tfs/Layout-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Headers.ps1
@@ -58,7 +58,7 @@ Get-ChildItem -Path $ReactWindowsRoot\Shared -Name -Recurse -Include $patterns |
 }
 
 # React.Windows.Desktop headers
-Get-ChildItem -Path $ReactWindowsRoot\Desktop -Name -Recurse -Include '*.h','*.hpp' | ForEach-Object { Copy-Item `
+Get-ChildItem -Path $ReactWindowsRoot\Desktop -Name -Recurse -Include '*.h','*.hpp','*.winmd' | ForEach-Object { Copy-Item `
 	-Path        $ReactWindowsRoot\Desktop\$_ `
 	-Destination (New-Item -ItemType Directory $TargetRoot\inc\ReactWin32\$(Split-Path $_) -Force) `
 	-Force


### PR DESCRIPTION
This change brings us much closer to aligning the API usage of Office with our public API 
Adds ReactInstanceWin and some remaining instance management code to the office dll.
Expands the winrt APIs that are included in the office dll.
Adds some new winrt APIs that are required to plug-in a different UI platform implementation.  In particular `ReactViewOptions` `IReactViewInstance` `IReactViewHost` and `ReactCoreInjection`.  Where `ReactCoreInjection` provides the entry point to be able to plug-in a custom ViewHost implementation when not using the XAML rootview.
Also added APIs to allow external dlls to post to the batching UI queue, and to get notified of a batch complete.  These are required for a custom UIManager implementation outside of the core dll.
Made changes to react-native-win32 to support running UIManager as a TurboModule.  (Use UIManager from react-native, instead of NativeModules.UIManager, and copy of the changes from PaperUIManager.windows.js)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8170)