### PR TITLE
Support 'focusable' prop on all ControlViewManager-derived components

### DIFF
--- a/change/react-native-windows-9824cf9a-62b1-400e-b905-e9fb51a82809.json
+++ b/change/react-native-windows-9824cf9a-62b1-400e-b905-e9fb51a82809.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable use of 'focusable' prop on ControlViewManager-derived controls",
+  "packageName": "react-native-windows",
+  "email": "aschultz@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -14,8 +14,10 @@
 
 #ifdef USE_WINUI3
 #define TAB_INDEX_PROPERTY xaml::UIElement::TabIndexProperty
+#define TAB_STOP_PROPERTY xaml::UIElement::IsTabStopProperty
 #else
 #define TAB_INDEX_PROPERTY xaml::Controls::Control::TabIndexProperty
+#define TAB_STOP_PROPERTY xaml::Controls::Control::IsTabStopProperty
 #endif
 
 namespace Microsoft::ReactNative {
@@ -25,6 +27,7 @@ ControlViewManager::ControlViewManager(const Mso::React::IReactContext &context)
 void ControlViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
   Super::GetNativeProps(writer);
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"tabIndex", L"number");
+  winrt::Microsoft::ReactNative::WriteProperty(writer, L"focusable", L"boolean");
 }
 void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlView &newView) {
   TransferProperty(oldView, newView, xaml::Controls::Control::FontSizeProperty());
@@ -39,6 +42,7 @@ void ControlViewManager::TransferProperties(const XamlView &oldView, const XamlV
   TransferProperty(oldView, newView, xaml::Controls::Control::PaddingProperty());
   TransferProperty(oldView, newView, xaml::Controls::Control::ForegroundProperty());
   TransferProperty(oldView, newView, TAB_INDEX_PROPERTY());
+  TransferProperty(oldView, newView, TAB_STOP_PROPERTY());
 
   // Control.CornerRadius is only supported on >= RS5
   if (oldView.try_as<xaml::Controls::IControl7>() && newView.try_as<xaml::Controls::IControl7>()) {
@@ -73,6 +77,12 @@ bool ControlViewManager::UpdateProperty(
         control.TabIndex(static_cast<int32_t>(tabIndex));
       } else if (propertyValue.IsNull()) {
         control.ClearValue(TAB_INDEX_PROPERTY());
+      }
+    } else if (propertyName == "focusable") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean) {
+        control.IsTabStop(propertyValue.AsBoolean());
+      } else if (propertyValue.IsNull()) {
+        control.ClearValue(TAB_STOP_PROPERTY());
       }
     } else {
       ret = Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);


### PR DESCRIPTION
This resolves #8423.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8450)