### PR TITLE
Update instructions for running a single E2E test

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -35,16 +35,11 @@ module.exports = {
 
 > C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest`
 
-or
-
-> C:\repo\react-native-windows\packages\e2e-test-app\test> `yarn e2etest`
-
 
 **Running a specific test**
 
-> C:\repo\react-native-windows\packages\e2e-test-app\test> `yarn e2etest .\visitAllPages.test.ts`
-
-⚠ This command will only work from the `test` directory ([#7272](https://github.com/microsoft/react-native-windows/issues/7272))
+⚠ Only the test filename (without the rest of the path) should be included.
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest visitAllPages.test.ts`
 
 ## Debugging E2E Tests in CI
 ### Increasing verbosity


### PR DESCRIPTION
Fixes #7272

Jest CLI params for test selection are a bit funky. Update docs to make them clearer, and show how you can run from package root.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8282)