### PR TITLE
Allow multiple calls to alert

### DIFF
--- a/change/react-native-windows-296a5268-bc99-4005-884c-1196ca4b8bac.json
+++ b/change/react-native-windows-296a5268-bc99-4005-884c-1196ca4b8bac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Batch calls to alert() instead of crashing",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -36,7 +36,7 @@ void Alert::ProcessPendingAlertRequests() noexcept {
       dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
       dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
 
-      if (react::uwp::Is19H1OrHigher()) {
+      if (Is19H1OrHigher()) {
         // XamlRoot added in 19H1
         if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context.Properties().Handle())) {
           dialog.XamlRoot(xamlRoot);

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -16,10 +16,14 @@
 namespace Microsoft::ReactNative {
 
 void Alert::showAlert(ShowAlertArgs const &args, std::function<void(std::string)> result) noexcept {
-  pendingAlerts.push({args, result});
-  if (pendingAlerts.size() == 1) {
-    ProcessPendingAlertRequests();
-  }
+  m_context.UIDispatcher().Post([weakThis = weak_from_this(), args, result] {
+    if (auto strongThis = weakThis.lock()) {
+      strongThis->pendingAlerts.push({args, result});
+      if (strongThis->pendingAlerts.size() == 1) {
+        strongThis->ProcessPendingAlertRequests();
+      }
+    }
+  });
 }
 
 void Alert::ProcessPendingAlertRequests() noexcept {
@@ -27,65 +31,62 @@ void Alert::ProcessPendingAlertRequests() noexcept {
     return;
   const auto &[args, result] = pendingAlerts.front();
   auto jsDispatcher = m_context.JSDispatcher();
-  m_context.UIDispatcher().Post([weakThis = weak_from_this(), jsDispatcher, result, args] {
-    if (auto strongThis = weakThis.lock()) {
-      xaml::Controls::ContentDialog dialog{};
-      dialog.Title(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(args.title)));
-      dialog.Content(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(args.message)));
-      dialog.PrimaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonPositive));
-      dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
-      dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
 
-      if (Is19H1OrHigher()) {
-        // XamlRoot added in 19H1
-        if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(strongThis->m_context.Properties().Handle())) {
-          dialog.XamlRoot(xamlRoot);
-          auto rootChangedToken = xamlRoot.Changed([=](auto &&, auto &&) {
-            const auto rootSize = xamlRoot.Size();
-            const auto popupRoot = xaml::Media::VisualTreeHelper::GetParent(dialog);
-            const auto nChildren = xaml::Media::VisualTreeHelper::GetChildrenCount(popupRoot);
-            if (nChildren == 2) {
-              // The first is supposed to be the smoke screen (Rectangle), and the second the content dialog
-              if (const auto smoke =
-                      xaml::Media::VisualTreeHelper::GetChild(popupRoot, 0).try_as<xaml::Shapes::Rectangle>()) {
-                const auto assertDialog =
-                    xaml::Media::VisualTreeHelper::GetChild(popupRoot, 1).try_as<xaml::Controls::ContentDialog>();
-                if (assertDialog == dialog) {
-                  smoke.Width(rootSize.Width);
-                  smoke.Height(rootSize.Height);
-                  dialog.Width(rootSize.Width);
-                  dialog.Height(rootSize.Height);
-                }
-              }
+  xaml::Controls::ContentDialog dialog{};
+  dialog.Title(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(args.title)));
+  dialog.Content(winrt::box_value(Microsoft::Common::Unicode::Utf8ToUtf16(args.message)));
+  dialog.PrimaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonPositive));
+  dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
+  dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
+
+  if (Is19H1OrHigher()) {
+    // XamlRoot added in 19H1
+    if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle())) {
+      dialog.XamlRoot(xamlRoot);
+      auto rootChangedToken = xamlRoot.Changed([=](auto &&, auto &&) {
+        const auto rootSize = xamlRoot.Size();
+        const auto popupRoot = xaml::Media::VisualTreeHelper::GetParent(dialog);
+        const auto nChildren = xaml::Media::VisualTreeHelper::GetChildrenCount(popupRoot);
+        if (nChildren == 2) {
+          // The first is supposed to be the smoke screen (Rectangle), and the second the content dialog
+          if (const auto smoke =
+                  xaml::Media::VisualTreeHelper::GetChild(popupRoot, 0).try_as<xaml::Shapes::Rectangle>()) {
+            const auto assertDialog =
+                xaml::Media::VisualTreeHelper::GetChild(popupRoot, 1).try_as<xaml::Controls::ContentDialog>();
+            if (assertDialog == dialog) {
+              smoke.Width(rootSize.Width);
+              smoke.Height(rootSize.Height);
+              dialog.Width(rootSize.Width);
+              dialog.Height(rootSize.Height);
             }
-          });
-
-          dialog.Closed([=](auto &&, auto &&) { xamlRoot.Changed(rootChangedToken); });
+          }
         }
-      }
+      });
 
-      auto asyncOp = dialog.ShowAsync();
-      asyncOp.Completed(
-          [jsDispatcher, result, strongThis](
-              const winrt::IAsyncOperation<xaml::Controls::ContentDialogResult> &asyncOp, winrt::AsyncStatus status) {
-            switch (asyncOp.GetResults()) {
-              case xaml::Controls::ContentDialogResult::Primary:
-                jsDispatcher.Post([result] { result("positive"); });
-                break;
-              case xaml::Controls::ContentDialogResult::Secondary:
-                jsDispatcher.Post([result] { result("negative"); });
-                break;
-              case xaml::Controls::ContentDialogResult::None:
-                jsDispatcher.Post([result] { result("neutral"); });
-                break;
-              default:
-                break;
-            }
-            strongThis->pendingAlerts.pop();
-            strongThis->ProcessPendingAlertRequests();
-          });
+      dialog.Closed([=](auto &&, auto &&) { xamlRoot.Changed(rootChangedToken); });
     }
-  });
+  }
+
+  auto asyncOp = dialog.ShowAsync();
+  asyncOp.Completed(
+      [jsDispatcher, result, this](
+          const winrt::IAsyncOperation<xaml::Controls::ContentDialogResult> &asyncOp, winrt::AsyncStatus status) {
+        switch (asyncOp.GetResults()) {
+          case xaml::Controls::ContentDialogResult::Primary:
+            jsDispatcher.Post([result] { result("positive"); });
+            break;
+          case xaml::Controls::ContentDialogResult::Secondary:
+            jsDispatcher.Post([result] { result("negative"); });
+            break;
+          case xaml::Controls::ContentDialogResult::None:
+            jsDispatcher.Post([result] { result("neutral"); });
+            break;
+          default:
+            break;
+        }
+        pendingAlerts.pop();
+        ProcessPendingAlertRequests();
+      });
 }
 
 void Alert::Initialize(React::ReactContext const &reactContext) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -6,6 +6,7 @@
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Graphics.Display.h>
+#include <queue>
 
 namespace Microsoft::ReactNative {
 
@@ -37,6 +38,15 @@ struct Alert : public std::enable_shared_from_this<Alert> {
 
  private:
   React::ReactContext m_context;
+
+  struct AlertRequest {
+    ShowAlertArgs args;
+    std::function<void(std::string)> result;
+  };
+
+  std::queue<AlertRequest> pendingAlerts{};
+
+  void ProcessPendingAlertRequests() noexcept;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
ContentDialog / MessageDialog only allows one active dialog per thread. This means that if JS calls `alert(...)` while there is a dialog already showing, it will crash the app. A better approach is to batch pending alert requests in a queue. When one alert is dismissed, we check if there is another one pending and dispatch that one.

Fixes #7297 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8209)