### PR TITLE
Enable WarnAsError for builds in PR, CI and publish

### DIFF
--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -38,6 +38,7 @@ jobs:
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           msbuildArguments: /p:UseWinUI3=true
+          warnAsError: false # Disable warn as error until we fix #
 
       - task: CopyFiles@2
         displayName: Copy NuGet artifacts

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -23,12 +23,14 @@ parameters:
 steps:
   - powershell: |
       Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.buildPlatform }}\${{ parameters.buildConfiguration }}\BuildLogs"
-    displayName: Set Log directory
+      Write-Host "##vso[task.setvariable variable=MsBuildWarnAsErrorArgument]/warnaserror"
+    displayName: Set Log directory and warn as error
 
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=MsBuildWarnAsErrorArgument]/warnaserror"
-    condition: ${{parameters.warnAsError}}
-    displayName: Enable WarnAsError
+      Write-Host "##vso[task.setvariable variable=MsBuildWarnAsErrorArgument]"
+    condition: not(eq('${{parameters.warnAsError}}', 'true'))
+    displayName: Disable WarnAsError
+
 
   - template: prepare-env.yml
     parameters:

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -13,6 +13,7 @@ parameters:
   buildConfiguration: Debug
   msbuildArguments: ''
   multicoreBuild: false
+  warnAsError: true
 
   # Visual Studio Installer
   vsComponents: ''
@@ -23,6 +24,11 @@ steps:
   - powershell: |
       Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.buildPlatform }}\${{ parameters.buildConfiguration }}\BuildLogs"
     displayName: Set Log directory
+
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=MsBuildWarnAsErrorArgument]/warnaserror"
+    condition: ${{parameters.warnAsError}}
+    displayName: Enable WarnAsError
 
   - template: prepare-env.yml
     parameters:
@@ -68,6 +74,7 @@ steps:
         /flp1:errorsonly;logfile=$(BuildLogDirectory)\MsBuild.err
         /flp2:warningsonly;logfile=$(BuildLogDirectory)\MsBuild.wrn
         /flp3:verbosity=diagnostic;logfile=$(BuildLogDirectory)\MsBuild.log
+        $(MsBuildWarnAsErrorArgument)
         ${{parameters.msbuildArguments}}
 
   - template: upload-build-logs.yml

--- a/change/react-native-windows-49a918d2-853a-457e-9d6b-2b643b1ff6c4.json
+++ b/change/react-native-windows-49a918d2-853a-457e-9d6b-2b643b1ff6c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable WarnAsError for universal and desktop builds in PR and CI",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
@@ -44,7 +44,7 @@ struct TestExecuteJsiModule {
           PropNameID::forAscii(rt, "hostGreeter"),
           1,
           [](Runtime &rt, const Value & /*thisVal*/, const Value *args, size_t count) {
-            TestCheckEqual(1, count);
+            TestCheckEqual(1u, count);
             return Value{rt, String::createFromUtf8(rt, "Hello " + args[0].getString(rt).utf8(rt))};
           });
       TestCheckEqual("Hello World", hostGreeter.call(rt, "World").getString(rt).utf8(rt));


### PR DESCRIPTION
This does not enable it in project reunion yet.  #8312 Tracks enabeling this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8313)