### PR TITLE
Do not start packager for run-windows release builds

### DIFF
--- a/change/@react-native-windows-cli-f7148586-13ff-456d-8981-5dfe310c2e37.json
+++ b/change/@react-native-windows-cli-f7148586-13ff-456d-8981-5dfe310c2e37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not start packager for run-windows release builds",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -316,7 +316,9 @@ async function runWindowsInternal(
     newInfo('Build step is skipped');
   }
 
-  await deploy.startServerInNewWindow(options, verbose);
+  if (shouldLaunchPackager(options)) {
+    await deploy.startServerInNewWindow(options, verbose);
+  }
 
   if (options.deploy) {
     runWindowsPhase = 'FindSolution';
@@ -341,6 +343,13 @@ async function runWindowsInternal(
   } else {
     newInfo('Deploy step is skipped');
   }
+}
+
+function shouldLaunchPackager(options: RunWindowsOptions): boolean {
+  return (
+    options.packager === true ||
+    (options.packager === undefined && options.release !== true)
+  );
 }
 
 /*

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -41,7 +41,7 @@ export interface RunWindowsOptions {
   target?: string;
   remoteDebugging?: string;
   logging: boolean;
-  packager: boolean;
+  packager?: boolean;
   bundle: boolean;
   launch: boolean;
   autolink: boolean;
@@ -102,7 +102,6 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--no-packager',
     description: 'Do not launch packager while building',
-    default: false,
   },
   {
     name: '--bundle',

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -385,23 +385,19 @@ export function startServerInNewWindow(
   verbose: boolean,
 ): Promise<void> {
   return new Promise(resolve => {
-    if (options.packager) {
-      http
-        .get('http://localhost:8081/status', res => {
-          if (res.statusCode === 200) {
-            newSuccess('React-Native Server already started');
-          } else {
-            newError('React-Native Server not responding');
-          }
-          resolve();
-        })
-        .on('error', () => {
-          launchServer(options, verbose);
-          resolve();
-        });
-    } else {
-      resolve();
-    }
+    http
+      .get('http://localhost:8081/status', res => {
+        if (res.statusCode === 200) {
+          newSuccess('React-Native Server already started');
+        } else {
+          newError('React-Native Server not responding');
+        }
+        resolve();
+      })
+      .on('error', () => {
+        launchServer(options, verbose);
+        resolve();
+      });
   });
 }
 


### PR DESCRIPTION
Fixes #6214

Release builds do not use the bundle server. Don't launch it unless explicitly requested.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8281)