### PR TITLE
[0.63] Add check to cancel publish if the last commit was itself a publish (#7716)

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -1,5 +1,11 @@
 name: 0.0.$(Date:yyMM.d)$(Rev:rrr)
 
+parameters:
+- name: stopOnNoCI
+  displayName: Stop if latest commit is ***NO_CI***
+  type: boolean
+  default: true
+
 variables:
   - template: variables/msbuild.yml
   - template: variables/release.yml
@@ -37,6 +43,11 @@ jobs:
         submodules: false
 
       - template: templates/configure-git.yml
+
+      - powershell: |
+          Write-Error "Stopping because commit message contains ***NO_CI***."
+        displayName: Stop pipeline if latest commit message contains ***NO_CI***
+        condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
 
       - template: templates/yarn-install.yml
 


### PR DESCRIPTION
This PR backport #7716 to 0.63.

If the last commit includes `***NO_CI***` in the subject line, throw an
error so the pipeline stops before wasting time building, or worse,
trying to publish.

Closes #7547

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8226)