### PR TITLE
Fix e2e-test-app yarn windows script 

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -29,7 +29,7 @@ module.exports = {
 
 > C:\repo\react-native-windows> `cd packages\e2e-test-app`
 >
-> C:\repo\react-native-windows\packages\e2e-test-app> `yarn windows --no-launch --deploy-from-layout --msbuildprops AppxPackageSigningEnabled=False`
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn windows --no-launch`
 
 **Running all tests**
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -29,7 +29,7 @@ module.exports = {
 
 > C:\repo\react-native-windows> `cd packages\e2e-test-app`
 >
-> C:\repo\react-native-windows\packages\e2e-test-app> `yarn windows --no-launch`
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn windows --no-launch --deploy-from-layout --msbuildprops AppxPackageSigningEnabled=False`
 
 **Running all tests**
 

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -7,7 +7,7 @@
     "lint": "rnw-scripts lint",
     "lint:fix": "rnw-scripts lint:fix",
     "watch": "rnw-scripts watch",
-    "windows": "react-native run-windows",
+    "windows": "react-native run-windows --deploy-from-layout --msbuildprops AppxPackageSigningEnabled=False",
     "e2etest": "jest --color"
   },
   "dependencies": {


### PR DESCRIPTION
Updating the command for building test app as the current one fails with the following error:

`C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VisualStudio\v16.0\AppxPackage\M
       icrosoft.AppXPackage.Targets(3449,5): error APPX0101: A signing key is required in order to package this project
       . Please specify a PackageCertificateKeyFile or PackageCertificateThumbprint value in the project file. [C:\repo
       s\a-rnw\packages\e2e-test-app\windows\ReactUWPTestApp\ReactUWPTestApp.csproj]`
 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8229)