### PR TITLE
Add Support For "togglebutton" accessibilityRole 

### DIFF
--- a/change/react-native-windows-5e29bef1-d45a-490a-8073-a2818fd7c102.json
+++ b/change/react-native-windows-5e29bef1-d45a-490a-8073-a2818fd7c102.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add togglebutton accessibilityRole",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -50,7 +50,7 @@ winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore
     case winrt::Microsoft::ReactNative::AccessibilityRoles::Button:
     case winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton:
     case winrt::Microsoft::ReactNative::AccessibilityRoles::Switch:
-    case winrt::Microsoft::ReactNative::AccessibilityRoles::ToggleButton
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ToggleButton:
       return winrt::AutomationControlType::Button;
     case winrt::Microsoft::ReactNative::AccessibilityRoles::Link:
       return winrt::AutomationControlType::Hyperlink;

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -49,9 +49,8 @@ winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore
   switch (accessibilityRole) {
     case winrt::Microsoft::ReactNative::AccessibilityRoles::Button:
     case winrt::Microsoft::ReactNative::AccessibilityRoles::ImageButton:
-    case winrt::Microsoft::ReactNative::AccessibilityRoles::Switch: // Both ToggleSwitch and
-                                                                    // ToggleButton return
-                                                                    // "Button"
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::Switch:
+    case winrt::Microsoft::ReactNative::AccessibilityRoles::ToggleButton
       return winrt::AutomationControlType::Button;
     case winrt::Microsoft::ReactNative::AccessibilityRoles::Link:
       return winrt::AutomationControlType::Hyperlink;
@@ -121,7 +120,8 @@ winrt::IInspectable DynamicAutomationPeer::GetPatternCore(winrt::PatternInterfac
       patternInterface == winrt::PatternInterface::Toggle &&
       (accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::CheckBox ||
        accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Switch ||
-       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio) &&
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::Radio ||
+       accessibilityRole == winrt::Microsoft::ReactNative::AccessibilityRoles::ToggleButton) &&
       (HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Checked) ||
        HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates::Unchecked))) {
     return *this;

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -382,6 +382,9 @@ bool FrameworkElementViewManager::UpdateProperty(
         else if (role == "timer")
           DynamicAutomationProperties::SetAccessibilityRole(
               element, winrt::Microsoft::ReactNative::AccessibilityRoles::Timer);
+        else if (role == "togglebutton")
+          DynamicAutomationProperties::SetAccessibilityRole(
+              element, winrt::Microsoft::ReactNative::AccessibilityRoles::ToggleButton);
         else if (role == "toolbar")
           DynamicAutomationProperties::SetAccessibilityRole(
               element, winrt::Microsoft::ReactNative::AccessibilityRoles::ToolBar);

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/DynamicAutomationPeer.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/DynamicAutomationPeer.idl
@@ -36,6 +36,7 @@ namespace Microsoft.ReactNative
     Tab,
     TabList,
     Timer,
+    ToggleButton, 
     ToolBar,
     List, // RNW extension
     ListItem, // RNW extension


### PR DESCRIPTION
https://github.com/facebook/react-native/commit/da899c0cc4372830e5ca053a096b74fff2a19cb8 added a Toggle Button accessibility role for Android, in iOS this gets treated same as accessibilityRole="button". This PR adds ToggleButton role to rnw, and since there's no equivalent AutomationControlType, it also gets treated same as accessibilityRole="button". 

Fixes #7856. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8273)