### PR TITLE
Adds hook for view managers to capture pointer events

### DIFF
--- a/change/react-native-windows-aaade5cd-5bf8-4e76-8a0f-ebf880e356b1.json
+++ b/change/react-native-windows-aaade5cd-5bf8-4e76-8a0f-ebf880e356b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds hook for view managers to capture pointer events",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -160,6 +160,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\JsiApi.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactInstanceSettings.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactNativeHost.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactPointerEventArgs.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -216,34 +216,53 @@ YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
   }
 }
 
-bool ABIViewManager::OnPointerPressed(const xaml::Input::PointerRoutedEventArgs &args) {
-  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerPressed(args)
-                                        : Super::OnPointerPressed(args);
-}
-
-bool ABIViewManager::OnPointerMoved(const xaml::Input::PointerRoutedEventArgs &args) {
-  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerMoved(args)
-                                        : Super::OnPointerMoved(args);
-}
-
-bool ABIViewManager::OnPointerReleased(const xaml::Input::PointerRoutedEventArgs &args) {
-  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerReleased(args)
-                                        : Super::OnPointerReleased(args);
-}
-
-void ABIViewManager::OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs &args) {
+void ABIViewManager::OnPointerPressed(
+    const ::Microsoft::ReactNative::ShadowNodeBase *node,
+    const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerCanceled(args);
+    m_viewManagerWithPointerEvents.OnPointerPressed(node->GetView(), args);
   } else {
-    Super::OnPointerCanceled(args);
+    Super::OnPointerCaptureLost(node, args);
   }
 }
 
-void ABIViewManager::OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs &args) {
+void ABIViewManager::OnPointerMoved(
+    const ::Microsoft::ReactNative::ShadowNodeBase *node,
+    const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerCaptureLost(args);
+    m_viewManagerWithPointerEvents.OnPointerMoved(node->GetView(), args);
   } else {
-    Super::OnPointerCaptureLost(args);
+    Super::OnPointerCaptureLost(node, args);
+  }
+}
+
+void ABIViewManager::OnPointerReleased(
+    const ::Microsoft::ReactNative::ShadowNodeBase *node,
+    const ReactPointerEventArgs &args) {
+  if (m_viewManagerWithPointerEvents) {
+    m_viewManagerWithPointerEvents.OnPointerReleased(node->GetView(), args);
+  } else {
+    Super::OnPointerCaptureLost(node, args);
+  }
+}
+
+void ABIViewManager::OnPointerCanceled(
+    const ::Microsoft::ReactNative::ShadowNodeBase *node,
+    const ReactPointerEventArgs &args) {
+  if (m_viewManagerWithPointerEvents) {
+    m_viewManagerWithPointerEvents.OnPointerCanceled(node->GetView(), args);
+  } else {
+    Super::OnPointerCaptureLost(node, args);
+  }
+}
+
+void ABIViewManager::OnPointerCaptureLost(
+    const ::Microsoft::ReactNative::ShadowNodeBase *node,
+    const ReactPointerEventArgs &args) {
+  if (m_viewManagerWithPointerEvents) {
+    m_viewManagerWithPointerEvents.OnPointerCaptureLost(node->GetView(), args);
+  } else {
+    Super::OnPointerCaptureLost(node, args);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -239,6 +239,14 @@ void ABIViewManager::OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs
   }
 }
 
+void ABIViewManager::OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs &args) {
+  if (m_viewManagerWithPointerEvents) {
+    m_viewManagerWithPointerEvents.OnPointerCaptureLost(args);
+  } else {
+    Super::OnPointerCaptureLost(args);
+  }
+}
+
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {
   return new ABIShadowNode(
       m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout());

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -216,9 +216,7 @@ YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
   }
 }
 
-void ABIViewManager::OnPointerEvent(
-    const ::Microsoft::ReactNative::ShadowNodeBase *node,
-    const ReactPointerEventArgs &args) {
+void ABIViewManager::OnPointerEvent(::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerEvent(node->GetView(), args);
   }

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -40,7 +40,8 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithCommands{viewManager.try_as<IViewManagerWithCommands>()},
       m_viewManagerWithExportedEventTypeConstants{viewManager.try_as<IViewManagerWithExportedEventTypeConstants>()},
       m_viewManagerRequiresNativeLayout{viewManager.try_as<IViewManagerRequiresNativeLayout>()},
-      m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()} {
+      m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()},
+      m_viewManagerWithPointerEvents{viewManager.try_as<IViewManagerWithPointerEvents>()} {
   if (m_viewManagerWithReactContext) {
     m_viewManagerWithReactContext.ReactContext(winrt::make<implementation::ReactContext>(Mso::Copy(reactContext)));
   }
@@ -212,6 +213,29 @@ YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
     return ::Microsoft::ReactNative::DefaultYogaSelfMeasureFunc;
   } else {
     return nullptr;
+  }
+}
+
+bool ABIViewManager::OnPointerPressed(const xaml::Input::PointerRoutedEventArgs &args) {
+  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerPressed(args)
+                                        : Super::OnPointerPressed(args);
+}
+
+bool ABIViewManager::OnPointerMoved(const xaml::Input::PointerRoutedEventArgs &args) {
+  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerMoved(args)
+                                        : Super::OnPointerMoved(args);
+}
+
+bool ABIViewManager::OnPointerReleased(const xaml::Input::PointerRoutedEventArgs &args) {
+  return m_viewManagerWithPointerEvents ? m_viewManagerWithPointerEvents.OnPointerReleased(args)
+                                        : Super::OnPointerReleased(args);
+}
+
+void ABIViewManager::OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs &args) {
+  if (m_viewManagerWithPointerEvents) {
+    m_viewManagerWithPointerEvents.OnPointerCanceled(args);
+  } else {
+    Super::OnPointerCanceled(args);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -216,54 +216,14 @@ YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
   }
 }
 
-void ABIViewManager::OnPointerPressed(
+void ABIViewManager::OnPointerEvent(
     const ::Microsoft::ReactNative::ShadowNodeBase *node,
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerPressed(node->GetView(), args);
+    m_viewManagerWithPointerEvents.OnPointerEvent(node->GetView(), args);
   }
   // Call the base method to handle `pointerEvents` behavior
-  Super::OnPointerPressed(node, args);
-}
-
-void ABIViewManager::OnPointerMoved(
-    const ::Microsoft::ReactNative::ShadowNodeBase *node,
-    const ReactPointerEventArgs &args) {
-  if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerMoved(node->GetView(), args);
-  }
-  // Call the base method to handle `pointerEvents` behavior
-  Super::OnPointerMoved(node, args);
-}
-
-void ABIViewManager::OnPointerReleased(
-    const ::Microsoft::ReactNative::ShadowNodeBase *node,
-    const ReactPointerEventArgs &args) {
-  if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerReleased(node->GetView(), args);
-  }
-  // Call the base method to handle `pointerEvents` behavior
-  Super::OnPointerReleased(node, args);
-}
-
-void ABIViewManager::OnPointerCanceled(
-    const ::Microsoft::ReactNative::ShadowNodeBase *node,
-    const ReactPointerEventArgs &args) {
-  if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerCanceled(node->GetView(), args);
-  }
-  // Call the base method to handle `pointerEvents` behavior
-  Super::OnPointerCanceled(node, args);
-}
-
-void ABIViewManager::OnPointerCaptureLost(
-    const ::Microsoft::ReactNative::ShadowNodeBase *node,
-    const ReactPointerEventArgs &args) {
-  if (m_viewManagerWithPointerEvents) {
-    m_viewManagerWithPointerEvents.OnPointerCaptureLost(node->GetView(), args);
-  }
-  // Call the base method to handle `pointerEvents` behavior
-  Super::OnPointerCaptureLost(node, args);
+  Super::OnPointerEvent(node, args);
 }
 
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -221,9 +221,9 @@ void ABIViewManager::OnPointerPressed(
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerPressed(node->GetView(), args);
-  } else {
-    Super::OnPointerCaptureLost(node, args);
   }
+  // Call the base method to handle `pointerEvents` behavior
+  Super::OnPointerPressed(node, args);
 }
 
 void ABIViewManager::OnPointerMoved(
@@ -231,9 +231,9 @@ void ABIViewManager::OnPointerMoved(
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerMoved(node->GetView(), args);
-  } else {
-    Super::OnPointerCaptureLost(node, args);
   }
+  // Call the base method to handle `pointerEvents` behavior
+  Super::OnPointerMoved(node, args);
 }
 
 void ABIViewManager::OnPointerReleased(
@@ -241,9 +241,9 @@ void ABIViewManager::OnPointerReleased(
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerReleased(node->GetView(), args);
-  } else {
-    Super::OnPointerCaptureLost(node, args);
   }
+  // Call the base method to handle `pointerEvents` behavior
+  Super::OnPointerReleased(node, args);
 }
 
 void ABIViewManager::OnPointerCanceled(
@@ -251,9 +251,9 @@ void ABIViewManager::OnPointerCanceled(
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerCanceled(node->GetView(), args);
-  } else {
-    Super::OnPointerCaptureLost(node, args);
   }
+  // Call the base method to handle `pointerEvents` behavior
+  Super::OnPointerCanceled(node, args);
 }
 
 void ABIViewManager::OnPointerCaptureLost(
@@ -261,9 +261,9 @@ void ABIViewManager::OnPointerCaptureLost(
     const ReactPointerEventArgs &args) {
   if (m_viewManagerWithPointerEvents) {
     m_viewManagerWithPointerEvents.OnPointerCaptureLost(node->GetView(), args);
-  } else {
-    Super::OnPointerCaptureLost(node, args);
   }
+  // Call the base method to handle `pointerEvents` behavior
+  Super::OnPointerCaptureLost(node, args);
 }
 
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -69,6 +69,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   bool OnPointerMoved(const xaml::Input::PointerRoutedEventArgs &args) override;
   bool OnPointerReleased(const xaml::Input::PointerRoutedEventArgs &args) override;
   void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs &args) override;
+  void OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs &args) override;
 
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -65,7 +65,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
     return m_viewManagerRequiresNativeLayout != nullptr && m_viewManagerRequiresNativeLayout.RequiresNativeLayout();
   }
 
-  void OnPointerEvent(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) override;
+  void OnPointerEvent(::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) override;
 
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -65,6 +65,11 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
     return m_viewManagerRequiresNativeLayout != nullptr && m_viewManagerRequiresNativeLayout.RequiresNativeLayout();
   }
 
+  bool OnPointerPressed(const xaml::Input::PointerRoutedEventArgs &args) override;
+  bool OnPointerMoved(const xaml::Input::PointerRoutedEventArgs &args) override;
+  bool OnPointerReleased(const xaml::Input::PointerRoutedEventArgs &args) override;
+  void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs &args) override;
+
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
@@ -77,6 +82,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithExportedEventTypeConstants m_viewManagerWithExportedEventTypeConstants;
   IViewManagerWithChildren m_viewManagerWithChildren;
   IViewManagerRequiresNativeLayout m_viewManagerRequiresNativeLayout;
+  IViewManagerWithPointerEvents m_viewManagerWithPointerEvents;
 
   winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, ViewManagerPropertyType> m_nativeProps;
 };

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -65,15 +65,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
     return m_viewManagerRequiresNativeLayout != nullptr && m_viewManagerRequiresNativeLayout.RequiresNativeLayout();
   }
 
-  void OnPointerPressed(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
-      override;
-  void OnPointerMoved(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) override;
-  void OnPointerReleased(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
-      override;
-  void OnPointerCanceled(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
-      override;
-  void OnPointerCaptureLost(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
-      override;
+  void OnPointerEvent(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) override;
 
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -65,11 +65,15 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
     return m_viewManagerRequiresNativeLayout != nullptr && m_viewManagerRequiresNativeLayout.RequiresNativeLayout();
   }
 
-  bool OnPointerPressed(const xaml::Input::PointerRoutedEventArgs &args) override;
-  bool OnPointerMoved(const xaml::Input::PointerRoutedEventArgs &args) override;
-  bool OnPointerReleased(const xaml::Input::PointerRoutedEventArgs &args) override;
-  void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs &args) override;
-  void OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs &args) override;
+  void OnPointerPressed(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
+      override;
+  void OnPointerMoved(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args) override;
+  void OnPointerReleased(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
+      override;
+  void OnPointerCanceled(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
+      override;
+  void OnPointerCaptureLost(const ::Microsoft::ReactNative::ShadowNodeBase *node, const ReactPointerEventArgs &args)
+      override;
 
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "IViewManagerCore.idl";
+import "ReactPointerEventArgs.idl";
 
 #include "NamespaceRedirect.h"
 #include "DocString.h"
@@ -69,10 +70,10 @@ namespace Microsoft.ReactNative
     "Enables a view manager to release pointer capture from the React root view and start handling pointer events itself."
   )
   interface IViewManagerWithPointerEvents {
-    Boolean OnPointerPressed(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
-    Boolean OnPointerMoved(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
-    Boolean OnPointerReleased(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
-    void OnPointerCanceled(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
-    void OnPointerCaptureLost(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+    void OnPointerPressed(Object view, ReactPointerEventArgs args);
+    void OnPointerMoved(Object view, ReactPointerEventArgs args);
+    void OnPointerReleased(Object view, ReactPointerEventArgs args);
+    void OnPointerCanceled(Object view, ReactPointerEventArgs args);
+    void OnPointerCaptureLost(Object view, ReactPointerEventArgs args);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -65,9 +65,11 @@ namespace Microsoft.ReactNative
     Object CreateViewWithProperties(IJSValueReader propertyMapReader);
   };
 
+  [experimental]
   [webhosthidden]
   DOC_STRING(
-    "Enables a view manager to release pointer capture from the React root view and start handling pointer events itself."
+    "Experimental interface enabling view managers to release pointer capture "
+    "from the React root view and start handling pointer events itself."
   )
   interface IViewManagerWithPointerEvents {
     void OnPointerEvent(Object view, ReactPointerEventArgs args);

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -73,5 +73,6 @@ namespace Microsoft.ReactNative
     Boolean OnPointerMoved(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
     Boolean OnPointerReleased(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
     void OnPointerCanceled(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+    void OnPointerCaptureLost(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -70,10 +70,6 @@ namespace Microsoft.ReactNative
     "Enables a view manager to release pointer capture from the React root view and start handling pointer events itself."
   )
   interface IViewManagerWithPointerEvents {
-    void OnPointerPressed(Object view, ReactPointerEventArgs args);
-    void OnPointerMoved(Object view, ReactPointerEventArgs args);
-    void OnPointerReleased(Object view, ReactPointerEventArgs args);
-    void OnPointerCanceled(Object view, ReactPointerEventArgs args);
-    void OnPointerCaptureLost(Object view, ReactPointerEventArgs args);
+    void OnPointerEvent(Object view, ReactPointerEventArgs args);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -72,6 +72,20 @@ namespace Microsoft.ReactNative
     "from the React root view and start handling pointer events itself."
   )
   interface IViewManagerWithPointerEvents {
+    DOC_STRING(
+      "When pointer events are received on the React root view, the top-level "
+      "pointer event handler invokes this callback for each React view "
+      "ancestor of the @Windows.UI.Xaml.RoutedEventArgs.OriginalSource "
+      "element with a view manager that implements "
+      "@IViewManagerWithPointerEvents to allow the view manager to modify "
+      "handling for the pointer event. This can be used to refine the target "
+      "view. E.g., setting the @ReactPointerEventArgs.Target property to null "
+      "will force the React root view to choose one of the view's ancestors "
+      "as the hit target. Alternatively, the view manager may also set the "
+      "@ReactPointerEventArgs.Target to any descendent of provided view to "
+      "enable hit testing on views that do not derive from "
+      "@Windows.UI.Xaml.UIElement."
+    )
     void OnPointerEvent(Object view, ReactPointerEventArgs args);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -63,4 +63,15 @@ namespace Microsoft.ReactNative
   interface IViewManagerCreateWithProperties {
     Object CreateViewWithProperties(IJSValueReader propertyMapReader);
   };
+
+  [webhosthidden]
+  DOC_STRING(
+    "Enables a view manager to release pointer capture from the React root view and start handling pointer events itself."
+  )
+  interface IViewManagerWithPointerEvents {
+    Boolean OnPointerPressed(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+    Boolean OnPointerMoved(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+    Boolean OnPointerReleased(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+    void OnPointerCanceled(XAML_NAMESPACE.Input.PointerRoutedEventArgs args);
+  };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -389,6 +389,10 @@
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="XamlView.h" />
+    <ClInclude Include="ReactPointerEventArgs.h">
+      <DependentUpon>ReactPointerEventArgs.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup Condition="'$(UseFabric)' == 'true'">
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\config\ReactNativeConfig.cpp" />
@@ -575,6 +579,10 @@
     <ClCompile Include="Modules\TimingModule.cpp" />
     <ClCompile Include="Modules\PaperUIManagerModule.cpp" />
     <ClCompile Include="NativeModulesProvider.cpp" />
+    <ClCompile Include="ReactPointerEventArgs.cpp">
+      <DependentUpon>ReactPointerEventArgs.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="RedBoxErrorInfo.cpp" />
     <ClCompile Include="RedBoxErrorFrameInfo.cpp" />
     <ClCompile Include="TurboModulesProvider.cpp" />
@@ -746,6 +754,7 @@
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="XamlHelper.idl" />
+    <Midl Include="ReactPointerEventArgs.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -327,6 +327,7 @@
     <ClCompile Include="Views\Text\TextVisitor.cpp">
       <Filter>Views\Text</Filter>
     </ClCompile>
+    <ClCompile Include="ReactPointerEventArgs.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
@@ -714,6 +715,7 @@
     <ClInclude Include="Views\Text\TextVisitors.h">
       <Filter>Views\Text</Filter>
     </ClInclude>
+    <ClInclude Include="ReactPointerEventArgs.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />
@@ -751,6 +753,7 @@
     <Midl Include="JsiApi.idl" />
     <Midl Include="DocString.idl" />
     <Midl Include="DesktopWindowMessage.idl" />
+    <Midl Include="ReactPointerEventArgs.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -31,10 +31,6 @@ void ReactPointerEventArgs::ReleaseCapture() {
   m_captureReleased = true;
 }
 
-void ReactPointerEventArgs::StopPropagation() {
-  m_propagationStopped = true;
-}
-
 ReactPointerEventArgs::ReactPointerEventArgs(
     PointerEventKind kind,
     xaml::Input::PointerRoutedEventArgs const &args) noexcept
@@ -46,10 +42,6 @@ bool ReactPointerEventArgs::CaptureReleased() const noexcept {
 
 bool ReactPointerEventArgs::DefaultPrevented() const noexcept {
   return m_defaultPrevented;
-}
-
-bool ReactPointerEventArgs::PropagationStopped() const noexcept {
-  return m_propagationStopped;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -7,6 +7,10 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
+PointerEventKind ReactPointerEventArgs::Kind() const noexcept {
+  return m_kind;
+}
+
 xaml::Input::PointerRoutedEventArgs ReactPointerEventArgs::Args() const noexcept {
   return m_args;
 }
@@ -31,7 +35,10 @@ void ReactPointerEventArgs::StopPropagation() {
   m_propagationStopped = true;
 }
 
-ReactPointerEventArgs::ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept : m_args{args} {}
+ReactPointerEventArgs::ReactPointerEventArgs(
+    PointerEventKind kind,
+    xaml::Input::PointerRoutedEventArgs const &args) noexcept
+    : m_kind{kind}, m_args{args} {}
 
 bool ReactPointerEventArgs::CaptureReleased() const noexcept {
   return m_captureReleased;

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -23,12 +23,12 @@ void ReactPointerEventArgs::Target(winrt::IInspectable const &target) noexcept {
   m_target = target;
 }
 
-void ReactPointerEventArgs::PreventDefault() {
-  m_defaultPrevented = true;
+void ReactPointerEventArgs::AllowUncaptured() {
+  m_uncapturedAllowed = true;
 }
 
-void ReactPointerEventArgs::ReleaseCapture() {
-  m_captureReleased = true;
+void ReactPointerEventArgs::PreventDefault() {
+  m_defaultPrevented = true;
 }
 
 ReactPointerEventArgs::ReactPointerEventArgs(
@@ -36,12 +36,12 @@ ReactPointerEventArgs::ReactPointerEventArgs(
     xaml::Input::PointerRoutedEventArgs const &args) noexcept
     : m_kind{kind}, m_args{args} {}
 
-bool ReactPointerEventArgs::CaptureReleased() const noexcept {
-  return m_captureReleased;
-}
-
 bool ReactPointerEventArgs::DefaultPrevented() const noexcept {
   return m_defaultPrevented;
+}
+
+bool ReactPointerEventArgs::UncapturedAllowed() const noexcept {
+  return m_uncapturedAllowed;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -12,13 +12,7 @@ xaml::Input::PointerRoutedEventArgs ReactPointerEventArgs::Args() const noexcept
 }
 
 PointerEventKind ReactPointerEventArgs::Kind() const noexcept {
-  return m_kind.has_value() ? m_kind.value() : m_originalKind;
-}
-
-void ReactPointerEventArgs::Kind(PointerEventKind const &kind) noexcept {
-  if (m_originalKind == PointerEventKind::CaptureLost && kind == PointerEventKind::End) {
-    m_kind = kind;
-  }
+  return m_kind;
 }
 
 winrt::IInspectable ReactPointerEventArgs::Target() const noexcept {
@@ -29,25 +23,9 @@ void ReactPointerEventArgs::Target(winrt::IInspectable const &target) noexcept {
   m_target = target;
 }
 
-void ReactPointerEventArgs::AllowUncaptured() {
-  m_uncapturedAllowed = true;
-}
-
-void ReactPointerEventArgs::PreventDefault() {
-  m_defaultPrevented = true;
-}
-
 ReactPointerEventArgs::ReactPointerEventArgs(
     PointerEventKind kind,
     xaml::Input::PointerRoutedEventArgs const &args) noexcept
-    : m_originalKind{kind}, m_args{args} {}
-
-bool ReactPointerEventArgs::DefaultPrevented() const noexcept {
-  return m_defaultPrevented;
-}
-
-bool ReactPointerEventArgs::UncapturedAllowed() const noexcept {
-  return m_uncapturedAllowed;
-}
+    : m_kind{kind}, m_args{args} {}
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "ReactPointerEventArgs.g.cpp"
+#include "ReactPointerEventArgs.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+xaml::Input::PointerRoutedEventArgs ReactPointerEventArgs::Args() const noexcept {
+  return m_args;
+}
+
+winrt::IInspectable ReactPointerEventArgs::Target() const noexcept {
+  return m_target;
+}
+
+void ReactPointerEventArgs::Target(winrt::IInspectable const &target) noexcept {
+  m_target = target;
+}
+
+void ReactPointerEventArgs::PreventDefault() {
+  m_defaultPrevented = true;
+}
+
+void ReactPointerEventArgs::ReleaseCapture() {
+  m_captureReleased = true;
+}
+
+void ReactPointerEventArgs::StopPropagation() {
+  m_propagationStopped = true;
+}
+
+ReactPointerEventArgs::ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept
+    : m_args{args} {}
+
+bool ReactPointerEventArgs::CaptureReleased() const noexcept {
+  return m_captureReleased;
+}
+
+bool ReactPointerEventArgs::DefaultPrevented() const noexcept {
+  return m_defaultPrevented;
+}
+
+bool ReactPointerEventArgs::PropagationStopped() const noexcept {
+  return m_propagationStopped;
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -7,12 +7,18 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-PointerEventKind ReactPointerEventArgs::Kind() const noexcept {
-  return m_kind;
-}
-
 xaml::Input::PointerRoutedEventArgs ReactPointerEventArgs::Args() const noexcept {
   return m_args;
+}
+
+PointerEventKind ReactPointerEventArgs::Kind() const noexcept {
+  return m_kind.has_value() ? m_kind.value() : m_originalKind;
+}
+
+void ReactPointerEventArgs::Kind(PointerEventKind const &kind) noexcept {
+  if (m_originalKind == PointerEventKind::CaptureLost && kind == PointerEventKind::End) {
+    m_kind = kind;
+  }
 }
 
 winrt::IInspectable ReactPointerEventArgs::Target() const noexcept {
@@ -34,7 +40,7 @@ void ReactPointerEventArgs::PreventDefault() {
 ReactPointerEventArgs::ReactPointerEventArgs(
     PointerEventKind kind,
     xaml::Input::PointerRoutedEventArgs const &args) noexcept
-    : m_kind{kind}, m_args{args} {}
+    : m_originalKind{kind}, m_args{args} {}
 
 bool ReactPointerEventArgs::DefaultPrevented() const noexcept {
   return m_defaultPrevented;

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include "ReactPointerEventArgs.g.cpp"
 #include "ReactPointerEventArgs.h"
+#include "ReactPointerEventArgs.g.cpp"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -31,8 +31,7 @@ void ReactPointerEventArgs::StopPropagation() {
   m_propagationStopped = true;
 }
 
-ReactPointerEventArgs::ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept
-    : m_args{args} {}
+ReactPointerEventArgs::ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept : m_args{args} {}
 
 bool ReactPointerEventArgs::CaptureReleased() const noexcept {
   return m_captureReleased;

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -11,28 +11,17 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
   xaml::Input::PointerRoutedEventArgs Args() const noexcept;
 
   PointerEventKind Kind() const noexcept;
-  void Kind(PointerEventKind const &kind) noexcept;
 
   winrt::IInspectable Target() const noexcept;
   void Target(winrt::IInspectable const &target) noexcept;
 
-  void AllowUncaptured();
-  void PreventDefault();
-
   // Internal use
   ReactPointerEventArgs(PointerEventKind kind, xaml::Input::PointerRoutedEventArgs const &args) noexcept;
 
-  bool UncapturedAllowed() const noexcept;
-  bool DefaultPrevented() const noexcept;
-
  private:
-  PointerEventKind m_originalKind;
-  std::optional<PointerEventKind> m_kind{std::nullopt};
+  PointerEventKind m_kind;
   xaml::Input::PointerRoutedEventArgs const &m_args;
   winrt::IInspectable m_target{nullptr};
-
-  bool m_uncapturedAllowed{false};
-  bool m_defaultPrevented{false};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -16,14 +16,12 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
 
   void PreventDefault();
   void ReleaseCapture();
-  void StopPropagation();
 
   // Internal use
   ReactPointerEventArgs(PointerEventKind kind, xaml::Input::PointerRoutedEventArgs const &args) noexcept;
 
   bool CaptureReleased() const noexcept;
   bool DefaultPrevented() const noexcept;
-  bool PropagationStopped() const noexcept;
 
  private:
   PointerEventKind m_kind;
@@ -32,7 +30,6 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
 
   bool m_captureReleased{false};
   bool m_defaultPrevented{false};
-  bool m_propagationStopped{false};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -14,13 +14,13 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
   winrt::IInspectable Target() const noexcept;
   void Target(winrt::IInspectable const &target) noexcept;
 
+  void AllowUncaptured();
   void PreventDefault();
-  void ReleaseCapture();
 
   // Internal use
   ReactPointerEventArgs(PointerEventKind kind, xaml::Input::PointerRoutedEventArgs const &args) noexcept;
 
-  bool CaptureReleased() const noexcept;
+  bool UncapturedAllowed() const noexcept;
   bool DefaultPrevented() const noexcept;
 
  private:
@@ -28,7 +28,7 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
   xaml::Input::PointerRoutedEventArgs const &m_args;
   winrt::IInspectable m_target{nullptr};
 
-  bool m_captureReleased{false};
+  bool m_uncapturedAllowed{false};
   bool m_defaultPrevented{false};
 };
 

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "ReactPointerEventArgs.g.h"
+#include <UI.Xaml.Input.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
+  xaml::Input::PointerRoutedEventArgs Args() const noexcept;
+
+  winrt::IInspectable Target() const noexcept;
+  void Target(winrt::IInspectable const &target) noexcept;
+
+  void PreventDefault();
+  void ReleaseCapture();
+  void StopPropagation();
+
+  // Internal use
+  ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept;
+
+  bool CaptureReleased() const noexcept;
+  bool DefaultPrevented() const noexcept;
+  bool PropagationStopped() const noexcept;
+
+ private:
+  xaml::Input::PointerRoutedEventArgs const &m_args;
+  winrt::IInspectable m_target{nullptr};
+
+  bool m_captureReleased{false};
+  bool m_defaultPrevented{false};
+  bool m_propagationStopped{false};
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -8,8 +8,10 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
-  PointerEventKind Kind() const noexcept;
   xaml::Input::PointerRoutedEventArgs Args() const noexcept;
+
+  PointerEventKind Kind() const noexcept;
+  void Kind(PointerEventKind const &kind) noexcept;
 
   winrt::IInspectable Target() const noexcept;
   void Target(winrt::IInspectable const &target) noexcept;
@@ -24,7 +26,8 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
   bool DefaultPrevented() const noexcept;
 
  private:
-  PointerEventKind m_kind;
+  PointerEventKind m_originalKind;
+  std::optional<PointerEventKind> m_kind{std::nullopt};
   xaml::Input::PointerRoutedEventArgs const &m_args;
   winrt::IInspectable m_target{nullptr};
 

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.h
@@ -8,6 +8,7 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
+  PointerEventKind Kind() const noexcept;
   xaml::Input::PointerRoutedEventArgs Args() const noexcept;
 
   winrt::IInspectable Target() const noexcept;
@@ -18,13 +19,14 @@ struct ReactPointerEventArgs : ReactPointerEventArgsT<ReactPointerEventArgs> {
   void StopPropagation();
 
   // Internal use
-  ReactPointerEventArgs(xaml::Input::PointerRoutedEventArgs const &args) noexcept;
+  ReactPointerEventArgs(PointerEventKind kind, xaml::Input::PointerRoutedEventArgs const &args) noexcept;
 
   bool CaptureReleased() const noexcept;
   bool DefaultPrevented() const noexcept;
   bool PropagationStopped() const noexcept;
 
  private:
+  PointerEventKind m_kind;
   xaml::Input::PointerRoutedEventArgs const &m_args;
   winrt::IInspectable m_target{nullptr};
 

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -5,6 +5,7 @@
 #include "NamespaceRedirect.h"
 
 namespace Microsoft.ReactNative {
+  [experimental]
   [webhosthidden]
   DOC_STRING("Pointer event type enum.")
   enum PointerEventKind {
@@ -16,6 +17,7 @@ namespace Microsoft.ReactNative {
     CaptureLost,
   };
 
+  [experimental]
   [webhosthidden]
   DOC_STRING("Event arguments wrapper for IViewManagerWithPointerEvents.")
   runtimeclass ReactPointerEventArgs {
@@ -23,25 +25,14 @@ namespace Microsoft.ReactNative {
     XAML_NAMESPACE.Input.PointerRoutedEventArgs Args {
       get;
     };
-    DOC_STRING(
-      "Gets or sets the pointer event kind. The setter should only be used to "
-      "change CaptureLost events to End (treat capture loss as pointer end). "
-      "All other changes will be ignored."
-    )
+    DOC_STRING("Gets the pointer event kind.")
     PointerEventKind Kind {
       get;
-      set;
     };
     DOC_STRING("Gets or sets the React target for the pointer event.")
     Object Target {
       get;
       set;
     };
-    DOC_STRING("Prevent event from being emitted to React JS component.")
-    void PreventDefault();
-    DOC_STRING(
-      "Allow events to be emitted to React JS even if pointer is not captured."
-    )
-    void AllowUncaptured();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -34,7 +34,7 @@ namespace Microsoft.ReactNative {
     };
     DOC_STRING("Prevent event from being emitted to React JS component.")
     void PreventDefault();
-    DOC_STRING("Prevent or release pointer capture in React Native pointer event handler.")
-    void ReleaseCapture();
+    DOC_STRING("Allow events to be emitted to React JS even if pointer is not captured.")
+    void AllowUncaptured();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -7,19 +7,42 @@
 namespace Microsoft.ReactNative {
   [experimental]
   [webhosthidden]
-  DOC_STRING("Pointer event type enum.")
   enum PointerEventKind {
+    DOC_STRING(
+      "Default pointer event kind that corresponding to events that should be "
+      "ignored by the React root view pointer event handler."
+    )
     None,
+    DOC_STRING(
+      "Pointer event kind corresponding to "
+      "@Windows.UI.Xaml.UIElement.PointerPressedEvent on the React root view."
+    )
     Start,
+    DOC_STRING(
+      "Pointer event kind corresponding to "
+      "@Windows.UI.Xaml.UIElement.PointerReleasedEvent on the React root view."
+    )
     End,
+    DOC_STRING(
+      "Pointer event kind corresponding to "
+      "@Windows.UI.Xaml.UIElement.PointerMovedEvent on the React root view."
+    )
     Move,
+    DOC_STRING(
+      "Pointer event kind corresponding to "
+      "@Windows.UI.Xaml.UIElement.PointerCanceledEvent on the React root view."
+    )
     Cancel,
+    DOC_STRING(
+      "Pointer event kind corresponding to "
+      "@Windows.UI.Xaml.UIElement.PointerCaptureLostEvent on the React root view."
+    )
     CaptureLost,
   };
 
   [experimental]
   [webhosthidden]
-  DOC_STRING("Event arguments wrapper for IViewManagerWithPointerEvents.")
+  DOC_STRING("Event arguments wrapper for @IViewManagerWithPointerEvents.")
   runtimeclass ReactPointerEventArgs {
     DOC_STRING("Gets the wrapped routed pointer event.")
     XAML_NAMESPACE.Input.PointerRoutedEventArgs Args {

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -36,7 +36,5 @@ namespace Microsoft.ReactNative {
     void PreventDefault();
     DOC_STRING("Prevent or release pointer capture in React Native pointer event handler.")
     void ReleaseCapture();
-    DOC_STRING("Prevent parent views from receiving pointer event callbacks.")
-    void StopPropagation();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -19,13 +19,18 @@ namespace Microsoft.ReactNative {
   [webhosthidden]
   DOC_STRING("Event arguments wrapper for IViewManagerWithPointerEvents.")
   runtimeclass ReactPointerEventArgs {
-    DOC_STRING("Gets the pointer event kind.")
-    PointerEventKind Kind {
-      get;
-    };
     DOC_STRING("Gets the wrapped routed pointer event.")
     XAML_NAMESPACE.Input.PointerRoutedEventArgs Args {
       get;
+    };
+    DOC_STRING(
+      "Gets or sets the pointer event kind. The setter should only be used to "
+      "change CaptureLost events to End (treat capture loss as pointer end). "
+      "All other changes will be ignored."
+    )
+    PointerEventKind Kind {
+      get;
+      set;
     };
     DOC_STRING("Gets or sets the React target for the pointer event.")
     Object Target {
@@ -34,7 +39,9 @@ namespace Microsoft.ReactNative {
     };
     DOC_STRING("Prevent event from being emitted to React JS component.")
     void PreventDefault();
-    DOC_STRING("Allow events to be emitted to React JS even if pointer is not captured.")
+    DOC_STRING(
+      "Allow events to be emitted to React JS even if pointer is not captured."
+    )
     void AllowUncaptured();
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -6,9 +6,24 @@
 
 namespace Microsoft.ReactNative {
   [webhosthidden]
+  DOC_STRING("Pointer event type enum.")
+  enum PointerEventKind {
+    None,
+    Start,
+    End,
+    Move,
+    Cancel,
+    CaptureLost,
+  };
+
+  [webhosthidden]
   DOC_STRING("Event arguments wrapper for IViewManagerWithPointerEvents.")
   runtimeclass ReactPointerEventArgs {
-    DOC_STRING("Prevent event from being emitted to React JS component.")
+    DOC_STRING("Gets the pointer event kind.")
+    PointerEventKind Kind {
+      get;
+    };
+    DOC_STRING("Gets the wrapped routed pointer event.")
     XAML_NAMESPACE.Input.PointerRoutedEventArgs Args {
       get;
     };

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.idl
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DocString.h"
+#include "NamespaceRedirect.h"
+
+namespace Microsoft.ReactNative {
+  [webhosthidden]
+  DOC_STRING("Event arguments wrapper for IViewManagerWithPointerEvents.")
+  runtimeclass ReactPointerEventArgs {
+    DOC_STRING("Prevent event from being emitted to React JS component.")
+    XAML_NAMESPACE.Input.PointerRoutedEventArgs Args {
+      get;
+    };
+    DOC_STRING("Gets or sets the React target for the pointer event.")
+    Object Target {
+      get;
+      set;
+    };
+    DOC_STRING("Prevent event from being emitted to React JS component.")
+    void PreventDefault();
+    DOC_STRING("Prevent or release pointer capture in React Native pointer event handler.")
+    void ReleaseCapture();
+    DOC_STRING("Prevent parent views from receiving pointer event callbacks.")
+    void StopPropagation();
+  }
+} // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -628,7 +628,7 @@ bool TouchEventHandler::TagFromOriginalSource(
 
     // Walk to root to find refined React target view
     const auto argsImpl = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactPointerEventArgs>(args);
-    while (node && !argsImpl->PropagationStopped()) {
+    while (node) {
       const auto previousTarget = args.Target();
       if (args.Target() == nullptr) {
         args.Target(node->GetView());

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -111,11 +111,12 @@ void TouchEventHandler::OnPointerPressed(
 
   if (!argsImpl->DefaultPrevented() &&
       (argsImpl->UncapturedAllowed() || m_xamlView.as<xaml::FrameworkElement>().CapturePointer(args.Pointer()))) {
+    assert(!tagsForBranch.empty());
+    const auto tag = tagsForBranch.front();
+
     // Pointer pressing updates the enter/leave state
     UpdatePointersInViews(args, sourceElement, std::move(tagsForBranch));
 
-    assert(!tagsForBranch.empty());
-    const auto tag = tagsForBranch.front();
     size_t pointerIndex = AddReactPointer(args, tag, sourceElement);
 
     // For now, when using the mouse we only want to send click events for the left button.

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -110,7 +110,7 @@ void TouchEventHandler::OnPointerPressed(
     return;
   }
 
-  if (!argsImpl->CaptureReleased() && m_xamlView.as<xaml::FrameworkElement>().CapturePointer(args.Pointer())) {
+  if (!argsImpl->CaptureReleased() && !argsImpl->DefaultPrevented() && m_xamlView.as<xaml::FrameworkElement>().CapturePointer(args.Pointer())) {
     // Pointer pressing updates the enter/leave state
     UpdatePointersInViews(args, tag, sourceElement, std::move(tagsForBranch));
 
@@ -118,7 +118,7 @@ void TouchEventHandler::OnPointerPressed(
 
     // For now, when using the mouse we only want to send click events for the left button.
     // Finger and pen taps will also set isLeftButton.
-    if (m_pointers[pointerIndex].isLeftButton && !argsImpl->DefaultPrevented()) {
+    if (m_pointers[pointerIndex].isLeftButton) {
       DispatchTouchEvent(eventType, pointerIndex);
     }
   }

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -177,7 +177,7 @@ void TouchEventHandler::OnPointerMoved(
       UpdateReactPointer(m_pointers[*optPointerIndex], args, sourceElement);
       DispatchTouchEvent(eventType, *optPointerIndex);
     }
-  } else {
+  } else if (!argsImpl->DefaultPrevented()) {
     // Move with no buttons pressed
     UpdatePointersInViews(args, tag, sourceElement);
   }
@@ -610,11 +610,10 @@ bool TouchEventHandler::TagFromOriginalSource(
   assert(pTag != nullptr);
   assert(pSourceElement != nullptr);
 
-  xaml::UIElement sourceElement = args.Args().OriginalSource().try_as<xaml::UIElement>();
-  winrt::IPropertyValue tag(nullptr);
-
-  ShadowNodeBase *node = nullptr;
   if (const auto uiManager = GetNativeUIManager(*m_context).lock()) {
+    xaml::UIElement sourceElement = args.Args().OriginalSource().try_as<xaml::UIElement>();
+    ShadowNodeBase *node = nullptr;
+
     // Find the "deepest" React element that triggered the input event
     while (sourceElement) {
       node = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(GetTag(sourceElement)));
@@ -637,7 +636,6 @@ bool TouchEventHandler::TagFromOriginalSource(
       node = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(node->m_parent));
     }
 
-    winrt::IPropertyValue tag;
     if (args.Target() != nullptr) {
       if (auto tag = GetTagAsPropertyValue(args.Target().as<XamlView>())) {
         sourceElement = args.Target().try_as<xaml::UIElement>();

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -654,6 +654,11 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactTarget(
         tagsForBranch.push_back(node->m_tag);
       }
 
+      // Stop traversing when we get to the root target
+      if (node->GetView() == m_xamlView) {
+        break;
+      }
+
       node = static_cast<ShadowNodeBase *>(uiManager->getHost()->FindShadowNodeForTag(node->m_parent));
     }
 
@@ -684,9 +689,12 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactTarget(
             bool isHit = false;
             const auto finerTag = TestHit(inlines, pointerPos, isHit);
             if (finerTag) {
+              // Insert nested text tags in reverse order
               const auto tagsToCurrentTarget = GetTagsForBranch(uiManager->getHost(), GetTag(finerTag), GetTag(tag));
-              for (auto tag : tagsToCurrentTarget) {
-                tagsForBranch.insert(tagsForBranch.begin(), tag);
+              auto iter = tagsToCurrentTarget.rbegin();
+              while (iter != tagsToCurrentTarget.rend()) {
+                tagsForBranch.insert(tagsForBranch.begin(), *iter);
+                iter++;
               }
             }
           }

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -104,7 +104,7 @@ class TouchEventHandler {
   std::unordered_map<uint32_t /*pointerId*/, TagSet /*tags*/> m_pointersInViews;
   int64_t m_touchId = 0;
 
-  bool PropagatePointerEventAndFindReactTarget(
+  bool PropagatePointerEventAndFindReactSourceBranch(
       const winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
       std::vector<int64_t> *pTagsForBranch,
       xaml::UIElement *pSourceElement);
@@ -112,7 +112,6 @@ class TouchEventHandler {
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);
-  bool IsPointerCaptured(uint32_t pointerId);
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -104,6 +104,7 @@ class TouchEventHandler {
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);
+  bool NotifyParentViewManagers(int64_t tag, TouchEventType eventType, const winrt::PointerRoutedEventArgs &args);
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -100,15 +100,15 @@ class TouchEventHandler {
   std::unordered_map<uint32_t /*pointerId*/, TagSet /*tags*/> m_pointersInViews;
   int64_t m_touchId = 0;
 
-  bool TagFromOriginalSource(const winrt::PointerRoutedEventArgs &args, int64_t *pTag, xaml::UIElement *pSourceElement);
+  bool TagFromOriginalSource(
+      winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
+      TouchEventType eventType,
+      int64_t *pTag,
+      xaml::UIElement *pSourceElement);
   winrt::IPropertyValue TestHit(
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);
-  bool NotifyParentViewManagers(
-      int64_t tag,
-      TouchEventType eventType,
-      const winrt::Microsoft::ReactNative::implementation::ReactPointerEventArgs &args);
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -80,7 +80,7 @@ class TouchEventHandler {
 #ifdef USE_FABRIC
   facebook::react::Touch TouchForPointer(const ReactPointer &pointer) noexcept;
 #endif
-  enum class TouchEventType { Start = 0, End, Move, Cancel, PointerEntered, PointerExited, PointerMove };
+  enum class TouchEventType { Start = 0, End, Move, Cancel, CaptureLost, PointerEntered, PointerExited, PointerMove };
   void OnPointerConcluded(TouchEventType eventType, const winrt::PointerRoutedEventArgs &args);
   void DispatchTouchEvent(TouchEventType eventType, size_t pointerIndex);
   bool DispatchBackEvent();

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -86,6 +86,7 @@ class TouchEventHandler {
   void DispatchTouchEvent(TouchEventType eventType, size_t pointerIndex);
   bool DispatchBackEvent();
   const char *GetPointerDeviceTypeName(winrt::Windows::Devices::Input::PointerDeviceType deviceType) noexcept;
+  winrt::Microsoft::ReactNative::PointerEventKind GetPointerEventKind(TouchEventType eventType) noexcept;
   const wchar_t *GetTouchEventTypeName(TouchEventType eventType) noexcept;
 
   std::optional<size_t> IndexOfPointerWithId(uint32_t pointerId);
@@ -102,7 +103,6 @@ class TouchEventHandler {
 
   bool TagFromOriginalSource(
       winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
-      TouchEventType eventType,
       int64_t *pTag,
       xaml::UIElement *pSourceElement);
   winrt::IPropertyValue TestHit(

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -79,7 +79,7 @@ class TouchEventHandler {
   void UpdatePointersInViews(
       const winrt::PointerRoutedEventArgs &args,
       xaml::UIElement sourceElement,
-      std::vector<int64_t> &&tagsForBranch);
+      std::vector<int64_t> &&newViews);
 
 #ifdef USE_FABRIC
   facebook::react::Touch TouchForPointer(const ReactPointer &pointer) noexcept;
@@ -105,7 +105,7 @@ class TouchEventHandler {
   int64_t m_touchId = 0;
 
   bool PropagatePointerEventAndFindReactTarget(
-      winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
       std::vector<int64_t> *pTagsForBranch,
       xaml::UIElement *pSourceElement);
   winrt::IPropertyValue TestHit(

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <IReactInstance.h>
 #include <JSValue.h>
+#include <ReactPointerEventArgs.h>
 #include <UI.Xaml.Documents.h>
 #include <winrt/Windows.Devices.Input.h>
 #include <optional>
@@ -104,7 +105,10 @@ class TouchEventHandler {
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);
-  bool NotifyParentViewManagers(int64_t tag, TouchEventType eventType, const winrt::PointerRoutedEventArgs &args);
+  bool NotifyParentViewManagers(
+      int64_t tag,
+      TouchEventType eventType,
+      const winrt::Microsoft::ReactNative::implementation::ReactPointerEventArgs &args);
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -78,7 +78,6 @@ class TouchEventHandler {
   UpdateReactPointer(ReactPointer &pointer, const winrt::PointerRoutedEventArgs &args, xaml::UIElement sourceElement);
   void UpdatePointersInViews(
       const winrt::PointerRoutedEventArgs &args,
-      int64_t tag,
       xaml::UIElement sourceElement,
       std::vector<int64_t> &&tagsForBranch);
 
@@ -105,11 +104,10 @@ class TouchEventHandler {
   std::unordered_map<uint32_t /*pointerId*/, TagSet /*tags*/> m_pointersInViews;
   int64_t m_touchId = 0;
 
-  bool TagFromOriginalSource(
+  bool PropagatePointerEventAndFindReactTarget(
       winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
-      int64_t *pTag,
-      xaml::UIElement *pSourceElement,
-      std::vector<int64_t> &tagsForBranch);
+      std::vector<int64_t> *pTagsForBranch,
+      xaml::UIElement *pSourceElement);
   winrt::IPropertyValue TestHit(
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -76,7 +76,11 @@ class TouchEventHandler {
   CreateReactPointer(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::UIElement sourceElement);
   void
   UpdateReactPointer(ReactPointer &pointer, const winrt::PointerRoutedEventArgs &args, xaml::UIElement sourceElement);
-  void UpdatePointersInViews(const winrt::PointerRoutedEventArgs &args, int64_t tag, xaml::UIElement sourceElement);
+  void UpdatePointersInViews(
+      const winrt::PointerRoutedEventArgs &args,
+      int64_t tag,
+      xaml::UIElement sourceElement,
+      std::vector<int64_t> &&tagsForBranch);
 
 #ifdef USE_FABRIC
   facebook::react::Touch TouchForPointer(const ReactPointer &pointer) noexcept;
@@ -104,7 +108,8 @@ class TouchEventHandler {
   bool TagFromOriginalSource(
       winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
       int64_t *pTag,
-      xaml::UIElement *pSourceElement);
+      xaml::UIElement *pSourceElement,
+      std::vector<int64_t> &tagsForBranch);
   winrt::IPropertyValue TestHit(
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -112,6 +112,7 @@ class TouchEventHandler {
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);
+  bool IsPointerCaptured(uint32_t pointerId);
 
   XamlView m_xamlView;
   Mso::CntPtr<const Mso::React::IReactContext> m_context;

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -79,6 +79,17 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
 
+  virtual bool OnPointerPressed(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
+    return false;
+  }
+  virtual bool OnPointerMoved(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
+    return false;
+  }
+  virtual bool OnPointerReleased(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
+    return false;
+  }
+  virtual void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs & /*args*/) {}
+
   const Mso::React::IReactContext &GetReactContext() const {
     return *m_context;
   }

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -79,17 +79,21 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
 
-  virtual bool OnPointerPressed(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
-    return false;
-  }
-  virtual bool OnPointerMoved(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
-    return false;
-  }
-  virtual bool OnPointerReleased(const xaml::Input::PointerRoutedEventArgs & /*args*/) {
-    return false;
-  }
-  virtual void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs & /*args*/) {}
-  virtual void OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs & /*args*/) {}
+  virtual void OnPointerPressed(
+      const ShadowNodeBase * /*node*/,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
+  virtual void OnPointerMoved(
+      const ShadowNodeBase * /*node*/,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
+  virtual void OnPointerReleased(
+      const ShadowNodeBase * /*node*/,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
+  virtual void OnPointerCanceled(
+      const ShadowNodeBase * /*node*/,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
+  virtual void OnPointerCaptureLost(
+      const ShadowNodeBase * /*node*/,
+      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
 
   const Mso::React::IReactContext &GetReactContext() const {
     return *m_context;

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -79,19 +79,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
 
-  virtual void OnPointerPressed(
-      const ShadowNodeBase * /*node*/,
-      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
-  virtual void OnPointerMoved(
-      const ShadowNodeBase * /*node*/,
-      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
-  virtual void OnPointerReleased(
-      const ShadowNodeBase * /*node*/,
-      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
-  virtual void OnPointerCanceled(
-      const ShadowNodeBase * /*node*/,
-      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
-  virtual void OnPointerCaptureLost(
+  virtual void OnPointerEvent(
       const ShadowNodeBase * /*node*/,
       const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
 

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -80,7 +80,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   bool IsNativeControlWithSelfLayout() const;
 
   virtual void OnPointerEvent(
-      const ShadowNodeBase * /*node*/,
+      ShadowNodeBase * /*node*/,
       const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
 
   const Mso::React::IReactContext &GetReactContext() const {

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -89,6 +89,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
     return false;
   }
   virtual void OnPointerCanceled(const xaml::Input::PointerRoutedEventArgs & /*args*/) {}
+  virtual void OnPointerCaptureLost(const xaml::Input::PointerRoutedEventArgs & /*args*/) {}
 
   const Mso::React::IReactContext &GetReactContext() const {
     return *m_context;

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -36,9 +36,9 @@ inline int64_t GetTag(winrt::IPropertyValue value) {
   return value.GetInt64();
 }
 
-inline winrt::IPropertyValue GetTagAsPropertyValue(xaml::FrameworkElement fe) {
-  assert(fe);
-  return fe.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
+inline winrt::IPropertyValue GetTagAsPropertyValue(XamlView view) {
+  assert(view);
+  return view.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);


### PR DESCRIPTION
Closes #8499

Currently, there is no way for ViewManagers to capture the pointer to perform it's own pointer event handling. This change introduces a new interface, `IViewManagerWithPointerEvents`, so third party modules can be notified when the ReactRootView receives pointer events. The behavior is as follows:

`ViewManagerBase` adds a virtual method:
`OnPointerEvent(object sender, ReactPointerEventArgs args)`

We have a `ReactPointerEventArgs` wrapper around `PointerRoutedEventArgs` that view managers can use to:
1. Call `PreventDefault` to suppress the corresponding React event from being emitted
2. Call `ReleaseCapture` to force the TouchEventEmitter to release pointer capture (triggering an `onTouchCancel` event to React Native)
3. Update the `Target` property to refine for hit testing
 
The `ReactPointerEventArgs` wrapper also includes an enum `Kind` value for the type of pointer event so we can reduce the number of methods that need to be implemented for this interface.

TODO:
- [x] Only release pointer in `OnPointerMoved` rather than invoking `OnPointerConcluded`.
- [x] Consolidate parent traversals so we only traverse shadow node tree once per event.
- [x] ~~Add custom view manager example that uses this API.~~ N/A since we now leverage these APIs in core view managers
- [x] Determine if IViewManagerWithPointerEvents should participate in `onMouseEnter` / `onMouseLeave` events: The current approach should start onMouseEnter / onMouseLeave events at the ReactPointerEventArgs.Target() element.

We will need to update a few other PRs to leverage these APIs once they merge:
- Update #7553 and #8454 to use the `OnPointer*` APIs for Text hit testing
- [x] Update #7813 to use `PreventDefault` to suppress `OnPointerCaptureLost` from firing an `onTouchCancel` event

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8495)