### PR TITLE
Run E2E Test App Against Both Chakra and Hermes

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -6,111 +6,135 @@ parameters:
     values: 
      - PullRequest 
      - Continuous 
+  - name: buildMatrix
+    type: object
+    default:
+      - BuildEnvironment: PullRequest
+        Matrix:
+          - Name: X64Chakra
+            BuildPlatform: x64
+            DeployOptions: --deploy-from-layout
+            UseHermes: false
+          - Name: X64Hermes
+            BuildPlatform: x64
+            DeployOptions: --deploy-from-layout
+            UseHermes: true
+      - BuildEnvironment: Continuous
+        Matrix:
+          - Name: X64Chakra
+            BuildPlatform: x64
+            DeployOptions:
+            UseHermes: false
+          - Name: X64Hermes
+            BuildPlatform: x64
+            DeployOptions:
+            UseHermes: true
+          - Name: X86Chakra
+            BuildPlatform: x86
+            DeployOptions:
+            UseHermes: false
+          - Name: X86Hermes
+            BuildPlatform: x86
+            DeployOptions:
+            UseHermes: true
 
 jobs:
-  - job: E2ETest
-    displayName: E2E Test App
-    strategy:
-      matrix:
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          # Arm E2E does not build on non-arm agents
-          # Arm64:
-          #   BuildPlatform: ARM64
-          x64:
-            BuildPlatform: x64
-            DeployOption:
-          x86:
-            BuildPlatform: x86
-        # End Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
-          x86:
-            BuildPlatform: x86
-            DeployOption: --deploy-from-layout
+  - ${{ each config in parameters.buildMatrix }}:
+      - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
+        - ${{ each matrix in config.Matrix }}:
+          - job: E2ETest${{ matrix.Name }}
+            displayName: E2E Test App ${{ matrix.Name }}
 
-    variables:
-      - template: ../variables/vs2019.yml
-    pool: $(AgentPool.Medium)
-    timeoutInMinutes: 60 # how long to run the job before automatically cancelling
-    cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+      variables:
+        - template: ../variables/vs2019.yml
+      pool: $(AgentPool.Medium)
+      timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+      cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
-    steps:
-      - checkout: self
-        clean: true
-        submodules: false
-            
-      - powershell: |
-          Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\$(BuildPlatform)\BuildLogs"
-        displayName: Set BuildLogDirectory
+      steps:
+        - checkout: self
+          clean: true
+          submodules: false
 
-      - template: ../templates/prepare-env.yml
+        - powershell: |
+            Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
+          displayName: Set BuildLogDirectory
 
-      - task: CmdLine@2
-        displayName: Set LocalDumps
-        inputs:
-          script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd ReactUWPTestApp
-          workingDirectory: $(Build.SourcesDirectory)
+        - template: ../templates/prepare-env.yml
 
-      - task: CmdLine@2
-        displayName: Set up AppVerifer on ReactUWPTestApp
-        inputs:
-          script: regedit /S $(Build.SourcesDirectory)\.ado\scripts\ReactUWPTestApp.reg
-          workingDirectory: $(Build.SourcesDirectory)
-        condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
+        - task: CmdLine@2
+          displayName: Set LocalDumps
+          inputs:
+            script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd ReactUWPTestApp
+            workingDirectory: $(Build.SourcesDirectory)
 
-      - template: ../templates/run-windows-with-certificates.yml
-        parameters:
-          buildEnvironment: ${{ parameters.BuildEnvironment }}
-          encodedKey: reactUWPTestAppEncodedKey
-          buildConfiguration: Release
-          buildPlatform: $(BuildPlatform)
-          deployOption: $(DeployOption)
-          buildLogDirectory: $(BuildLogDirectory)
+        - task: CmdLine@2
+          displayName: Set up AppVerifer on ReactUWPTestApp
+          inputs:
+            script: regedit /S $(Build.SourcesDirectory)\.ado\scripts\ReactUWPTestApp.reg
+            workingDirectory: $(Build.SourcesDirectory)
+          condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
+
+        - template: ../templates/set-experimental-feature.yml
+          parameters:
+            package: packages/e2e-test-app
+            feature: UseHermes
+            value: ${{ matrix.UseHermes }}
+
+        - template: ../templates/run-windows-with-certificates.yml
+          parameters:
+            buildEnvironment: ${{ parameters.BuildEnvironment }}
+            encodedKey: reactUWPTestAppEncodedKey
+            buildConfiguration: Release
+            buildPlatform: ${{ matrix.BuildPlatform }}
+            deployOption: ${{ matrix.DeployOption }}
+            buildLogDirectory: $(BuildLogDirectory)
+            workingDirectory: packages/e2e-test-app
+
+        - script: |
+            echo ##vso[task.setvariable variable=StartedTests]true
+          displayName: Set StartedTests
+
+        - script: yarn e2etest
+          displayName: yarn e2etest
           workingDirectory: packages/e2e-test-app
 
-      - script: |
-          echo ##vso[task.setvariable variable=StartedTests]true
-        displayName: Set StartedTests
+        - script: yarn e2etest -u
+          displayName: Update snapshots
+          workingDirectory: packages/e2e-test-app
+          condition: and(failed(), eq(variables.StartedTests, 'true'))
 
-      - script: yarn e2etest
-        displayName: yarn e2etest
-        workingDirectory: packages/e2e-test-app
+        - task: CopyFiles@2
+          displayName: Copy snapshots
+          inputs:
+            sourceFolder: packages/e2e-test-app/test/__snapshots__
+            targetFolder: $(Build.StagingDirectory)/snapshots
+            contents: "**"
+          condition: failed()
 
-      - script: yarn e2etest -u
-        displayName: Update snapshots
-        workingDirectory: packages/e2e-test-app
-        condition: and(failed(), eq(variables.StartedTests, 'true'))
+        - task: CopyFiles@2
+          displayName: Copy ReactUWPTestApp artifacts
+          inputs:
+            sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app/windows/ReactUWPTestApp
+            targetFolder: $(Build.StagingDirectory)/ReactUWPTestApp
+            contents: AppPackages\**
+          condition: failed()
 
-      - task: CopyFiles@2
-        displayName: Copy snapshots
-        inputs:
-          sourceFolder: packages/e2e-test-app/test/__snapshots__
-          targetFolder: $(Build.StagingDirectory)/snapshots
-          contents: "**"
-        condition: failed()
+        - task: PublishPipelineArtifact@1
+          displayName: "Publish Artifact:ReactUWPTestApp"
+          inputs:
+            artifactName: ReactUWPTestApp-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+            targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
+          condition: failed()
 
-      - task: CopyFiles@2
-        displayName: Copy ReactUWPTestApp artifacts
-        inputs:
-          sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app/windows/ReactUWPTestApp
-          targetFolder: $(Build.StagingDirectory)/ReactUWPTestApp
-          contents: AppPackages\**
-        condition: failed()
+        - task: PublishPipelineArtifact@1
+          displayName: "Publish Artifact:Snapshots"
+          inputs:
+            artifactName: Snapshots-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+            targetPath: $(Build.StagingDirectory)/snapshots
+          condition: failed()
 
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish Artifact:ReactUWPTestApp"
-        inputs:
-          artifactName: ReactUWPTestApp-$(BuildPlatform)-$(System.JobAttempt)
-          targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
-        condition: failed()
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish Artifact:Snapshots"
-        inputs:
-          artifactName: Snapshots-$(BuildPlatform)-$(System.JobAttempt)
-          targetPath: $(Build.StagingDirectory)/snapshots
-        condition: failed()
-
-      - template: ../templates/upload-build-logs.yml
-        parameters:
-          buildLogDirectory: '$(BuildLogDirectory)'
-          condition: succeededOrFailed()
+        - template: ../templates/upload-build-logs.yml
+          parameters:
+            buildLogDirectory: '$(BuildLogDirectory)'
+            condition: succeededOrFailed()

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -40,101 +40,101 @@ parameters:
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
-      - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
-        - ${{ each matrix in config.Matrix }}:
-          - job: E2ETest${{ matrix.Name }}
-            displayName: E2E Test App ${{ matrix.Name }}
+    - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
+      - ${{ each matrix in config.Matrix }}:
+        - job: E2ETest${{ matrix.Name }}
+          displayName: E2E Test App ${{ matrix.Name }}
 
-      variables:
-        - template: ../variables/vs2019.yml
-      pool: $(AgentPool.Medium)
-      timeoutInMinutes: 60 # how long to run the job before automatically cancelling
-      cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+          variables:
+            - template: ../variables/vs2019.yml
+          pool: $(AgentPool.Medium)
+          timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+          cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
-      steps:
-        - checkout: self
-          clean: true
-          submodules: false
+          steps:
+            - checkout: self
+              clean: true
+              submodules: false
 
-        - powershell: |
-            Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
-          displayName: Set BuildLogDirectory
+            - powershell: |
+                Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
+              displayName: Set BuildLogDirectory
 
-        - template: ../templates/prepare-env.yml
+            - template: ../templates/prepare-env.yml
 
-        - task: CmdLine@2
-          displayName: Set LocalDumps
-          inputs:
-            script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd ReactUWPTestApp
-            workingDirectory: $(Build.SourcesDirectory)
+            - task: CmdLine@2
+              displayName: Set LocalDumps
+              inputs:
+                script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd ReactUWPTestApp
+                workingDirectory: $(Build.SourcesDirectory)
 
-        - task: CmdLine@2
-          displayName: Set up AppVerifer on ReactUWPTestApp
-          inputs:
-            script: regedit /S $(Build.SourcesDirectory)\.ado\scripts\ReactUWPTestApp.reg
-            workingDirectory: $(Build.SourcesDirectory)
-          condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
+            - task: CmdLine@2
+              displayName: Set up AppVerifer on ReactUWPTestApp
+              inputs:
+                script: regedit /S $(Build.SourcesDirectory)\.ado\scripts\ReactUWPTestApp.reg
+                workingDirectory: $(Build.SourcesDirectory)
+              condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
 
-        - template: ../templates/set-experimental-feature.yml
-          parameters:
-            package: packages/e2e-test-app
-            feature: UseHermes
-            value: ${{ matrix.UseHermes }}
+            - template: ../templates/set-experimental-feature.yml
+              parameters:
+                package: packages/e2e-test-app
+                feature: UseHermes
+                value: ${{ matrix.UseHermes }}
 
-        - template: ../templates/run-windows-with-certificates.yml
-          parameters:
-            buildEnvironment: ${{ parameters.BuildEnvironment }}
-            encodedKey: reactUWPTestAppEncodedKey
-            buildConfiguration: Release
-            buildPlatform: ${{ matrix.BuildPlatform }}
-            deployOption: ${{ matrix.DeployOption }}
-            buildLogDirectory: $(BuildLogDirectory)
-            workingDirectory: packages/e2e-test-app
+            - template: ../templates/run-windows-with-certificates.yml
+              parameters:
+                buildEnvironment: ${{ parameters.BuildEnvironment }}
+                encodedKey: reactUWPTestAppEncodedKey
+                buildConfiguration: Release
+                buildPlatform: ${{ matrix.BuildPlatform }}
+                deployOption: ${{ matrix.DeployOption }}
+                buildLogDirectory: $(BuildLogDirectory)
+                workingDirectory: packages/e2e-test-app
 
-        - script: |
-            echo ##vso[task.setvariable variable=StartedTests]true
-          displayName: Set StartedTests
+            - script: |
+                echo ##vso[task.setvariable variable=StartedTests]true
+              displayName: Set StartedTests
 
-        - script: yarn e2etest
-          displayName: yarn e2etest
-          workingDirectory: packages/e2e-test-app
+            - script: yarn e2etest
+              displayName: yarn e2etest
+              workingDirectory: packages/e2e-test-app
 
-        - script: yarn e2etest -u
-          displayName: Update snapshots
-          workingDirectory: packages/e2e-test-app
-          condition: and(failed(), eq(variables.StartedTests, 'true'))
+            - script: yarn e2etest -u
+              displayName: Update snapshots
+              workingDirectory: packages/e2e-test-app
+              condition: and(failed(), eq(variables.StartedTests, 'true'))
 
-        - task: CopyFiles@2
-          displayName: Copy snapshots
-          inputs:
-            sourceFolder: packages/e2e-test-app/test/__snapshots__
-            targetFolder: $(Build.StagingDirectory)/snapshots
-            contents: "**"
-          condition: failed()
+            - task: CopyFiles@2
+              displayName: Copy snapshots
+              inputs:
+                sourceFolder: packages/e2e-test-app/test/__snapshots__
+                targetFolder: $(Build.StagingDirectory)/snapshots
+                contents: "**"
+              condition: failed()
 
-        - task: CopyFiles@2
-          displayName: Copy ReactUWPTestApp artifacts
-          inputs:
-            sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app/windows/ReactUWPTestApp
-            targetFolder: $(Build.StagingDirectory)/ReactUWPTestApp
-            contents: AppPackages\**
-          condition: failed()
+            - task: CopyFiles@2
+              displayName: Copy ReactUWPTestApp artifacts
+              inputs:
+                sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app/windows/ReactUWPTestApp
+                targetFolder: $(Build.StagingDirectory)/ReactUWPTestApp
+                contents: AppPackages\**
+              condition: failed()
 
-        - task: PublishPipelineArtifact@1
-          displayName: "Publish Artifact:ReactUWPTestApp"
-          inputs:
-            artifactName: ReactUWPTestApp-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
-            targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
-          condition: failed()
+            - task: PublishPipelineArtifact@1
+              displayName: "Publish Artifact:ReactUWPTestApp"
+              inputs:
+                artifactName: ReactUWPTestApp-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+                targetPath: $(Build.StagingDirectory)/ReactUWPTestApp
+              condition: failed()
 
-        - task: PublishPipelineArtifact@1
-          displayName: "Publish Artifact:Snapshots"
-          inputs:
-            artifactName: Snapshots-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
-            targetPath: $(Build.StagingDirectory)/snapshots
-          condition: failed()
+            - task: PublishPipelineArtifact@1
+              displayName: "Publish Artifact:Snapshots"
+              inputs:
+                artifactName: Snapshots-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+                targetPath: $(Build.StagingDirectory)/snapshots
+              condition: failed()
 
-        - template: ../templates/upload-build-logs.yml
-          parameters:
-            buildLogDirectory: '$(BuildLogDirectory)'
-            condition: succeededOrFailed()
+            - template: ../templates/upload-build-logs.yml
+              parameters:
+                buildLogDirectory: '$(BuildLogDirectory)'
+                condition: succeededOrFailed()

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -10,7 +10,7 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
-          - Name: X64Debug
+          - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
             DeployOptions:
@@ -27,7 +27,7 @@ parameters:
             BuildConfiguration: Debug
             DeployOptions: --no-deploy # We don't have Arm agents
             UseHermes: false
-          - Name: X64Debug
+          - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
             DeployOptions:
@@ -37,11 +37,16 @@ parameters:
             BuildConfiguration: Release
             DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
             UseHermes: true
-          - Name: X86Debug
+          - Name: X86WebDebug
             BuildPlatform: x86
             BuildConfiguration: Debug
             DeployOptions:
             UseHermes: false
+          - Name: X86ReleaseHermes
+            BuildPlatform: x86
+            BuildConfiguration: Release
+            DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
+            UseHermes: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -69,13 +74,11 @@ jobs:
             - script: .ado\scripts\SetupLocalDumps.cmd integrationtest
               displayName: Set LocalDumps
 
-            - ${{ if eq(matrix.UseHermes, 'true') }}:
-              - powershell: |
-                  [xml] $experimentalFeatures = Get-Content .\ExperimentalFeatures.props
-                  $experimentalFeatures.Project.PropertyGroup.UseHermes = 'true'
-                  $experimentalFeatures.Save("$pwd\ExperimentalFeatures.props")
-                displayName: Enable Hermes
-                workingDirectory: packages/integration-test-app/windows
+            - template: ../templates/set-experimental-feature.yml
+              parameters:
+                package: packages/integration-test-app
+                feature: UseHermes
+                value: ${{ matrix.UseHermes }}
 
             - ${{ if eq(matrix.BuildConfiguration, 'Debug') }}:
               # The build is more likely to crash after we've started other bits that

--- a/.ado/templates/set-experimental-feature.yml
+++ b/.ado/templates/set-experimental-feature.yml
@@ -1,0 +1,15 @@
+parameters:
+- name: package
+  type: string
+- name: feature
+  type: string
+- name: value
+  type: string
+
+steps:
+  - powershell: |
+      [xml] $experimentalFeatures = Get-Content .\ExperimentalFeatures.props
+      $experimentalFeatures.Project.PropertyGroup.${{ parameters.feature }} = '${{ parameters.value }}'
+      $experimentalFeatures.Save("$pwd\ExperimentalFeatures.props")
+    displayName: Set "${{ parameters.feature }}" to "${{ parameters.value }}"
+    workingDirectory: ${{ parameters.package }}/windows

--- a/packages/e2e-test-app/windows/ExperimentalFeatures.props
+++ b/packages/e2e-test-app/windows/ExperimentalFeatures.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
+    <UseHermes>false</UseHermes>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This expands E2ETest coverage to include Hermes support. This shares the same logic as we used for doing Hermes release integration tests. E2E YAML is moved to template-time matrix form instead of previous runtime matrix form, along with adding some more flavors to our more comprehensive nightly CI runs.

Checked that (the C# based) E2E Test App already contains the Hermes PackageReference in the user project.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8360)