### PR TITLE
Drop BaseIntDir setting from CI

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -2,9 +2,9 @@ parameters:
   - name: buildEnvironment
     type: string
     default : PullRequest
-    values: 
-     - PullRequest 
-     - Continuous 
+    values:
+     - PullRequest
+     - Continuous
 
 jobs:
   - job: Playground
@@ -91,7 +91,6 @@ jobs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             $(BuildWinUI3Properties)
-            /p:BaseIntDir=$(BaseIntDir)
             /p:AppxPackageSigningEnabled=false
         condition: eq('${{ parameters.BuildEnvironment }}', 'PullRequest')
 
@@ -110,7 +109,6 @@ jobs:
             /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
             /p:PlatformToolset=$(MSBuildPlatformToolset)
             $(BuildWinUI3Properties)
-            /p:BaseIntDir=$(BaseIntDir)
             /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
         condition: eq('${{ parameters.BuildEnvironment }}', 'Continuous')
 

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -58,7 +58,6 @@ steps:
       msbuildArgs:
         /p:PreferredToolArchitecture=${{parameters.preferredToolArchitecture}}
         /p:PlatformToolset=${{parameters.platformToolset}}
-        /p:BaseIntDir=$(BaseIntDir)
         /p:RNW_PKG_VERSION_STR="$(RNW_PKG_VERSION_STR)"
         /p:RNW_PKG_VERSION_MAJOR="$(RNW_PKG_VERSION_MAJOR)"
         /p:RNW_PKG_VERSION_MINOR="$(RNW_PKG_VERSION_MINOR)"

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -2,8 +2,8 @@ parameters:
   - name: buildEnvironment
     type: string
     default: PullRequest
-    values: 
-     - PullRequest 
+    values:
+     - PullRequest
      - Continuous
   - name: encodedKey
     type: string
@@ -31,21 +31,21 @@ steps:
   - task: CmdLine@2
     displayName: run-windows (Debug)
     inputs:
-      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --msbuildprops AppxPackageSigningEnabled=False
       workingDirectory: ${{ parameters.workingDirectory }}
     condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Debug'))
 
   - task: CmdLine@2
     displayName: run-windows (Release) - PR
     inputs:
-      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops BaseIntDir=$(BaseIntDir),AppxPackageSigningEnabled=False
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops AppxPackageSigningEnabled=False
       workingDirectory: ${{ parameters.workingDirectory }}
     condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'PullRequest'))
 
   - task: CmdLine@2
     displayName: run-windows (Release) - CI
     inputs:
-      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops BaseIntDir=$(BaseIntDir),PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+      script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
       workingDirectory: ${{ parameters.workingDirectory }}
     condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'Continuous'))
 

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -4,8 +4,6 @@ variables:
   AgentPool.Interactive: rnw-pool-4-ui
   AgentPool.Large: windevbuildagents
   MSBuildVersion: 16.0
-  BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60
-  


### PR DESCRIPTION
The MSBuild base intermediate build directory (`vnext/build`) was overrode to circumvent a drive space limitation in the previous CI vm images used.

The currently used VM pools don't have this limitation, making that setting unnecessary.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8268)