### PR TITLE
Re-adding the compatibility checks on --useHermes and language:cs

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -144,13 +144,16 @@ jobs:
             projectType: app
             additionalInitArguments: --useHermes
             additionalRunArguments:
-          X64ReleaseCsHermes:
-            language: cs
-            configuration: Release
-            platform: x64
-            projectType: app
-            additionalInitArguments: --useHermes
-            additionalRunArguments:
+          # --useHermes and language:cs doesn't work together in RN64 and older. 
+          # This needs to be enabled in RN65 once the init-cli is made version aware
+          # X64ReleaseCsHermes:
+          #   language: cs
+          #   configuration: Release
+          #   platform: x64
+          #   projectType: app
+          #   additionalInitArguments: --useHermes
+          #   additionalRunArguments:
+          # 
           # ARM64ReleaseCsHermes:
           #   language: cs
           #   configuration: Release

--- a/change/react-native-windows-init-880aa0d6-47c8-4010-afdd-66785b084790.json
+++ b/change/react-native-windows-init-880aa0d6-47c8-4010-afdd-66785b084790.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Re-adding the compatibility checks on --useHermes and language:cs as the CLI is shared across RN versions",
+  "packageName": "react-native-windows-init",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -385,6 +385,22 @@ function isProjectUsingYarn(cwd: string): boolean {
       );
     }
 
+    if (argv.useHermes && argv.experimentalNuGetDependency) {
+      throw new CodedError(
+        'IncompatibleOptions',
+        "Error: Incompatible options specified. Options '--useHermes' and '--experimentalNuGetDependency' are incompatible",
+        {detail: 'useHermes and experimentalNuGetDependency'},
+      );
+    }
+
+    if (argv.useHermes && argv.language === 'cs') {
+      throw new CodedError(
+        'IncompatibleOptions',
+        "Error: Incompatible options specified. Options '--useHermes' and '--language cs' are incompatible",
+        {detail: 'useHermes and C#'},
+      );
+    }
+
     if (!useDevMode) {
       if (!version) {
         const rnVersion = getReactNativeVersion();


### PR DESCRIPTION
--useHermes and language:cs options doesn't work together on RN64 and older. We fixed the incompatibility on RN65. But, it turned out that the init-cli is always based on the main branch. Hence re-enabling the compatibility checks until we make the init cli version aware.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8240)