### PR TITLE
Replace @rnx-kit/jest-resolver with @rnx-kit/preset

### DIFF
--- a/change/@office-iss-react-native-win32-d41fc6e3-bacd-45af-a63e-3f7b91a45bda.json
+++ b/change/@office-iss-react-native-win32-d41fc6e3-bacd-45af-a63e-3f7b91a45bda.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "`@rnx-kit/jest-preset` has a simpler implementation of the path filter in `@rnx-kit/jest-resolver` (and `@rnw-scripts/jest-out-of-tree-resolver` before that), using the `moduleNameMapper` option to redirect `react-native` to `react-native-windows` instead. Like its predecessors, it can also detect that it's being used inside an out-of-tree platform package and configure `jest-haste-map` to pick up the appropriate file extensions.",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/react-native-windows-7013c272-48ae-4a55-b5db-f6b2795c585e.json
+++ b/change/react-native-windows-7013c272-48ae-4a55-b5db-f6b2795c585e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "`@rnx-kit/jest-preset` has a simpler implementation of the path filter in `@rnx-kit/jest-resolver` (and `@rnw-scripts/jest-out-of-tree-resolver` before that), using the `moduleNameMapper` option to redirect `react-native` to `react-native-windows` instead. Like its predecessors, it can also detect that it's being used inside an out-of-tree platform package and configure `jest-haste-map` to pick up the appropriate file extensions.",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@office-iss/react-native-win32/jest.config.js
+++ b/packages/@office-iss/react-native-win32/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
+  preset: '@rnx-kit/jest-preset',
   verbose: true,
-  resolver: '@rnx-kit/jest-resolver',
   snapshotResolver: './jest-snapshot-resolver.js',
   transform: {
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$':
@@ -15,10 +15,6 @@ module.exports = {
     // Only run the version of the tests that are part of the merged source output
     'src',
   ],
-  haste: {
-    defaultPlatform: 'win32',
-    platforms: ['win32']
-  },
   unmockedModulePathPatterns: [
     'react',
     'Libraries/Renderer',

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.1.7",
     "@rnw-scripts/jest-out-of-tree-snapshot-resolver": "^1.0.1",
-    "@rnx-kit/jest-resolver": "^0.1.0",
+    "@rnx-kit/jest-preset": "^0.1.0",
     "@types/node": "^14.14.22",
     "@types/prop-types": "15.7.1",
     "@types/react": "16.9.11",

--- a/packages/e2e-test-app/jest.config.js
+++ b/packages/e2e-test-app/jest.config.js
@@ -10,6 +10,8 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
+  preset: '@rnx-kit/jest-preset',
+
   // A list of paths to directories that Jest should use to search for files in
   roots: ['<rootDir>/test/'],
 
@@ -21,15 +23,6 @@ module.exports = {
 
   // Default timeout of a test in milliseconds
   testTimeout: 70000,
-
-  // This option allows the use of a custom resolver
-  resolver: '@rnx-kit/jest-resolver',
-
-  // This will be used to configure the behavior of jest-haste-map, Jest's internal file crawler/cache system
-  haste: {
-    defaultPlatform: 'windows',
-    platforms: ['windows'],
-  },
 
   // A map from regular expressions to paths to transformers
   transform: {

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -27,7 +27,7 @@
     "@rnw-scripts/eslint-config": "1.1.7",
     "@rnw-scripts/just-task": "2.2.0",
     "@rnw-scripts/ts-config": "2.0.0",
-    "@rnx-kit/jest-resolver": "^0.1.0",
+    "@rnx-kit/jest-preset": "^0.1.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",

--- a/vnext/jest.config.js
+++ b/vnext/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
+  preset: '@rnx-kit/jest-preset',
   verbose: true,
-  resolver: '@rnx-kit/jest-resolver',
   snapshotResolver: './jest-snapshot-resolver.js',
   transform: {
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$':
@@ -15,10 +15,6 @@ module.exports = {
     // Only run the version of the tests that are part of the merged source output
     'src',
   ],
-  haste: {
-    defaultPlatform: 'windows',
-    platforms: ['windows']
-  },
   unmockedModulePathPatterns: [
     'react',
     'Libraries/Renderer',

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -60,7 +60,7 @@
     "@react-native-windows/codegen": "0.0.0-canary.9",
     "@rnw-scripts/eslint-config": "1.1.7",
     "@rnw-scripts/jest-out-of-tree-snapshot-resolver": "^1.0.1",
-    "@rnx-kit/jest-resolver": "^0.1.0",
+    "@rnx-kit/jest-preset": "^0.1.0",
     "@types/node": "^14.14.22",
     "@types/react": "16.9.11",
     "@types/react-native": "^0.64.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,7 +980,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.14.5"
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/preset-env@^7.1.6", "@babel/preset-env@^7.11.5", "@babel/preset-env@^7.8.4":
+"@babel/preset-env@^7.0.0", "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.11.5", "@babel/preset-env@^7.8.4":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.14.8.tgz#254942f5ca80ccabcfbb2a9f524c74bca574005b"
   integrity sha512-a9aOppDU93oArQ51H+B8M1vH+tayZbuBqzjOhntGetZVa+4tTu5jp+XTwqHGG2lxslqomPYVSjIxQkFwXzgnxg==
@@ -1078,7 +1078,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-typescript@^7.1.0", "@babel/preset-typescript@^7.11.5", "@babel/preset-typescript@^7.8.3":
+"@babel/preset-typescript@^7.0.0", "@babel/preset-typescript@^7.1.0", "@babel/preset-typescript@^7.11.5", "@babel/preset-typescript@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.14.5.tgz#aa98de119cf9852b79511f19e7f44a2d379bcce0"
   integrity sha512-u4zO6CdbRKbS9TypMqrlGH7sd2TAJppZwn3c/ZRLeO/wGsbddxgbPDUZVNrie3JWYLQ9vpineKlsrWFvO6Pwkw==
@@ -1815,13 +1815,14 @@
   resolved "https://registry.yarnpkg.com/@reactions/component/-/component-2.0.2.tgz#40f8c1c2c37baabe57a0c944edb9310dc1ec6642"
   integrity sha1-QPjBwsN7qr5XoMlE7bkxDcHsZkI=
 
-"@rnx-kit/jest-resolver@^0.1.0":
+"@rnx-kit/jest-preset@^0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/jest-resolver/-/jest-resolver-0.1.0.tgz#42c318edae890bd507c599687c594a64cd543515"
-  integrity sha512-qjVEQchdUXC7Eh+r94kyM6hdaJFY+kxjoKu4wjcwiTIa/CndOsDHeF+f50wX9HyrweNzBcg+tn5bFKjwLHf7lA==
+  resolved "https://registry.yarnpkg.com/@rnx-kit/jest-preset/-/jest-preset-0.1.0.tgz#e1863a3962e703ec31ea425e50fd8ce1242f4bae"
+  integrity sha512-6d3B7c1eHCoJ2npolnJwcKhM5lgDL7Ipx3ui8H3iTA2++D0FV7XmC7Vp+okK4ZH3H1Y7+HZvXmSM7Rw5pK668g==
   dependencies:
-    pkg-dir "^5.0.0"
-    resolve "^1.20.0"
+    "@babel/preset-env" "^7.0.0"
+    "@babel/preset-typescript" "^7.0.0"
+    find-up "^5.0.0"
 
 "@rushstack/node-core-library@3.35.2":
   version "3.35.2"
@@ -9854,7 +9855,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1, resolve@^1.19.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==


### PR DESCRIPTION
`@rnx-kit/jest-preset` has a simpler implementation of the path filter in `@rnx-kit/jest-resolver` (and `@rnw-scripts/jest-out-of-tree-resolver` before that), using the `moduleNameMapper` option to redirect `react-native` to `react-native-windows` instead.

Like its predecessors, it can also detect that it's being used inside an out-of-tree platform package and configure `jest-haste-map` to pick up the appropriate file extensions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8336)