### PR TITLE
Add support for UIA accessibility headings

### DIFF
--- a/change/react-native-windows-a8b5bad4-4783-4c5f-a6f4-c227c9b6c8d9.json
+++ b/change/react-native-windows-a8b5bad4-4783-4c5f-a6f4-c227c9b6c8d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add accessibility UIA headings",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -303,6 +303,7 @@ bool TextViewManager::UpdateProperty(
       }
     } else if (propertyValue.IsNull()) {
       textBlock.ClearValue(winrt::AutomationProperties::LocalizedControlTypeProperty());
+      textBlock.ClearValue(winrt::AutomationProperties::HeadingLevelProperty());
     }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -288,6 +288,22 @@ bool TextViewManager::UpdateProperty(
       node->m_backgroundColor = OptionalColorFrom(propertyValue);
       node->RecalculateTextHighlighters();
     }
+  } else if (propertyName == "accessibilityRole") {
+    if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+      const std::string &role = propertyValue.AsString();
+      auto value = asHstring(propertyValue);
+      auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
+
+      textBlock.SetValue(winrt::AutomationProperties::LocalizedControlTypeProperty(), boxedValue);
+      if (role == "header") {
+        xaml::Automation::AutomationProperties::SetHeadingLevel(
+            textBlock, winrt::Peers::AutomationHeadingLevel::Level2);
+      } else {
+        textBlock.ClearValue(winrt::AutomationProperties::HeadingLevelProperty());
+      }
+    } else if (propertyValue.IsNull()) {
+      textBlock.ClearValue(winrt::AutomationProperties::LocalizedControlTypeProperty());
+    }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }


### PR DESCRIPTION
Related to: https://github.com/microsoft/react-native-windows/issues/8452
When accessibilityRole is set to "header" in RN-core, the native values that are updated (Heading for Android and accessibilityTrait for iOS) are the same values that used by screen readers to determine if some text is a heading. On Windows, screen readers check the UIA Heading Level to determine if something is a heading -- this PR sets the UIA Heading Level to a default level 2 whenever accessibilityRole="header" in Text. This will match the behavior in RN-core, although we might want to create a windows-specific prop down the road to allow for control over the exact heading level passed to UIA. 

Also included is an update to automationProperties.localizedControlTypeProperty when setting accessibilityRole in Text as a slight improvement for https://github.com/microsoft/react-native-windows/issues/8191 until we decide on a workaround for custom automation peer functionality for Text. 

**Testing:** Tested using Narrator and Accessibility Insights For Windows. When accessibilityRole="header" is set on a Text component Narrator Scan mode announces the heading as expected and Accessibility Insights shows the localizedControlTypeProperty as "header". 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8516)