### PR TITLE
Clear tintColor when prop set to null

### DIFF
--- a/change/react-native-windows-6bd5ecf8-9e67-49a6-8b65-ea0d5f53e42b.json
+++ b/change/react-native-windows-6bd5ecf8-9e67-49a6-8b65-ea0d5f53e42b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Clear tintColor when prop set to null",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -135,9 +135,13 @@ bool ImageViewManager::UpdateProperty(
        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)) {
     auto reactImage{grid.as<ReactImage>()};
     reactImage->BlurRadius(propertyValue.AsSingle());
-  } else if (propertyName == "tintColor" && IsValidColorValue(propertyValue)) {
-    auto reactImage{grid.as<ReactImage>()};
-    reactImage->TintColor(ColorFrom(propertyValue));
+  } else if (propertyName == "tintColor") {
+    const auto isValidColorValue = IsValidColorValue(propertyValue);
+    if (isValidColorValue || propertyValue.IsNull()) {
+      auto reactImage{grid.as<ReactImage>()};
+      const auto color = isValidColorValue ? ColorFrom(propertyValue) : winrt::Colors::Transparent();
+      reactImage->TintColor(ColorFrom(propertyValue));
+    }
   } else if (TryUpdateCornerRadiusOnNode(nodeToUpdate, grid, propertyName, propertyValue)) {
     finalizeBorderRadius = true;
   } else if (TryUpdateBorderProperties(nodeToUpdate, grid, propertyName, propertyValue)) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -140,7 +140,7 @@ bool ImageViewManager::UpdateProperty(
     if (isValidColorValue || propertyValue.IsNull()) {
       auto reactImage{grid.as<ReactImage>()};
       const auto color = isValidColorValue ? ColorFrom(propertyValue) : winrt::Colors::Transparent();
-      reactImage->TintColor(ColorFrom(propertyValue));
+      reactImage->TintColor(color);
     }
   } else if (TryUpdateCornerRadiusOnNode(nodeToUpdate, grid, propertyName, propertyValue)) {
     finalizeBorderRadius = true;


### PR DESCRIPTION
Sets color to Transparent when prop is explicitly set to null. Setting the color to Transparent will set the A value to 0, which will allow us to switch from a ReactImageBrush to a standard bitmap. It will also remove the tint effect from the CompositionEffect for images that use either repeat resizeMode or blurRadius.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8387)