### PR TITLE
"0.65" -> "Future Version" in deprecation warnings

### DIFF
--- a/change/react-native-windows-0083fc4b-cb06-46b1-b965-f826cc669832.json
+++ b/change/react-native-windows-0083fc4b-cb06-46b1-b965-f826cc669832.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "\"0.65\" -> \"Future Version\" in deprecation warnings",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -138,12 +138,12 @@ namespace Microsoft.ReactNative
       "Gets the JavaScript runtime for the running React instance.\n"
       "It can be null if Web debugging is used.\n"
       "**Note: do not use this property directly. "
-      "It is an experimental property that may be removed or changed in version 0.65.")
+      "It is an experimental property that may be removed or changed in a future version.")
     Object JSRuntime { get; };
 
 #ifndef CORE_ABI
     [deprecated("Use @XamlUIService.DispatchEvent instead", deprecate, 1)]
-    DOC_STRING("Deprecated property. Use @XamlUIService.DispatchEvent instead. It will be removed in version 0.65.")
+    DOC_STRING("Deprecated property. Use @XamlUIService.DispatchEvent instead. It will be removed in a future version.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 #endif
 

--- a/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
+++ b/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
@@ -79,7 +79,7 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "Gets atomic @IReactPropertyName for the namespace `ns` and the `localName`.\n"
-      "**Note that passing `null` as `ns` is reserved for local values in a future version. "
+      "**Note that passing `null` as `ns` is reserved for local values since 0.65. "
       "In previous versions it was the same as passing @.GlobalNamespace.**")
     static IReactPropertyName GetName(IReactPropertyNamespace ns, String localName);
 

--- a/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
+++ b/vnext/Microsoft.ReactNative/IReactPropertyBag.idl
@@ -68,8 +68,8 @@ namespace Microsoft.ReactNative
   DOC_STRING("Helper methods for the property bag implementation.")
   static runtimeclass ReactPropertyBagHelper
   {
-    [deprecated("Do not use. It will be removed in version 0.65.", deprecate, 1)]
-    DOC_STRING("Deprecated. Do not use. It will be removed in version 0.65.")
+    [deprecated("Do not use. It will be removed in a future version.", deprecate, 1)]
+    DOC_STRING("Deprecated. Do not use. It will be removed in a future version.")
     static IReactPropertyNamespace GlobalNamespace { get; };
 
     DOC_STRING(
@@ -79,7 +79,7 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "Gets atomic @IReactPropertyName for the namespace `ns` and the `localName`.\n"
-      "**Note that passing `null` as `ns` is reserved for local values in version 0.65. "
+      "**Note that passing `null` as `ns` is reserved for local values in a future version. "
       "In previous versions it was the same as passing @.GlobalNamespace.**")
     static IReactPropertyName GetName(IReactPropertyNamespace ns, String localName);
 

--- a/vnext/Microsoft.ReactNative/JsiApi.idl
+++ b/vnext/Microsoft.ReactNative/JsiApi.idl
@@ -18,7 +18,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -37,7 +37,7 @@ namespace Microsoft.ReactNative
   [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -54,7 +54,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -72,7 +72,7 @@ namespace Microsoft.ReactNative
   [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -85,7 +85,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -97,7 +97,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -109,7 +109,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -121,7 +121,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -133,7 +133,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -145,7 +145,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -157,7 +157,7 @@ namespace Microsoft.ReactNative
   [experimental, default_interface]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -168,7 +168,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -177,7 +177,7 @@ namespace Microsoft.ReactNative
   [experimental, webhosthidden]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -191,7 +191,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -204,7 +204,7 @@ namespace Microsoft.ReactNative
   [experimental, webhosthidden, default_interface]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")
@@ -220,7 +220,7 @@ namespace Microsoft.ReactNative
   [experimental, webhosthidden, default_interface]
   DOC_STRING(
     "An experimental API. Do not use it directly. "
-    "It may be removed or changed in 0.65. Instead, use the JSI API that uses this API internally.\n"
+    "It may be removed or changed in a future version. Instead, use the JSI API that uses this API internally.\n"
     "See the `ExecuteJsi` method in `JsiApiContext.h` of the `Microsoft.ReactNative.Cxx` shared project, "
     "or the examples of the JSI-based TurboModules in the `Microsoft.ReactNative.IntegrationTests` project.\n"
     "Note that the JSI is defined only for C++ code. We plan to add the .Net support in future.")

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -138,7 +138,7 @@ namespace Microsoft.ReactNative
     // Deprecated
     [deprecated(
       "This property has been replaced by @.UseDeveloperSupport. "
-      "In version 0.63 both properties will do the same thing. It will be removed in version 0.65.", deprecate, 1)]
+      "In version 0.63 both properties will do the same thing. It will be removed in a future version.", deprecate, 1)]
     DOC_STRING(
       "This controls whether various developer experience features are available for this instance. "
       "In particular the developer menu, and the default `RedBox` experience.")


### PR DESCRIPTION
A whole bunch of APIs were marked as going to be removed in 0.65, but were not removed. Update the docs to a label which will stay correct.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8283)