### PR TITLE
[0.65] Pass JSValueArgWriter around instead of immediately converting to dynamic

### DIFF
--- a/change/react-native-windows-f9440adc-f697-40d9-99c3-495aaf01ab8f.json
+++ b/change/react-native-windows-f9440adc-f697-40d9-99c3-495aaf01ab8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Pass JSValueArgWriter around instead of immediately converting to dynamic",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -9,7 +9,6 @@
 #include "ReactContext.h"
 #include "ReactInstanceWin.h"
 
-#include "DynamicWriter.h"
 #include "ReactNativeHost.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
@@ -25,17 +24,17 @@ void ReactViewOptions::ComponentName(winrt::hstring value) noexcept {
 }
 
 ReactNative::JSValueArgWriter ReactViewOptions::InitialProps() noexcept {
-  return m_initalProps;
+  return m_initialProps;
 }
 
 void ReactViewOptions::InitialProps(ReactNative::JSValueArgWriter value) noexcept {
-  m_initalProps = value;
+  m_initialProps = value;
 }
 
 Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
   Mso::React::ReactViewOptions viewOptions;
   viewOptions.ComponentName = winrt::to_string(m_componentName);
-  viewOptions.InitialProps = DynamicWriter::ToDynamic(m_initalProps);
+  viewOptions.InitialProps = m_initialProps;
   return std::move(viewOptions);
 }
 
@@ -116,7 +115,7 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
 
       ReactNative::ReactViewOptions options;
       options.ComponentName(winrt::to_hstring(viewOptions.ComponentName));
-      // TODO add a value writer to ViewOptions, to allow the writer to pass through
+      options.InitialProps(viewOptions.InitialProps);
 
       rootControl.InitRootView(winrt::make<ReactContext>(std::move(context)), options);
     });

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -27,7 +27,7 @@ struct ReactViewOptions : ReactViewOptionsT<ReactViewOptions> {
 
  private:
   winrt::hstring m_componentName;
-  JSValueArgWriter m_initalProps;
+  JSValueArgWriter m_initialProps;
 };
 
 struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -86,7 +86,7 @@ struct IReactInstance : IUnknown {
 
   virtual void AttachMeasuredRootView(
       facebook::react::IReactRootView *rootView,
-      folly::dynamic &&initialProps) noexcept = 0;
+      const winrt::Microsoft::ReactNative::JSValueArgWriter &initialProps) noexcept = 0;
   virtual void DetachRootView(facebook::react::IReactRootView *rootView) noexcept = 0;
 };
 
@@ -123,8 +123,8 @@ struct ReactViewOptions {
   //! Name of a component registered in JavaScript via AppRegistry.registerComponent('ModuleName', () => ModuleName);
   std::string ComponentName;
 
-  //! Set of initial component properties. It is a JSON string.
-  folly::dynamic InitialProps;
+  // Initial component properties.
+  winrt::Microsoft::ReactNative::JSValueArgWriter InitialProps;
 };
 
 struct ReactDevOptions {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -39,6 +39,7 @@
 #include <Views/ViewManager.h>
 #include <base/CoreNativeModules.h>
 #include <dispatchQueue/dispatchQueue.h>
+#include "DynamicWriter.h"
 #ifndef CORE_ABI
 #include "ConfigureBundlerDlg.h"
 #include "DevMenu.h"
@@ -922,7 +923,7 @@ bool ReactInstanceWin::IsLoaded() const noexcept {
 
 void ReactInstanceWin::AttachMeasuredRootView(
     facebook::react::IReactRootView *rootView,
-    folly::dynamic &&initialProps) noexcept {
+    const winrt::Microsoft::ReactNative::JSValueArgWriter &initialProps) noexcept {
 #ifndef CORE_ABI
   if (State() == ReactInstanceState::HasError)
     return;
@@ -936,7 +937,7 @@ void ReactInstanceWin::AttachMeasuredRootView(
 
     auto rootTag = Microsoft::ReactNative::getNextRootViewTag();
     rootView->SetTag(rootTag);
-    uiManager->startSurface(rootView, rootTag, rootView->JSComponentName(), std::move(initialProps));
+    uiManager->startSurface(rootView, rootTag, rootView->JSComponentName(), DynamicWriter::ToDynamic(initialProps));
 
   } else
 #endif
@@ -951,7 +952,8 @@ void ReactInstanceWin::AttachMeasuredRootView(
     std::string jsMainModuleName = rootView->JSComponentName();
     folly::dynamic params = folly::dynamic::array(
         std::move(jsMainModuleName),
-        folly::dynamic::object("initialProps", std::move(initialProps))("rootTag", rootTag)("fabric", false));
+        folly::dynamic::object("initialProps", DynamicWriter::ToDynamic(initialProps))("rootTag", rootTag)(
+            "fabric", false));
     CallJsFunction("AppRegistry", "runApplication", std::move(params));
   }
 #endif

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -52,8 +52,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   const ReactOptions &Options() const noexcept override;
   ReactInstanceState State() const noexcept override;
   Mso::React::IReactContext &GetReactContext() const noexcept override;
-  void AttachMeasuredRootView(facebook::react::IReactRootView *rootView, folly::dynamic &&initialProps) noexcept
-      override;
+  void AttachMeasuredRootView(
+      facebook::react::IReactRootView *rootView,
+      const winrt::Microsoft::ReactNative::JSValueArgWriter &initialProps) noexcept override;
   void DetachRootView(facebook::react::IReactRootView *rootView) noexcept override;
 
  public: // IReactInstanceInternal

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -10,7 +10,6 @@
 #include <Utils/Helpers.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Windows.UI.Core.h>
-#include "DynamicWriter.h"
 #include "ReactNativeHost.h"
 #include "ReactViewInstance.h"
 
@@ -64,7 +63,6 @@ ReactNative::JSValueArgWriter ReactRootView::InitialProps() noexcept {
 void ReactRootView::InitialProps(ReactNative::JSValueArgWriter const &value) noexcept {
   if (m_initialPropsWriter != value) {
     m_initialPropsWriter = value;
-    m_initialProps = DynamicWriter::ToDynamic(m_initialPropsWriter);
     ReloadView();
   }
 }
@@ -73,7 +71,7 @@ void ReactRootView::ReloadView() noexcept {
   if (m_reactNativeHost && !m_componentName.empty()) {
     Mso::React::ReactViewOptions viewOptions{};
     viewOptions.ComponentName = to_string(m_componentName);
-    viewOptions.InitialProps = m_initialProps;
+    viewOptions.InitialProps = m_initialPropsWriter;
     if (auto reactViewHost = ReactViewHost()) {
       reactViewHost->ReloadViewInstanceWithOptions(std::move(viewOptions));
     } else {

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -64,7 +64,6 @@ struct ReactRootView : ReactRootViewT<ReactRootView>, ::Microsoft::ReactNative::
   ReactNative::ReactNativeHost m_reactNativeHost{nullptr};
   hstring m_componentName;
   ReactNative::JSValueArgWriter m_initialPropsWriter;
-  folly::dynamic m_initialProps;
   bool m_isPerspectiveEnabled{true};
   bool m_isInitialized{false};
   bool m_isJSViewAttached{false};


### PR DESCRIPTION
Port #8487 to 0.65

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8494)