### PR TITLE
[0.65] Fixes Issues with Text backgroundColor

### DIFF
--- a/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
+++ b/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issues with Text backgroundColor",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
+++ b/change/react-native-windows-57b2d9fa-1663-4577-b3bf-4e684b970508.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fixes issues with Text backgroundColor",
-  "packageName": "react-native-windows",
-  "email": "erozell@outlook.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-d5ee9be9-4beb-4ab9-897d-f9fe3808d36b.json
+++ b/change/react-native-windows-d5ee9be9-4beb-4ab9-897d-f9fe3808d36b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Cherry Pick e64bc29",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Text/TextExample.windows.tsx
@@ -10,7 +10,9 @@
 import * as React from 'react';
 import {
   /*Image,*/ StyleSheet,
+  Switch,
   Text,
+  TextInput,
   View,
   TextStyle,
   TouchableWithoutFeedback,
@@ -162,6 +164,66 @@ export class BackgroundColorDemo extends React.Component<{}> {
           </Text>{' '}
           attributes.
         </Text>
+      </View>
+    );
+  }
+}
+
+export class TextHighlightDemo extends React.Component<
+  {},
+  {search: string; toggled: boolean}
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {search: '', toggled: false};
+  }
+
+  private getTextParts(text: string) {
+    if (this.state.search === '') {
+      return [text];
+    }
+
+    let parts = text.split(this.state.search);
+    for (let i = parts.length - 2; i >= 0; --i) {
+      parts = [
+        ...parts.slice(0, i + 1),
+        this.state.search,
+        ...parts.slice(i + 1),
+      ];
+    }
+
+    const highlight = {
+      backgroundColor: 'yellow',
+    };
+
+    return parts.map((part, i) => (
+      <Text key={i} style={i % 2 === 0 ? undefined : highlight}>
+        {part}
+      </Text>
+    ));
+  }
+
+  public render() {
+    const exampleText = 'The quick brown fox jumped over the lazy dog.';
+    const parts = this.getTextParts(exampleText);
+    const rootHighlight = {
+      backgroundColor: this.state.toggled ? 'cyan' : undefined,
+    };
+    return (
+      <View testID={'highlights'}>
+        <TextInput
+          placeholder="Enter search text"
+          value={this.state.search}
+          onChangeText={text => this.setState({search: text})}
+        />
+        <View style={{flexDirection: 'row', alignItems: 'center'}}>
+          <Text style={{paddingRight: 5}}>Toggle highlight on all text:</Text>
+          <Switch
+            onValueChange={isOn => this.setState({toggled: isOn})}
+            value={this.state.toggled}
+          />
+        </View>
+        <Text style={rootHighlight}>{parts}</Text>
       </View>
     );
   }
@@ -791,6 +853,9 @@ export class TextExample extends React.Component<
               normal text.
             </Text>
           </View>
+        </RNTesterBlock>
+        <RNTesterBlock title="Dynamic backgroundColor">
+          <TextHighlightDemo />
         </RNTesterBlock>
       </RNTesterPage>
     );

--- a/packages/e2e-test-app/test/__snapshots__/TextComponentTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/TextComponentTest.test.ts.snap
@@ -217,18 +217,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 14,
+              "Length": 44,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 14,
             },
           ],
         },
@@ -265,18 +255,8 @@ Object {
           "Foreground": "#FFFFA500",
           "Ranges": Array [
             Object {
-              "Length": 21,
+              "Length": 42,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFA500",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 21,
             },
           ],
         },
@@ -369,18 +349,8 @@ Object {
           "Foreground": "#FFFFFFFF",
           "Ranges": Array [
             Object {
-              "Length": 18,
+              "Length": 59,
               "StartIndex": 15,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 33,
             },
           ],
         },
@@ -391,26 +361,6 @@ Object {
             Object {
               "Length": 29,
               "StartIndex": 34,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 63,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": "#FFFFFFFF",
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 64,
             },
           ],
         },
@@ -465,38 +415,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 19,
+              "Length": 57,
               "StartIndex": 15,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 27,
-              "StartIndex": 34,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 61,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 62,
             },
           ],
         },
@@ -523,78 +443,8 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 9,
+              "Length": 83,
               "StartIndex": 0,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 9,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 25,
-              "StartIndex": 10,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 25,
-              "StartIndex": 35,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 60,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 61,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 71,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 11,
-              "StartIndex": 72,
             },
           ],
         },
@@ -621,38 +471,18 @@ Object {
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 9,
+              "Length": 70,
               "StartIndex": 0,
             },
           ],
         },
         Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 9,
-            },
-          ],
-        },
-        Object {
           "Background": "#FF008000",
           "Foreground": null,
           "Ranges": Array [
             Object {
-              "Length": 18,
+              "Length": 48,
               "StartIndex": 10,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 28,
             },
           ],
         },
@@ -663,46 +493,6 @@ Object {
             Object {
               "Length": 18,
               "StartIndex": 29,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 47,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FF008000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 10,
-              "StartIndex": 48,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 1,
-              "StartIndex": 58,
-            },
-          ],
-        },
-        Object {
-          "Background": "#FFFF0000",
-          "Foreground": null,
-          "Ranges": Array [
-            Object {
-              "Length": 11,
-              "StartIndex": 59,
             },
           ],
         },

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -178,6 +178,7 @@
     <ClInclude Include="Base\CxxReactIncludes.h" />
     <ClInclude Include="Base\FollyIncludes.h" />
     <ClInclude Include="ReactHost\JSCallInvokerScheduler.h" />
+    <ClInclude Include="Utils\ShadowNodeTypeUtils.h" />
     <ClInclude Include="Utils\BatchingEventEmitter.h" />
     <ClInclude Include="DevMenuControl.h">
       <DependentUpon>DevMenuControl.xaml</DependentUpon>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -675,6 +675,9 @@
     <ClInclude Include="Utils\TextTransform.h">
       <Filter>Utils</Filter>
     </ClInclude>
+    <ClInclude Include="Utils\ShadowNodeTypeUtils.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Views/ShadowNodeBase.h>
+
+namespace Microsoft::ReactNative {
+
+static inline bool IsNodeType(ShadowNodeBase const *node, wchar_t const *name) {
+  return std::wcscmp(node->GetViewManager()->GetName(), name) == 0;
+}
+
+static inline bool IsTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTText");
+}
+
+static inline bool IsVirtualTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTVirtualText");
+}
+
+static inline bool IsRawTextShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTRawText");
+}
+
+}; // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -317,4 +317,12 @@ winrt::Uri UriTryCreate(winrt::param::hstring const &uri) {
   }
 }
 
+bool IsValidOptionalColorValue(const winrt::Microsoft::ReactNative::JSValue &v) {
+  return v.Type() == winrt::Microsoft::ReactNative::JSValueType::Null || IsValidColorValue(v);
+}
+
+std::optional<winrt::Color> OptionalColorFrom(const winrt::Microsoft::ReactNative::JSValue &v) {
+  return v.IsNull() ? std::optional<winrt::Color>{} : ColorFrom(v);
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -26,9 +26,8 @@ xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSV
 xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);
 
 REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const folly::dynamic &d);
-REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const winrt::Microsoft::ReactNative::JSValue &d);
-REACTWINDOWS_API_(xaml::Media::Brush)
-BrushFrom(const folly::dynamic &d);
+REACTWINDOWS_API_(winrt::Windows::UI::Color) ColorFrom(const winrt::Microsoft::ReactNative::JSValue &v);
+REACTWINDOWS_API_(xaml::Media::Brush) BrushFrom(const folly::dynamic &d);
 
 REACTWINDOWS_API_(xaml::Media::Brush)
 BrushFrom(const winrt::Microsoft::ReactNative::JSValue &v);
@@ -60,4 +59,8 @@ TimeSpanFromMs(double ms);
 winrt::Uri UriTryCreate(winrt::param::hstring const &uri);
 
 winrt::Windows::UI::Color ColorFromNumber(DWORD argb) noexcept;
+
+bool IsValidOptionalColorValue(const winrt::Microsoft::ReactNative::JSValue &v);
+std::optional<winrt::Windows::UI::Color> OptionalColorFrom(const winrt::Microsoft::ReactNative::JSValue &v);
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -10,6 +10,7 @@
 #include <Views/ShadowNodeBase.h>
 
 #include <INativeUIManager.h>
+#include <Utils/ShadowNodeTypeUtils.h>
 #include <Utils/ValueUtils.h>
 
 #include <Modules/NativeUIManager.h>
@@ -67,7 +68,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
     while (parent) {
       auto viewManager = parent->GetViewManager();
       const auto nodeType = viewManager->GetName();
-      if (!std::wcscmp(nodeType, L"RCTText")) {
+      if (IsTextShadowNode(parent)) {
         const auto textViewManager = static_cast<TextViewManager *>(viewManager);
         if (textTransform == TextTransform::Undefined) {
           textTransform = textViewManager->GetTextTransformValue(parent);
@@ -91,7 +92,7 @@ void RawTextViewManager::NotifyAncestorsTextChanged(ShadowNodeBase *nodeToUpdate
 
         // We have reached the parent TextBlock, so there're no more parent <Text> elements in this tree.
         break;
-      } else if (!std::wcscmp(nodeType, L"RCTVirtualText") && textTransform == TextTransform::Undefined) {
+      } else if (IsVirtualTextShadowNode(parent) && textTransform == TextTransform::Undefined) {
         textTransform = static_cast<VirtualTextShadowNode *>(parent)->textTransform;
       }
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -4,7 +4,10 @@
 #include "pch.h"
 
 #include "TextViewManager.h"
+#include "Utils/ShadowNodeTypeUtils.h"
 
+#include <Modules/NativeUIManager.h>
+#include <Modules/PaperUIManagerModule.h>
 #include <Views/RawTextViewManager.h>
 #include <Views/ShadowNodeBase.h>
 #include <Views/VirtualTextViewManager.h>
@@ -32,8 +35,8 @@ class TextShadowNode final : public ShadowNodeBase {
  private:
   ShadowNode *m_firstChildNode;
 
-  std::optional<winrt::Windows::UI::Color> m_backgroundColor = std::nullopt;
-  std::optional<winrt::Windows::UI::Color> m_foregroundColor = std::nullopt;
+  std::optional<winrt::Windows::UI::Color> m_backgroundColor{};
+  std::optional<winrt::Windows::UI::Color> m_foregroundColor{};
 
   int32_t m_prevCursorEnd = 0;
 
@@ -50,19 +53,20 @@ class TextShadowNode final : public ShadowNodeBase {
     VirtualTextShadowNode::ApplyTextTransform(
         childNode, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
 
+    if (IsVirtualTextShadowNode(&childNode)) {
+      auto &textChildNode = static_cast<VirtualTextShadowNode &>(childNode);
+      m_hasDescendantBackgroundColor |= textChildNode.m_hasDescendantBackgroundColor;
+    }
+
+    auto addInline = true;
     if (index == 0) {
       auto run = childNode.GetView().try_as<winrt::Run>();
       if (run != nullptr) {
         m_firstChildNode = &child;
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         textBlock.Text(run.Text());
-
-        if (m_backgroundColor) {
-          AddHighlighter(m_backgroundColor.value(), m_foregroundColor, textBlock.Text().size());
-        }
         m_prevCursorEnd += textBlock.Text().size();
-
-        return;
+        addInline = false;
       }
     } else if (index == 1 && m_firstChildNode != nullptr) {
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
@@ -71,66 +75,17 @@ class TextShadowNode final : public ShadowNodeBase {
       m_firstChildNode = nullptr;
     }
 
-    Super::AddView(child, index);
-
-    if (auto run = static_cast<ShadowNodeBase &>(child).GetView().try_as<winrt::Run>()) {
-      if (m_backgroundColor) {
-        AddHighlighter(m_backgroundColor.value(), m_foregroundColor, run.Text().size());
-      }
-      m_prevCursorEnd += run.Text().size();
-    } else if (auto span = static_cast<ShadowNodeBase &>(child).GetView().try_as<winrt::Span>()) {
-      AddNestedTextHighlighter(
-          m_backgroundColor, m_foregroundColor, span, static_cast<VirtualTextShadowNode &>(child).m_highlightData);
-    }
-  }
-
-  void AddNestedTextHighlighter(
-      const std::optional<winrt::Windows::UI::Color> &parentBackColor,
-      const std::optional<winrt::Windows::UI::Color> &parentForeColor,
-      winrt::Span &span,
-      VirtualTextShadowNode::HighlightData highData) {
-    if (!highData.backgroundColor && parentBackColor) {
-      highData.backgroundColor = parentBackColor;
+    if (addInline) {
+      Super::AddView(child, index);
     }
 
-    if (!highData.foregroundColor && parentForeColor) {
-      highData.foregroundColor = parentForeColor;
-    }
-
-    for (const auto &el : span.Inlines()) {
-      if (auto run = el.try_as<winrt::Run>()) {
-        if (highData.backgroundColor) {
-          AddHighlighter(highData.backgroundColor.value(), highData.foregroundColor, run.Text().size());
-        }
-
-        m_prevCursorEnd += run.Text().size();
-      } else if (auto spanChild = el.try_as<winrt::Span>()) {
-        AddNestedTextHighlighter(
-            highData.backgroundColor, highData.foregroundColor, spanChild, highData.data[highData.spanIdx++]);
-      }
-    }
-  }
-
-  void AddHighlighter(
-      const winrt::Windows::UI::Color &backgroundColor,
-      const std::optional<winrt::Windows::UI::Color> &foregroundColor,
-      size_t runSize) {
-    auto newHigh = winrt::TextHighlighter{};
-    newHigh.Background(SolidBrushFromColor(backgroundColor));
-
-    if (foregroundColor) {
-      newHigh.Foreground(SolidBrushFromColor(foregroundColor.value()));
-    }
-
-    winrt::TextRange newRange{m_prevCursorEnd, static_cast<int32_t>(runSize)};
-    newHigh.Ranges().Append(newRange);
-
-    this->GetView().as<xaml::Controls::TextBlock>().TextHighlighters().Append(newHigh);
+    RecalculateTextHighlighters();
   }
 
   void removeAllChildren() override {
     m_firstChildNode = nullptr;
     Super::removeAllChildren();
+    RecalculateTextHighlighters();
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
@@ -138,9 +93,99 @@ class TextShadowNode final : public ShadowNodeBase {
       m_firstChildNode = nullptr;
     }
     Super::RemoveChildAt(indexToRemove);
+    RecalculateTextHighlighters();
+  }
+
+  void RecalculateTextHighlighters() {
+    const auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
+    textBlock.TextHighlighters().Clear();
+
+    auto nestedIndex = 0;
+    if (m_hasDescendantBackgroundColor) {
+      const auto highlighterCount = textBlock.TextHighlighters().Size();
+      if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+        for (auto childTag : m_children) {
+          if (const auto childNode = uiManager->getHost()->FindShadowNodeForTag(childTag)) {
+            nestedIndex = AddNestedTextHighlighter(
+                m_backgroundColor, m_foregroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
+          }
+        }
+      }
+
+      if (textBlock.TextHighlighters().Size() == 0) {
+        m_hasDescendantBackgroundColor = false;
+      }
+    } else {
+      nestedIndex = textBlock.Text().size();
+    }
+
+    if (m_backgroundColor) {
+      winrt::TextHighlighter highlighter{};
+      highlighter.Ranges().Append({0, nestedIndex});
+      highlighter.Background(SolidBrushFromColor(m_backgroundColor.value()));
+      if (m_foregroundColor) {
+        highlighter.Foreground(SolidBrushFromColor(m_foregroundColor.value()));
+      }
+      GetView().as<xaml::Controls::TextBlock>().TextHighlighters().InsertAt(0, highlighter);
+    }
+  }
+
+  int AddNestedTextHighlighter(
+      const std::optional<winrt::Windows::UI::Color> &backgroundColor,
+      const std::optional<winrt::Windows::UI::Color> &foregroundColor,
+      ShadowNodeBase *node,
+      int startIndex) {
+    if (const auto run = node->GetView().try_as<winrt::Run>()) {
+      return startIndex + run.Text().size();
+    } else if (const auto span = node->GetView().try_as<winrt::Span>()) {
+      const auto textBlock = GetView().as<xaml::Controls::TextBlock>();
+      winrt::TextHighlighter highlighter{nullptr};
+      auto parentBackgroundColor = backgroundColor;
+      auto parentForegroundColor = foregroundColor;
+      if (IsVirtualTextShadowNode(node)) {
+        const auto virtualTextNode = static_cast<VirtualTextShadowNode *>(node);
+        const auto requiresHighlighter =
+            virtualTextNode->m_backgroundColor || (backgroundColor && virtualTextNode->m_foregroundColor);
+        if (requiresHighlighter) {
+          highlighter = {};
+          parentBackgroundColor =
+              virtualTextNode->m_backgroundColor ? virtualTextNode->m_backgroundColor : parentBackgroundColor;
+          parentForegroundColor =
+              virtualTextNode->m_foregroundColor ? virtualTextNode->m_foregroundColor : parentForegroundColor;
+          highlighter.Background(SolidBrushFromColor(parentBackgroundColor.value()));
+          if (parentForegroundColor) {
+            highlighter.Foreground(SolidBrushFromColor(parentForegroundColor.value()));
+          }
+        }
+      }
+
+      const auto initialHighlighterCount = textBlock.TextHighlighters().Size();
+      auto nestedIndex = startIndex;
+      if (const auto uiManager = GetNativeUIManager(node->GetViewManager()->GetReactContext()).lock()) {
+        for (auto childTag : node->m_children) {
+          if (const auto childNode = uiManager->getHost()->FindShadowNodeForTag(childTag)) {
+            nestedIndex = AddNestedTextHighlighter(
+                parentBackgroundColor, parentForegroundColor, static_cast<ShadowNodeBase *>(childNode), nestedIndex);
+          }
+        }
+      }
+
+      if (highlighter) {
+        highlighter.Ranges().Append({startIndex, nestedIndex - startIndex});
+        textBlock.TextHighlighters().InsertAt(0, highlighter);
+      } else if (IsVirtualTextShadowNode(node) && textBlock.TextHighlighters().Size() == initialHighlighterCount) {
+        const auto virtualTextNode = static_cast<VirtualTextShadowNode *>(node);
+        virtualTextNode->m_hasDescendantBackgroundColor = false;
+      }
+
+      return nestedIndex;
+    }
+
+    return 0;
   }
 
   TextTransform textTransform{TextTransform::Undefined};
+  bool m_hasDescendantBackgroundColor{false};
 };
 
 TextViewManager::TextViewManager(const Mso::React::IReactContext &context) : Super(context) {}
@@ -168,7 +213,11 @@ bool TextViewManager::UpdateProperty(
     return true;
 
   if (TryUpdateForeground(textBlock, propertyName, propertyValue)) {
-    static_cast<TextShadowNode *>(nodeToUpdate)->m_foregroundColor = ColorFrom(propertyValue);
+    const auto node = static_cast<TextShadowNode *>(nodeToUpdate);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_foregroundColor = OptionalColorFrom(propertyValue);
+      node->RecalculateTextHighlighters();
+    }
   } else if (TryUpdateFontProperties(textBlock, propertyName, propertyValue)) {
   } else if (propertyName == "textTransform") {
     auto textNode = static_cast<TextShadowNode *>(nodeToUpdate);
@@ -227,8 +276,10 @@ bool TextViewManager::UpdateProperty(
     } else
       textBlock.ClearValue(xaml::Controls::TextBlock::SelectionHighlightColorProperty());
   } else if (propertyName == "backgroundColor") {
-    if (IsValidColorValue(propertyValue)) {
-      static_cast<TextShadowNode *>(nodeToUpdate)->m_backgroundColor = ColorFrom(propertyValue);
+    const auto node = static_cast<TextShadowNode *>(nodeToUpdate);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_backgroundColor = OptionalColorFrom(propertyValue);
+      node->RecalculateTextHighlighters();
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
@@ -267,23 +318,39 @@ YGMeasureFunc TextViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }
 
-void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node) {
-  if (auto element = node->GetView().try_as<xaml::Controls::TextBlock>()) {
-    // If name is set, it's controlled by accessibilityLabel, and it's already
-    // handled in FrameworkElementViewManager. Here it only handles when name is
-    // not set.
-    if (xaml::Automation::AutomationProperties::GetLiveSetting(element) != winrt::AutomationLiveSetting::Off &&
-        xaml::Automation::AutomationProperties::GetName(element).empty() &&
-        xaml::Automation::AutomationProperties::GetAccessibilityView(element) != winrt::Peers::AccessibilityView::Raw) {
-      if (auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element)) {
-        peer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
+void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node, PropertyChangeType propertyChangeType) {
+  if (IsTextShadowNode(node)) {
+    const auto textNode = static_cast<TextShadowNode *>(node);
+
+    if ((propertyChangeType & PropertyChangeType::Text) == PropertyChangeType::Text) {
+      const auto element = node->GetView().as<xaml::Controls::TextBlock>();
+
+      // If name is set, it's controlled by accessibilityLabel, and it's already
+      // handled in FrameworkElementViewManager. Here it only handles when name is
+      // not set.
+      if (xaml::Automation::AutomationProperties::GetLiveSetting(element) != winrt::AutomationLiveSetting::Off &&
+          xaml::Automation::AutomationProperties::GetName(element).empty() &&
+          xaml::Automation::AutomationProperties::GetAccessibilityView(element) !=
+              winrt::Peers::AccessibilityView::Raw) {
+        if (auto peer = xaml::Automation::Peers::FrameworkElementAutomationPeer::FromElement(element)) {
+          peer.RaiseAutomationEvent(winrt::AutomationEvents::LiveRegionChanged);
+        }
       }
     }
+
+    // If a property change added a background color to the text tree, update
+    // the flag to signal recursive highlighter updates are required.
+    if ((propertyChangeType & PropertyChangeType::AddBackgroundColor) == PropertyChangeType::AddBackgroundColor) {
+      textNode->m_hasDescendantBackgroundColor = true;
+    }
+
+    // Recalculate text highlighters
+    textNode->RecalculateTextHighlighters();
   }
 }
 
 TextTransform TextViewManager::GetTextTransformValue(ShadowNodeBase *node) {
-  if (!std::wcscmp(node->GetViewManager()->GetName(), GetName())) {
+  if (IsTextShadowNode(node)) {
     return static_cast<TextShadowNode *>(node)->textTransform;
   }
 

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -8,6 +8,14 @@
 
 namespace Microsoft::ReactNative {
 
+enum class PropertyChangeType : std::uint_fast8_t {
+  None = 0,
+  Text = 1 << 0,
+  AddBackgroundColor = 1 << 1,
+};
+
+DEFINE_ENUM_FLAG_OPERATORS(PropertyChangeType);
+
 class TextViewManager : public FrameworkElementViewManager {
   using Super = FrameworkElementViewManager;
 
@@ -24,7 +32,9 @@ class TextViewManager : public FrameworkElementViewManager {
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
-  void OnDescendantTextPropertyChanged(ShadowNodeBase *node);
+  void OnDescendantTextPropertyChanged(
+      ShadowNodeBase *node,
+      PropertyChangeType propertyChangeType = PropertyChangeType::Text);
 
   TextTransform GetTextTransformValue(ShadowNodeBase *node);
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -12,6 +12,7 @@
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <Utils/PropertyUtils.h>
+#include <Utils/ShadowNodeTypeUtils.h>
 #include <Utils/TransformableText.h>
 #include <Utils/ValueUtils.h>
 
@@ -27,11 +28,25 @@ namespace Microsoft::ReactNative {
 void VirtualTextShadowNode::AddView(ShadowNode &child, int64_t index) {
   auto &childNode = static_cast<ShadowNodeBase &>(child);
   ApplyTextTransform(childNode, textTransform, /* forceUpdate = */ false, /* isRoot = */ false);
-  if (auto span = childNode.GetView().try_as<xaml::Documents::Span>()) {
-    auto &childVTSN = static_cast<VirtualTextShadowNode &>(child);
-    m_highlightData.data.emplace_back(childVTSN.m_highlightData);
+  auto propertyChangeType = PropertyChangeType::Text;
+  if (IsVirtualTextShadowNode(&childNode)) {
+    const auto &childTextNode = static_cast<VirtualTextShadowNode &>(childNode);
+    m_hasDescendantBackgroundColor |= childTextNode.m_hasDescendantBackgroundColor;
+    propertyChangeType |=
+        childTextNode.m_backgroundColor ? PropertyChangeType::AddBackgroundColor : PropertyChangeType::None;
   }
   Super::AddView(child, index);
+  NotifyAncestorsTextPropertyChanged(propertyChangeType);
+}
+
+void VirtualTextShadowNode::RemoveChildAt(int64_t indexToRemove) {
+  Super::RemoveChildAt(indexToRemove);
+  NotifyAncestorsTextPropertyChanged(PropertyChangeType::Text);
+}
+
+void VirtualTextShadowNode::removeAllChildren() {
+  Super::removeAllChildren();
+  NotifyAncestorsTextPropertyChanged(PropertyChangeType::Text);
 }
 
 void VirtualTextShadowNode::ApplyTextTransform(
@@ -48,7 +63,7 @@ void VirtualTextShadowNode::ApplyTextTransform(
     const auto nodeType = viewManager->GetName();
 
     // Base case: apply the inherited textTransform to the raw text node
-    if (!std::wcscmp(nodeType, L"RCTRawText")) {
+    if (IsRawTextShadowNode(&node)) {
       auto &rawTextNode = static_cast<RawTextShadowNode &>(node);
       auto originalText = rawTextNode.originalText;
       auto run = node.GetView().try_as<winrt::Run>();
@@ -61,13 +76,13 @@ void VirtualTextShadowNode::ApplyTextTransform(
 
       run.Text(TransformableText::TransformText(originalText, transform));
 
-      if (!std::wcscmp(originalText.c_str(), run.Text().c_str())) {
+      if (std::wcscmp(originalText.c_str(), run.Text().c_str()) == 0) {
         // If the transformed text is the same as the original, we no longer need a second copy
         rawTextNode.originalText = winrt::hstring{};
       }
     } else {
       // Recursively apply the textTransform to the children of the composite text node
-      if (!std::wcscmp(nodeType, L"RCTVirtualText")) {
+      if (IsVirtualTextShadowNode(&node)) {
         auto &virtualTextNode = static_cast<VirtualTextShadowNode &>(node);
         // If this is not the root call, we can skip sub-trees with explicit textTransform settings.
         if (!isRoot && virtualTextNode.textTransform != TextTransform::Undefined) {
@@ -81,6 +96,25 @@ void VirtualTextShadowNode::ApplyTextTransform(
           ApplyTextTransform(*childNode, transform, forceUpdate, /* isRoot = */ false);
         }
       }
+    }
+  }
+}
+
+void VirtualTextShadowNode::NotifyAncestorsTextPropertyChanged(PropertyChangeType propertyChangeType) {
+  if (auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
+    auto host = uiManager->getHost();
+    ShadowNodeBase *parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(m_parent));
+    while (parent) {
+      auto viewManager = parent->GetViewManager();
+      const auto nodeType = viewManager->GetName();
+      if (IsTextShadowNode(parent)) {
+        (static_cast<TextViewManager *>(viewManager))->OnDescendantTextPropertyChanged(parent, propertyChangeType);
+        break;
+      } else if (IsVirtualTextShadowNode(parent)) {
+        auto textParent = static_cast<VirtualTextShadowNode *>(parent);
+        textParent->m_hasDescendantBackgroundColor |= m_hasDescendantBackgroundColor;
+      }
+      parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(parent->GetParent()));
     }
   }
 }
@@ -106,7 +140,14 @@ bool VirtualTextViewManager::UpdateProperty(
   // FUTURE: In the future cppwinrt will generate code where static methods on
   // base types can be called.  For now we specify the base type explicitly
   if (TryUpdateForeground<winrt::TextElement>(span, propertyName, propertyValue)) {
-    static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.foregroundColor = ColorFrom(propertyValue);
+    auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_foregroundColor = OptionalColorFrom(propertyValue);
+      node->m_hasDescendantBackgroundColor |= node->m_foregroundColor.has_value();
+      const auto propertyChangeType =
+          node->m_foregroundColor ? PropertyChangeType::AddBackgroundColor : PropertyChangeType::None;
+      node->NotifyAncestorsTextPropertyChanged(propertyChangeType);
+    }
   } else if (TryUpdateFontProperties<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateCharacterSpacing<winrt::TextElement>(span, propertyName, propertyValue)) {
   } else if (TryUpdateTextDecorationLine<winrt::TextElement>(span, propertyName, propertyValue)) {
@@ -116,8 +157,13 @@ bool VirtualTextViewManager::UpdateProperty(
     VirtualTextShadowNode::ApplyTextTransform(
         *node, node->textTransform, /* forceUpdate = */ true, /* isRoot = */ true);
   } else if (propertyName == "backgroundColor") {
-    if (IsValidColorValue(propertyValue)) {
-      static_cast<VirtualTextShadowNode *>(nodeToUpdate)->m_highlightData.backgroundColor = ColorFrom(propertyValue);
+    auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+    if (IsValidOptionalColorValue(propertyValue)) {
+      node->m_backgroundColor = OptionalColorFrom(propertyValue);
+      node->m_hasDescendantBackgroundColor |= node->m_backgroundColor.has_value();
+      const auto propertyChangeType =
+          node->m_backgroundColor ? PropertyChangeType::AddBackgroundColor : PropertyChangeType::None;
+      node->NotifyAncestorsTextPropertyChanged(propertyChangeType);
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -8,6 +8,8 @@
 #include <UI.Xaml.Documents.h>
 #include <Utils/TextTransform.h>
 #include <Views/FrameworkElementViewManager.h>
+#include <Views/ShadowNodeBase.h>
+#include <Views/TextViewManager.h>
 
 namespace Microsoft::ReactNative {
 
@@ -16,17 +18,16 @@ struct VirtualTextShadowNode final : public ShadowNodeBase {
   TextTransform textTransform{TextTransform::Undefined};
 
   void AddView(ShadowNode &child, int64_t index) override;
+  void RemoveChildAt(int64_t indexToRemove) override;
+  void removeAllChildren() override;
+
+  void NotifyAncestorsTextPropertyChanged(PropertyChangeType propertyChangeType);
 
   static void ApplyTextTransform(ShadowNodeBase &node, TextTransform transform, bool forceUpdate, bool isRoot);
 
-  struct HighlightData {
-    std::vector<HighlightData> data;
-    size_t spanIdx = 0;
-    std::optional<winrt::Windows::UI::Color> backgroundColor;
-    std::optional<winrt::Windows::UI::Color> foregroundColor;
-  };
-
-  HighlightData m_highlightData;
+  std::optional<winrt::Windows::UI::Color> m_backgroundColor;
+  std::optional<winrt::Windows::UI::Color> m_foregroundColor;
+  bool m_hasDescendantBackgroundColor{false};
 };
 
 class VirtualTextViewManager : public ViewManagerBase {


### PR DESCRIPTION
There were two issues with the Text backgroundColor prop:

Changes to the backgroundColor prop on virtual text nodes did not update their corresponding TextHighlighters
Changes to the underlying text did not update the TextHighlighter ranges
This change forces a refresh of all TextHighlighters any time:

A raw text node changes text value
A virtual text node is added or removed from the text tree
A virtual text or root text node updates its backgroundColor prop
TODOs:

 Pass inherited foreground color down so virtual text highlighters apply the correct foreground color
 Update snapshots since highlighter approach has changed
 Produce a before and after video to ensure RNTester TextExample still works as expected
 Add examples to RNTester to toggle background colors on RCTText and RCTVirtualText to see highlighter updates working
 Add examples to RNTester to remove RCTRawText and RCTVirtualText nodes to see highlighter updates working

Backport #8408 to 0.65.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8490)