### PR TITLE
Prevent crash in AnimationDriver when RN instance destroyed

### DIFF
--- a/change/react-native-windows-e95ae09a-3ccc-4ae3-a539-086bd5ad1e6d.json
+++ b/change/react-native-windows-e95ae09a-3ccc-4ae3-a539-086bd5ad1e6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent crash in AnimationDriver when RN instance destroyed",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
@@ -54,9 +54,9 @@ void AnimationDriver::StartAnimation() {
   }
   scopedBatch.End();
 
-  m_scopedBatchCompletedToken = scopedBatch.Completed([&](auto sender, auto) {
-    DoCallback(true);
-    if (auto manager = m_manager.lock()) {
+  m_scopedBatchCompletedToken = scopedBatch.Completed([&, weakManager = m_manager](auto sender, auto) {
+    if (auto manager = weakManager.lock()) {
+      DoCallback(true);
       if (auto const animatedValue = manager->GetValueAnimatedNode(m_animatedValueTag)) {
         animatedValue->RemoveActiveAnimation(m_id);
         animatedValue->FlattenOffset();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -10,7 +10,7 @@ namespace Microsoft::ReactNative {
 typedef std::function<void(std::vector<folly::dynamic>)> Callback;
 
 class ValueAnimatedNode;
-class AnimationDriver {
+class AnimationDriver : std::enable_shared_from_this<AnimationDriver> {
  public:
   AnimationDriver(
       int64_t id,
@@ -51,9 +51,10 @@ class AnimationDriver {
     return std::vector<double>();
   }
 
+  void DoCallback(bool value);
+
  private:
   Callback m_endCallback{};
-  void DoCallback(bool value);
 #ifdef DEBUG
   int m_debug_callbackAttempts{0};
 #endif // DEBUG


### PR DESCRIPTION
This change ensures that the NativeAnimatedNodeManager still exists before attempting to call the `DoCallback` instance method on AnimationDriver from the CompositionScopedBatch::Completed callback.

Co-authored-by: Mykola Lando <lando.koljaka@gmail.com>

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8418)