### PR TITLE
Add QuirkSettings::SetEnableBackHandler to opt out of BackHandler functionality

### DIFF
--- a/change/react-native-windows-9fa432a3-64da-497e-8f46-b276ea85891a.json
+++ b/change/react-native-windows-9fa432a3-64da-497e-8f46-b276ea85891a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add QuirkSettings::SetEnableBackHandler to opt out of the backhandler behaviors",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -33,8 +33,7 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
 }
 
 winrt::Microsoft::ReactNative::ReactPropertyId<bool> EnableBackHandlerProperty() noexcept {
-  winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
-      L"ReactNative.QuirkSettings", L"EnableBackHandler"};
+  winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{L"ReactNative.QuirkSettings", L"EnableBackHandler"};
 
   return propId;
 }

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -32,6 +32,13 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
   return propId;
 }
 
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> EnableBackHandlerProperty() noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"EnableBackHandler"};
+
+  return propId;
+}
+
 #pragma region IDL interface
 
 /*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(
@@ -46,6 +53,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
   ReactPropertyBag(settings.Properties()).Set(AcceptSelfSignedCertsProperty(), value);
 }
 
+/*static*/ void QuirkSettings::SetEnableBackHandler(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
+  ReactPropertyBag(settings.Properties()).Set(EnableBackHandlerProperty(), value);
+}
+
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
@@ -54,6 +67,10 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProper
 
 /*static*/ bool QuirkSettings::GetAcceptSelfSigned(ReactPropertyBag properties) noexcept {
   return properties.Get(AcceptSelfSignedCertsProperty()).value_or(false);
+}
+
+/*static*/ bool QuirkSettings::GetEnableBackHandler(ReactPropertyBag properties) noexcept {
+  return properties.Get(EnableBackHandlerProperty()).value_or(true);
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -21,6 +21,7 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
   static bool GetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
   static bool GetAcceptSelfSigned(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+  static bool GetEnableBackHandler(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
   static bool GetEnableFabric(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
@@ -30,6 +31,7 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       bool value) noexcept;
 
   static void SetAcceptSelfSigned(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
+  static void SetEnableBackHandler(winrt::Microsoft::ReactNative::ReactInstanceSettings settings, bool value) noexcept;
 #pragma endregion Public API - part of IDL interface
 };
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -26,5 +26,12 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.")
     static void SetAcceptSelfSigned(ReactInstanceSettings settings, Boolean value);
+
+    DOC_STRING(
+      "Runtime setting that can be used to skip the default back handler logic.  "
+      "If you have an application that wants to handle back bahavior in native code "
+      "instead of JavaScript, setting this to false will prevent the native module "
+      "from handling the events. Default: true")
+    static void SetEnableBackHandler(ReactInstanceSettings settings, Boolean value);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -4,6 +4,7 @@
 #include "ReactRootView.h"
 #include "ReactRootView.g.cpp"
 
+#include <QuirkSettings.h>
 #include <ReactHost/MsoUtils.h>
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.Media3D.h>
@@ -362,7 +363,8 @@ void ReactRootView::AttachBackHandlers() noexcept {
   if (::Microsoft::ReactNative::IsXamlIsland())
     return;
 
-  if (!React::implementation::QuirkSettings::GetEnableBackHandler(m_context.Properties()))
+  if (!React::implementation::QuirkSettings::GetEnableBackHandler(
+          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties())))
     return;
 
   auto weakThis = this->get_weak();

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -363,7 +363,7 @@ void ReactRootView::AttachBackHandlers() noexcept {
   if (::Microsoft::ReactNative::IsXamlIsland())
     return;
 
-  if (!React::implementation::QuirkSettings::GetEnableBackHandler(
+  if (!winrt::Microsoft::ReactNative::implementation::QuirkSettings::GetEnableBackHandler(
           winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties())))
     return;
 

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -362,6 +362,9 @@ void ReactRootView::AttachBackHandlers() noexcept {
   if (::Microsoft::ReactNative::IsXamlIsland())
     return;
 
+  if (!React::implementation::QuirkSettings::GetEnableBackHandler(m_context.Properties()))
+    return;
+
   auto weakThis = this->get_weak();
   m_backRequestedRevoker = winrt::Windows::UI::Core::SystemNavigationManager::GetForCurrentView().BackRequested(
       winrt::auto_revoke,


### PR DESCRIPTION
Fixes #8262

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8365)