### PR TITLE
Generalizes hit testing so all view managers can participate

### DIFF
--- a/change/react-native-windows-795913fa-a52e-495a-b00e-69535a976969.json
+++ b/change/react-native-windows-795913fa-a52e-495a-b00e-69535a976969.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generalizes hit testing so all view managers can participate",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -114,4 +114,26 @@ bool RawTextViewManager::RequiresYogaNode() const {
   return false;
 }
 
+XamlView RawTextViewManager::HitTest(const ShadowNodeBase *node, const winrt::Point &point) {
+  const auto run = node->GetView().as<xaml::Documents::Run>();
+  const auto start = run.ContentStart();
+  const auto end = run.ContentEnd();
+
+  auto startRect = start.GetCharacterRect(xaml::Documents::LogicalDirection::Forward);
+  auto endRect = end.GetCharacterRect(xaml::Documents::LogicalDirection::Forward);
+
+  // Swap rectangles in RTL scenarios.
+  if (startRect.X > endRect.X) {
+    const auto tempRect = startRect;
+    startRect = endRect;
+    endRect = tempRect;
+  }
+
+  // Approximate the bounding rect (for now, don't account for text wrapping).
+  return (startRect.X <= point.X) && (endRect.X + endRect.Width >= point.X) && (startRect.Y <= point.Y) &&
+          (endRect.Y + endRect.Height >= point.Y)
+      ? nullptr
+      : run;
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.h
@@ -34,6 +34,8 @@ class RawTextViewManager : public ViewManagerBase {
       float height) override;
   bool RequiresYogaNode() const override;
 
+  XamlView HitTest(const ShadowNodeBase *node, const winrt::Point &point) override;
+
  protected:
   bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -325,6 +325,23 @@ YGMeasureFunc TextViewManager::GetYogaCustomMeasureFunc() const {
   return DefaultYogaSelfMeasureFunc;
 }
 
+XamlView TextViewManager::HitTest(const ShadowNodeBase *node, const winrt::Point &point) {
+  const auto textBlock = node->GetView().as<xaml::Controls::TextBlock>();
+  if (const auto uiManager = GetNativeUIManager(node->GetViewManager()->GetReactContext()).lock()) {
+    for (auto childTag : node->m_children) {
+      if (const auto childNode = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(childTag))) {
+        if (!IsRawTextShadowNode(childNode)) {
+          if (const auto targetView = childNode->GetViewManager()->HitTest(childNode, point)) {
+            return targetView;
+          }
+        }
+      }
+    }
+  }
+
+  return Super::HitTest(node, point);
+}
+
 void TextViewManager::OnDescendantTextPropertyChanged(ShadowNodeBase *node, PropertyChangeType propertyChangeType) {
   if (IsTextShadowNode(node)) {
     const auto textNode = static_cast<TextShadowNode *>(node);

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -32,6 +32,8 @@ class TextViewManager : public FrameworkElementViewManager {
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 
+  XamlView HitTest(const ShadowNodeBase *node, const winrt::Point &point) override;
+
   void OnDescendantTextPropertyChanged(
       ShadowNodeBase *node,
       PropertyChangeType propertyChangeType = PropertyChangeType::Text);

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -364,6 +364,10 @@ bool ViewManagerBase::RequiresYogaNode() const {
   return true;
 }
 
+XamlView ViewManagerBase::HitTest(const ShadowNodeBase *node, const winrt::Point &point) {
+  return node->GetView();
+}
+
 bool ViewManagerBase::IsNativeControlWithSelfLayout() const {
   return GetYogaCustomMeasureFunc() != nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -77,6 +77,9 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
       float height);
   virtual YGMeasureFunc GetYogaCustomMeasureFunc() const;
   virtual bool RequiresYogaNode() const;
+
+  virtual XamlView HitTest(const ShadowNodeBase *node, const winrt::Point &point);
+
   bool IsNativeControlWithSelfLayout() const;
 
   const Mso::React::IReactContext &GetReactContext() const {

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -192,4 +192,18 @@ bool VirtualTextViewManager::RequiresYogaNode() const {
   return false;
 }
 
+XamlView VirtualTextViewManager::HitTest(const ShadowNodeBase *node, const winrt::Point &point) {
+  if (const auto uiManager = GetNativeUIManager(node->GetViewManager()->GetReactContext()).lock()) {
+    for (auto childTag : node->m_children) {
+      if (const auto childNode = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(childTag))) {
+        if (const auto targetView = childNode->GetViewManager()->HitTest(childNode, point)) {
+          return targetView.try_as<winrt::Run>() ? node->GetView() : targetView;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -46,6 +46,8 @@ class VirtualTextViewManager : public ViewManagerBase {
 
   bool RequiresYogaNode() const override;
 
+  XamlView HitTest(const ShadowNodeBase *node, const winrt::Point &point) override;
+
  protected:
   bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -36,9 +36,9 @@ inline int64_t GetTag(winrt::IPropertyValue value) {
   return value.GetInt64();
 }
 
-inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
-  assert(fe);
-  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+inline winrt::IPropertyValue GetTagAsPropertyValue(XamlView view) {
+  assert(view);
+  return view.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);


### PR DESCRIPTION
One of the comments in #7553 (https://github.com/microsoft/react-native-windows/pull/7553#discussion_r640427024) was that a community module view manager would not be able to implement hit testing the way we implemented it for TextViewManager. This change generalizes hit testing so any view manager can participate. We don't (yet) have a use case for community modules to participate in hit testing, but presumably when we do, we can add an `IViewManagerWithHitTest` interface that allows community modules to participate.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8493)