### PR TITLE
Fix AccessibilityInfo.announceForAccessibility not working in playground-win32 solution

### DIFF
--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -18,6 +18,7 @@
 #include <winrt/Microsoft.ReactNative.h>
 
 #include <CppWinRTIncludes.h>
+#include <UI.Xaml.Automation.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Hosting.h>
 #include <winrt/Windows.Foundation.Collections.h>
@@ -110,6 +111,11 @@ struct WindowData {
           auto rootElement = m_desktopWindowXamlSource.Content().as<controls::Panel>();
           winrt::Microsoft::ReactNative::XamlUIService::SetXamlRoot(
               host.InstanceSettings().Properties(), rootElement.XamlRoot());
+          winrt::Microsoft::ReactNative::XamlUIService::SetAccessibleRoot(
+              host.InstanceSettings().Properties(), rootElement);
+          rootElement.SetValue(
+              winrt::Windows::UI::Xaml::Automation::AutomationProperties::LandmarkTypeProperty(),
+              winrt::box_value(80002));
 
 #ifdef USE_WINUI3
           const auto islandWindow = (uint64_t)GetXamlIslandHwnd(m_desktopWindowXamlSource);


### PR DESCRIPTION
Per #7290 these changes are required. I confirmed that the Playground-win32 announceForAccessibility example now works with this change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8248)