### PR TITLE
[0.64] DisconnectFromView can be called on an view that has no connected tag…

### DIFF
--- a/change/react-native-windows-b7db929b-8aa9-43a8-9770-c46a8a6ad8cb.json
+++ b/change/react-native-windows-b7db929b-8aa9-43a8-9770-c46a8a6ad8cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "DisconnectFromView can be called on an view that has no connected tag. Also fix exceptions to be thrown by value as the rest of the code expects them to be",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -41,7 +41,7 @@ PropsAnimatedNode::PropsAnimatedNode(
 
 void PropsAnimatedNode::ConnectToView(int64_t viewTag) {
   if (m_connectedViewTag != s_connectedViewTagUnset) {
-    throw new std::invalid_argument(
+    throw std::invalid_argument(
         "Animated node " + std::to_string(m_tag) + " has already been attached to a view already exists.");
     return;
   }
@@ -50,8 +50,10 @@ void PropsAnimatedNode::ConnectToView(int64_t viewTag) {
 }
 
 void PropsAnimatedNode::DisconnectFromView(int64_t viewTag) {
-  if (m_connectedViewTag != viewTag) {
-    throw new std::invalid_argument(
+  if (m_connectedViewTag == s_connectedViewTagUnset) {
+    return;
+  } else if (m_connectedViewTag != viewTag) {
+    throw std::invalid_argument(
         "Attempting to disconnect view that has not been connected with the given animated node.");
     return;
   }


### PR DESCRIPTION
…. Also fix exceptions to be thrown by value as the rest of the code expects them to be

Port #8220 to 0.64

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8234)