### PR TITLE
Fix crash in NativeUIManager when processing extra layout nodes

### DIFF
--- a/change/react-native-windows-b4f125ea-015b-4c96-a89a-906de480fe68.json
+++ b/change/react-native-windows-b4f125ea-015b-4c96-a89a-906de480fe68.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in NativeUIManager when handling \"extra layout\" nodes",
+  "packageName": "react-native-windows",
+  "email": "aschultz@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -892,9 +892,11 @@ void NativeUIManager::DoLayout() {
   // Process vector of RN controls needing extra layout here.
   const auto extraLayoutNodes = m_extraLayoutNodes;
   for (const int64_t tag : extraLayoutNodes) {
-    ShadowNodeBase &node = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    auto element = node.GetView().as<xaml::FrameworkElement>();
-    element.UpdateLayout();
+    ShadowNodeBase *node = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag));
+    if (node) {
+      auto element = node->GetView().as<xaml::FrameworkElement>();
+      element.UpdateLayout();
+    }
   }
   // Values need to be cleared from the vector before next call to DoLayout.
   m_extraLayoutNodes.clear();


### PR DESCRIPTION
Fix for #8441. Skip processing of "extra layout" nodes that were removed from the tree before DoLayout has had a chance to process them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8449)