### PR TITLE
Skip user agent HTTP header validation

### DIFF
--- a/change/react-native-windows-65c127f0-920a-4ead-9f78-28f9aefd9aa6.json
+++ b/change/react-native-windows-65c127f0-920a-4ead-9f78-28f9aefd9aa6.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Skip user agent HTTP header validation",
+  "comment": "Skip user agent HTTP header validation.",
   "packageName": "react-native-windows",
   "email": "erozell@outlook.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-65c127f0-920a-4ead-9f78-28f9aefd9aa6.json
+++ b/change/react-native-windows-65c127f0-920a-4ead-9f78-28f9aefd9aa6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Skip user agent HTTP header validation",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/NetworkingModule.cpp
+++ b/vnext/Shared/Modules/NetworkingModule.cpp
@@ -288,7 +288,7 @@ void NetworkingModule::NetworkingHelper::SendRequest(
           contentEncoding = value;
         else if (_stricmp(name.c_str(), "content-length") == 0)
           contentLength = value;
-        else if (_stricmp(name.c_str(), "authorization") == 0)
+        else if (_stricmp(name.c_str(), "authorization") == 0 || _stricmp(name.c_str(), "user-agent") == 0)
           request.Headers().TryAppendWithoutValidation(
               Microsoft::Common::Unicode::Utf8ToUtf16(name), Microsoft::Common::Unicode::Utf8ToUtf16(value));
         else


### PR DESCRIPTION
Allow customization of User-Agent header string for apps built on react-native-windows.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8392)