### PR TITLE
Fix issue using react-native-debugger with react-native-windows

### DIFF
--- a/change/react-native-windows-5d74fe3c-efd2-479b-ab75-810f5f266a11.json
+++ b/change/react-native-windows-5d74fe3c-efd2-479b-ab75-810f5f266a11.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix issue using react-native-debugger with react-native-windows",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Executors/WebSocketJSExecutor.cpp
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.cpp
@@ -108,13 +108,6 @@ void WebSocketJSExecutor::registerBundle(uint32_t bundleId, const std::string &b
   std::terminate();
 }
 
-void WebSocketJSExecutor::flush() {
-  folly::dynamic jarray = folly::dynamic::array();
-  auto calls = Call("flushedQueue", jarray);
-  if (m_delegate && !IsInError())
-    m_delegate->callNativeModules(*this, folly::parseJson(std::move(calls)), true);
-}
-
 void WebSocketJSExecutor::callFunction(
     const std::string &moduleId,
     const std::string &methodId,

--- a/vnext/Shared/Executors/WebSocketJSExecutor.h
+++ b/vnext/Shared/Executors/WebSocketJSExecutor.h
@@ -72,7 +72,6 @@ class WebSocketJSExecutor : public facebook::react::JSExecutor,
   std::string Call(const std::string &methodName, folly::dynamic &arguments);
   std::future<std::string> SendMessageAsync(int requestId, const std::string &message);
   void OnMessageReceived(const std::string &msg);
-  void flush();
 
   void SetState(State state) noexcept {
     m_state = state;


### PR DESCRIPTION
`react-native-debugger` has a slightly different implementation of the debugger WS protocol that is used by the standard `http://localhost:8081/debugger-ui/`.  In particular it queues up any method requests until after the `executeApplicationScript` call.

`react-native-windows` currently makes a call to `flushedQueue` before the call to `executeApplicationScript`.  The normal debugger ui responds with an error to this call.  `react-native-debugger` doesn't respond, as its queued up until the `executeApplicationScript` call.  Unfortunately `react-native-windows` waits on the response to the `flushedQueue` call before it'll make the `executeApplicationScript` call, so we end up in a hung state.

As it turns out the call to `flushedQueue` is only needed when there are TurboModules running.  The bridge will already flush the queue after any native module call.  Since JSI doesn't work when we are web debugging, there is no need to do anything on the flush call.  So the `flush` method on the `WebSocketJSExecutor` can actually just be left as the default implementation which is a no-op.

#8325 will likely want this backported to 0.65 and 0.64.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8344)