### PR TITLE
Updates to support private image

### DIFF
--- a/.ado/image/rnw-pool.json
+++ b/.ado/image/rnw-pool.json
@@ -1,0 +1,50 @@
+{
+    "imageType": "Managed",
+    "baseImage": "/MicrosoftWindowsServer/WindowsServer/2019-Datacenter/latest",
+    "artifacts": [
+        {
+            "Name": "windows-EnableDeveloperMode"
+        },
+        {
+            "Name": "windows-enable-long-paths"
+        },
+        {
+            "Name": "windows-gitinstall"
+        },
+        {
+            "Name": "windows-AzPipeline-ImageHelpers"
+        },
+        {
+            "Name": "windows-AzPipeline-InitializeVM"
+        },
+        {
+            "Name": "windows-AzPipeline-Install-VS",
+            "Parameters": {
+                "ToolSetFileName": "2019-default.json"
+            }
+        },
+        {
+            "Name": "windows-AzPipeline-NodeLts"
+        },
+        {
+            "Name": "windows-chrome"
+        },
+        {
+            "Name": "windows-AzPipeline-WinAppDriver"
+        },
+        {
+            "Name": "windows-dotnetcore-sdk",
+            "Parameters": {
+                "DotNetCoreVersion": "3.1.401"
+            }
+        }
+    ],
+    "publishingProfile": {
+        "targetRegions": [
+            {
+                "name": "westus2",
+                "replicas": 1
+            }
+        ]
+    }
+}

--- a/change/react-native-windows-508a0db3-8e5b-4a1b-9d80-fee68a18cf72.json
+++ b/change/react-native-windows-508a0db3-8e5b-4a1b-9d80-fee68a18cf72.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable private agent image",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -331,6 +331,7 @@ $requirements = @(
         Tags = @('buildLab');
         Valid = (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Windows Performance Toolkit\wpr.exe");
         Install = { choco install -y windows-adk };
+        Optional = $true
     },
     @{
         Id=[CheckId]::RNWClone;


### PR DESCRIPTION
This change checks in the configuration file we use for our hosted pool images.
Since there is no prescribed tool for the windows ADK yet, this changes makes that step optional.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8343)