### PR TITLE
Do not write codegen files if the contents have not changed, as this breaks incremental builds

### DIFF
--- a/change/@react-native-windows-codegen-37b535ff-56eb-4a82-9483-1daf94a54fee.json
+++ b/change/@react-native-windows-codegen-37b535ff-56eb-4a82-9483-1daf94a54fee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not write codegen files if the contents have not changed, as this breaks incremental builds",
+  "packageName": "@react-native-windows/codegen",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -109,7 +109,12 @@ function writeMapToFiles(map: Map<string, string>, outputDir: string) {
     try {
       const location = path.join(outputDir, fileName);
       fs.mkdirSync(path.dirname(location), {recursive: true});
-      fs.writeFileSync(location, contents);
+      const thisMap = new Map<string, string>();
+      thisMap.set(contents, fileName);
+      // Don't update the files if there are no changes as this breaks incremental builds
+      if (checkFilesForChanges(thisMap, outputDir)) {
+        fs.writeFileSync(location, contents);
+      }
     } catch (error) {
       success = false;
       console.error(`Failed to write ${fileName} to ${outputDir}`, error);


### PR DESCRIPTION


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8363)