### PR TITLE
Suppresses auto-focus under certain conditions

### DIFF
--- a/change/react-native-windows-3f1cdae2-0985-46e8-811f-5bf27d5897e3.json
+++ b/change/react-native-windows-3f1cdae2-0985-46e8-811f-5bf27d5897e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Suppresses auto-focus under certain conditions",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -64,6 +64,13 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   properties.Set(MapWindowDeactivatedToAppStateInactiveProperty(), value);
 }
 
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> SuppressWindowFocusOnViewFocusProperty() noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"SuppressWindowFocusOnViewFocus"};
+
+  return propId;
+}
+
 #pragma region IDL interface
 
 /*static*/ void QuirkSettings::SetMatchAndroidAndIOSStretchBehavior(
@@ -96,6 +103,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   SetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag(settings.Properties()), value);
 }
 
+/*static*/ void QuirkSettings::SetSuppressWindowFocusOnViewFocus(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
+  ReactPropertyBag(settings.Properties()).Set(SuppressWindowFocusOnViewFocusProperty(), value);
+}
+
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
@@ -118,6 +131,10 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 
 /*static*/ bool QuirkSettings::GetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag properties) noexcept {
   return properties.Get(MapWindowDeactivatedToAppStateInactiveProperty()).value_or(false);
+}
+
+/*static*/ bool QuirkSettings::GetSuppressWindowFocusOnViewFocus(ReactPropertyBag properties) noexcept {
+  return properties.Get(SuppressWindowFocusOnViewFocusProperty()).value_or(false);
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -28,6 +28,7 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
   static bool GetAcceptSelfSigned(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
   static winrt::Microsoft::ReactNative::BackNavigationHandlerKind GetBackHandlerKind(
       winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+  static bool GetSuppressWindowFocusOnViewFocus(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
   static bool GetEnableFabric(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
@@ -52,6 +53,10 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       winrt::Microsoft::ReactNative::BackNavigationHandlerKind kind) noexcept;
 
   static void SetMapWindowDeactivatedToAppStateInactive(
+      winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+      bool value) noexcept;
+
+  static void SetSuppressWindowFocusOnViewFocus(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
       bool value) noexcept;
 #pragma endregion Public API - part of IDL interface

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -53,5 +53,11 @@ namespace Microsoft.ReactNative
       "`inactive` tracks the [Window.Activated Event](https://docs.microsoft.com/uwp/api/windows.ui.core.corewindow.activated) when the window is deactivated.")
     DOC_DEFAULT("false")
     static void SetMapWindowDeactivatedToAppStateInactive(ReactInstanceSettings settings, Boolean value);
+
+    DOC_STRING(
+        "When running multiple windows from a single UI thread, focusing a native view causes the parent "
+        "window of that view to get focus as well. Set this setting to true to prevent focus of a blurred "
+        "window when a view in that window is programmatically focused.")
+    static void SetSuppressWindowFocusOnViewFocus(ReactInstanceSettings settings, Boolean value);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -193,12 +193,14 @@ void FlyoutShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueOb
 
   m_flyoutClosedRevoker = m_flyout.Closed(winrt::auto_revoke, [=](auto &&, auto &&) {
     if (!m_updating) {
-      if (m_targetElement != nullptr) {
+      if (m_targetTag > 0) {
         // When the flyout closes, attempt to move focus to
         // its anchor element to prevent cases where focus can land on
         // an outer flyout content and therefore trigger a unexpected flyout
         // dismissal
-        xaml::Input::FocusManager::TryFocusAsync(m_targetElement, winrt::FocusState::Programmatic);
+        if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+          uiManager->focus(m_targetTag);
+        }
       }
 
       OnFlyoutClosed(GetViewManager()->GetReactContext(), m_tag, false);

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -312,7 +312,9 @@ void TextInputShadowNode::registerEvents() {
 
   m_controlLoadedRevoker = control.Loaded(winrt::auto_revoke, [=](auto &&, auto &&) {
     if (m_autoFocus) {
-      control.Focus(xaml::FocusState::Keyboard);
+      if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+        uiManager->focus(m_tag);
+      }
     }
 
     auto contentElement = control.GetTemplateChild(L"ContentElement");


### PR DESCRIPTION
In multi-window XAML Islands apps that share a single UI thread for each window, focusing a view on a blurred window causes that window to get focus. Generally speaking, focusing a window should be explicit, and it's likely very rare that you would want a view getting focus to cause the entire window to get focus.

This manifests as problematic in two ways:
1. If you have a flyout shown and the flyout gets dismissed because you switch to another window, the parent window for the flyout would steal focus again when react-native-windows attempts to focus the target element.
2. If you re-render a view with a TextInput with `autoFocus={true}` and the parent window for that TextInput is blurred, the window will steal focus.

This change forces the user to first focus the window and update the active XamlRoot via the `XamlUIService::SetXamlRoot` API before a view in the window can get focus. In other words, the user has to explicitly focus the window before a programmatic view focus behavior can cause the window to get focused.

Fixes #8251 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8393)