### PR TITLE
[DRAFT] Enable V8 via NAPI

### DIFF
--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -83,7 +83,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
   devSettings->platformName = "windesktop";
 
   // Set to JSIEngineOverride::Chakra when testing the Chakra.dll JSI runtime.
-  devSettings->jsiEngineOverride = JSIEngineOverride::ChakraCore;
+  devSettings->jsiEngineOverride = JSIEngineOverride::V8Napi;
 
   auto instanceWrapper = CreateReactInstance(
       "",

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -54,6 +54,9 @@
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
     <IncludePath>$(ReactNativeWindowsDir);$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeDir)\ReactCommon;$(ReactNativeDir)ReactCommon\callinvoker;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <!--
+      C4459 - declaration hides global declaration
+     -->
     <ExtraWarningsToDisable>$(ExtraWarningsToDisable);4459</ExtraWarningsToDisable>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -53,13 +53,14 @@
   <PropertyGroup>
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
-    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeDir)\ReactCommon;$(ReactNativeDir)ReactCommon\callinvoker;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeDir)\ReactCommon;$(ReactNativeDir)ReactCommon\callinvoker;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <ExtraWarningsToDisable>$(ExtraWarningsToDisable);4459</ExtraWarningsToDisable>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions Condition="'$(CHAKRACOREUWP)'=='true'">CHAKRACORE_UWP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CHAKRACORE;FOLLY_NO_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- /Zc:strictStrings enforces the standard C++ const qualifications for
       string literals. It prevents code like
         wchar_t* str = L"hello";
@@ -85,6 +86,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" Condition="'$(CHAKRACOREUWP)'!='true'">
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.20\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.20\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" />
     <Import Project="$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" />
@@ -94,6 +96,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Warning Condition="'$(USE_V8)' != 'true'" Text="Building desktop project without USE_V8 (value is '$(USE_V8)')" />
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.20\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.20\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="!Exists('$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8_Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />

--- a/vnext/JSI/Desktop/packages.config
+++ b/vnext/JSI/Desktop/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems
@@ -24,6 +24,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntimeArgs.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntimeFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntime.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ScriptStore.h" />
   </ItemGroup>

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems
@@ -17,6 +17,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraObjectRef.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraRuntime.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)ByteArrayBuffer.h" />

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntimeFactory.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraObjectRef.cpp">

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
@@ -44,5 +44,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
@@ -29,7 +29,7 @@ struct NapiTask {
 
   ~NapiTask() {
     if (m_finalizeCallback) {
-      m_finalizeCallback(m_env, m_taskCallback, m_finalizeHint);
+      m_finalizeCallback(m_env, m_taskData, m_finalizeHint);
     }
   }
 

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
@@ -16,6 +16,16 @@ using std::unique_ptr;
 
 namespace Microsoft::JSI {
 
+// See napi_ext_schedule_task_callback definition.
+void ScheduleTaskCallback(
+  napi_env env,
+  napi_ext_task_callback taskCb,
+  void *taskData,
+  uint32_t delayMs,
+  napi_finalize finalizeCb,
+  void *finalizeint) {
+}
+
 NapiJsiV8RuntimeHolder::NapiJsiV8RuntimeHolder(
     shared_ptr<DevSettings> devSettings,
     shared_ptr<MessageQueueThread> jsQueue,
@@ -42,7 +52,7 @@ void NapiJsiV8RuntimeHolder::InitRuntime() noexcept {
   // TODO: debuggerRuntimeName?
 
   // TODO
-  settings.foreground_scheduler = nullptr;
+  settings.foreground_scheduler = &ScheduleTaskCallback;
   // TODO: scriptStore
 
   napi_ext_create_env(&settings, &env);

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "NapiJsiV8RuntimeHolder.h"
+
+// V8-JSI
+#include <NapiJsiRuntime.h>
+
+// Standard Library
+
+using namespace facebook::jsi;
+using namespace facebook::react;
+
+using std::shared_ptr;
+using std::unique_ptr;
+
+namespace Microsoft::JSI {
+
+NapiJsiV8RuntimeHolder::NapiJsiV8RuntimeHolder(
+    shared_ptr<DevSettings> devSettings,
+    shared_ptr<MessageQueueThread> jsQueue,
+    unique_ptr<ScriptStore> &&scriptStore,
+    unique_ptr<PreparedScriptStore> &&preparedScritpStore) noexcept
+    : m_useDirectDebugger{devSettings->useDirectDebugger},
+      m_debuggerBreakOnNextLine{devSettings->debuggerBreakOnNextLine},
+      m_debuggerPort{devSettings->debuggerPort},
+      m_debuggerRuntimeName{devSettings->debuggerRuntimeName},
+      m_jsQueue{std::move(jsQueue)},
+      m_scriptStore{std::move(scriptStore)},
+      m_preparedScriptStore{std::move(preparedScritpStore)} {}
+
+void NapiJsiV8RuntimeHolder::InitRuntime() noexcept {
+  napi_env env{};
+  napi_ext_env_settings settings{};
+  settings.this_size = sizeof(napi_ext_env_settings);
+  settings.flags.enable_gc_api = true;
+  if (m_debuggerPort > 0)
+    settings.inspector_port = m_debuggerPort;
+
+  settings.flags.enable_inspector = m_useDirectDebugger;
+  settings.flags.wait_for_debugger = m_debuggerBreakOnNextLine;
+  // TODO: debuggerRuntimeName?
+
+  // TODO
+  settings.foreground_scheduler = nullptr;
+  // TODO: scriptStore
+
+  napi_ext_create_env(&settings, &env);
+  m_runtime = MakeNapiJsiRuntime(env);
+
+  m_ownThreadId = std::this_thread::get_id();
+}
+
+#pragma region facebook::jsi::RuntimeHolderLazyInit
+
+shared_ptr<Runtime> NapiJsiV8RuntimeHolder::getRuntime() noexcept /*override*/
+{
+  std::call_once(m_onceFlag, [this]() { InitRuntime(); });
+
+  if (!m_runtime)
+    std::terminate();
+
+  // V8 NapiJsiRuntime is not known to be thread safe.
+  if (m_ownThreadId != std::this_thread::get_id())
+    std::terminate();
+
+  return m_runtime;
+}
+
+#pragma endregion facebook::jsi::RuntimeHolderLazyInit
+
+} // namespace Microsoft::JSI

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
@@ -56,8 +56,7 @@ struct NapiTask {
   NapiJsiV8RuntimeHolder *holder;
   auto result = napi_get_instance_data(env, (void **)&holder);
   if (result != napi_status::napi_ok) {
-    // TODO: Signal error
-    return;
+    std::terminate();
   }
 
   auto task = std::make_shared<NapiTask>(env, taskCallback, taskData, finalizeCallback, finalizeHint);

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <DevSettings.h>
-#include <JSI/Shared/RuntimeHolder.h>
-#include <JSI/Shared/ScriptStore.h>
+#include "RuntimeHolder.h"
+#include "ScriptStore.h"
 
 namespace Microsoft::JSI {
 

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
@@ -4,8 +4,8 @@
 #pragma once
 
 #include <DevSettings.h>
-#include <RuntimeHolder.h>
-#include <ScriptStore.h>
+#include <JSI/Shared/RuntimeHolder.h>
+#include <JSI/Shared/ScriptStore.h>
 
 namespace Microsoft::JSI {
 

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <DevSettings.h>
+#include <NapiJsiRuntime.h>
 #include "RuntimeHolder.h"
 #include "ScriptStore.h"
 
@@ -20,7 +21,15 @@ class NapiJsiV8RuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
 
  private:
-  void InitRuntime() noexcept;
+  static void ScheduleTaskCallback(
+      napi_env env,
+      napi_ext_task_callback taskCb,
+      void *taskData,
+      uint32_t delayMs,
+      napi_finalize finalizeCb,
+      void *finalizeint);
+
+   void InitRuntime() noexcept;
 
   std::shared_ptr<facebook::jsi::Runtime> m_runtime;
   std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <DevSettings.h>
+#include <RuntimeHolder.h>
+#include <ScriptStore.h>
+
+namespace Microsoft::JSI {
+
+class NapiJsiV8RuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+ public:
+  std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+
+  NapiJsiV8RuntimeHolder(
+      std::shared_ptr<facebook::react::DevSettings> devSettings,
+      std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
+      std::unique_ptr<facebook::jsi::ScriptStore> &&scriptStore,
+      std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
+
+ private:
+  void InitRuntime() noexcept;
+
+  std::shared_ptr<facebook::jsi::Runtime> m_runtime;
+  std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
+
+  std::unique_ptr<facebook::jsi::ScriptStore> m_scriptStore;
+  std::unique_ptr<facebook::jsi::PreparedScriptStore> m_preparedScriptStore;
+
+  std::once_flag m_onceFlag;
+  std::thread::id m_ownThreadId;
+
+  std::uint16_t m_debuggerPort;
+  bool m_useDirectDebugger;
+  bool m_debuggerBreakOnNextLine;
+  std::string m_debuggerRuntimeName;
+};
+
+} // namespace Microsoft::JSI

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -30,9 +30,10 @@ enum class JSIEngineOverride : int32_t {
   ChakraCore = 2, // Use the JSIExecutorFactory with ChakraCoreRuntime
   Hermes = 3, // Use the JSIExecutorFactory with Hermes
   V8 = 4, // Use the JSIExecutorFactory with V8
-  V8NAPI = 5, // Use the JSIExecutorFactory with V8-NAPI
+  V8Lite = 5, // Use the JSIExecutorFactory with V8-NAPI
+  V8Napi = 6, // Use the JSIExecutorFactory with V8 via ABI-safe NAPI
 
-  Last = V8NAPI
+  Last = V8Napi
 };
 
 struct ChakraBundleMetadata {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -375,9 +375,6 @@ InstanceImpl::InstanceImpl(
       Microsoft::ReactNative::PackagerConnection::CreateOrReusePackagerConnection(*m_devSettings);
     }
 
-    //TODO: REVERT BEFORE MERGING.
-    m_devSettings->jsiEngineOverride = JSIEngineOverride::V8Napi;
-
     // If the consumer gives us a JSI runtime, then  use it.
     if (m_devSettings->jsiRuntimeHolder) {
       assert(m_devSettings->jsiEngineOverride == JSIEngineOverride::Default);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -432,9 +432,8 @@ InstanceImpl::InstanceImpl(
             preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
           }
 
-          //TODO!
-          //m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
-          //    m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
+          m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
+              m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
 
           break;
 #else

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -375,6 +375,8 @@ InstanceImpl::InstanceImpl(
       Microsoft::ReactNative::PackagerConnection::CreateOrReusePackagerConnection(*m_devSettings);
     }
 
+    m_devSettings->jsiEngineOverride = JSIEngineOverride::V8Napi;
+
     // If the consumer gives us a JSI runtime, then  use it.
     if (m_devSettings->jsiRuntimeHolder) {
       assert(m_devSettings->jsiEngineOverride == JSIEngineOverride::Default);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -50,6 +50,7 @@
 #include "HermesRuntimeHolder.h"
 #endif
 #if defined(USE_V8)
+#include <NapiJsiV8RuntimeHolder.h>
 #include "BaseScriptStoreImpl.h"
 #include "V8JSIRuntimeHolder.h"
 #endif
@@ -151,6 +152,9 @@ std::string GetJSBundleFilePath(const std::string &jsBundleBasePath, const std::
 } // namespace
 
 using namespace facebook;
+using namespace Microsoft::JSI;
+
+using std::make_shared;
 
 namespace facebook {
 namespace react {
@@ -428,6 +432,7 @@ InstanceImpl::InstanceImpl(
             preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
           }
 
+          //TODO!
           //m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
           //    m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -375,6 +375,7 @@ InstanceImpl::InstanceImpl(
       Microsoft::ReactNative::PackagerConnection::CreateOrReusePackagerConnection(*m_devSettings);
     }
 
+    //TODO: REVERT BEFORE MERGING.
     m_devSettings->jsiEngineOverride = JSIEngineOverride::V8Napi;
 
     // If the consumer gives us a JSI runtime, then  use it.

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -427,7 +427,6 @@ InstanceImpl::InstanceImpl(
           break;
         case JSIEngineOverride::V8Napi: {
 #if defined(USE_V8)
-          std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
           std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
           char tempPath[MAX_PATH];
@@ -436,7 +435,7 @@ InstanceImpl::InstanceImpl(
           }
 
           m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
-              m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
+              m_devSettings, m_jsThread, nullptr /*scriptStore*/, std::move(preparedScriptStore));
 
           break;
 #else

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -418,6 +418,25 @@ InstanceImpl::InstanceImpl(
           m_devSettings->jsiRuntimeHolder =
               std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(m_devSettings, m_jsThread, nullptr, nullptr);
           break;
+        case JSIEngineOverride::V8Napi: {
+#if defined(USE_V8)
+          std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
+          std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
+
+          char tempPath[MAX_PATH];
+          if (GetTempPathA(MAX_PATH, tempPath)) {
+            preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
+          }
+
+          //m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
+          //    m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
+
+          break;
+#else
+          assert(false); // V8 is not available in this build, fallthrough
+          [[fallthrough]];
+#endif
+        }
       }
       jsef = std::make_shared<OJSIExecutorFactory>(
           m_devSettings->jsiRuntimeHolder,


### PR DESCRIPTION
Draft for initial discussion.
After approval, an equivalent PR will be submitted against `main` and then backported.

- Defines a JSIRuntimeHolder for V8 using NAPI.

Pending verification: task scheduling (under direct debugging).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8378)