### PR TITLE
Use Hyperlink for pressable virtual text

### DIFF
--- a/change/react-native-windows-4853d4ae-046d-4ac4-8c63-fc2efbf1e66e.json
+++ b/change/react-native-windows-4853d4ae-046d-4ac4-8c63-fc2efbf1e66e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use Hyperlink for pressable virtual text",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -30,6 +30,7 @@
 <PROJECT_ROOT>/Libraries/NewAppScreen/components/DebugInstructions.js
 <PROJECT_ROOT>/Libraries/NewAppScreen/components/ReloadInstructions.js
 <PROJECT_ROOT>/Libraries/Pressability/Pressability.js
+<PROJECT_ROOT>/Libraries/Text/TextNativeComponent.js
 <PROJECT_ROOT>/Libraries/Types/CoreEventTypes.js
 
 ; Ignore react-native files in node_modules since they are copied into project root

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -120,20 +120,22 @@ winrt::XamlRoot NativeUIManager::tryGetXamlRoot(int64_t rootTag) {
   return nullptr;
 }
 
-XamlView NativeUIManager::reactPeerOrContainerFrom(xaml::FrameworkElement fe) {
+XamlView NativeUIManager::reactPeerOrContainerFrom(XamlView view) {
   if (m_host) {
-    while (fe) {
-      if (auto value = GetTagAsPropertyValue(fe)) {
+    while (view) {
+      if (auto value = GetTagAsPropertyValue(view)) {
         auto tag = GetTag(value);
         if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag))) {
           if (auto xamlView = shadowNode->GetView()) {
-            if (xamlView == fe) {
+            if (xamlView == view) {
               return xamlView;
             }
           }
         }
       }
-      fe = fe.Parent().try_as<xaml::FrameworkElement>();
+      if (const auto fe = view.try_as<xaml::FrameworkElement>()) {
+        view = fe.Parent();
+      }
     }
   }
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -95,7 +95,7 @@ class NativeUIManager final : public INativeUIManager {
 
   // Searches itself and its parent to get a valid XamlView.
   // Like Mouse/Keyboard, the event source may not have matched XamlView.
-  XamlView reactPeerOrContainerFrom(xaml::FrameworkElement fe);
+  XamlView reactPeerOrContainerFrom(XamlView fe);
 
   int64_t AddMeasuredRootView(facebook::react::IReactRootView *rootView);
 

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -30,10 +30,10 @@ namespace Microsoft::ReactNative {
 // </NavigationView>
 // Instead of deduce view id directly from FrameworkElement.Tag, this do
 // additional check by uimanager.
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe) {
+ReactId getViewId(const Mso::React::IReactContext &context, XamlView const &view) {
   ReactId reactId;
   if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(context).lock()) {
-    if (auto peer = uiManager->reactPeerOrContainerFrom(fe)) {
+    if (auto peer = uiManager->reactPeerOrContainerFrom(view)) {
       reactId.isValid = true;
       reactId.tag = Microsoft::ReactNative::GetTag(peer);
     }

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -22,7 +22,7 @@ inline typename T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());
 }
 
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe);
+ReactId getViewId(const Mso::React::IReactContext &context, XamlView const &fe);
 std::int32_t CountOpenPopups();
 
 bool IsRS3OrHigher();

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -213,7 +213,7 @@ void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
     xaml::Input::KeyRoutedEventArgs const &args) {
   const auto timestamp =
       std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count();
-  if (auto source = args.OriginalSource().try_as<xaml::FrameworkElement>()) {
+  if (auto source = args.OriginalSource().try_as<XamlView>()) {
     auto reactId = getViewId(*m_context, source);
     if (reactId.isValid) {
       ReactKeyboardEvent event;

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -270,6 +270,17 @@ void TextViewManager::RemoveChildAt(const XamlView &parent, int64_t index) {
   return textBlock.Inlines().RemoveAt(static_cast<uint32_t>(index));
 }
 
+void TextViewManager::ReplaceChild(const XamlView &parent, const XamlView &oldChild, const XamlView &newChild) {
+  const auto textBlock{parent.as<xaml::Controls::TextBlock>()};
+  const auto oldInline{oldChild.as<xaml::Documents::Inline>()};
+  const auto newInline{newChild.as<xaml::Documents::Inline>()};
+  uint32_t index;
+  if (textBlock.Inlines().IndexOf(oldInline, index)) {
+    textBlock.Inlines().RemoveAt(index);
+    textBlock.Inlines().InsertAt(index, newInline);
+  }
+}
+
 YGMeasureFunc TextViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -21,6 +21,7 @@ class TextViewManager : public FrameworkElementViewManager {
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
   void RemoveAllChildren(const XamlView &parent) override;
   void RemoveChildAt(const XamlView &parent, int64_t index) override;
+  void ReplaceChild(const XamlView &parent, const XamlView &oldChild, const XamlView &newChild) override;
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp-e2651f4e
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp-e2651f4e
@@ -11,8 +11,6 @@
 #include <Modules/PaperUIManagerModule.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
-#include <uiautomationcore.h>
-#include <uiautomationcoreapi.h>
 #include <Utils/PropertyUtils.h>
 #include <Utils/TransformableText.h>
 #include <Utils/ValueUtils.h>
@@ -87,20 +85,6 @@ void VirtualTextShadowNode::ApplyTextTransform(
   }
 }
 
-void VirtualTextShadowNode::AddHyperlinkClickHandler(const winrt::Hyperlink &hyperlink) {
-  hyperlink.Click([=](auto &&...) {
-    // TODO: How can we limit this to fire exclusively when an accessibility
-    // invoke action is triggered? Does View suffer the same limitation where
-    // a double tap for accessibility invoke will fire both the `onTouch*`
-    // events and the `onClick` / `onAccessibilityTap` events?
-    if (UiaClientsAreListening()) {
-      const auto eventName = m_onClick ? "topClick" : "topAccessibilityTap";
-      GetViewManager()->GetReactContext().DispatchEvent(
-          m_tag, std::move(eventName), folly::dynamic::object("target", m_tag));
-    }
-  });
-}
-
 VirtualTextViewManager::VirtualTextViewManager(const Mso::React::IReactContext &context) : Super(context) {}
 
 const wchar_t *VirtualTextViewManager::GetName() const {
@@ -146,11 +130,14 @@ bool VirtualTextViewManager::UpdateProperty(
       // Underline should be handled by base class using 'textDecorationLine' prop
       hyperlink.UnderlineStyle(winrt::UnderlineStyle::None);
       const auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+      hyperlink.Click([this, tag = node->m_tag, onClick = node->m_onClick](auto &&, auto &&) {
+        const auto eventName = onClick ? L"topClick" : L"topAccessibilityTap";
+        DispatchEvent(tag, eventName, folly::dynamic::object("tag", tag));
+      });
       if (node->m_tabIndex.has_value()) {
         hyperlink.TabIndex(node->m_tabIndex.value());
       }
       nodeToUpdate->ReparentView(hyperlink);
-      node->AddHyperlinkClickHandler(hyperlink);
     } else if (!isHyperlink && wasHyperlink) {
       nodeToUpdate->ReparentView(winrt::Span{});
     }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -43,8 +43,11 @@ class VirtualTextViewManager : public ViewManagerBase {
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
   void RemoveAllChildren(const XamlView &parent) override;
   void RemoveChildAt(const XamlView &parent, int64_t index) override;
+  void ReplaceChild(const XamlView &parent, const XamlView &oldChild, const XamlView &newChild) override;
+  void TransferProperties(const XamlView &oldChild, const XamlView &newChild) override;
 
   bool RequiresYogaNode() const override;
+
 
  protected:
   bool UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -19,7 +19,11 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
-  void AddHyperlinkClickHandler(const xaml::Documents::Hyperlink &hyperlink);
+  void DispatchEvent(std::string &&eventName, folly::dynamic &&eventData);
+
+  void RegisterHyperlinkEvents(const xaml::Documents::Hyperlink &hyperlink);
+
+  void dispatchCommand(const std::string &commandId, winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) override;
 
   struct HighlightData {
     std::vector<HighlightData> data;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -27,6 +27,7 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   };
 
   HighlightData m_highlightData;
+  std::optional<int32_t> m_tabIndex;
 };
 
 class VirtualTextViewManager : public ViewManagerBase {
@@ -47,7 +48,6 @@ class VirtualTextViewManager : public ViewManagerBase {
   void TransferProperties(const XamlView &oldChild, const XamlView &newChild) override;
 
   bool RequiresYogaNode() const override;
-
 
  protected:
   bool UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -19,6 +19,8 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
+  void AddHyperlinkClickHandler(const xaml::Documents::Hyperlink &hyperlink);
+
   struct HighlightData {
     std::vector<HighlightData> data;
     size_t spanIdx = 0;
@@ -28,6 +30,7 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
 
   HighlightData m_highlightData;
   std::optional<int32_t> m_tabIndex;
+  bool m_onClick;
 };
 
 class VirtualTextViewManager : public ViewManagerBase {

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -9,13 +9,21 @@ namespace Microsoft::ReactNative {
 
 using XamlView = xaml::DependencyObject;
 
+inline int64_t GetTag(winrt::IPropertyValue value) {
+  assert(value);
+  return value.GetInt64();
+}
+
+inline winrt::IPropertyValue GetTagAsPropertyValue(XamlView view) {
+  assert(view);
+  return view.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+}
+
 inline int64_t GetTag(XamlView view) {
-  auto tagValue = view.ReadLocalValue(xaml::FrameworkElement::TagProperty());
-  if (tagValue != xaml::DependencyProperty::UnsetValue()) {
-    return tagValue.as<winrt::IPropertyValue>().GetInt64();
-  } else {
-    return -1;
+  if (const auto value = GetTagAsPropertyValue(view)) {
+    return GetTag(value);
   }
+  return -1;
 }
 
 inline void SetTag(XamlView view, int64_t tag) {
@@ -29,16 +37,6 @@ inline void SetTag(XamlView view, winrt::IInspectable tag) {
 inline bool IsValidTag(winrt::IPropertyValue value) {
   assert(value);
   return (value.Type() == winrt::PropertyType::Int64);
-}
-
-inline int64_t GetTag(winrt::IPropertyValue value) {
-  assert(value);
-  return value.GetInt64();
-}
-
-inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
-  assert(fe);
-  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -450,6 +450,12 @@
       "baseHash": "4437d86c40009c937c279b9ce9e924ebfa46ddd6"
     },
     {
+      "type": "derived",
+      "file": "src/Libraries/Text/TextNativeComponent.windows.js",
+      "baseFile": "Libraries/Text/TextNativeComponent.js",
+      "baseHash": "93377ff5089d981e56094329b6f6893b3124be12"
+    },
+    {
       "type": "patch",
       "file": "src/Libraries/Types/CoreEventTypes.windows.js",
       "baseFile": "Libraries/Types/CoreEventTypes.js",

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -98,6 +98,10 @@ const Text: React.AbstractComponent<
       eventHandlers == null
         ? null
         : {
+            // [Windows
+            onKeyDown: eventHandlers.onKeyDown,
+            onKeyUp: eventHandlers.onKeyUp,
+            // Windows]
             onResponderGrant(event) {
               eventHandlers.onResponderGrant(event);
               if (onResponderGrant != null) {

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -99,6 +99,7 @@ const Text: React.AbstractComponent<
         ? null
         : {
             // [Windows
+            onClick: eventHandlers.onClick,
             onKeyDown: eventHandlers.onKeyDown,
             onKeyUp: eventHandlers.onKeyUp,
             // Windows]
@@ -161,7 +162,7 @@ const Text: React.AbstractComponent<
     return (
       <NativeVirtualText
         {...restProps}
-        {...eventHandlersForText}
+        {...{...eventHandlersForText}}
         isHighlighted={isHighlighted}
         selectionColor={selectionColor}
         style={style}
@@ -229,7 +230,7 @@ const Text: React.AbstractComponent<
         <TextAncestor.Provider value={true}>
           <NativeText
             {...restProps}
-            {...eventHandlersForText}
+            {...{...eventHandlersForText}}
             accessible={accessible !== false}
             allowFontScaling={allowFontScaling !== false}
             ellipsizeMode={ellipsizeMode ?? 'tail'}

--- a/vnext/src/Libraries/Text/TextNativeComponent.windows.js
+++ b/vnext/src/Libraries/Text/TextNativeComponent.windows.js
@@ -63,6 +63,16 @@ export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComp
       },
       // Windows]
     },
+    // [Windows
+    bubblingEventTypes: {
+      topFocus: {
+        registrationName: 'onFocus',
+      },
+      topBlur: {
+        registrationName: 'onBlur',
+      },
+    },
+    // Windows]
     uiViewClassName: 'RCTText',
   }),
 ): any);

--- a/vnext/src/Libraries/Text/TextNativeComponent.windows.js
+++ b/vnext/src/Libraries/Text/TextNativeComponent.windows.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import ReactNativeViewAttributes from '../Components/View/ReactNativeViewAttributes';
+import UIManager from '../ReactNative/UIManager';
+import {type HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import createReactNativeComponentClass from '../Renderer/shims/createReactNativeComponentClass';
+import {type ProcessedColorValue} from '../StyleSheet/processColor';
+import {type TextProps} from './TextProps';
+
+type NativeTextProps = $ReadOnly<{
+  ...TextProps,
+  focusable?: ?boolean,
+  isHighlighted?: ?boolean,
+  selectionColor?: ?ProcessedColorValue,
+}>;
+
+export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComponentClass(
+  'RCTText',
+  () => ({
+    // $FlowFixMe[incompatible-call]
+    validAttributes: {
+      ...ReactNativeViewAttributes.UIView,
+      isHighlighted: true,
+      numberOfLines: true,
+      ellipsizeMode: true,
+      allowFontScaling: true,
+      maxFontSizeMultiplier: true,
+      disabled: true,
+      selectable: true,
+      selectionColor: true,
+      adjustsFontSizeToFit: true,
+      minimumFontScale: true,
+      textBreakStrategy: true,
+      onTextLayout: true,
+      onInlineViewLayout: true,
+      dataDetectorType: true,
+      android_hyphenationFrequency: true,
+      focusable: true, // [Windows]
+      tabIndex: true, // [Windows]
+    },
+    directEventTypes: {
+      topTextLayout: {
+        registrationName: 'onTextLayout',
+      },
+      topInlineViewLayout: {
+        registrationName: 'onInlineViewLayout',
+      },
+    },
+    uiViewClassName: 'RCTText',
+  }),
+): any);
+
+export const NativeVirtualText: HostComponent<NativeTextProps> =
+  !global.RN$Bridgeless && !UIManager.hasViewManagerConfig('RCTVirtualText')
+    ? NativeText
+    : (createReactNativeComponentClass('RCTVirtualText', () => ({
+        // $FlowFixMe[incompatible-call]
+        validAttributes: {
+          ...ReactNativeViewAttributes.UIView,
+          isHighlighted: true,
+          maxFontSizeMultiplier: true,
+          focusable: true, // [Windows]
+          tabIndex: true, // [Windows]
+        },
+        uiViewClassName: 'RCTVirtualText',
+      })): any);

--- a/vnext/src/Libraries/Text/TextNativeComponent.windows.js
+++ b/vnext/src/Libraries/Text/TextNativeComponent.windows.js
@@ -45,6 +45,7 @@ export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComp
       android_hyphenationFrequency: true,
       focusable: true, // [Windows]
       tabIndex: true, // [Windows]
+      onClick: true, // [Windows]
     },
     directEventTypes: {
       topTextLayout: {
@@ -53,6 +54,14 @@ export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComp
       topInlineViewLayout: {
         registrationName: 'onInlineViewLayout',
       },
+      // [Windows
+      topClick: {
+        registrationName: 'onClick',
+      },
+      topAccessibilityTap: {
+        registrationName: 'onAccessibilityTap',
+      },
+      // Windows]
     },
     uiViewClassName: 'RCTText',
   }),
@@ -69,6 +78,7 @@ export const NativeVirtualText: HostComponent<NativeTextProps> =
           maxFontSizeMultiplier: true,
           focusable: true, // [Windows]
           tabIndex: true, // [Windows]
+          onClick: true, // [Windows]
         },
         uiViewClassName: 'RCTVirtualText',
       })): any);


### PR DESCRIPTION
We had previously created a custom component called HyperlinkTextViewManager that derived from VirtualTextViewManager to:
1. Enable focus on pressable text
2. Get appropriate mouse cursor behavior for pressable text
3. To work around the issue with text hit testing that is being addressed in #7553

Rather than adding a new component that has no meaning on other platforms, we can use Hyperlink when intermediate text nodes meet certain conditions.

This is really just a proposal for now, we should discuss if this change is warranted and, if so, under what conditions the Span should be swapped out for a Hyperlink.

Please note this diff is dependent on #7553 and #7813 as we want to use the TouchEventHandler implementation to handle clicks in a way that they leverage the existing bubble / capture mechanisms of React Native. Also, the Hyperlink::Click event does not given you important details like the pointer position (see https://github.com/microsoft/microsoft-ui-xaml/issues/4730).

Remaining TODOs are:
- [x] Ensure keyboard events on Hyperlink enable `usePressability` can handle keyboard invocation events.
- [x] Decide under what conditions we want to swap Span with Hyperlink. This PR uses `accessibilityRole` settings as an example, but we could also send an `isPressable` prop and use Hyperlink for all pressable inlines.
- [x] Add focus-related props to virtual text, so Hyperlink can set properties like TabIndex and IsTabStop.
Hyperlink.
- [x] Ensure `onClick` and `onAccessibilityTap` work via the `Hyperlink::Click` event
  - Click fires when narrator is on and off so I included a `UiaClientsAreListening` check, but I think we only want to fire `onClick` or `onAccessibilityTap` when narrator is attached, and only when the regular `onTouch*` events would not fire (e.g., when CapsLock+Enter is pressed or the view is double tapped). However, I think double tap suffers a similar limitation on View.
- [ ] Ensure root Text embeds a hyperlink when focusable (or else the pointer behavior will not match virtual text)
- [x] Wire up focus events for virtual text
- [x] Ensure imperative .focus() works on Text

❌ Ensure Narrator reports accessibilityRole correctly
  - Note, all Hyperlinks are reported by Narrator as links, and I haven't found a way to customize the AutomationControlType for 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8335)