### PR TITLE
Fixes bugs for pointerEvents prop

### DIFF
--- a/change/react-native-windows-b49059c5-b0c3-467a-a1aa-fbe285cb5fff.json
+++ b/change/react-native-windows-b49059c5-b0c3-467a-a1aa-fbe285cb5fff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds functionality for box-only and box-none via OnPointerEvent callback",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -128,6 +128,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   bool m_onMouseEnterRegistered = false;
   bool m_onMouseLeaveRegistered = false;
 
+  // Pointer events
+  std::string m_pointerEvents = "";
+
   // Support Keyboard
  public:
   void UpdateHandledKeyboardEvents(

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -16,6 +16,8 @@ namespace Microsoft::ReactNative {
 
 class ViewManagerBase;
 
+enum class PointerEventsKind : uint8_t { Auto = 0, BoxNone, BoxOnly, None };
+
 enum class ShadowEdges : uint8_t {
   Left = 0,
   Top,
@@ -129,7 +131,7 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   bool m_onMouseLeaveRegistered = false;
 
   // Pointer events
-  std::string m_pointerEvents = "";
+  PointerEventsKind m_pointerEvents = PointerEventsKind::Auto;
 
   // Support Keyboard
  public:

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -79,9 +79,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
 
-  virtual void OnPointerEvent(
-      ShadowNodeBase * /*node*/,
-      const winrt::Microsoft::ReactNative::ReactPointerEventArgs & /*args*/) {}
+  virtual void OnPointerEvent(ShadowNodeBase *node, const winrt::Microsoft::ReactNative::ReactPointerEventArgs &args);
 
   const Mso::React::IReactContext &GetReactContext() const {
     return *m_context;

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -406,12 +406,6 @@ bool ViewViewManager::UpdateProperty(
         bool clipChildren = propertyValue.AsString() == "hidden";
         pPanel.ClipChildren(clipChildren);
       }
-    } else if (propertyName == "pointerEvents") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        bool hitTestable = propertyValue.AsString() != "none";
-        if (const auto element = nodeToUpdate->GetView().try_as<xaml::UIElement>())
-          element.IsHitTestVisible(hitTestable);
-      }
     } else if (propertyName == "focusable") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
         pViewShadowNode->IsFocusable(propertyValue.AsBoolean());


### PR DESCRIPTION
Adds functionality for box-only and box-none via OnPointerEvent callback 

This change checks if the React node has `pointerEvents="box-only"` or `pointerEvents="box-none"` set. If the node is `box-only`, it updates the `ReactPointerEventArgs.Target` view to itself (preventing children from becoming the hit test target for the React pointer event. If the node is `box-none` and the current `ReactPointerEventArgs.Target` value is the current view, it sets the target to `null`, forcing the `TouchEventHandler` to choose an ancestor as the hit target.

https://user-images.githubusercontent.com/1106239/131200698-1bf38123-33ea-49af-8aff-a2f0942d3193.mp4dfs

Fixes #8496

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8500)