### PR TITLE
Use WinUI 2.x ProgressRing instead of XAML ProgressRing

### DIFF
--- a/change/react-native-windows-8e5fe054-f8cb-424f-b89a-818edcb03446.json
+++ b/change/react-native-windows-8e5fe054-f8cb-424f-b89a-818edcb03446.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use WinUI 2.x ProgressRing instead of XAML ProgressRing",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground/App.xaml
+++ b/packages/playground/windows/playground/App.xaml
@@ -3,6 +3,14 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:playground"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls"
     xmlns:react="using:Microsoft.ReactNative">
+    <Application.Resources>
+        <controls:XamlControlsResources>
+            <controls:XamlControlsResources.MergedDictionaries>
+                <!-- Other app resources here -->
+            </controls:XamlControlsResources.MergedDictionaries>
+        </controls:XamlControlsResources>
+    </Application.Resources>
 
 </react:ReactApplication>

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -14,6 +14,8 @@
 #include "ReactNativeHost.h"
 #include "ReactViewInstance.h"
 
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+
 #ifdef USE_FABRIC
 #include <Fabric/FabricUIManagerModule.h>
 #include <react/renderer/core/LayoutConstraints.h>
@@ -271,7 +273,7 @@ void ReactRootView::EnsureLoadingUI() noexcept {
       m_greenBoxGrid.Background(xaml::Media::SolidColorBrush(winrt::ColorHelper::FromArgb(0x80, 0x03, 0x29, 0x29)));
       m_greenBoxGrid.Children().Append(m_waitingTextBlock);
       m_greenBoxGrid.VerticalAlignment(xaml::VerticalAlignment::Center);
-      xaml::Controls::ProgressRing ring{};
+      Microsoft::UI::Xaml::Controls::ProgressRing ring{};
       ring.SetValue(xaml::Controls::Grid::ColumnProperty(), winrt::box_value(2));
       ring.IsActive(true);
       m_greenBoxGrid.Children().Append(ring);


### PR DESCRIPTION
Looks like we can use the WinUI 2.x ProgressRing which has the updated visuals. Updating Playground to bring in the WinUI 2 resources too (which are part of the app template)

![image](https://user-images.githubusercontent.com/22989529/125558832-65ec0919-c931-4bbf-8454-d7b6efca42cf.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8245)