### PR TITLE
Enable inlineRequires for all projects

### DIFF
--- a/change/@office-iss-react-native-win32-a2bf706d-8737-4b7b-9cc4-5849dbefaf02.json
+++ b/change/@office-iss-react-native-win32-a2bf706d-8737-4b7b-9cc4-5849dbefaf02.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable inlineRequires for all projects",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-51809f92-5a38-4f18-8302-ac6a93f8589e.json
+++ b/change/react-native-windows-51809f92-5a38-4f18-8302-ac6a93f8589e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable inlineRequires for all projects",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/metro.config.js
+++ b/packages/@office-iss/react-native-win32/metro.config.js
@@ -42,7 +42,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },

--- a/packages/e2e-test-app/metro.config.js
+++ b/packages/e2e-test-app/metro.config.js
@@ -68,7 +68,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },

--- a/packages/sample-apps/metro.config.js
+++ b/packages/sample-apps/metro.config.js
@@ -55,7 +55,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },

--- a/vnext/metro.config.js
+++ b/vnext/metro.config.js
@@ -68,7 +68,7 @@ module.exports = {
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
-        inlineRequires: false,
+        inlineRequires: true,
       },
     }),
   },


### PR DESCRIPTION
This has been the default behavior since 0.64, and our template was updated, but some of the metro configurations in our repo are on the old behavior. Enable inlineRequires everywhere. The most significant affected being e2e-test-app.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8434)