### PR TITLE
Allow override of global.nativeLoggingHook

### DIFF
--- a/change/react-native-windows-7bd134b0-fc4f-4916-b38f-ca8f29e8b4fb.json
+++ b/change/react-native-windows-7bd134b0-fc4f-4916-b38f-ca8f29e8b4fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow override of global.nativeLoggingHook",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -115,6 +115,9 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   IRedBoxHandler RedBoxHandler() noexcept;
   void RedBoxHandler(IRedBoxHandler const &value) noexcept;
 
+  LogHandler NativeLogger() noexcept;
+  void NativeLogger(LogHandler const &value) noexcept;
+
   IReactDispatcher UIDispatcher() noexcept;
   void UIDispatcher(IReactDispatcher const &value) noexcept;
 
@@ -167,6 +170,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   IRedBoxHandler m_redBoxHandler{nullptr};
   hstring m_sourceBundleHost{};
   uint16_t m_sourceBundlePort{0};
+  LogHandler m_nativeLogger{nullptr};
 
 #if USE_HERMES
   JSIEngine m_jSIEngineOverride{JSIEngine::Hermes};
@@ -266,6 +270,14 @@ inline IRedBoxHandler ReactInstanceSettings::RedBoxHandler() noexcept {
 
 inline void ReactInstanceSettings::RedBoxHandler(IRedBoxHandler const &value) noexcept {
   m_redBoxHandler = value;
+}
+
+inline LogHandler ReactInstanceSettings::NativeLogger() noexcept {
+  return m_nativeLogger;
+}
+
+inline void ReactInstanceSettings::NativeLogger(LogHandler const &value) noexcept {
+  m_nativeLogger = value;
 }
 
 inline hstring ReactInstanceSettings::SourceBundleHost() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -13,6 +13,22 @@ import "RedBoxHandler.idl";
 namespace Microsoft.ReactNative
 {
   DOC_STRING(
+    "Used in @LogHandler to represent different LogLevels")
+  enum LogLevel
+  {
+    Trace = 0,
+    Info = 1,
+    Warning = 2,
+    Error = 3,
+    Fatal = 4
+  };
+
+  DOC_STRING(
+    "delegate to represent a logging function.")
+  delegate void LogHandler(LogLevel level, String message);
+
+
+  DOC_STRING(
     "A JavaScript engine type that can be set for a React instance in @ReactInstanceSettings.JSIEngineOverride")
   // Keep in sync with enum in IReactInstance.h
   enum JSIEngine
@@ -168,6 +184,12 @@ namespace Microsoft.ReactNative
       "Provides an extension point to allow custom error handling within the react instance. "
       "See @IRedBoxHandler for more information.")
     IRedBoxHandler RedBoxHandler { get; set; };
+
+    DOC_STRING(
+      "Function that will be hooked into the JavaScript instance as global.nativeLoggingHook. "
+      "This allows native hooks for JavaScript's console implementation. "
+      "If this is not set then logs will print output to the native debug output in debug builds, and no-op in release builds.")
+      LogHandler NativeLogger { get; set; };
 
     DOC_STRING(
       "Control the main UI dispatcher to be used by the React instance. "

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -118,6 +118,17 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   if (m_instanceSettings.RedBoxHandler()) {
     reactOptions.RedBoxHandler = Mso::React::CreateRedBoxHandler(m_instanceSettings.RedBoxHandler());
   }
+  if (m_instanceSettings.NativeLogger()) {
+    reactOptions.OnLogging = [handler = m_instanceSettings.NativeLogger()](
+                                 Mso::React::LogLevel logLevel, const char *message) {
+      static_assert(LogLevel::Error == static_cast<LogLevel>(Mso::React::LogLevel::Error));
+      static_assert(LogLevel::Fatal == static_cast<LogLevel>(Mso::React::LogLevel::Fatal));
+      static_assert(LogLevel::Info == static_cast<LogLevel>(Mso::React::LogLevel::Info));
+      static_assert(LogLevel::Trace == static_cast<LogLevel>(Mso::React::LogLevel::Trace));
+      static_assert(LogLevel::Warning == static_cast<LogLevel>(Mso::React::LogLevel::Warning));
+      handler(static_cast<LogLevel>(logLevel), winrt::to_hstring(message));
+    };
+  }
   reactOptions.DeveloperSettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
   reactOptions.DeveloperSettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
 


### PR DESCRIPTION
This functionality is available in the lower levels of the APIs that Office uses today, but to move to the higher level APIs Office will need them exposed through the IDL too.

This is the current LoggingCallback used, which will continue to be the default:
https://github.com/microsoft/react-native-windows/blob/ac25661d077eb4d4728042486c60341e6a5984d7/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp#L712

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8497)