### PR TITLE
Remove AppTheme Shim

### DIFF
--- a/change/react-native-windows-236d6752-8db9-4928-8195-abd089164605.json
+++ b/change/react-native-windows-236d6752-8db9-4928-8195-abd089164605.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove AppTheme Shim",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -8,17 +8,14 @@
 import {NativeEventEmitter, NativeModules} from 'react-native';
 import {IHighContrastColors, IHighContrastChangedEvent} from './AppThemeTypes';
 
-const invariant = require('invariant');
 const NativeAppTheme = NativeModules.RTCAppTheme;
 
 class AppThemeModule extends NativeEventEmitter {
-  public isAvailable: boolean;
   private _isHighContrast: boolean;
   private _highContrastColors: IHighContrastColors;
 
   constructor() {
     super(NativeAppTheme);
-    this.isAvailable = true;
 
     this._highContrastColors = NativeAppTheme.initialHighContrastColors;
     this._isHighContrast = NativeAppTheme.initialHighContrast;
@@ -40,54 +37,5 @@ class AppThemeModule extends NativeEventEmitter {
   }
 }
 
-function throwMissingNativeModule() {
-  invariant(
-    false,
-    'Cannot use AppTheme module when native RTCAppTheme is not included in the build.\n' +
-      'Either include it, or check AppTheme.isAvailable before calling any methods.',
-  );
-}
-
-// This module depends on the native `RCTAppTheme` module. If you don't include it,
-// `AppTheme.isAvailable` will return `false`, and any method calls will throw.
-class MissingNativeAppThemeShim {
-  public isAvailable = false;
-  public isHighContrast = false;
-  public currentHighContrastColors = {} as IHighContrastColors;
-
-  addEventListener() {
-    throwMissingNativeModule();
-  }
-
-  removeEventListener() {
-    throwMissingNativeModule();
-  }
-
-  // EventEmitter
-  addListener(
-    _eventType: string,
-    _listener: (nativeEvent: IHighContrastChangedEvent) => void,
-  ): any {
-    throwMissingNativeModule();
-  }
-
-  removeAllListeners() {
-    throwMissingNativeModule();
-  }
-
-  removeListener(
-    _eventType: string,
-    _listener: (nativeEvent: IHighContrastChangedEvent) => void,
-  ) {
-    throwMissingNativeModule();
-  }
-
-  removeSubscription() {
-    throwMissingNativeModule();
-  }
-}
-
 export type AppTheme = AppThemeModule;
-export const AppTheme = NativeAppTheme
-  ? new AppThemeModule()
-  : new MissingNativeAppThemeShim();
+export const AppTheme = new AppThemeModule();


### PR DESCRIPTION
The shim returned `any` for `addListener`,  which broke typings for non-deprecated pattern of unsubsribing from the listener via calling `remove()` on the subscription returned by `addListener`.

`AppTheme` is always provided by the UWP ReactNativeHost, and we do not special case other modules in the same way for when an NM isn't present, so I just removed the shim, since the NM is always available. TS can then infer the correct subscription type from NativeEventEmitter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8277)