### PR TITLE
Adds shouldConstrainToRootBounds prop to Flyout

### DIFF
--- a/change/react-native-windows-926ba5d6-6de7-4b3a-82ff-44117751b1ba.json
+++ b/change/react-native-windows-926ba5d6-6de7-4b3a-82ff-44117751b1ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds shouldConstrainToRootBounds prop to Flyout",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -352,6 +352,10 @@ void FlyoutShadowNode::updateProperties(winrt::Microsoft::ReactNative::JSValueOb
       if (m_isFlyoutShowOptionsSupported) {
         m_showOptions.ShowMode(showMode);
       }
+    } else if (propertyName == "shouldConstrainToRootBounds") {
+      if (propertyValue.Type() == React::JSValueType::Boolean) {
+        m_flyout.ShouldConstrainToRootBounds(propertyValue.AsBoolean());
+      }
     }
   }
 
@@ -478,6 +482,7 @@ void FlyoutViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSV
   React::WriteProperty(writer, L"verticalOffset", L"number");
   React::WriteProperty(writer, L"isOverlayEnabled", L"boolean");
   React::WriteProperty(writer, L"showMode", L"string");
+  React::WriteProperty(writer, L"shouldConstrainToRootBounds", L"boolean");
 }
 
 void FlyoutViewManager::GetExportedCustomDirectEventTypeConstants(

--- a/vnext/src/Libraries/Components/Flyout/FlyoutProps.ts
+++ b/vnext/src/Libraries/Components/Flyout/FlyoutProps.ts
@@ -30,6 +30,7 @@ export type ShowMode =
 export interface IFlyoutProps extends ViewProps {
   horizontalOffset?: number;
   isLightDismissEnabled?: boolean;
+  shouldConstrainToRootBounds?: boolean;
 
   /**
    * Specifies whether the area outside the flyout is darkened


### PR DESCRIPTION
Adds the ability to set the `FlyoutBase::ShouldConstrainToRootBounds` property in the `FlyoutViewManager`.

Co-authored-by: Liron Yahdav <lyahdav@fb.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8414)