### PR TITLE
DRAFT: Prototype of exposing hooks for core view manager providers

### DIFF
--- a/change/react-native-windows-322d2385-abd8-417b-8a4c-479d82db9d2a.json
+++ b/change/react-native-windows-322d2385-abd8-417b-8a4c-479d82db9d2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prototype of exposing hooks for core view manager providers",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -33,6 +33,13 @@ void ReactPackageBuilder::AddViewManager(
     ReactViewManagerProvider const &viewManagerProvider) noexcept {
   m_viewManagersProvider->AddViewManagerProvider(viewManagerName, viewManagerProvider);
 }
+
+void ReactPackageBuilder::AddViewManager(
+    hstring const &viewManagerName,
+    std::function<std::unique_ptr<::Microsoft::ReactNative::IViewManager>(
+        Mso::CntPtr<Mso::React::IReactContext> const &)> const &viewManagerProvider) noexcept {
+  m_viewManagersProvider->AddViewManagerProvider(viewManagerName, viewManagerProvider);
+}
 #endif
 
 void ReactPackageBuilder::AddTurboModule(

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -24,6 +24,10 @@ struct ReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 #ifndef CORE_ABI
   void AddViewManager(hstring const &viewManagerName, ReactViewManagerProvider const &viewManagerProvider) noexcept;
+  void AddViewManager(
+      hstring const &viewManagerName,
+      std::function<std::unique_ptr<::Microsoft::ReactNative::IViewManager>(
+          Mso::CntPtr<Mso::React::IReactContext> const &)> const &viewManagerProvider) noexcept;
 #endif
   void AddTurboModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ViewManagersProvider.cpp
+++ b/vnext/Microsoft.ReactNative/ViewManagersProvider.cpp
@@ -20,7 +20,7 @@ std::vector<std::unique_ptr<::Microsoft::ReactNative::IViewManager>> ViewManager
   for (auto &entry : m_viewManagerProviders) {
     auto viewManagerProvider = entry.second;
 
-    auto viewManager = std::make_unique<ABIViewManager>(reactContext, viewManagerProvider());
+    auto viewManager = viewManagerProvider(reactContext);
 
     viewManagers.emplace_back(std::move(viewManager));
   }
@@ -33,6 +33,16 @@ ViewManagersProvider::ViewManagersProvider() noexcept {}
 void ViewManagersProvider::AddViewManagerProvider(
     winrt::hstring const &viewManagerName,
     ReactViewManagerProvider const &viewManagerProvider) noexcept {
+  m_viewManagerProviders.emplace(
+      to_string(viewManagerName), [viewManagerProvider](Mso::CntPtr<Mso::React::IReactContext> const &reactContext) {
+        return std::make_unique<ABIViewManager>(reactContext, viewManagerProvider());
+      });
+}
+
+void ViewManagersProvider::AddViewManagerProvider(
+    winrt::hstring const &viewManagerName,
+    std::function<std::unique_ptr<::Microsoft::ReactNative::IViewManager>(
+        Mso::CntPtr<Mso::React::IReactContext> const &)> const &viewManagerProvider) noexcept {
   m_viewManagerProviders.emplace(to_string(viewManagerName), viewManagerProvider);
 }
 

--- a/vnext/Microsoft.ReactNative/ViewManagersProvider.h
+++ b/vnext/Microsoft.ReactNative/ViewManagersProvider.h
@@ -20,8 +20,16 @@ class ViewManagersProvider final : public Mso::React::ViewManagerProvider2 {
   void AddViewManagerProvider(
       winrt::hstring const &viewManagerName,
       ReactViewManagerProvider const &viewManagerProvider) noexcept;
+  void AddViewManagerProvider(
+      winrt::hstring const &viewManagerName,
+      std::function<std::unique_ptr<::Microsoft::ReactNative::IViewManager>(
+          Mso::CntPtr<Mso::React::IReactContext> const &)> const &viewManagerProvider) noexcept;
 
  private:
-  std::unordered_map<std::string, ReactViewManagerProvider> m_viewManagerProviders;
+  std::unordered_map<
+      std::string,
+      std::function<std::unique_ptr<::Microsoft::ReactNative::IViewManager>(
+          Mso::CntPtr<Mso::React::IReactContext> const &)>>
+      m_viewManagerProviders;
 };
 } // namespace winrt::Microsoft::ReactNative


### PR DESCRIPTION
For apps that don't require ABI, expose an API to create IViewManager instances (including those that derive from ViewManagerBase) directly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8326)