### PR TITLE
Add theme picker to Playground app

### DIFF
--- a/packages/playground/windows/playground/MainPage.cpp
+++ b/packages/playground/windows/playground/MainPage.cpp
@@ -35,6 +35,7 @@ MainPage::MainPage() {
   x_engineV8().IsEnabled(true);
 
   x_JsEngine().SelectedIndex(1);
+  x_Theme().SelectedIndex(0);
 }
 
 void MainPage::OnUnloadClick(
@@ -105,8 +106,10 @@ void MainPage::OnLoadClick(
               strongThis->x_DebuggerPort().Text(winrt::to_hstring(context.SettingsSnapshot().DebuggerPort()));
               if (context.SettingsSnapshot().UseWebDebugger()) {
                 strongThis->RequestedTheme(xaml::ElementTheme::Light);
-              } else {
+                strongThis->x_themeLight().IsSelected(true);
+              } else if (strongThis->RequestedTheme() == xaml::ElementTheme::Light) {
                 strongThis->RequestedTheme(xaml::ElementTheme::Default);
+                strongThis->x_themeDefault().IsSelected(true);
               }
             }
           });
@@ -165,6 +168,18 @@ void winrt::playground::implementation::MainPage::x_UseWebDebuggerCheckBox_Unche
   if (x_BreakOnFirstLineCheckBox()) {
     x_BreakOnFirstLineCheckBox().IsEnabled(true);
   }
+}
+
+void winrt::playground::implementation::MainPage::x_Theme_SelectionChanged(
+    winrt::Windows::Foundation::IInspectable const &sender,
+    winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const &e) {
+  auto theme = ElementTheme::Default;
+  if (x_Theme().SelectedItem() == x_themeLight()) {
+    theme = ElementTheme::Light;
+  } else if (x_Theme().SelectedItem() == x_themeDark()) {
+    theme = ElementTheme::Dark;
+  }
+  RequestedTheme(theme);
 }
 
 void MainPage::OnNavigatedTo(xaml::Navigation::NavigationEventArgs const &e) {

--- a/packages/playground/windows/playground/MainPage.h
+++ b/packages/playground/windows/playground/MainPage.h
@@ -29,6 +29,9 @@ struct MainPage : MainPageT<MainPage> {
   void x_UseWebDebuggerCheckBox_Unchecked(
       winrt::Windows::Foundation::IInspectable const &sender,
       winrt::Windows::Foundation::IInspectable const &e);
+  void x_Theme_SelectionChanged(
+      winrt::Windows::Foundation::IInspectable const &sender,
+      winrt::Windows::UI::Xaml::Controls::SelectionChangedEventArgs const &e);
   void OnNavigatedTo(xaml::Navigation::NavigationEventArgs const &e);
 };
 

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -168,6 +168,23 @@
                     <ComboBoxItem Content="V8" x:Name="x_engineV8" />
                 </ComboBox.Items>
             </ComboBox>
+            <TextBlock
+                Margin="4"
+                VerticalAlignment="Center"
+                Text="Theme:"/>
+            <ComboBox
+                x:Name="x_Theme"
+                Margin="4"
+                MinWidth="150"
+                HorizontalAlignment="Stretch"
+                VerticalAlignment="Center"
+                SelectionChanged="x_Theme_SelectionChanged">
+                <ComboBox.Items>
+                    <ComboBoxItem Content="Default" x:Name="x_themeDefault" />
+                    <ComboBoxItem Content="Light" x:Name="x_themeLight" />
+                    <ComboBoxItem Content="Dark" x:Name="x_themeDark" />
+                </ComboBox.Items>
+            </ComboBox>
             <CheckBox x:Name="x_UseFabric"
                 Margin="4"
                 VerticalAlignment="Center"


### PR DESCRIPTION
This is the first step in working around some XAML bugs when the OS is set to light mode but a XAML parent element is set to dark. This will allow us to expose those bugs and then prove we've fixed them.

Here's how the Playground window looks when dark theme is selected:
![pg-dark](https://user-images.githubusercontent.com/359157/125874399-ff6500de-8277-4e62-87d5-7d26db4db49f.png)

And here's how it looks in light theme:
![pg-light-default](https://user-images.githubusercontent.com/359157/125874407-72f69c2d-9d0b-492e-812d-f508667df200.png)

CC @acoates-ms since this touches some theme logic from https://github.com/microsoft/react-native-windows/pull/6135.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8263)