### PR TITLE
Consuming new UWP friendly Hermes package

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -137,7 +137,6 @@ jobs:
             projectType: app
             additionalInitArguments: --useWinUI3 true
             additionalRunArguments:
-
           X86DebugCppHermes:
             language: cpp
             configuration: Debug
@@ -145,13 +144,20 @@ jobs:
             projectType: app
             additionalInitArguments: --useHermes
             additionalRunArguments:
-          Arm64ReleaseCsHermes:
+          X64ReleaseCsHermes:
             language: cs
             configuration: Release
-            platform: ARM64
+            platform: x64
             projectType: app
             additionalInitArguments: --useHermes
             additionalRunArguments:
+          # ARM64ReleaseCsHermes:
+          #   language: cs
+          #   configuration: Release
+          #   platform: arm64
+          #   projectType: app
+          #   additionalInitArguments: --useHermes
+          #   additionalRunArguments:
           X64ReleaseCppHermes:
             language: cpp
             configuration: Release

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -145,14 +145,13 @@ jobs:
             projectType: app
             additionalInitArguments: --useHermes
             additionalRunArguments:
-          # #7225 ReactNative.Hermes.Windows is not yet seen as compatible for usage in C# projects
-          # Arm64ReleaseCsHermes:
-          #   language: cs
-          #   configuration: Release
-          #   platform: ARM64
-          #   projectType: app
-          #   additionalInitArguments: --useHermes
-          #   additionalRunArguments:
+          Arm64ReleaseCsHermes:
+            language: cs
+            configuration: Release
+            platform: ARM64
+            projectType: app
+            additionalInitArguments: --useHermes
+            additionalRunArguments:
           X64ReleaseCppHermes:
             language: cpp
             configuration: Release

--- a/change/@react-native-windows-cli-b2e5b36c-d2d6-4430-8f08-cf531309f36a.json
+++ b/change/@react-native-windows-cli-b2e5b36c-d2d6-4430-8f08-cf531309f36a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Consuming C# friendly hermes nuget package",
+  "packageName": "@react-native-windows/cli",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-5322b3cd-1801-49f7-b5b3-9bff23f0985b.json
+++ b/change/react-native-windows-5322b3cd-1801-49f7-b5b3-9bff23f0985b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": " Consuming C# friendly hermes nuget package",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-e6c57d75-3fb7-4abd-8797-c86fc26b340f.json
+++ b/change/react-native-windows-init-e6c57d75-3fb7-4abd-8797-c86fc26b340f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": " Consuming C# friendly hermes nuget package",
+  "packageName": "react-native-windows-init",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -226,11 +226,10 @@ export async function copyProjectTemplateAndReplace(
       id: 'Microsoft.NETCore.UniversalWindowsPlatform',
       version: '6.2.9',
     },
-    /* #7225 ReactNative.Hermes.Windows is not yet seen as compatible for usage in C# projects
     {
       id: 'ReactNative.Hermes.Windows',
       version: hermesVersion,
-    }, */
+    },
   ];
 
   const cppNugetPackages: CppNugetPackage[] = [

--- a/packages/integration-test-app/windows/integrationtest/packages.config
+++ b/packages/integration-test-app/windows/integrationtest/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native"/>
 </packages>

--- a/packages/playground/packages.config
+++ b/packages/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native"/>
 </packages>

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -385,22 +385,6 @@ function isProjectUsingYarn(cwd: string): boolean {
       );
     }
 
-    if (argv.useHermes && argv.experimentalNuGetDependency) {
-      throw new CodedError(
-        'IncompatibleOptions',
-        "Error: Incompatible options specified. Options '--useHermes' and '--experimentalNuGetDependency' are incompatible",
-        {detail: 'useHermes and experimentalNuGetDependency'},
-      );
-    }
-
-    if (argv.useHermes && argv.language === 'cs') {
-      throw new CodedError(
-        'IncompatibleOptions',
-        "Error: Incompatible options specified. Options '--useHermes' and '--language cs' are incompatible",
-        {detail: 'useHermes and C#'},
-      );
-    }
-
     if (!useDevMode) {
       if (!version) {
         const rnVersion = getReactNativeVersion();

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.8.0-staging3" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native" />
   <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.64.17" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -69,7 +69,7 @@
     <HermesSourceMap Condition="'$(HermesSourceMap)' == '' AND '$(UseHermes)' == 'true'">$(BaseBundleSourceMap).compiler.map</HermesSourceMap>
 
     <!-- Command to compile Hermes bytecode -->
-    <HermesCompilerCommand Condition="'$(HermesCompilerCommand)' == ''">$(HermesPackage)\tools\release\x86\hermes.exe</HermesCompilerCommand>
+    <HermesCompilerCommand Condition="'$(HermesCompilerCommand)' == ''">$(HermesPackage)\tools\native\release\x86\hermes.exe</HermesCompilerCommand>
 
     <!-- Flags passed to Hermes when compiling a bundle -->
     <HermesCompilerFlags Condition="'$(HermesCompilerFlags)' == '' AND '$(Configuration)' != 'Debug'">-O</HermesCompilerFlags>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.8.0-staging3</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.8.0-ms.0</HermesVersion>   
+    <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)</HermesPackage>
     <!-- TODO: Can we automatically distinguish between uwp and win32 here? -->
     <HermesArch Condition="'$(HermesArch)' == ''">uwp</HermesArch>


### PR DESCRIPTION
This change updates the hermes nuget package reference in RNW to the latest one which is C# project friendly. This change is already submitted to the 0.65-stable branch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8224)