### PR TITLE
Fix crash in KeyboardEventHandler.cpp when handling undefined keyDownEvents prop

### DIFF
--- a/change/react-native-windows-569ef05e-75d4-4af7-9197-8ebc3dca1c37.json
+++ b/change/react-native-windows-569ef05e-75d4-4af7-9197-8ebc3dca1c37.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in KeyboardHelper when provided undefined keyDownEvents prop.",
+  "packageName": "react-native-windows",
+  "email": "aschultz@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -53,10 +53,10 @@ struct json_type_traits<Microsoft::ReactNative::HandledKeyboardEvent> {
 namespace Microsoft::ReactNative {
 
 std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::ReactNative::JSValue const &obj) {
-  if (obj.IsNull()) {
-    return std::vector<HandledKeyboardEvent>{};
+  if (obj.Type() == winrt::Microsoft::ReactNative::JSValueType::Array) {
+    return json_type_traits<std::vector<HandledKeyboardEvent>>::parseJson(obj);
   }
-  return json_type_traits<std::vector<HandledKeyboardEvent>>::parseJson(obj);
+  return std::vector<HandledKeyboardEvent>{};
 }
 
 static folly::dynamic ToEventData(ReactKeyboardEvent event, double timestamp) {

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -53,6 +53,9 @@ struct json_type_traits<Microsoft::ReactNative::HandledKeyboardEvent> {
 namespace Microsoft::ReactNative {
 
 std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::ReactNative::JSValue const &obj) {
+  if (obj.IsNull()) {
+    return std::vector<HandledKeyboardEvent>{};
+  }
   return json_type_traits<std::vector<HandledKeyboardEvent>>::parseJson(obj);
 }
 


### PR DESCRIPTION
Fixes #3863

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8451)