### PR TITLE
Strict Handling of Node Unhandled Promise Rejections

### DIFF
--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -62,10 +62,6 @@ jobs:
           pathToPublish: $(Build.StagingDirectory)
           parallel: true
 
-      - task: NuGetToolInstaller@0
-        inputs:
-          versionSpec: ">=5.8.0"
-
       - template: ../templates/prep-and-pack-nuget.yml
         parameters:
           packDesktop: false

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -23,15 +23,15 @@ steps:
         Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\runtime.win10-x86.Microsoft.Net.Native.SharedLibrary" | Select-Object FullName
         Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk" | Select-Object FullName
 
-  # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
-  - task: NuGetToolInstaller@0
-    inputs:
-      versionSpec: ">=5.8.0"
-
   - task: NodeTool@0
     displayName: Installing Node
     inputs:
       versionSpec: '14.x' 
+
+  # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
+  - task: NuGetToolInstaller@0
+    inputs:
+      versionSpec: ">=5.8.0"
 
   - task: CmdLine@2
     displayName: Installing Yarm

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -6,3 +6,4 @@ variables:
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60
+  NODE_OPTIONS: --unhandled-rejections=strict

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -6,4 +6,4 @@ variables:
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
   NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60
-  NODE_OPTIONS: --unhandled-rejections=strict
+  NODE_OPTIONS: --unhandled-rejections=throw


### PR DESCRIPTION
Fixes #7804

We do not terminate or return non-zero exit codes in CI if a script has an unexpected async exception. This is due to permissive handling of unhandled promise rejections by node. The deault changes in Node 15/16 to become stricter, but these are not yet LTS. Change node options to conform to future, stricter behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8280)