### PR TITLE
[0.64] Add React.Windows.Desktop\** to published build artifacts

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -136,6 +136,7 @@ jobs:
         parameters:
           artifactName: ReactWindows
           contents: |
+            React.Windows.Desktop\**
             React.Windows.Desktop.DLL\**
             React.Windows.Desktop.Test.DLL\**
       


### PR DESCRIPTION
This PR backports #8230 to 0.64.

The OfficeReact nuget was updated to include some more files, however
those files are not being uploaded to the build artifacts during
publish, which causes the nuget pack/publish to fail.

Closes #8228