### PR TITLE
Fix crash in Islands when opening Flyout without a target

### DIFF
--- a/change/react-native-windows-e865cdf3-241b-45bd-ad8b-fa2df55df4cf.json
+++ b/change/react-native-windows-e865cdf3-241b-45bd-ad8b-fa2df55df4cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in Islands when opening Flyout without a target #6714",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Flyout/FlyoutExample.windows.tsx
@@ -10,9 +10,11 @@ import {Flyout, Picker, Popup, Placement} from 'react-native-windows';
 
 interface IFlyoutExampleState {
   isFlyoutVisible: boolean;
+  isFlyoutNoTargetVisible: boolean;
   isFlyoutTwoVisible: boolean;
   isPopupVisible: boolean;
   buttonTitle: string;
+  buttonNoTargetTitle: string;
   isLightDismissEnabled: boolean;
   isOverlayEnabled: boolean;
   popupSwitchState: boolean;
@@ -41,9 +43,11 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
 
   public state: IFlyoutExampleState = {
     isFlyoutVisible: false,
+    isFlyoutNoTargetVisible: false,
     isFlyoutTwoVisible: false,
     isPopupVisible: false,
     buttonTitle: 'Open Flyout',
+    buttonNoTargetTitle: 'Open Flyout without Target',
     isLightDismissEnabled: true,
     isOverlayEnabled: false,
     popupSwitchState: true,
@@ -75,6 +79,12 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
         </View>
         <View style={{justifyContent: 'center', padding: 20, width: 200}}>
           <Button onPress={this._onPress} title={this.state.buttonTitle} />
+        </View>
+        <View style={{justifyContent: 'center', padding: 20, width: 200}}>
+          <Button
+            onPress={this._onPressButtonNoTarget}
+            title={this.state.buttonNoTargetTitle}
+          />
         </View>
         <View style={{flexDirection: 'row', paddingTop: 200}}>
           <Text style={{padding: 10, width: 300, height: 32}}>
@@ -193,6 +203,17 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
             </View>
           </Flyout>
         )}
+        {this.state.isFlyoutNoTargetVisible && (
+          <Flyout
+            isOpen={this.state.isFlyoutNoTargetVisible}
+            isLightDismissEnabled={true}
+            onDismiss={this._onFlyoutNoTargetDismissed}>
+            <View
+              style={{backgroundColor: 'lightblue', width: 200, height: 300}}>
+              <Text>{lorumIpsum}</Text>
+            </View>
+          </Flyout>
+        )}
         {this.state.isPopupVisible && (
           <Popup
             isOpen={this.state.isPopupVisible}
@@ -225,6 +246,13 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
     this.setState({buttonTitle: 'Close Flyout', isFlyoutVisible: true});
   };
 
+  _onPressButtonNoTarget = () => {
+    this.setState({
+      buttonNoTargetTitle: 'Close Flyout without Target',
+      isFlyoutNoTargetVisible: true,
+    });
+  };
+
   _onFlyoutButtonPressed = () => {
     this.setState({buttonTitle: 'Open Flyout', isFlyoutVisible: false});
   };
@@ -246,6 +274,13 @@ class FlyoutExample extends React.Component<{}, IFlyoutExampleState> {
 
   _onFlyoutTwoDismissed = (_isOpen: boolean) => {
     this.setState({isFlyoutTwoVisible: false});
+  };
+
+  _onFlyoutNoTargetDismissed = (_isOpen: boolean) => {
+    this.setState({
+      buttonNoTargetTitle: 'Open Flyout without Target',
+      isFlyoutNoTargetVisible: false,
+    });
   };
 }
 

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -384,7 +384,16 @@ void FlyoutShadowNode::SetTargetFrameworkElement() {
       }
     }
   } else {
-    m_targetElement = xaml::Window::Current().Content().as<xaml::FrameworkElement>();
+    if (IsXamlIsland()) {
+      // // XamlRoot added in 19H1
+      if (Is19H1OrHigher()) {
+        if (auto xamlRoot = React::XamlUIService::GetXamlRoot(GetViewManager()->GetReactContext().Properties())) {
+          m_targetElement = xamlRoot.Content().try_as<xaml::FrameworkElement>();
+        }
+      }
+    } else {
+      m_targetElement = xaml::Window::Current().Content().as<xaml::FrameworkElement>();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #6714.

Before:

https://user-images.githubusercontent.com/359157/126539625-bf2d55b7-1d6d-4045-bce0-5608ff0eecab.mov

After:

https://user-images.githubusercontent.com/359157/126539654-490ada1a-13dc-48a5-921c-eaadea09ddae.mov


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8300)