### PR TITLE
Sets the default button for the ContentDialog

### DIFF
--- a/change/react-native-windows-9327e4f0-c4f9-4c6a-b2cc-25c0ecf9e89a.json
+++ b/change/react-native-windows-9327e4f0-c4f9-4c6a-b2cc-25c0ecf9e89a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Sets the default button for the ContentDialog",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -38,6 +38,10 @@ void Alert::ProcessPendingAlertRequests() noexcept {
   dialog.PrimaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonPositive));
   dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
   dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
+  dialog.DefaultButton(
+      !args.buttonPositive.empty() ? xaml::Controls::ContentDialogButton::Primary
+                                   : !args.buttonNegative.empty() ? xaml::Controls::ContentDialogButton::Secondary
+                                                                  : xaml::Controls::ContentDialogButton::Close);
 
   if (Is19H1OrHigher()) {
     // XamlRoot added in 19H1

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -38,10 +38,9 @@ void Alert::ProcessPendingAlertRequests() noexcept {
   dialog.PrimaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonPositive));
   dialog.SecondaryButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNegative));
   dialog.CloseButtonText(Microsoft::Common::Unicode::Utf8ToUtf16(args.buttonNeutral));
-  dialog.DefaultButton(
-      !args.buttonPositive.empty() ? xaml::Controls::ContentDialogButton::Primary
-                                   : !args.buttonNegative.empty() ? xaml::Controls::ContentDialogButton::Secondary
-                                                                  : xaml::Controls::ContentDialogButton::Close);
+  if (args.defaultButton >= 0 && args.defaultButton <= 3) {
+    dialog.DefaultButton(static_cast<xaml::Controls::ContentDialogButton>(args.defaultButton));
+  }
 
   if (Is19H1OrHigher()) {
     // XamlRoot added in 19H1

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -26,6 +26,9 @@ struct ShowAlertArgs {
 
   REACT_FIELD(buttonNeutral)
   std::string buttonNeutral;
+
+  REACT_FIELD(defaultButton)
+  int defaultButton;
 };
 
 REACT_MODULE(Alert)

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -18,7 +18,6 @@ export type Buttons = Array<{
   text?: string,
   onPress?: ?Function,
   style?: AlertButtonStyle,
-  default?: boolean,
   ...
 }>;
 
@@ -39,7 +38,7 @@ class Alert {
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const validButtons: Buttons = buttons
       ? buttons.slice(0, 3)
-      : [{text: 'OK', default: true}];
+      : [{text: 'OK', style: 'default'}];
     const buttonPositive = validButtons.pop();
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();
@@ -50,7 +49,7 @@ class Alert {
       buttonNeutral,
       buttonNegative,
       buttonPositive,
-    ].findIndex(b => b != null && b.default);
+    ].findIndex(b => b != null && b.style === 'default');
 
     // XAML has an enum to specify the default button, which is:
     //   None = 0, Primary = 1, Secondary = 2, Close = 3

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -18,7 +18,7 @@ export type Buttons = Array<{
   text?: string,
   onPress?: ?Function,
   style?: AlertButtonStyle,
-  isDefault?: boolean,
+  default?: boolean,
   ...
 }>;
 
@@ -39,18 +39,18 @@ class Alert {
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const validButtons: Buttons = buttons
       ? buttons.slice(0, 3)
-      : [{text: 'OK'}];
+      : [{text: 'OK', default: true}];
     const buttonPositive = validButtons.pop();
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();
 
-    // Find the first button where isDefault is set to true
+    // Find the first button where 'default' is set to true
     // in order of declared buttons.
     const defaultIndex = [
       buttonNeutral,
       buttonNegative,
       buttonPositive,
-    ].findIndex(b => b != null && b.isDefault);
+    ].findIndex(b => b != null && b.default);
 
     // XAML has an enum to specify the default button, which is:
     //   None = 0, Primary = 1, Secondary = 2, Close = 3

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -18,6 +18,7 @@ export type Buttons = Array<{
   text?: string,
   onPress?: ?Function,
   style?: AlertButtonStyle,
+  isDefault?: boolean,
   ...
 }>;
 
@@ -43,6 +44,20 @@ class Alert {
     const buttonNegative = validButtons.pop();
     const buttonNeutral = validButtons.pop();
 
+    // Find the first button where isDefault is set to true
+    // in order of declared buttons.
+    const defaultIndex = [
+      buttonNeutral,
+      buttonNegative,
+      buttonPositive,
+    ].findIndex(b => b != null && b.isDefault);
+
+    // XAML has an enum to specify the default button, which is:
+    //   None = 0, Primary = 1, Secondary = 2, Close = 3
+    // If no default button is found, specify 0 for None, otherwise
+    // convert the index to its corresponding XAML enum value.
+    const defaultButton = defaultIndex >= 0 ? 3 - defaultIndex : 0;
+
     let args = {
       title: title || '',
       message: message || '',
@@ -50,6 +65,7 @@ class Alert {
       buttonNeutral: buttonNeutral ? buttonNeutral.text : '',
       buttonNegative: buttonNegative ? buttonNegative.text : '',
       buttonPositive: buttonPositive ? buttonPositive.text : '',
+      defaultButton,
     };
 
     AlertNative.showAlert(args, (actionResult: string) => {


### PR DESCRIPTION
Sets the default button to `Primary` when a positive button is specified, `Secondary` when a negative button is specified but not a positive button, or falls back on the `Close` (neutral) button.

Co-authored-by: Mykola Lando <lando.koljaka@gmail.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8386)