### PR TITLE
Fixes issues with Text backgroundColor

### DIFF
--- a/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
+++ b/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issues with Text backgroundColor",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -10,7 +10,9 @@
 import React from 'react';
 import {
   /*Image,*/ StyleSheet,
+  Switch,
   Text,
+  TextInput,
   View,
   TextStyle,
   TouchableWithoutFeedback,
@@ -162,6 +164,66 @@ export class BackgroundColorDemo extends React.Component<{}> {
           </Text>{' '}
           attributes.
         </Text>
+      </View>
+    );
+  }
+}
+
+export class TextHighlightDemo extends React.Component<
+  {},
+  {search: string; toggled: boolean}
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {search: '', toggled: false};
+  }
+
+  private getTextParts(text: string) {
+    if (this.state.search === '') {
+      return [text];
+    }
+
+    let parts = text.split(this.state.search);
+    for (let i = parts.length - 2; i >= 0; --i) {
+      parts = [
+        ...parts.slice(0, i + 1),
+        this.state.search,
+        ...parts.slice(i + 1),
+      ];
+    }
+
+    const highlight = {
+      backgroundColor: 'yellow',
+    };
+
+    return parts.map((part, i) => (
+      <Text key={i} style={i % 2 === 0 ? undefined : highlight}>
+        {part}
+      </Text>
+    ));
+  }
+
+  public render() {
+    const exampleText = 'The quick brown fox jumped over the lazy dog.';
+    const parts = this.getTextParts(exampleText);
+    const rootHighlight = {
+      backgroundColor: this.state.toggled ? 'cyan' : undefined,
+    };
+    return (
+      <View testID={'highlights'}>
+        <TextInput
+          placeholder="Enter search text"
+          value={this.state.search}
+          onChangeText={text => this.setState({search: text})}
+        />
+        <View style={{flexDirection: 'row', alignItems: 'center'}}>
+          <Text style={{paddingRight: 5}}>Toggle highlight on all text:</Text>
+          <Switch
+            onValueChange={isOn => this.setState({toggled: isOn})}
+            value={this.state.toggled}
+          />
+        </View>
+        <Text style={rootHighlight}>{parts}</Text>
       </View>
     );
   }
@@ -791,6 +853,9 @@ export class TextExample extends React.Component<
               normal text.
             </Text>
           </View>
+        </RNTesterBlock>
+        <RNTesterBlock title="Dynamic backgroundColor">
+          <TextHighlightDemo />
         </RNTesterBlock>
       </RNTesterPage>
     );

--- a/packages/e2e-test-app/test/__snapshots__/TextComponentTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/TextComponentTest.test.ts.snap
@@ -217,18 +217,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 14,
+              "Length": 44,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 14,
             },
           ],
         },
@@ -265,18 +255,8 @@ Object {
           "Foreground": "#FFFFA500",
           "Ranges": Array [
             Object {
-              "Length": 21,
+              "Length": 42,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFA500",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 21,
             },
           ],
         },
@@ -369,18 +349,8 @@ Object {
           "Foreground": "#FFFFFFFF",
           "Ranges": Array [
             Object {
-              "Length": 18,
+              "Length": 59,
               "StartIndex": 15,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 33,
             },
           ],
         },
@@ -391,26 +361,6 @@ Object {
             Object {
               "Length": 29,
               "StartIndex": 34,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 63,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 64,
             },
           ],
         },
@@ -465,38 +415,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 19,
+              "Length": 57,
               "StartIndex": 15,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 27,
-              "StartIndex": 34,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 61,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 62,
             },
           ],
         },
@@ -523,78 +443,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 9,
+              "Length": 83,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 9,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 25,
-              "StartIndex": 10,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 25,
-              "StartIndex": 35,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 60,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 61,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 71,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 11,
-              "StartIndex": 72,
             },
           ],
         },
@@ -621,38 +471,18 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 9,
+              "Length": 70,
               "StartIndex": 0,
             },
           ],
         },
         Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 9,
-            },
-          ],
-        },
-        Object {
           "Background": "#FF008000",
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 18,
+              "Length": 48,
               "StartIndex": 10,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 28,
             },
           ],
         },
@@ -663,46 +493,6 @@ Object {
             Object {
               "Length": 18,
               "StartIndex": 29,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 47,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 48,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 58,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 11,
-              "StartIndex": 59,
             },
           ],
         },

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="Base\CxxReactIncludes.h" />
     <ClInclude Include="Base\FollyIncludes.h" />
     <ClInclude Include="ReactHost\JSCallInvokerScheduler.h" />
+    <ClInclude Include="Utils\ShadowNodeTypeUtils.h" />
     <ClInclude Include="Utils\BatchingEventEmitter.h" />
     <ClInclude Include="DevMenuControl.h">
       <DependentUpon>DevMenuControl.xaml</DependentUpon>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -675,6 +675,9 @@
     <ClInclude Include="Utils\TextTransform.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\ShadowNodeTypeUtils.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Views/ShadowNodeBase.h>
+
+namespace Microsoft::ReactNative {
+
+static inline bool IsNodeType(ShadowNodeBase const *node, wchar_t const *name) {
+  return std::wcscmp(node->GetViewManager()->GetName(), name) == 0;
+}
+
+static inline bool IsTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTText");
+}
+
+static inline bool IsVirtualTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTVirtualText");
+}
+
+static inline bool IsRawTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTRawText");
+}
+
+}; // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -317,4 +317,12 @@ winrt::Uri UriTryCreate(winrt::param::hstring const &uri) {
   }
 }
 
+bool IsValidOptionalColorValue(const winrt::Microsoft::ReactNative::JSValue &v) {
+  return v.Type() == winrt::Microsoft::ReactNative::JSValueType::Null || IsValidColorValue(v);
+}
+
+std::optional<winrt::Color> OptionalColorFrom(const winrt::Microsoft::ReactNative::JSValue &v) {
+  return v.IsNull() ? std::optional<winrt::Color>{} : ColorFrom(v);
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -26,9 +26,8 @@ xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSV
 xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);
 
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const winrt::Microsoft::ReactNative::JSValue &d);
-REACTWINDOWS_API_(xaml::Media::Brush)
-BrushFrom(const folly::dynamic &d);
+REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const winrt::Microsoft::ReactNative::JSValue &v);
+REACTWINDOWS_API_(xaml::Media::Brush) BrushFrom(const folly::dynamic &d);
 
 REACTWINDOWS_API_(xaml::Media::Brush)
 BrushFrom(const winrt::Microsoft::ReactNative::JSValue &v);
@@ -60,4 +59,8 @@ TimeSpanFromMs(double ms);
 winrt::Uri UriTryCreate(winrt::param::hstring const &uri);
 
 winrt::Windows::UI::Color ColorFromNumber(DWORD argb) noexcept;
+
+bool IsValidOptionalColorValue(const winrt::Microsoft::ReactNative::JSValue &v);
+std::optional<winrt::Windows::UI::Color> OptionalColorFrom(const winrt::Microsoft::ReactNative::JSValue &v);
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -10,6 +10,7 @@
 #include <Views/ShadowNodeBase.h>
 
 #include <INativeUIManager.h>
+#include <Utils/ShadowNodeTypeUtils.h>
 #include <Utils/ValueUtils.h>
 
 #include <Modules/NativeUIManager.h>
@@ -67,7 +68,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
-      if (std::wcscmp(nodeType, L"RCTText") == 0) {
+      if (IsTextShadowNode(parent)) {
         const auto textViewManager = static_cast<TextViewManager *>(viewManager);
         if (textTransform == TextTransform::Undefined) {
           textTransform = textViewManager->GetTextTransformValue(parent);
@@ -91,7 +92,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
 
         // We have reached the parent TextBlock, so there're no more parent <Text> elements in this tree.
         break;
-      } else if (std::wcscmp(nodeType, L"RCTVirtualText") == 0 && textTransform == TextTransform::Undefined) {
+      } else if (IsVirtualTextShadowNode(parent) && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
 

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -67,7 +67,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
-      if (!std::wcscmp(nodeType, L"RCTText")) {
+      if (std::wcscmp(nodeType, L"RCTText") == 0) {
         const auto textViewManager = static_cast<TextViewManager *>(viewManager);
         if (textTransform == TextTransform::Undefined) {
           textTransform = textViewManager->GetTextTransformValue(parent);
@@ -91,7 +91,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
 
         // We have reached the parent TextBlock, so there're no more parent <Text> elements in this tree.
         break;
-      } else if (!std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
+      } else if (std::wcscmp(nodeType, L"RCTVirtualText") == 0 && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -53,6 +53,7 @@ class TextShadowNode final : public ShadowNodeBase {
     VirtualTextShadowNode::ApplyTextTransform(
         childNode, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
 
+    auto addInline = true;
     if (index == 0) {
       auto run = childNode.GetView().try_as<winrt::Run>();
       if (run != nullptr) {
@@ -60,8 +61,7 @@ class TextShadowNode final : public ShadowNodeBase {
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         textBlock.Text(run.Text());
         m_prevCursorEnd += textBlock.Text().size();
-
-        return;
+        addInline = false;
       }
     } else if (index == 1 && m_firstChildNode != nullptr) {
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
@@ -70,7 +70,10 @@ class TextShadowNode final : public ShadowNodeBase {
       m_firstChildNode = nullptr;
     }
 
-    Super::AddView(child, index);
+    if (addInline) {
+      Super::AddView(child, index);
+    }
+
     UpdateTextHighlighters();
   }
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -96,8 +96,8 @@ class TextShadowNode final : public ShadowNodeBase {
     if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
       for (auto childTag : m_children) {
         if (const auto childNode = uiManager->getHost()->FindShadowNodeForTag(childTag)) {
-          nestedIndex = AddNestedTextHighlighter(
-              m_backgroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
+          nestedIndex =
+              AddNestedTextHighlighter(m_backgroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
         }
       }
     }
@@ -142,7 +142,8 @@ class TextShadowNode final : public ShadowNodeBase {
       if (const auto uiManager = GetNativeUIManager(node->GetViewManager()->GetReactContext()).lock()) {
         for (auto childTag : node->m_children) {
           if (const auto childNode = uiManager->getHost()->FindShadowNodeForTag(childTag)) {
-            nestedIndex = AddNestedTextHighlighter(parentBackgroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
+            nestedIndex =
+                AddNestedTextHighlighter(parentBackgroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
           }
         }
       }

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -12,7 +12,7 @@ class TextViewManager : public FrameworkElementViewManager {
   using Super = FrameworkElementViewManager;
 
  public:
-  enum class PropertyChangeType { Text = 0, BackgroundColor };
+  enum class PropertyChangeType { Text = 0, Highlight };
 
   TextViewManager(const Mso::React::IReactContext &context);
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -26,7 +26,9 @@ class TextViewManager : public FrameworkElementViewManager {
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
-  void OnDescendantTextPropertyChanged(ShadowNodeBase *node, PropertyChangeType propertyChangeType = PropertyChangeType::Text);
+  void OnDescendantTextPropertyChanged(
+      ShadowNodeBase *node,
+      PropertyChangeType propertyChangeType = PropertyChangeType::Text);
 
   TextTransform GetTextTransformValue(ShadowNodeBase *node);
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -12,6 +12,8 @@ class TextViewManager : public FrameworkElementViewManager {
   using Super = FrameworkElementViewManager;
 
  public:
+  enum class PropertyChangeType { Text = 0, BackgroundColor };
+
   TextViewManager(const Mso::React::IReactContext &context);
 
   ShadowNode *createShadow() const override;
@@ -24,7 +26,7 @@ class TextViewManager : public FrameworkElementViewManager {
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
-  void OnDescendantTextPropertyChanged(ShadowNodeBase *node);
+  void OnDescendantTextPropertyChanged(ShadowNodeBase *node, PropertyChangeType propertyChangeType = PropertyChangeType::Text);
 
   TextTransform GetTextTransformValue(ShadowNodeBase *node);
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -8,12 +8,18 @@
 
 namespace Microsoft::ReactNative {
 
+enum class PropertyChangeType : std::uint_fast8_t {
+  None = 0,
+  Text = 1 << 0,
+  AddBackgroundColor = 1 << 1,
+};
+
+DEFINE_ENUM_FLAG_OPERATORS(PropertyChangeType);
+
 class TextViewManager : public FrameworkElementViewManager {
   using Super = FrameworkElementViewManager;
 
  public:
-  enum class PropertyChangeType { Text = 0, Highlight };
-
   TextViewManager(const Mso::React::IReactContext &context);
 
   ShadowNode *createShadow() const override;

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -143,6 +143,7 @@ bool VirtualTextViewManager::UpdateProperty(
     auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
     if (IsValidOptionalColorValue(propertyValue)) {
       node->m_foregroundColor = OptionalColorFrom(propertyValue);
+      node->m_hasDescendantBackgroundColor |= node->m_foregroundColor.has_value();
       const auto propertyChangeType =
           node->m_foregroundColor ? PropertyChangeType::AddBackgroundColor : PropertyChangeType::None;
       node->NotifyAncestorsTextPropertyChanged(propertyChangeType);

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -129,7 +129,12 @@ bool VirtualTextViewManager::UpdateProperty(
   // FUTURE: In the future cppwinrt will generate code where static methods on
   // base types can be called.  For now we specify the base type explicitly
   if (TryUpdateForeground<winrt::TextElement>(span, propertyName, propertyValue)) {
-    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_foregroundColor = ColorFrom(propertyValue);
+    auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_foregroundColor = OptionalColorFrom(propertyValue);
+      node->NotifyAncestorsTextPropertyChanged(TextViewManager::PropertyChangeType::Highlight);
+    }
+  } else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (propertyName == "textTransform") {
@@ -139,13 +144,10 @@ bool VirtualTextViewManager::UpdateProperty(
         *node, node->textTransform, /* forceUpdate = */ true, /* isRoot = */ true);
   } else if (propertyName == "backgroundColor") {
     auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
-    if (propertyValue.IsNull()) {
-      node->m_backgroundColor = std::nullopt;
-    } else {
-      node->m_backgroundColor = ColorFrom(propertyValue);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_backgroundColor = OptionalColorFrom(propertyValue);
+      node->NotifyAncestorsTextPropertyChanged(TextViewManager::PropertyChangeType::Highlight);
     }
-
-    node->NotifyAncestorsTextPropertyChanged(TextViewManager::PropertyChangeType::BackgroundColor);
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -12,6 +12,7 @@
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <Utils/PropertyUtils.h>
+#include <Utils/ShadowNodeTypeUtils.h>
 #include <Utils/TransformableText.h>
 #include <Utils/ValueUtils.h>
 
@@ -55,7 +56,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
     const auto nodeType = viewManager->GetName();
 
     // Base case: apply the inherited textTransform to the raw text node
-    if (std::wcscmp(nodeType, L"RCTRawText") == 0) {
+    if (IsRawTextShadowNode(&node)) {
       auto &rawTextNode = static_cast<RawTextShadowNode &>(node);
       auto originalText = rawTextNode.originalText;
       auto run = node.GetView().try_as<winrt::Run>();
@@ -74,7 +75,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
       }
     } else {
       // Recursively apply the textTransform to the children of the composite text node
-      if (std::wcscmp(nodeType, L"RCTVirtualText") == 0) {
+      if (IsVirtualTextShadowNode(&node)) {
         auto &virtualTextNode = static_cast<VirtualTextShadowNode &>(node);
         // If this is not the root call, we can skip sub-trees with explicit textTransform settings.
         if (!isRoot && virtualTextNode.textTransform != TextTransform::Undefined) {
@@ -99,7 +100,7 @@ void VirtualTextShadowNode::NotifyAncestorsTextPropertyChanged(TextViewManager::
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
-      if (std::wcscmp(nodeType, L"RCTText") == 0) {
+      if (IsTextShadowNode(parent)) {
         (static_cast<TextViewManager *>(viewManager))->OnDescendantTextPropertyChanged(parent, propertyChangeType);
         break;
       }

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -20,12 +20,13 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   void RemoveChildAt(int64_t indexToRemove) override;
   void removeAllChildren() override;
 
-  void NotifyAncestorsTextPropertyChanged(TextViewManager::PropertyChangeType propertyChangeType);
+  void NotifyAncestorsTextPropertyChanged(PropertyChangeType propertyChangeType);
 
   static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
   std::optional<winrt::Windows::UI::Color> m_backgroundColor;
   std::optional<winrt::Windows::UI::Color> m_foregroundColor;
+  bool m_hasDescendantBackgroundColor{false};
 };
 
 class VirtualTextViewManager : public ViewManagerBase {

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -8,6 +8,7 @@
 #include <Utils/TextTransform.h>
 #include <Views/FrameworkElementViewManager.h>
 #include <Views/ShadowNodeBase.h>
+#include <Views/TextViewManager.h>
 
 namespace Microsoft::ReactNative {
 
@@ -16,17 +17,15 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   TextTransform textTransform{TextTransform::Undefined};
 
   void AddView(ShadowNode &child, int64_t index) override;
+  void RemoveChildAt(int64_t indexToRemove) override;
+  void removeAllChildren() override;
+
+  void NotifyAncestorsTextPropertyChanged(TextViewManager::PropertyChangeType propertyChangeType);
 
   static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
-  struct HighlightData {
-    std::vector<HighlightData> data;
-    size_t spanIdx = 0;
-    std::optional<winrt::Windows::UI::Color> backgroundColor;
-    std::optional<winrt::Windows::UI::Color> foregroundColor;
-  };
-
-  HighlightData m_highlightData;
+  std::optional<winrt::Windows::UI::Color> m_backgroundColor;
+  std::optional<winrt::Windows::UI::Color> m_foregroundColor;
 };
 
 class VirtualTextViewManager : public ViewManagerBase {


### PR DESCRIPTION
There were two issues with the Text backgroundColor prop:
1. Changes to the backgroundColor prop on virtual text nodes did not update their corresponding TextHighlighters
2. Changes to the underlying text did not update the TextHighlighter ranges

This change forces a refresh of all TextHighlighters any time:
1. A raw text node changes text value
2. A virtual text node is added or removed from the text tree
3. A virtual text or root text node updates its backgroundColor prop

TODOs:
- [x] Pass inherited foreground color down so virtual text highlighters apply the correct foreground color
- [x] Update snapshots since highlighter approach has changed
- [x] Produce a before and after video to ensure RNTester TextExample still works as expected
- [x] Add examples to RNTester to toggle background colors on RCTText and RCTVirtualText to see highlighter updates working
- [x] Add examples to RNTester to remove RCTRawText and RCTVirtualText nodes to see highlighter updates working

Fixes #7568
Fixes #7569
Fixes #8407

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8408)