### PR TITLE
Add Xaml type js reader unit test

### DIFF
--- a/change/react-native-windows-42e33449-db1e-4403-ab06-0213eea7ea90.json
+++ b/change/react-native-windows-42e33449-db1e-4403-ab06-0213eea7ea90.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add cxx unit test for xaml types",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
@@ -3,11 +3,11 @@
 
 #include "pch.h"
 #include "JSValueReader.h"
+#include <CppWinRTIncludes.h>
 #include <variant>
 #include "JSValueWriter.h"
-#include "JsonJSValueReader.h"
-#include <CppWinRTIncludes.h>
 #include "JSValueXaml.h"
+#include "JsonJSValueReader.h"
 
 namespace winrt::Microsoft::ReactNative {
 
@@ -482,7 +482,6 @@ TEST_CLASS (JSValueReaderTest) {
   }
 
   TEST_METHOD(TestReadValueXamlTypes) {
-
     const wchar_t *json =
         LR"JSON({
       "Thickness1": 2,
@@ -523,7 +522,7 @@ TEST_CLASS (JSValueReaderTest) {
         auto uri = jsValue.To<Uri>();
         TestCheck(uri.RawUri() == L"https://bing.com");
       }
-    }    
+    }
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/JSValueReaderTest.cpp
@@ -6,6 +6,8 @@
 #include <variant>
 #include "JSValueWriter.h"
 #include "JsonJSValueReader.h"
+#include <CppWinRTIncludes.h>
+#include "JSValueXaml.h"
 
 namespace winrt::Microsoft::ReactNative {
 
@@ -477,6 +479,51 @@ TEST_CLASS (JSValueReaderTest) {
     TestCheck(jsValue["FloatValue"] == 3.14);
     TestCheck(jsValue["NullValue"] == nullptr);
     TestCheck(jsValue["NullValue"] == JSValue::Null);
+  }
+
+  TEST_METHOD(TestReadValueXamlTypes) {
+
+    const wchar_t *json =
+        LR"JSON({
+      "Thickness1": 2,
+      "Thickness2": 2.5,
+      "Thickness3": [1,2,3,4],
+      "Thickness4": {"left": 1, "top": 2, "right": 3, "bottom": 4},
+      "CornerRadius1": 2,
+      "CornerRadius2": 2.5,
+      "CornerRadius3": [1,2,3,4],
+      "CornerRadius4": {"topLeft": 1, "topRight": 2, "bottomRight": 3, "bottomLeft": 4},
+      "Uri1": "https://bing.com",
+    })JSON";
+
+    IJSValueReader reader = make<JsonJSValueReader>(json);
+
+    TestCheck(reader.ValueType() == JSValueType::Object);
+    hstring propertyName;
+    while (reader.GetNextObjectProperty(/*out*/ propertyName)) {
+      if (propertyName == L"Thickness1") {
+        TestCheck(ReadValue<xaml::Thickness>(reader) == xaml::ThicknessHelper::FromUniformLength(2));
+      } else if (propertyName == L"Thickness2") {
+        TestCheck(ReadValue<xaml::Thickness>(reader) == xaml::ThicknessHelper::FromUniformLength(2.5));
+      } else if (propertyName == L"Thickness3") {
+        TestCheck(ReadValue<xaml::Thickness>(reader) == xaml::ThicknessHelper::FromLengths(1, 2, 3, 4));
+      } else if (propertyName == L"Thickness4") {
+        TestCheck(ReadValue<xaml::Thickness>(reader) == xaml::ThicknessHelper::FromLengths(1, 2, 3, 4));
+      } else if (propertyName == L"CornerRadius1") {
+        TestCheck(ReadValue<xaml::CornerRadius>(reader) == xaml::CornerRadiusHelper::FromUniformRadius(2));
+      } else if (propertyName == L"CornerRadius2") {
+        TestCheck(ReadValue<xaml::CornerRadius>(reader) == xaml::CornerRadiusHelper::FromUniformRadius(2.5));
+      } else if (propertyName == L"CornerRadius3") {
+        TestCheck(ReadValue<xaml::CornerRadius>(reader) == xaml::CornerRadiusHelper::FromRadii(1, 2, 3, 4));
+      } else if (propertyName == L"CornerRadius4") {
+        TestCheck(ReadValue<xaml::CornerRadius>(reader) == xaml::CornerRadiusHelper::FromRadii(1, 2, 3, 4));
+      } else if (propertyName == L"Uri1") {
+        // Uri has no default ctor, so instead we read this way:
+        auto jsValue = JSValue::ReadFrom(reader);
+        auto uri = jsValue.To<Uri>();
+        TestCheck(uri.RawUri() == L"https://bing.com");
+      }
+    }    
   }
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
@@ -10,7 +10,6 @@
 namespace winrt::Microsoft::ReactNative {
 
 #ifndef CXXUNITTESTS
-
 inline void ReadValue(JSValue const &jsValue, xaml::Media::Brush &value) noexcept {
   value = XamlHelper::BrushFrom([&jsValue](IJSValueWriter const &writer) noexcept { jsValue.WriteTo(writer); });
 }
@@ -18,6 +17,7 @@ inline void ReadValue(JSValue const &jsValue, xaml::Media::Brush &value) noexcep
 inline void ReadValue(JSValue const &jsValue, Windows::UI::Color &value) noexcept {
   value = XamlHelper::ColorFrom([&jsValue](IJSValueWriter const &writer) noexcept { jsValue.WriteTo(writer); });
 }
+#endif
 
 inline void ReadValue(JSValue const &jsValue, xaml::Thickness &value) noexcept {
   if (auto array = jsValue.TryGetArray()) {
@@ -65,8 +65,6 @@ inline void ReadValue(JSValue const &jsValue, xaml::CornerRadius &value) noexcep
 inline void ReadValue(JSValue const &jsValue, winrt::Windows::Foundation::Uri &value) noexcept {
   value = Uri{winrt::to_hstring(jsValue.AsString())};
 }
-
-#endif
 
 } // namespace winrt::Microsoft::ReactNative
 


### PR DESCRIPTION
Add a couple of simple tests for the JSValue reader tests for xaml/winrt types (thickness, corner radius, uri)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8359)