### PR TITLE
[0.64] Consume Node-Api V8 JSI Runtime

### DIFF
--- a/change/react-native-windows-24c06f48-422a-4110-8886-448345a95f36.json
+++ b/change/react-native-windows-24c06f48-422a-4110-8886-448345a95f36.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.64] Consume Node-Api V8 JSI Runtime",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/.editorconfig
+++ b/vnext/.editorconfig
@@ -13,8 +13,8 @@ indent_size = 2
 [*.{c,cpp,h,hpp}]
 end_of_line = crlf
 
-# Xml project files
-[*.{config,csproj,njsproj,props,targets,vcxitems,vcxproj,vcxproj.filters}]
+# Visual Studio project files
+[*.{config,csproj,njsproj,props,targets,vcxitems,vcxitems.filters,vcxproj,vcxproj.filters}]
 end_of_line = crlf
 insert_final_newline = false
 

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -101,7 +101,6 @@
         WindowsApp_downlevel.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
-      <AdditionalDependencies>WindowsApp_downlevel.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>ChakraCore.Debugger.DLL;ChakraCore.dll;Chakra.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.ChakraCore.vc140" version="1.11.24" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.64.15" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.64.24" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.7.2" targetFramework="native" / -->

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -29,9 +29,12 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{17DD1B17-3094-40DD-9373-AC2497932ECA}</ProjectGuid>
     <ProjectName>JSI.Desktop</ProjectName>
+    <UseV8>true</UseV8>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\ReactCommunity.Cpp.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
@@ -90,6 +93,7 @@
     <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" />
+    <Import Project="$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets" Condition="Exists('$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(UseV8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild" Condition="'$(CHAKRACOREUWP)'!='true'">
     <PropertyGroup>
@@ -98,6 +102,7 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets'))" />
+    <Error Condition="!Exists('$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets') AND '$(UseV8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(V8Package)\build\native\ReactNative.V8JSI.Windows.targets'))" />
     <Error Condition="'$(Platform)' == 'ARM64' AND !Exists('$(SolutionDir)packages\ReactWindows.ChakraCore.ARM64.1.11.20\build\native\ReactWindows.ChakraCore.ARM64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.ChakraCore.ARM64.1.11.20\build\native\ReactWindows.ChakraCore.ARM64.targets'))" />
   </Target>
 </Project>

--- a/vnext/JSI/Desktop/JSI.Desktop.vcxproj
+++ b/vnext/JSI/Desktop/JSI.Desktop.vcxproj
@@ -51,13 +51,17 @@
   <PropertyGroup>
     <!-- We need $(ReactNativeWindowsDir)Chakra for ChakraCoreDebugger.h.
     We should remove it from IncludePath once we retire the ChakraExecutor stack. -->
-    <IncludePath>$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir);$(FollyDir);$(ReactNativeWindowsDir)stubs;$(ReactNativeDir)\ReactCommon;$(ReactNativeDir)ReactCommon\callinvoker;$(JSI_SourcePath);$(JSI_Source);$(ReactNativeWindowsDir)Chakra;$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <!--
+      C4459 - declaration hides global declaration
+     -->
+    <ExtraWarningsToDisable>$(ExtraWarningsToDisable);4459</ExtraWarningsToDisable>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PreprocessorDefinitions Condition="'$(CHAKRACOREUWP)'=='true'">CHAKRACORE_UWP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <PreprocessorDefinitions>CHAKRACORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>CHAKRACORE;FOLLY_NO_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- /Zc:strictStrings enforces the standard C++ const qualifications for
       string literals. It prevents code like
         wchar_t* str = L"hello";
@@ -83,6 +87,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" Condition="'$(CHAKRACOREUWP)'!='true'">
+    <Import Project="$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets')" />
     <Import Project="$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets" Condition="Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" />
   </ImportGroup>
@@ -90,6 +95,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.72.0.0\build\boost.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.ChakraCore.vc140.1.11.24\build\native\Microsoft.ChakraCore.vc140.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ChakraCore.Debugger.0.0.0.44\build\native\ChakraCore.Debugger.targets'))" />
     <Error Condition="'$(Platform)' == 'ARM64' AND !Exists('$(SolutionDir)packages\ReactWindows.ChakraCore.ARM64.1.11.20\build\native\ReactWindows.ChakraCore.ARM64.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactWindows.ChakraCore.ARM64.1.11.20\build\native\ReactWindows.ChakraCore.ARM64.targets'))" />

--- a/vnext/JSI/Desktop/packages.config
+++ b/vnext/JSI/Desktop/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="boost" version="1.72.0.0" targetFramework="native" />
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.24" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems
@@ -17,6 +17,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraApi.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraRuntime.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)ByteArrayBuffer.h" />
@@ -25,6 +26,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntimeArgs.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntimeFactory.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraRuntime.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ScriptStore.h" />
   </ItemGroup>

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems
@@ -17,7 +17,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraApi.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraRuntime.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp">
+      <ExcludedFromBuild Condition="'$(UseV8)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(MSBuildThisFileDirectory)ByteArrayBuffer.h" />

--- a/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
+++ b/vnext/JSI/Shared/JSI.Shared.vcxitems.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)ChakraCoreRuntime.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraRuntime.cpp">
@@ -42,6 +45,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)ChakraJsiRuntime_edgemode.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)NapiJsiV8RuntimeHolder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "NapiJsiV8RuntimeHolder.h"
+
+using namespace facebook::jsi;
+using namespace facebook::react;
+
+using std::shared_ptr;
+using std::unique_ptr;
+
+namespace Microsoft::JSI {
+
+struct NapiTask {
+  NapiTask(
+      napi_env env,
+      napi_ext_task_callback taskCallback,
+      void *taskData,
+      napi_finalize finalizeCallback,
+      void *finalizeHint) noexcept
+      : m_env{env},
+        m_taskCallback{taskCallback},
+        m_taskData{taskData},
+        m_finalizeCallback{finalizeCallback},
+        m_finalizeHint{finalizeHint} {}
+
+  NapiTask(const NapiTask &) = delete;
+  NapiTask &operator=(const NapiTask &) = delete;
+
+  ~NapiTask() {
+    if (m_finalizeCallback) {
+      m_finalizeCallback(m_env, m_taskData, m_finalizeHint);
+    }
+  }
+
+  void operator()() noexcept {
+    m_taskCallback(m_env, m_taskData);
+  }
+
+ private:
+  napi_env m_env;
+  napi_ext_task_callback m_taskCallback;
+  void *m_taskData;
+  napi_finalize m_finalizeCallback;
+  void *m_finalizeHint;
+};
+
+// See napi_ext_schedule_task_callback definition.
+/*static*/ void NapiJsiV8RuntimeHolder::ScheduleTaskCallback(
+    napi_env env,
+    napi_ext_task_callback taskCallback,
+    void *taskData,
+    uint32_t /*delayInMsec*/,
+    napi_finalize finalizeCallback,
+    void *finalizeHint) {
+  NapiJsiV8RuntimeHolder *holder;
+  auto result = napi_get_instance_data(env, (void **)&holder);
+  if (result != napi_status::napi_ok) {
+    std::terminate();
+  }
+
+  auto task = std::make_shared<NapiTask>(env, taskCallback, taskData, finalizeCallback, finalizeHint);
+  holder->m_jsQueue->runOnQueue([task = std::move(task)]() { task->operator()(); });
+}
+
+NapiJsiV8RuntimeHolder::NapiJsiV8RuntimeHolder(
+    shared_ptr<DevSettings> devSettings,
+    shared_ptr<MessageQueueThread> jsQueue,
+    unique_ptr<ScriptStore> &&scriptStore,
+    unique_ptr<PreparedScriptStore> &&preparedScriptStore) noexcept
+    : m_useDirectDebugger{devSettings->useDirectDebugger},
+      m_debuggerBreakOnNextLine{devSettings->debuggerBreakOnNextLine},
+      m_debuggerPort{devSettings->debuggerPort},
+      m_debuggerRuntimeName{devSettings->debuggerRuntimeName},
+      m_jsQueue{jsQueue},
+      m_scriptStore{std::move(scriptStore)},
+      m_preparedScriptStore{std::move(preparedScriptStore)} {}
+
+void NapiJsiV8RuntimeHolder::InitRuntime() noexcept {
+  napi_env env{};
+  napi_ext_env_settings settings{};
+  settings.this_size = sizeof(settings);
+  settings.flags.enable_gc_api = true;
+  if (m_debuggerPort > 0)
+    settings.inspector_port = m_debuggerPort;
+
+  settings.flags.enable_inspector = m_useDirectDebugger;
+  settings.flags.wait_for_debugger = m_debuggerBreakOnNextLine;
+  settings.foreground_scheduler = &NapiJsiV8RuntimeHolder::ScheduleTaskCallback;
+
+  napi_ext_create_env(&settings, &env);
+  // Associate environment to holder.
+  napi_set_instance_data(env, this, nullptr /*finalize_cb*/, nullptr /*finalize_hint*/);
+
+  m_runtime = MakeNapiJsiRuntime(env);
+  m_ownThreadId = std::this_thread::get_id();
+}
+
+#pragma region facebook::jsi::RuntimeHolderLazyInit
+
+shared_ptr<Runtime> NapiJsiV8RuntimeHolder::getRuntime() noexcept /*override*/
+{
+  std::call_once(m_onceFlag, [this]() { InitRuntime(); });
+
+  if (!m_runtime)
+    std::terminate();
+
+  // V8 NapiJsiRuntime is not known to be thread safe.
+  if (m_ownThreadId != std::this_thread::get_id())
+    __fastfail(FAST_FAIL_INVALID_THREAD);
+
+  return m_runtime;
+}
+
+#pragma endregion facebook::jsi::RuntimeHolderLazyInit
+
+} // namespace Microsoft::JSI

--- a/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
+++ b/vnext/JSI/Shared/NapiJsiV8RuntimeHolder.h
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <DevSettings.h>
+#include <NapiJsiRuntime.h>
+#include "RuntimeHolder.h"
+#include "ScriptStore.h"
+
+namespace Microsoft::JSI {
+
+class NapiJsiV8RuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+ public:
+  std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+
+  NapiJsiV8RuntimeHolder(
+      std::shared_ptr<facebook::react::DevSettings> devSettings,
+      std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
+      std::unique_ptr<facebook::jsi::ScriptStore> &&scriptStore,
+      std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
+
+ private:
+  static void ScheduleTaskCallback(
+      napi_env env,
+      napi_ext_task_callback taskCb,
+      void *taskData,
+      uint32_t delayMs,
+      napi_finalize finalizeCb,
+      void *finalizeHint);
+
+  void InitRuntime() noexcept;
+
+  std::shared_ptr<facebook::jsi::Runtime> m_runtime;
+  std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
+
+  std::unique_ptr<facebook::jsi::ScriptStore> m_scriptStore;
+  std::unique_ptr<facebook::jsi::PreparedScriptStore> m_preparedScriptStore;
+
+  std::once_flag m_onceFlag;
+  std::thread::id m_ownThreadId;
+
+  uint16_t m_debuggerPort;
+  bool m_useDirectDebugger{false};
+  bool m_debuggerBreakOnNextLine{false};
+  std::string m_debuggerRuntimeName;
+};
+
+} // namespace Microsoft::JSI

--- a/vnext/JSI/Universal/JSI.Universal.vcxproj
+++ b/vnext/JSI/Universal/JSI.Universal.vcxproj
@@ -65,14 +65,14 @@
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>$(ReactNativeWindowsDir)Common;$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
+    <IncludePath>$(ReactNativeWindowsDir)Common;$(FollyDir);$(JSI_Source);$(ReactNativeWindowsDir);$(ReactNativeWindowsDir)Shared;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>USE_EDGEMODE_JSRT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>USE_EDGEMODE_JSRT;FOLLY_NO_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <!-- /Zc:strictStrings enforces the standard C++ const qualifications for
       string literals. It prevents code like
         wchar_t* str = L"hello";

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
   <!-- package id="ReactNative.Hermes.Windows" version="0.7.2" targetFramework="native" / -->
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.64.15" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.64.24" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -9,7 +9,7 @@
     <HermesArch Condition="'$(HermesArch)' == ''">uwp</HermesArch>
 
     <UseV8 Condition="('$(UseV8)' == '') OR ('$(Platform)' == 'ARM')">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.64.15</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.64.24</V8Version>
     <V8Package Condition="'$(V8Package)' == '' AND '$(V8AppPlatform)' == 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8Version)</V8Package>
     <V8Package Condition="'$(V8Package)' == '' AND '$(V8AppPlatform)' != 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.$(V8Version)</V8Package>
   </PropertyGroup>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -52,6 +52,13 @@
   </ItemDefinitionGroup>
 
   <PropertyGroup>
+    <!-- This prop is used for shared JSI code and headers -->
+    <JSI_Source Condition="'$(JSI_Source)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_Source>
+
+    <!-- This prop is used for JSI code that may be overridden in external JSI implementations -->
+    <JSI_SourcePath Condition="'$(JSI_SourcePath)' == ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_SourcePath>
+    <JSI_SourcePath Condition="'$(USE_V8)' == 'true'">$(V8Package)\build\native\include</JSI_SourcePath>
+    <JSI_SourcePath Condition="'$(USE_HERMES)' == 'true'">$(HERMES_Package)\build\native\include</JSI_SourcePath>
     <!-- This disables copying the v8 DLL to outputs; it is re-enabled locally in win32 projects -->
     <V8JSI_NODLLCOPY>true</V8JSI_NODLLCOPY>
   </PropertyGroup>

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -31,8 +31,9 @@ enum class JSIEngineOverride : int32_t {
   Hermes = 3, // Use the JSIExecutorFactory with Hermes
   V8 = 4, // Use the JSIExecutorFactory with V8
   V8Lite = 5, // Use the JSIExecutorFactory with V8Lite
+  V8NodeApi = 6, // Use the JSIExecutorFactory with V8 via ABI-safe NAPI
 
-  Last = V8Lite
+  Last = V8NodeApi
 };
 
 struct ChakraBundleMetadata {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -49,6 +49,8 @@
 #include "HermesRuntimeHolder.h"
 #endif
 #if defined(USE_V8)
+#include <JSI/NapiJsiV8RuntimeHolder.h>
+
 #include "BaseScriptStoreImpl.h"
 #include "V8JSIRuntimeHolder.h"
 #endif
@@ -150,6 +152,9 @@ std::string GetJSBundleFilePath(const std::string &jsBundleBasePath, const std::
 } // namespace
 
 using namespace facebook;
+using namespace Microsoft::JSI;
+
+using std::make_shared;
 
 namespace facebook {
 namespace react {
@@ -389,6 +394,33 @@ InstanceImpl::InstanceImpl(
           m_devSettings->jsiRuntimeHolder =
               std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(m_devSettings, m_jsThread, nullptr, nullptr);
           break;
+        case JSIEngineOverride::V8NodeApi: {
+#if defined(USE_V8)
+          std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore;
+
+          wchar_t tempPath[MAX_PATH];
+          if (GetTempPathW(static_cast<DWORD>(std::size(tempPath)), tempPath)) {
+            preparedScriptStore =
+                std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(winrt::to_string(tempPath));
+          }
+
+          if (!preparedScriptStore) {
+            if (m_devSettings->errorCallback)
+              m_devSettings->errorCallback("Could not initialize prepared script store");
+
+            break;
+          }
+
+          m_devSettings->jsiRuntimeHolder = make_shared<NapiJsiV8RuntimeHolder>(
+              m_devSettings, m_jsThread, nullptr /*scriptStore*/, std::move(preparedScriptStore));
+          break;
+#else
+          if (m_devSettings->errorCallback)
+            m_devSettings->errorCallback("JSI/V8/NAPI engine is not available in this build");
+          assert(false);
+          [[fallthrough]];
+#endif
+        }
         case JSIEngineOverride::ChakraCore:
         default: // TODO: Add other engines once supported
           m_devSettings->jsiRuntimeHolder =

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -49,7 +49,7 @@
 #include "HermesRuntimeHolder.h"
 #endif
 #if defined(USE_V8)
-#include <JSI/NapiJsiV8RuntimeHolder.h>
+#include <NapiJsiV8RuntimeHolder.h>
 
 #include "BaseScriptStoreImpl.h"
 #include "V8JSIRuntimeHolder.h"


### PR DESCRIPTION
Backport of #8455.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8477)