### PR TITLE
Add React.Windows.Desktop\** to published build artifacts

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -191,6 +191,7 @@ jobs:
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |
+            React.Windows.Desktop\**
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
       


### PR DESCRIPTION
The OfficeReact nuget was updated to include some more files, however
those files are not being uploaded to the build artifacts during
publish, which causes the nuget pack/publish to fail.

Closes #8228

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8230)