### PR TITLE
Fix usage of WinUI in unpackaged xaml islands app

### DIFF
--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -6,4 +6,8 @@
     <UseFabric>true</UseFabric>
   </PropertyGroup>
 
+  <PropertyGroup Label="Unpackaged playground-win32" Condition="'$(SolutionName)'=='playground-win32'">
+    <WinUI2xVersion>2.6.1-prerelease.210709001</WinUI2xVersion>
+  </PropertyGroup>
+
 </Project>

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -11,9 +11,9 @@
 #include <memory>
 #include <thread>
 
+#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
-#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
@@ -369,7 +369,6 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
 
   winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
 
-  
   xapp.Resources().MergedDictionaries().Append(winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources());
 
   hosting::DesktopWindowXamlSource desktopXamlSource;
@@ -403,7 +402,6 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
 
   HACCEL hAccelTable = LoadAccelerators(WindowData::s_instance, MAKEINTRESOURCE(IDC_PLAYGROUND_WIN32));
 
-  
   MSG msg = {};
   while (GetMessage(&msg, nullptr, 0, 0)) {
     auto xamlSourceNative2 = desktopXamlSource.as<IDesktopWindowXamlSourceNative2>();

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -11,6 +11,10 @@
 #include <memory>
 #include <thread>
 
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
+#include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
+
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
 
@@ -359,6 +363,15 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
 
   winrt::init_apartment(winrt::apartment_type::single_threaded);
 
+  auto winuiIXMP = winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider();
+
+  auto xapp = winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication({winuiIXMP});
+
+  winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
+
+  
+  xapp.Resources().MergedDictionaries().Append(winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources());
+
   hosting::DesktopWindowXamlSource desktopXamlSource;
   auto windowData = std::make_unique<WindowData>(desktopXamlSource);
   windowData->m_useWebDebugger = useWebDebugger;
@@ -390,6 +403,7 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
 
   HACCEL hAccelTable = LoadAccelerators(WindowData::s_instance, MAKEINTRESOURCE(IDC_PLAYGROUND_WIN32));
 
+  
   MSG msg = {};
   while (GetMessage(&msg, nullptr, 0, 0)) {
     auto xamlSourceNative2 = desktopXamlSource.as<IDesktopWindowXamlSourceNative2>();

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props" Condition="Exists('..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" />
   <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <PropertyGroup Label="Globals">
@@ -123,6 +124,47 @@
   <ItemGroup>
     <Image Include="Island_256.ico" />
   </ItemGroup>
+  <PropertyGroup>
+    <BeforeLinkTargets Condition="'$(WindowsTargetPlatformVersion)' &gt;= '10.0.18362.0'">
+      $(BeforeLinkTargets);
+      _UnpackagedWin32GenerateAdditionalWinmdManifests;
+    </BeforeLinkTargets>
+  </PropertyGroup>
+  <Target Name="_UnpackagedWin32MapWinmdsToManifestFiles" DependsOnTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <!-- For each non-system .winmd file in References, generate a .manifest in IntDir for it. -->
+      <_UnpackagedWin32WinmdManifest Include="@(ReferencePath->'$(IntDir)\%(FileName).manifest')" Condition="'%(ReferencePath.IsSystemReference)' != 'true' and '%(ReferencePath.WinMDFile)' == 'true' and '%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference' and '%(ReferencePath.Implementation)' != ''">
+        <WinMDPath>%(ReferencePath.FullPath)</WinMDPath>
+        <Implementation>%(ReferencePath.Implementation)</Implementation>
+      </_UnpackagedWin32WinmdManifest>
+      <!-- For each referenced project that _produces_ a winmd, generate a temporary item that maps to
+           the winmd, and use that temporary item to generate a .manifest in IntDir for it.
+           We don't set Implementation here because it's inherited from the _ResolvedNativeProjectReferencePaths. -->
+      <_UnpackagedWin32WinmdProjectReference Condition="'%(_ResolvedNativeProjectReferencePaths.ProjectType)' != 'StaticLibrary'" Include="@(_ResolvedNativeProjectReferencePaths-&gt;WithMetadataValue('FileType','winmd')-&gt;'%(RootDir)%(Directory)%(TargetPath)')" />
+      <_UnpackagedWin32WinmdManifest Include="@(_UnpackagedWin32WinmdProjectReference->'$(IntDir)\%(FileName).manifest')">
+        <WinMDPath>%(Identity)</WinMDPath>
+      </_UnpackagedWin32WinmdManifest>
+    </ItemGroup>
+  </Target>
+  <Target Name="_UnpackagedWin32GenerateAdditionalWinmdManifests" Inputs="@(_UnpackagedWin32WinmdManifest.WinMDPath)" Outputs="@(_UnpackagedWin32WinmdManifest)" DependsOnTargets="_UnpackagedWin32MapWinmdsToManifestFiles">
+    <Message Text="Generating manifest for %(_UnpackagedWin32WinmdManifest.WinMDPath)" Importance="High" />
+    <!-- This target is batched and a new Exec is spawned for each entry in _UnpackagedWin32WinmdManifest. -->
+    <Exec Command="mt.exe -winmd:%(_UnpackagedWin32WinmdManifest.WinMDPath) -dll:%(_UnpackagedWin32WinmdManifest.Implementation) -out:%(_UnpackagedWin32WinmdManifest.Identity)" />
+    <ItemGroup>
+      <!-- Emit the generated manifest into the Link inputs. -->
+      <Manifest Include="@(_UnpackagedWin32WinmdManifest)" />
+    </ItemGroup>
+  </Target>
+  <!--
+    Custom build step:
+      In an unpackaged app, MRT requires resources.pri in order to find resources. MUXC has resources it needs to work (theme assets).
+      This file is supposed to be a merge of all the pri files the app depends on plus the app's own resources.
+      In the case of playground-win32 we don't have our own pri so we can just take MUXC's and rename the pri to resources.pri.
+  -->
+  <Target Name="FakeResourcesPriMerge" BeforeTargets="FinalizeBuildStatus" DependsOnTargets="CopyFilesToOutputDirectory">
+    <Message Text="Renaming Microsoft.UI.Xaml.pri to resources.pri" />
+    <Move SourceFiles="$(OutDir)\Microsoft.UI.Xaml.pri" DestinationFiles="$(OutDir)\resources.pri" />
+  </Target>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
@@ -141,16 +183,20 @@
     <Import Project="$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(UseV8)' == 'true'" />
     <Import Project="$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets" Condition="Exists('..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Import Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VCRTForwarders.140.1.0.2-rc\build\native\Microsoft.VCRTForwarders.140.targets'))" />
     <Error Condition="!Exists('$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(UseV8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
     <Error Condition="!Exists('$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(HermesPackage)\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Toolkit.Win32.UI.XamlApplication.6.1.3\build\native\Microsoft.Toolkit.Win32.UI.XamlApplication.targets'))" />
   </Target>
 </Project>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -1,5 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Toolkit.Win32.UI.XamlApplication" version="6.1.3" targetFramework="native" />
+
+  <!--
+    WARNING - DO NOT MAKE THE VERSION OF MICROSOFT.UI.XAML BE ANYTHING BUT PRERELEASE.
+      Playground-Win32 is an unpackaged win32 app, and needs to use Microsoft.UI.Xaml from a prerelease, to be able to carry WinUI in-app instead of using the Framework Package 
+    /WARNING
+  -->
+  <package id="Microsoft.UI.Xaml" version="2.6.1-prerelease.210709001" targetFramework="native" />
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.8.0-ms.0" targetFramework="native" />


### PR DESCRIPTION
Fixes #8329 

Recently I made a change to the dev menu control, where I added usage of a WinUI 2.6 ProgressRing. All of the apps we enable devs to build, are UWP, and playground-win32 is the one example that isn’t. The UWP app templates that we ship with RNW, include the WinUI 2.6 dependency and all is well.

However, in the case of islands, the app started to crash because the it suddenly didn’t know what a MUX.ProgressRing was.

Below are the steps I had to take to get things to a working state and the reasons behind them being needed:

1) Reference the WinUI 2.x prerelease package. Release packages use the framework package (as opposed to carrying the DLLs) and do not have in-app support. Unpackaged apps cannot see framework packages*, so they need the DLL to be next to the exe / in the search path.

2) Since the app is unpackaged, we must tell WinRT what DLL to activate types from. The Win32 SxS manifest can do this:
```xml
    <file name="Microsoft.UI.Xaml.Controls.dll">
      <activatableClass name="Microsoft.UI.Xaml.Controls.XamlControlsResources" threadingModel="both" xmlns="urn:schemas-microsoft-com:winrt.v1" />
      <activatableClass name="Microsoft.UI.Xaml.Controls.ProgressRing" threadingModel="both" xmlns="urn:schemas-microsoft-com:winrt.v1" />
       <!-- hundreds of these... -->
    </file>
```
However, you’d have to do this for all of the types you want, which is madness. Luckily, our friends in Terminal had run into this problem, and fixed it, so I copied their solution, which adds a build step, which inspects the WinMD references, and run mt on it to produce the manifests, and let link.exe merge the produced manifests into the app’s, which has the net effect of adding all these activatableClass entries.

3)	WinUI requires resources (theme_resource.xaml e.g.) and this requires MRT to resolve them. However because we are unpackaged, there is no ms-appx:// lookup. Instead MRT falls back to looking inside of a file that must be named resources.pri next to the exe.
There is supposed to be a build step to merge different PRI files from your dependencies + your app’s own if it has some,  but since we aren't using the packaged app / uwp app build system for playground-win32, we don't get that for free.

Since playground-win32 doesn't have any pris of its own, I just added a build step in my project to rename the WinUI pri file to resources.pri, which lets me activate WinUI types
```xml
  <!--
    Custom build step:
      In an unpackaged app, MRT requires resources.pri in order to find resources. MUXC has resources it needs to work (theme assets).
      This file is supposed to be a merge of all the pri files the app depends on plus the app's own resources.
      In the case of playground-win32 we don't have our own pri so we can just take MUXC's and rename the pri to resources.pri.
  -->
  <Target Name="FakeResourcesPriMerge" BeforeTargets="FinalizeBuildStatus" DependsOnTargets="CopyFilesToOutputDirectory" >
    <Message Text="Renaming Microsoft.UI.Xaml.pri to resources.pri" />
    <Move SourceFiles="$(OutDir)\Microsoft.UI.Xaml.pri" DestinationFiles="$(OutDir)\resources.pri" />
  </Target>
```

4)	After that, we can activate types from code. However, XAML relies on IXMP for discovering types and metadata, so it needs to be able to see WinUI’s metadata provider. This is a type that provides metadata information that XAML can use to look up “what is a TextCommandBarFlyout”.
This type is `winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider`

5)	The way this is supposed to work is that your app has an IXMP (generated by the xaml compiler when it builds your app.xaml), and your app’s IXMP chains to WinUI’s (and whatever other packages). However, this app does not use/rely on the xaml compiler.
So the next step is to trick XAML into registering an IXMP, by having a type that implements IXamlMetadataProvider. Luckily for us, we have the [Microsoft.UI.Toolkit.Win32.XamlApplication](https://www.nuget.org/packages/Microsoft.Toolkit.Win32.UI.XamlApplication/) NuGet package. This package contains a XamlApplication type which implements IXMP, and allows us to pass WinUI’s IXMP to it

6)	The app then crashes because XamlApplication expects to be created first, and we already had a DesktopWindowXamlSource created, which the XamlApplication can’t see. The fix is to initialize things in this order:

```cpp
  winrt::init_apartment(winrt::apartment_type::single_threaded);
  auto winuiIXMP = winrt::Microsoft::UI::Xaml::XamlTypeInfo::XamlControlsXamlMetaDataProvider();
  auto xapp = winrt::Microsoft::Toolkit::Win32::UI::XamlHost::XamlApplication({winuiIXMP});
  winrt::Windows::UI::Xaml::Hosting::WindowsXamlManager::InitializeForCurrentThread();
  xapp.Resources().MergedDictionaries().Append(winrt::Microsoft::UI::Xaml::Controls::XamlControlsResources());
  hosting::DesktopWindowXamlSource desktopXamlSource;
```

After doing all of this, we get the fancy WinUI ProgressRing, even in xaml islands 😊


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8331)