### PR TITLE
[0.65] Add experimentalFeatures to projectConfig result

### DIFF
--- a/change/@react-native-windows-cli-35e87e87-c745-44ad-8f4c-2b38f9b46108.json
+++ b/change/@react-native-windows-cli-35e87e87-c745-44ad-8f4c-2b38f9b46108.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Normalize paths provided by react-native.config.js",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-85ae69ed-4113-468c-85b6-9e610f051b75.json
+++ b/change/@react-native-windows-cli-85ae69ed-4113-468c-85b6-9e610f051b75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable project/dependency config when not running on windows",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-eadba467-337a-4499-828e-32da360bf348.json
+++ b/change/@react-native-windows-cli-eadba467-337a-4499-828e-32da360bf348.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add experimentalFeatures to projectConfig result",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a4fae44b-7bd8-4956-8e09-a597dbcc199c.json
+++ b/change/react-native-windows-a4fae44b-7bd8-4956-8e09-a597dbcc199c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add experimentalFeatures to projectConfig result",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -318,3 +318,25 @@ export function getProjectNamespace(projectContents: Node): string | null {
 export function getProjectGuid(projectContents: Node): string | null {
   return tryFindPropertyValue(projectContents, 'ProjectGuid');
 }
+
+export function getExperimentalFeatures(
+  solutionDir: string,
+): Record<string, string> | undefined {
+  const propsFile = path.join(solutionDir, 'ExperimentalFeatures.props');
+
+  if (!fs.existsSync(propsFile)) {
+    return undefined;
+  }
+
+  const result: Record<string, any> = {};
+  const propsContents = readProjectFile(propsFile);
+  const nodes = msbuildSelect(
+    `//msbuild:PropertyGroup/msbuild:*`,
+    propsContents,
+  );
+  for (const node of nodes) {
+    const propertyNode = node as Node;
+    result[propertyNode.nodeName] = propertyNode.textContent;
+  }
+  return result;
+}

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -9,6 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
+import {platform} from 'os';
 import * as path from 'path';
 
 import * as configUtils from './configUtils';
@@ -117,6 +118,10 @@ export function dependencyConfigWindows(
   folder: string,
   userConfig: Partial<WindowsDependencyConfig> | null = {},
 ): WindowsDependencyConfig | null {
+  if (platform() !== 'win32') {
+    return null;
+  }
+
   if (userConfig === null) {
     return null;
   }
@@ -225,6 +230,8 @@ export function dependencyConfigWindows(
       const projectFile = path.join(sourceDir, project.projectFile);
 
       const projectContents = configUtils.readProjectFile(projectFile);
+
+      project.projectFile = path.relative(sourceDir, projectFile);
 
       // Calculating (auto) items
       project.projectName = configUtils.getProjectName(

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -9,6 +9,7 @@
 // guarantee correct types
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 
+import {platform} from 'os';
 import * as path from 'path';
 
 import * as configUtils from './configUtils';
@@ -38,6 +39,7 @@ opt  - Item is optional. If an override file exists, it MAY provide it. If no ov
     projectLang: string, // (auto) Language of the project, cpp or cs, determined from projectFile
     projectGuid: string, // (auto) Project identifier, determined from projectFile
   },
+  experimentalFeatures: Record<String, string> // (auto) Properties extracted from ExperimentalFeatures.props
 }
 
 Example react-native.config.js for a 'MyApp':
@@ -70,6 +72,7 @@ export interface WindowsProjectConfig {
   solutionFile: string;
   project: Project;
   useWinUI3?: boolean;
+  experimentalFeatures?: Record<string, string>;
 }
 
 type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
@@ -80,10 +83,16 @@ type DeepPartial<T> = {[P in keyof T]?: DeepPartial<T[P]>};
  * @param userConfig A manually specified override config.
  * @return The config if any RNW apps exist.
  */
+// Disabled due to existing high cyclomatic complexity
+// eslint-disable-next-line complexity
 export function projectConfigWindows(
   folder: string,
   userConfig: Partial<WindowsProjectConfig> | null = {},
 ): WindowsProjectConfig | null {
+  if (platform() !== 'win32') {
+    return null;
+  }
+
   if (userConfig === null) {
     return null;
   }
@@ -104,6 +113,7 @@ export function projectConfigWindows(
     sourceDir: path.relative(folder, sourceDir),
   };
 
+  let validSolution = false;
   let validProject = false;
 
   if (usingManualOverride) {
@@ -115,7 +125,8 @@ export function projectConfigWindows(
       result.solutionFile =
         'Error: Solution file is null in react-native.config.';
     } else {
-      result.solutionFile = userConfig.solutionFile;
+      result.solutionFile = path.normalize(userConfig.solutionFile!);
+      validSolution = true;
     }
 
     // Manual override, try to use it for project
@@ -140,7 +151,7 @@ export function projectConfigWindows(
         };
       } else {
         result.project = {
-          projectFile: userConfig.project.projectFile,
+          projectFile: path.normalize(userConfig.project.projectFile),
         };
         validProject = true;
       }
@@ -159,7 +170,8 @@ export function projectConfigWindows(
       result.solutionFile =
         'Error: Too many app solution files found, please specify in react-native.config.';
     } else {
-      result.solutionFile = foundSolutions[0];
+      result.solutionFile = path.normalize(foundSolutions[0]);
+      validSolution = true;
     }
 
     // No manually provided project, try to find it
@@ -176,15 +188,32 @@ export function projectConfigWindows(
       };
     } else {
       result.project = {
-        projectFile: foundProjects[0],
+        projectFile: path.normalize(foundProjects[0]),
       };
       validProject = true;
+    }
+  }
+
+  if (validSolution) {
+    result.solutionFile = path.relative(
+      sourceDir,
+      path.join(sourceDir, result.solutionFile),
+    );
+
+    // Populating experimental features from ExperimentalFeatures.props
+    const experimentalFeatures = configUtils.getExperimentalFeatures(
+      path.dirname(path.join(sourceDir, result.solutionFile)),
+    );
+    if (experimentalFeatures) {
+      result.experimentalFeatures = experimentalFeatures;
     }
   }
 
   if (validProject) {
     const projectFile = path.join(sourceDir, result.project.projectFile!);
     const projectContents = configUtils.readProjectFile(projectFile);
+
+    result.project.projectFile = path.relative(sourceDir, projectFile);
 
     // Add missing (auto) items
     result.project.projectName = configUtils.getProjectName(
@@ -193,6 +222,18 @@ export function projectConfigWindows(
     );
     result.project.projectLang = configUtils.getProjectLanguage(projectFile);
     result.project.projectGuid = configUtils.getProjectGuid(projectContents);
+
+    // Since we moved the UseExperimentalNuget property from the project to the
+    // ExperimentalFeatures.props file, we should should double-check the project file
+    // in case it was made with an older template
+    const useExperimentalNuget = configUtils.tryFindPropertyValue(
+      projectContents,
+      'UseExperimentalNuget',
+    );
+    if (useExperimentalNuget) {
+      result.experimentalFeatures = result.experimentalFeatures ?? {};
+      result.experimentalFeatures.UseExperimentalNuget = useExperimentalNuget;
+    }
   }
 
   return result as WindowsProjectConfig;

--- a/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
+++ b/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
@@ -82,8 +82,50 @@ Object {
 }
 `;
 
+exports[`projectConfig - WithExperimentalFeaturesProps (Ignore react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "false",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithExperimentalFeaturesProps",
+  "project": Object {
+    "projectFile": "WithExperimentalFeaturesProps\\\\WithExperimentalFeaturesProps.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithExperimentalFeaturesProps",
+  },
+  "solutionFile": "WithExperimentalFeaturesProps.sln",
+  "sourceDir": "windows",
+}
+`;
+
+exports[`projectConfig - WithExperimentalFeaturesProps (Use react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "false",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithExperimentalFeaturesProps",
+  "project": Object {
+    "projectFile": "WithExperimentalFeaturesProps\\\\WithExperimentalFeaturesProps.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithExperimentalFeaturesProps",
+  },
+  "solutionFile": "WithExperimentalFeaturesProps.sln",
+  "sourceDir": "windows",
+}
+`;
+
 exports[`projectConfig - WithIndirectDependency (Ignore react-native.config.js) 1`] = `
 Object {
+  "experimentalFeatures": Object {
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
   "folder": StringContaining "WithIndirectDependency",
   "project": Object {
     "projectFile": "Error: Too many app project files found, please specify in react-native.config.",
@@ -95,6 +137,10 @@ Object {
 
 exports[`projectConfig - WithIndirectDependency (Use react-native.config.js) 1`] = `
 Object {
+  "experimentalFeatures": Object {
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
   "folder": StringContaining "WithIndirectDependency",
   "project": Object {
     "projectFile": "WithIndirectDependency\\\\WithIndirectDependency.vcxproj",
@@ -108,8 +154,89 @@ Object {
 }
 `;
 
+exports[`projectConfig - WithUseExperimentalNuget (Ignore react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "true",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithUseExperimentalNuget",
+  "project": Object {
+    "projectFile": "WithUseExperimentalNuget\\\\WithUseExperimentalNuget.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithUseExperimentalNuget",
+  },
+  "solutionFile": "WithUseExperimentalNuget.sln",
+  "sourceDir": "windows",
+}
+`;
+
+exports[`projectConfig - WithUseExperimentalNuget (Use react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "true",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithUseExperimentalNuget",
+  "project": Object {
+    "projectFile": "WithUseExperimentalNuget\\\\WithUseExperimentalNuget.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithUseExperimentalNuget",
+  },
+  "solutionFile": "WithUseExperimentalNuget.sln",
+  "sourceDir": "windows",
+}
+`;
+
+exports[`projectConfig - WithUseExperimentalNugetSetInProject (Ignore react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "true",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithUseExperimentalNugetSetInProject",
+  "project": Object {
+    "projectFile": "WithUseExperimentalNugetSetInProject\\\\WithUseExperimentalNugetSetInProject.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithUseExperimentalNugetSetInProject",
+  },
+  "solutionFile": "WithUseExperimentalNugetSetInProject.sln",
+  "sourceDir": "windows",
+}
+`;
+
+exports[`projectConfig - WithUseExperimentalNugetSetInProject (Use react-native.config.js) 1`] = `
+Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "true",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
+  "folder": StringContaining "WithUseExperimentalNugetSetInProject",
+  "project": Object {
+    "projectFile": "WithUseExperimentalNugetSetInProject\\\\WithUseExperimentalNugetSetInProject.vcxproj",
+    "projectGuid": "{af576cbe-1aea-498d-be37-e9849a5fbf1b}",
+    "projectLang": "cpp",
+    "projectName": "WithUseExperimentalNugetSetInProject",
+  },
+  "solutionFile": "WithUseExperimentalNugetSetInProject.sln",
+  "sourceDir": "windows",
+}
+`;
+
 exports[`projectConfig - WithWinUI3 (Ignore react-native.config.js) 1`] = `
 Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "false",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
   "folder": StringContaining "WithWinUI3",
   "project": Object {
     "projectFile": "WithWinUI3\\\\WithWinUI3.vcxproj",
@@ -124,6 +251,11 @@ Object {
 
 exports[`projectConfig - WithWinUI3 (Use react-native.config.js) 1`] = `
 Object {
+  "experimentalFeatures": Object {
+    "UseExperimentalNuget": "false",
+    "UseHermes": "false",
+    "UseWinUI3": "false",
+  },
   "folder": StringContaining "WithWinUI3",
   "project": Object {
     "projectFile": "WithWinUI3\\\\WithWinUI3.vcxproj",
@@ -149,8 +281,14 @@ exports[`useWinUI3=true in react-native.config.js, useWinUI3=false in Experiment
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <Project xmlns=\\"http://schemas.microsoft.com/developer/msbuild/2003\\">
 
+  <!--
+    This file contains some important settings that will apply globally for
+    your app and *all* native modules your app consumes. These values were
+    set when you created the app project, and in some cases cannot be
+    simply changed here without recreating a new project.
+  -->
+
   <PropertyGroup Label=\\"Microsoft.ReactNative Experimental Features\\">
-    
     <!--
       Enables default usage of Hermes.
       
@@ -165,6 +303,15 @@ exports[`useWinUI3=true in react-native.config.js, useWinUI3=false in Experiment
       See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
     <UseWinUI3>true</UseWinUI3>
+
+    <!--
+      Changes compilation to assume use of Microsoft.ReactNative NuGet packages
+      instead of building the framework from source.
+      Requires creation of new project.
+
+      See https://microsoft.github.io/react-native-windows/docs/nuget
+    -->
+    <UseExperimentalNuget>false</UseExperimentalNuget>
   
   </PropertyGroup>
 

--- a/packages/@react-native-windows/cli/src/e2etest/dependencyConfig.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/dependencyConfig.test.ts
@@ -115,9 +115,8 @@ test.each(projects)(
     }
 
     const userConfig = null;
-    const expectedConfig: WindowsDependencyConfig | null = null;
 
-    expect(dependencyConfigWindows(folder, userConfig)).toBe(expectedConfig);
+    expect(dependencyConfigWindows(folder, userConfig)).toBeNull();
   },
 );
 

--- a/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/projectConfig.test.ts
@@ -102,6 +102,9 @@ const projects: TargetProject[] = [
     await ensureWinUI3Project(folder);
   }),
   project('WithIndirectDependency'),
+  project('WithExperimentalFeaturesProps'),
+  project('WithUseExperimentalNuget'),
+  project('WithUseExperimentalNugetSetInProject'),
 ];
 
 // Tests that given userConfig is null, the result will always be null

--- a/packages/@react-native-windows/cli/src/e2etest/projectConfig.utils.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/projectConfig.utils.ts
@@ -27,6 +27,7 @@ export async function ensureWinUI3Project(folder: string) {
     projectGuidLower: testProjectGuid.toLowerCase(),
     useWinUI3: false,
     useHermes: false,
+    useExperimentalNuget: false,
     packagesConfigCppNugetPackages: [
       {
         id: 'Microsoft.ReactNative.Cxx',

--- a/packages/@react-native-windows/cli/src/e2etest/projects/BlankApp/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/BlankApp/react-native.config.js
@@ -3,6 +3,4 @@ module.exports = {
   project: {
     windows: null,
   },
-  expectedConfig: null,
-  expectedConfigIgnoringOverride: null,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/BlankLib/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/BlankLib/react-native.config.js
@@ -5,6 +5,4 @@ module.exports = {
       windows: null,
     }
   },
-  expectedConfig: null,
-  expectedConfigIgnoringOverride: null,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/MissingProjectFilesApp/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/MissingProjectFilesApp/react-native.config.js
@@ -2,26 +2,8 @@ const projectConfig = {
   sourceDir: 'windows',
 };
 
-const expectedConfig = {
-  sourceDir: 'windows',
-  solutionFile: 'Error: Solution file is required but not specified in react-native.config.',
-  project: {
-    projectFile: 'Error: Project is required but not specified in react-native.config.',
-  },
-};
-
-const expectedConfigIgnoringOverride = {
-  sourceDir: 'windows',
-  solutionFile: 'Error: No app solution file found, please specify in react-native.config.',
-  project: {
-    projectFile: 'Error: No app project file found, please specify in react-native.config.',
-  },
-};
-
 module.exports = {
   project: {
     windows: projectConfig,
   },
-  expectedConfig: expectedConfig,
-  expectedConfigIgnoringOverride: expectedConfigIgnoringOverride,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/MissingProjectFilesLib/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/MissingProjectFilesLib/react-native.config.js
@@ -2,19 +2,10 @@ const projectConfig = {
   sourceDir: 'windows',
 };
 
-const expectedConfig = {
-  sourceDir: 'windows',
-  solutionFile: null,
-  projects: [],
-  nugetPackages: [],
-};
-
 module.exports = {
   dependency: {
     platforms: {
       windows: projectConfig,
     }
   },
-  expectedConfig: expectedConfig,
-  expectedConfigIgnoringOverride: expectedConfig,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/SimpleCSharpLib/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/SimpleCSharpLib/react-native.config.js
@@ -7,29 +7,10 @@ const projectConfig = {
   },
 };
 
-const expectedConfig = {
-  sourceDir: 'windows',
-  solutionFile: 'SimpleCSharpLib.sln',
-  projects: [{
-    projectFile: 'SimpleCSharpLib\\SimpleCSharpLib.csproj',
-    directDependency: true,
-    projectName: 'SimpleCSharpLib',
-    projectLang: 'cs',
-    projectGuid: '{416476D5-974A-4EE2-8145-4E331297247E}',
-    cppHeaders: ["winrt/SimpleCSharpLib.h"],
-    cppPackageProviders: ["SimpleCSharpLib::ReactPackageProvider"],
-    csNamespaces: ["SimpleCSharpLib"],
-    csPackageProviders: ["SimpleCSharpLib.ReactPackageProvider"],
-  }],
-  nugetPackages: [],
-};
-
 module.exports = {
   dependency: {
     platforms: {
       windows: projectConfig,
     }
   },
-  expectedConfig: expectedConfig,
-  expectedConfigIgnoringOverride: expectedConfig,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/SimpleCppLib/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/SimpleCppLib/react-native.config.js
@@ -7,29 +7,10 @@ const projectConfig = {
   },
 };
 
-const expectedConfig = {
-  sourceDir: 'windows',
-  solutionFile: 'SimpleCppLib.sln',
-  projects: [{
-    projectFile: 'SimpleCppLib\\SimpleCppLib.vcxproj',
-    directDependency: true,
-    projectName: 'SimpleCppLib',
-    projectLang: 'cpp',
-    projectGuid: '{416476d5-974a-4ee2-8145-4e331297247e}',
-    cppHeaders: ["winrt/SimpleCppLib.h"],
-    cppPackageProviders: ["SimpleCppLib::ReactPackageProvider"],
-    csNamespaces: ["SimpleCppLib"],
-    csPackageProviders: ["SimpleCppLib.ReactPackageProvider"],
-  }],
-  nugetPackages: [],
-};
-
 module.exports = {
   dependency: {
     platforms: {
       windows: projectConfig,
     }
   },
-  expectedConfig: expectedConfig,
-  expectedConfigIgnoringOverride: expectedConfig,
 };

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/.gitignore
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/.gitignore
@@ -1,0 +1,1 @@
+windows/

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/react-native.config.js
@@ -1,0 +1,13 @@
+const projectConfig = {
+  sourceDir: 'windows',
+  solutionFile: 'WithExperimentalFeaturesProps.sln',
+  project: {
+    projectFile: 'WithExperimentalFeaturesProps\\WithExperimentalFeaturesProps.vcxproj',
+  },
+};
+
+module.exports = {
+  project: {
+    windows: projectConfig,
+  },
+};

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/ExperimentalFeatures.props
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/ExperimentalFeatures.props
@@ -14,7 +14,7 @@
       
       See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
-    <UseHermes>{{useHermes}}</UseHermes>
+    <UseHermes>false</UseHermes>
 
     <!--
       Changes compilation to assume use of WinUI 3 instead of System XAML.
@@ -22,16 +22,16 @@
 
       See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
-    <UseWinUI3>{{useWinUI3}}</UseWinUI3>
+    <UseWinUI3>false</UseWinUI3>
 
     <!--
       Changes compilation to assume use of Microsoft.ReactNative NuGet packages
       instead of building the framework from source.
       Requires creation of new project.
-
+      
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
-    <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
+    <UseExperimentalNuget>false</UseExperimentalNuget>
   
   </PropertyGroup>
 

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/WithExperimentalFeaturesProps.sln
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/WithExperimentalFeaturesProps.sln
@@ -1,0 +1,156 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WithExperimentalFeaturesProps", "WithExperimentalFeaturesProps\WithExperimentalFeaturesProps.vcxproj", "{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {F7D32BD0-2749-483E-9A0D-1635EF7E3136}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Folly", "..\node_modules\react-native-windows\Folly\Folly.vcxproj", "{A990658C-CE31-4BCC-976F-0FC6B1AF693D}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fmt", "..\node_modules\react-native-windows\fmt\fmt.vcxproj", "{14B93DC8-FD93-4A6D-81CB-8BC96644501C}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactCommon", "..\node_modules\react-native-windows\ReactCommon\ReactCommon.vcxproj", "{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}"
+	ProjectSection(ProjectDependencies) = postProject
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {A990658C-CE31-4BCC-976F-0FC6B1AF693D}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Chakra", "..\node_modules\react-native-windows\Chakra\Chakra.vcxitems", "{C38970C0-5FBF-4D69-90D8-CBAC225AE895}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative", "..\node_modules\react-native-windows\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj", "{F7D32BD0-2749-483E-9A0D-1635EF7E3136}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Cxx", "..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems", "{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "..\node_modules\react-native-windows\Common\Common.vcxproj", "{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ReactNative", "ReactNative", "{5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Microsoft.ReactNative.Shared", "..\node_modules\react-native-windows\Shared\Shared.vcxitems", "{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\node_modules\react-native-windows\Mso\Mso.vcxitems", "{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Include", "..\node_modules\react-native-windows\include\Include.vcxitems", "{EF074BA1-2D54-4D49-A28E-5E040B47CD2E}"
+EndProject
+Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{84e05bfa-cbaf-4f0d-bfb6-4ce85742a57e}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{c38970c0-5fbf-4d69-90d8-cbac225ae895}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{da8b35b3-da00-4b02-bde6-6a397b3fd46b}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\include\Include.vcxitems*{ef074ba1-2d54-4d49-a28e-5e040b47cd2e}*SharedItemsImports = 9
+		..\node_modules\react-native-windows\Chakra\Chakra.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\node_modules\react-native-windows\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\node_modules\react-native-windows\Mso\Mso.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+		..\node_modules\react-native-windows\Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|ARM64.Build.0 = Debug|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x64.ActiveCfg = Debug|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x64.Build.0 = Debug|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x64.Deploy.0 = Debug|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x86.ActiveCfg = Debug|Win32
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x86.Build.0 = Debug|Win32
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Debug|x86.Deploy.0 = Debug|Win32
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|ARM64.Build.0 = Release|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|ARM64.Deploy.0 = Release|ARM64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x64.ActiveCfg = Release|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x64.Build.0 = Release|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x64.Deploy.0 = Release|x64
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x86.ActiveCfg = Release|Win32
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x86.Build.0 = Release|Win32
+		{AF576CBE-1AEA-498D-BE37-E9849A5FBF1B}.Release|x86.Deploy.0 = Release|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|ARM64.Build.0 = Debug|ARM64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.ActiveCfg = Debug|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x64.Build.0 = Debug|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x86.ActiveCfg = Debug|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Debug|x86.Build.0 = Debug|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|ARM64.ActiveCfg = Release|ARM64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|ARM64.Build.0 = Release|ARM64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x64.ActiveCfg = Release|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x64.Build.0 = Release|x64
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x86.ActiveCfg = Release|Win32
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D}.Release|x86.Build.0 = Release|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|ARM64.Build.0 = Debug|ARM64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x64.ActiveCfg = Debug|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x64.Build.0 = Debug|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x86.ActiveCfg = Debug|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Debug|x86.Build.0 = Debug|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|ARM64.ActiveCfg = Release|ARM64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|ARM64.Build.0 = Release|ARM64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x64.ActiveCfg = Release|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x64.Build.0 = Release|x64
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x86.ActiveCfg = Release|Win32
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD}.Release|x86.Build.0 = Release|Win32
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|ARM64.Build.0 = Debug|ARM64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|x64.ActiveCfg = Debug|x64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|x64.Build.0 = Debug|x64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|x86.ActiveCfg = Debug|Win32
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|x86.Build.0 = Debug|Win32
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|ARM64.ActiveCfg = Release|ARM64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|ARM64.Build.0 = Release|ARM64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|x64.ActiveCfg = Release|x64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|x64.Build.0 = Release|x64
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|x86.ActiveCfg = Release|Win32
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Release|x86.Build.0 = Release|Win32
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|ARM64.Build.0 = Debug|ARM64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|x64.ActiveCfg = Debug|x64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|x64.Build.0 = Debug|x64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|x86.ActiveCfg = Debug|Win32
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Debug|x86.Build.0 = Debug|Win32
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|ARM64.ActiveCfg = Release|ARM64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|ARM64.Build.0 = Release|ARM64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x64.ActiveCfg = Release|x64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x64.Build.0 = Release|x64
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.ActiveCfg = Release|Win32
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D}.Release|x86.Build.0 = Release|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|ARM64.Build.0 = Debug|ARM64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|x64.ActiveCfg = Debug|x64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|x64.Build.0 = Debug|x64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|x86.ActiveCfg = Debug|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|x86.Build.0 = Debug|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Debug|x86.Deploy.0 = Debug|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|ARM64.ActiveCfg = Release|ARM64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|ARM64.Build.0 = Release|ARM64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x64.ActiveCfg = Release|x64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x64.Build.0 = Release|x64
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.ActiveCfg = Release|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Build.0 = Release|Win32
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C}.Release|x86.Deploy.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A990658C-CE31-4BCC-976F-0FC6B1AF693D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{A9D95A91-4DB7-4F72-BEB6-FE8A5C89BFBD} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{C38970C0-5FBF-4D69-90D8-CBAC225AE895} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{F7D32BD0-2749-483E-9A0D-1635EF7E3136} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{DA8B35B3-DA00-4B02-BDE6-6A397B3FD46B} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{FCA38F3C-7C73-4C47-BE4E-32F77FA8538D} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{2049DBE9-8D13-42C9-AE4B-413AE38FFFD0} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{84E05BFA-CBAF-4F0D-BFB6-4CE85742A57E} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{EF074BA1-2D54-4D49-A28E-5E040B47CD2E} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+		{14B93DC8-FD93-4A6D-81CB-8BC96644501C} = {5EA20F54-880A-49F3-99FA-4B3FE54E8AB1}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}
+	EndGlobalSection
+EndGlobal

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/WithExperimentalFeaturesProps/WithExperimentalFeaturesProps.vcxproj
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithExperimentalFeaturesProps/windows/WithExperimentalFeaturesProps/WithExperimentalFeaturesProps.vcxproj
@@ -1,29 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
-  {{#cppNugetPackages}}
-  {{#propsTopOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsTopOfFile}}
-  {{/cppNugetPackages}}
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
-    <ProjectGuid>{{ projectGuidLower }}</ProjectGuid>
-    <ProjectName>{{ name }}</ProjectName>
-    <RootNamespace>{{ namespace }}</RootNamespace>
+    <ProjectGuid>{af576cbe-1aea-498d-be37-e9849a5fbf1b}</ProjectGuid>
+    <ProjectName>WithExperimentalFeaturesProps</ProjectName>
+    <RootNamespace>WithExperimentalFeaturesProps</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
-    <PackageCertificateKeyFile>{{ name }}_TemporaryKey.pfx</PackageCertificateKeyFile>
-    {{#certificateThumbprint}}
-    <PackageCertificateThumbprint>{{certificateThumbprint}}</PackageCertificateThumbprint>
-    {{/certificateThumbprint}}
+    <PackageCertificateKeyFile>WithExperimentalFeaturesProps_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>62D35D02DA7BC8704E386C104C9F69A878FC864E</PackageCertificateThumbprint>
     <PackageCertificatePassword>password</PackageCertificatePassword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -69,11 +63,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  {{#cppNugetPackages}}
-  {{#propsMiddleOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsMiddleOfFile}}
-  {{/cppNugetPackages}}
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings"></ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -186,25 +175,17 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    {{#cppNugetPackages}}
-    {{#hasTargets}}
-    <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    {{#cppNugetPackages}}
-    {{#hasProps}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props'))" />
-    {{/hasProps}}
-    {{#hasTargets}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets'))" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
   </Target>
 </Project>

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/.gitignore
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/.gitignore
@@ -1,0 +1,1 @@
+windows/

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/react-native.config.js
@@ -1,8 +1,8 @@
 const projectConfig = {
   sourceDir: 'windows',
-  solutionFile: 'SimpleCSharpApp.sln',
+  solutionFile: 'WithUseExperimentalNuget.sln',
   project: {
-    projectFile: 'SimpleCSharpApp\\SimpleCSharpApp.csproj',
+    projectFile: 'WithUseExperimentalNuget\\WithUseExperimentalNuget.vcxproj',
   },
 };
 

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/ExperimentalFeatures.props
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/ExperimentalFeatures.props
@@ -14,7 +14,7 @@
       
       See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
-    <UseHermes>{{useHermes}}</UseHermes>
+    <UseHermes>false</UseHermes>
 
     <!--
       Changes compilation to assume use of WinUI 3 instead of System XAML.
@@ -22,16 +22,16 @@
 
       See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
-    <UseWinUI3>{{useWinUI3}}</UseWinUI3>
+    <UseWinUI3>false</UseWinUI3>
 
     <!--
       Changes compilation to assume use of Microsoft.ReactNative NuGet packages
       instead of building the framework from source.
       Requires creation of new project.
-
+      
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
-    <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
+    <UseExperimentalNuget>true</UseExperimentalNuget>
   
   </PropertyGroup>
 

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/WithUseExperimentalNuget.sln
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/WithUseExperimentalNuget.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WithUseExperimentalNuget", "WithUseExperimentalNuget\WithUseExperimentalNuget.vcxproj", "{67A2EE22-34E3-4F4F-9D39-8828EB380361}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.Build.0 = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.ActiveCfg = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.Build.0 = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.Deploy.0 = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.ActiveCfg = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.Build.0 = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.Deploy.0 = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.ActiveCfg = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.Build.0 = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.Deploy.0 = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.ActiveCfg = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.Build.0 = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.Deploy.0 = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.ActiveCfg = Release|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.Build.0 = Release|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.Deploy.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}
+	EndGlobalSection
+EndGlobal

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/WithUseExperimentalNuget/WithUseExperimentalNuget.vcxproj
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNuget/windows/WithUseExperimentalNuget/WithUseExperimentalNuget.vcxproj
@@ -1,29 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
-  {{#cppNugetPackages}}
-  {{#propsTopOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsTopOfFile}}
-  {{/cppNugetPackages}}
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
-    <ProjectGuid>{{ projectGuidLower }}</ProjectGuid>
-    <ProjectName>{{ name }}</ProjectName>
-    <RootNamespace>{{ namespace }}</RootNamespace>
+    <ProjectGuid>{af576cbe-1aea-498d-be37-e9849a5fbf1b}</ProjectGuid>
+    <ProjectName>WithUseExperimentalNuget</ProjectName>
+    <RootNamespace>WithUseExperimentalNuget</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
-    <PackageCertificateKeyFile>{{ name }}_TemporaryKey.pfx</PackageCertificateKeyFile>
-    {{#certificateThumbprint}}
-    <PackageCertificateThumbprint>{{certificateThumbprint}}</PackageCertificateThumbprint>
-    {{/certificateThumbprint}}
+    <PackageCertificateKeyFile>WithUseExperimentalNuget_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>62D35D02DA7BC8704E386C104C9F69A878FC864E</PackageCertificateThumbprint>
     <PackageCertificatePassword>password</PackageCertificatePassword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -69,11 +63,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  {{#cppNugetPackages}}
-  {{#propsMiddleOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsMiddleOfFile}}
-  {{/cppNugetPackages}}
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings"></ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -186,25 +175,17 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    {{#cppNugetPackages}}
-    {{#hasTargets}}
-    <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    {{#cppNugetPackages}}
-    {{#hasProps}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props'))" />
-    {{/hasProps}}
-    {{#hasTargets}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets'))" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
   </Target>
 </Project>

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/.gitignore
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/.gitignore
@@ -1,0 +1,1 @@
+windows/

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/react-native.config.js
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/react-native.config.js
@@ -1,0 +1,13 @@
+const projectConfig = {
+  sourceDir: 'windows',
+  solutionFile: 'WithUseExperimentalNugetSetInProject.sln',
+  project: {
+    projectFile: 'WithUseExperimentalNugetSetInProject\\WithUseExperimentalNugetSetInProject.vcxproj',
+  },
+};
+
+module.exports = {
+  project: {
+    windows: projectConfig,
+  },
+};

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/ExperimentalFeatures.props
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/ExperimentalFeatures.props
@@ -14,7 +14,7 @@
       
       See https://microsoft.github.io/react-native-windows/docs/hermes
     -->
-    <UseHermes>{{useHermes}}</UseHermes>
+    <UseHermes>false</UseHermes>
 
     <!--
       Changes compilation to assume use of WinUI 3 instead of System XAML.
@@ -22,16 +22,7 @@
 
       See https://microsoft.github.io/react-native-windows/docs/winui3
     -->
-    <UseWinUI3>{{useWinUI3}}</UseWinUI3>
-
-    <!--
-      Changes compilation to assume use of Microsoft.ReactNative NuGet packages
-      instead of building the framework from source.
-      Requires creation of new project.
-
-      See https://microsoft.github.io/react-native-windows/docs/nuget
-    -->
-    <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
+    <UseWinUI3>false</UseWinUI3>
   
   </PropertyGroup>
 

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/WithUseExperimentalNugetSetInProject.sln
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/WithUseExperimentalNugetSetInProject.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29215.179
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "WithUseExperimentalNugetSetInProject", "WithUseExperimentalNugetSetInProject\WithUseExperimentalNugetSetInProject.vcxproj", "{67A2EE22-34E3-4F4F-9D39-8828EB380361}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.Build.0 = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.ActiveCfg = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.Build.0 = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x64.Deploy.0 = Debug|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.ActiveCfg = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.Build.0 = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Debug|x86.Deploy.0 = Debug|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.ActiveCfg = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.Build.0 = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|ARM64.Deploy.0 = Release|ARM64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.ActiveCfg = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.Build.0 = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x64.Deploy.0 = Release|x64
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.ActiveCfg = Release|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.Build.0 = Release|Win32
+		{67A2EE22-34E3-4F4F-9D39-8828EB380361}.Release|x86.Deploy.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D43FAD39-F619-437D-BB40-04A3982ACB6A}
+	EndGlobalSection
+EndGlobal

--- a/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/WithUseExperimentalNugetSetInProject/WithUseExperimentalNugetSetInProject.vcxproj
+++ b/packages/@react-native-windows/cli/src/e2etest/projects/WithUseExperimentalNugetSetInProject/windows/WithUseExperimentalNugetSetInProject/WithUseExperimentalNugetSetInProject.vcxproj
@@ -1,34 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
-  {{#cppNugetPackages}}
-  {{#propsTopOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsTopOfFile}}
-  {{/cppNugetPackages}}
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
   <PropertyGroup Label="Globals">
     <CppWinRTOptimized>true</CppWinRTOptimized>
     <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
     <MinimalCoreWin>true</MinimalCoreWin>
-    <ProjectGuid>{{ projectGuidLower }}</ProjectGuid>
-    <ProjectName>{{ name }}</ProjectName>
-    <RootNamespace>{{ namespace }}</RootNamespace>
+    <ProjectGuid>{af576cbe-1aea-498d-be37-e9849a5fbf1b}</ProjectGuid>
+    <ProjectName>WithUseExperimentalNugetSetInProject</ProjectName>
+    <RootNamespace>WithUseExperimentalNugetSetInProject</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
-    <PackageCertificateKeyFile>{{ name }}_TemporaryKey.pfx</PackageCertificateKeyFile>
-    {{#certificateThumbprint}}
-    <PackageCertificateThumbprint>{{certificateThumbprint}}</PackageCertificateThumbprint>
-    {{/certificateThumbprint}}
+    <PackageCertificateKeyFile>WithUseExperimentalNugetSetInProject_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>62D35D02DA7BC8704E386C104C9F69A878FC864E</PackageCertificateThumbprint>
     <PackageCertificatePassword>password</PackageCertificatePassword>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+    <UseExperimentalNuget>true</UseExperimentalNuget>    <!-- This will eventually default to true and this property should be removed -->
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -69,11 +64,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  {{#cppNugetPackages}}
-  {{#propsMiddleOfFile}}
-  <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" />
-  {{/propsMiddleOfFile}}
-  {{/cppNugetPackages}}
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings"></ImportGroup>
   <ImportGroup Label="PropertySheets">
@@ -186,25 +176,17 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    {{#cppNugetPackages}}
-    {{#hasTargets}}
-    <Import Project="..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets" Condition="Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    {{#cppNugetPackages}}
-    {{#hasProps}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.props'))" />
-    {{/hasProps}}
-    {{#hasTargets}}
-    <Error Condition="!Exists('..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\{{ id }}.{{ version }}\build\native\{{ id }}.targets'))" />
-    {{/hasTargets}}
-    {{/cppNugetPackages}}
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
   </Target>
 </Project>

--- a/vnext/template/cpp-lib/proj/MyLib.vcxproj
+++ b/vnext/template/cpp-lib/proj/MyLib.vcxproj
@@ -24,9 +24,6 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
-    {{#useExperimentalNuget}}
-    <UseExperimentalNuget>true</UseExperimentalNuget>    <!-- This will eventually default to true and this property should be removed -->
-    {{/useExperimentalNuget}}
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">

--- a/vnext/template/cs-app/proj/MyApp.csproj
+++ b/vnext/template/cs-app/proj/MyApp.csproj
@@ -28,9 +28,6 @@
     <PackageCertificatePassword>password</PackageCertificatePassword>
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.3</LangVersion>
-    {{#useExperimentalNuget}}
-    <UseExperimentalNuget>true</UseExperimentalNuget>    <!-- This will eventually default to true and this property should be removed -->
-    {{/useExperimentalNuget}}
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/template/cs-lib/proj/MyLib.csproj
+++ b/vnext/template/cs-lib/proj/MyLib.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
@@ -21,9 +22,6 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <LangVersion>7.3</LangVersion>
-    {{#useExperimentalNuget}}
-    <UseExperimentalNuget>true</UseExperimentalNuget>    <!-- This will eventually default to true and this property should be removed -->
-    {{/useExperimentalNuget}}
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/template/shared-lib/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-lib/proj/ExperimentalFeatures.props
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <AppProjectExperimentalFeaturesProps Condition="'$(AppProjectExperimentalFeaturesProps)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'windows\ExperimentalFeatures.props'))\windows\ExperimentalFeatures.props</AppProjectExperimentalFeaturesProps>
-  </PropertyGroup>
-  <Import Project="$(AppProjectExperimentalFeaturesProps)" Condition="Exists('$(AppProjectExperimentalFeaturesProps)')"/>
+
+  <!--
+    Application projects contain a file with this name to specify some important settings
+    that will apply globally for the app and *all* native modules the app consumes. These
+    values are set by the app developer.
+  -->
+
 </Project>


### PR DESCRIPTION
This PR backports #8402 (also #7980 and #7982) to 0.65.

Original commit messages:

Add experimentalFeatures to projectConfig result (#8402)

Experimental, build-wide settings (such as using the RNW nuget packages, or using Hermes instead of Chakra, or using WinUI3) are set in the `ExperimentalFeatures.props` file in the solution directory of RNW apps.

Sometimes we want the RNW CLI itself to behave differently given this information, specifically we want to report some of this data via telemetry.

This PR:

* Adds parsing of the properties in this props file to the project config (i.e. the windows result from calling `react-native config`)
* Moves the `UseExperimentalNuget` flag out of the project templates and into the `ExperimentalFeatures.props` file, so that modules loaded from elsewhere (say node_modules) can also access the property's value (keeping an app and it's modules in sync)
* Adds logic to make sure that the config still detects `UseExperimentalNuget` present within the project files of projects built using the old template logic
* Adds new tests to cover this new functionality
* Cleans up the project config tests to remove the unused "expected" objects when the the jest snapshots are doing the real validation

Disable project/dependency config when not running on windows (#7980)

This PR adds a check to project and dependency config to bail when not
running on windows, since we assume non-windows machines don't need the
windows config information.

Normalize paths provided by react-native.config.js (#7982)

* Normalize paths provided by react-native.config.js

This PR makes sure that raw paths specified in a react-native.config.js
are normalized when config is run, before the result is passed up to
whichever CLI command called for it.

Closes #7979

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8428)