### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/node-rnw-rpc/package.json
+++ b/packages/node-rnw-rpc/package.json
@@ -10,6 +10,11 @@
     "watch": "rnw-scripts watch",
     "windows": "react-native run-windows"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/node-rnw-rpc"
+  },
   "main": "lib-commonjs/nodeRnwRpc.js",
   "dependencies": {
     "jsonrpc-lite": "^2.2.0"


### PR DESCRIPTION
NOTE: This is not a bot. This change was made by and comments will be reviewed by humans. We are using this service account to be able to track the overall progress.

With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources. 

We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your package.json REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.

If you do not want us to create such PRs against your GitHub repositories, or wish to provide any other feedback, please comment on this PR. 

Published NPM packages with repository information:
• node-rnw-rpc

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8512)