### PR TITLE
 Fixes crash due to TextInput flyout Proofing sub-menu

### DIFF
--- a/change/react-native-windows-46981679-b297-4832-b6ce-8e296390d70b.json
+++ b/change/react-native-windows-46981679-b297-4832-b6ce-8e296390d70b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes crash due to TextInput flyout Proofing sub-menu",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -6,7 +6,9 @@
 #include "TextInputViewManager.h"
 
 #include "Unicode.h"
+#include "Utils/Helpers.h"
 
+#include <UI.Xaml.Controls.Primitives.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Shapes.h>
@@ -804,6 +806,18 @@ ShadowNode *TextInputViewManager::createShadow() const {
 
 XamlView TextInputViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
   xaml::Controls::TextBox textBox;
+  // This works around a XAML Islands bug where the XamlRoot of the first
+  // window the flyout is shown on takes ownership of the flyout and attempts
+  // to show the flyout on other windows cause the first window to get focus.
+  // https://github.com/microsoft/microsoft-ui-xaml/issues/5341
+  if (IsXamlIsland() &&
+      winrt::Windows::Foundation::Metadata::ApiInformation::IsApiContractPresent(
+          L"Windows.Foundation.UniversalApiContract", 7)) {
+    xaml::Controls::TextCommandBarFlyout flyout;
+    flyout.Placement(xaml::Controls::Primitives::FlyoutPlacementMode::BottomEdgeAlignedLeft);
+    textBox.ContextFlyout(flyout);
+    textBox.SelectionFlyout(flyout);
+  }
   return textBox;
 }
 


### PR DESCRIPTION
There is a well known crash in XAML Islands when a MenuFlyout or CommandBarFlyout has a sub-menu:
microsoft/microsoft-ui-xaml#3529. This crash is likely due to a race condition when animating the sub-menu flyout. This change replaces the Proofing sub-menu AppBarButton with a custom implementation that mimics the same behavior but does not encounter the crash.

Please note, this PR is dependent on #8249 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8252)