### PR TITLE
[0.65] Use app's ExperimentalFeatures.props in library project

### DIFF
--- a/change/react-native-windows-dba9665a-a1e1-4b98-824c-21504ac6d547.json
+++ b/change/react-native-windows-dba9665a-a1e1-4b98-824c-21504ac6d547.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Lib project will use the app's ExperimentalFeatures.props",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/cs-lib/proj/MyLib.csproj
+++ b/vnext/template/cs-lib/proj/MyLib.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>

--- a/vnext/template/shared-lib/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-lib/proj/ExperimentalFeatures.props
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <AppProjectExperimentalFeaturesProps Condition="'$(AppProjectExperimentalFeaturesProps)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'windows\ExperimentalFeatures.props'))\windows\ExperimentalFeatures.props</AppProjectExperimentalFeaturesProps>
-  </PropertyGroup>
-  <Import Project="$(AppProjectExperimentalFeaturesProps)" Condition="Exists('$(AppProjectExperimentalFeaturesProps)')"/>
+
+  <!--
+    Application projects contain a file with this name to specify some important settings
+    that will apply globally for the app and *all* native modules the app consumes. These
+    values are set by the app developer.
+  -->
+
 </Project>


### PR DESCRIPTION
Already fixed in main, this partially backports #8402 / #8428  to 0.65
Fixes #8467 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8472)