### PR TITLE
Add AutomationClient and AutomationElement Facade

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -116,7 +116,7 @@ describe('FancyWidget', () => {
 
   test('FancyWidget is populated with placeholder', async () => {
     // Query for an element with accessibilityId of "foo" (see "locators" below)
-    const field = await $('~foo');
+    const field = await app.findElementByTestID('foo');
     expect(await field.getText()).toBe('placeholder');
   });
 
@@ -183,10 +183,10 @@ of testing againt the react tree, e2e-test-app compares the fully rendered XAML 
 correctness of ViewManagers.
 
 ```ts
-import {dumpVisualTree} from './framework';
+import {automationClient} from './framework';
 
 test('Example test', async () => {
-  const dump = await dumpVisualTree('test-id-here');
+  const dump = await automationClient.dumpVisualTree({testId: 'test-id-here'});
   expect(dump).toMatchSnapshot();
 });
 ```

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -123,30 +123,6 @@ describe('FancyWidget', () => {
 });
 ```
 
-### Locators to find UI Element
-
-No matter what JavaScript framework you choose for native app testing, you have to use one of the locators which is described in [mobile JSON wire protocol](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#locator-strategies). Since locators are implemented significant different on iOS, Android and Windows, as below I only talk about the locators for Windows.
-
-[Locators WinAppDriver supports](https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#supported-locators-to-find-ui-elements)
-
- WinAppDriver provides rich API to help locate the UI element. If [testID](https://facebook.github.io/react-native/docs/picker-item#testid) is specified in React Native app for Windows, the locator strategy should choose `accessibility id`.
-
-| **Client API** | **Locator Strategy** | **Matched Attribute in inspect.exe** | **Example** |
-| --- | --- | --- | --- |
-| FindElementByAccessibilityId | accessibility id | AutomationId | AppNameTitle |
-| FindElementByClassName | class name | ClassName | TextBlock |
-| FindElementById | Id | RuntimeId (decimal) | 42.333896.3.1 |
-| FindElementByName | Name | Name | Calculator |
-| FindElementByTagName | tag name | LocalizedControlType (upper camel case) | Text |
-| FindElementByXPath | Xpath | Any | //Button[0] |
-
-[Selectors WebDriverIO supports](https://webdriver.io/docs/selectors.html#mobile-selectors)
-
-| **Client API by Example** | **Locator Strategy** |
-| --- | --- |
-| $(&#39;~AppNameTitle&#39;) | accessibility id |
-| $(&#39;TextBlock&#39;) | class name |
-
 ### Adding a custom RNTester page
 
 Before adding a custom page, consider whether the change can be made to an existing RNTester page and upstreamed. If needed, new examples may be integrated into the Windows fork of RNTester, [`@react-native-windows/tester`](../packages/@react-native-windows/tester).
@@ -183,7 +159,7 @@ of testing againt the react tree, e2e-test-app compares the fully rendered XAML 
 correctness of ViewManagers.
 
 ```ts
-import {automationClient} from './framework';
+import {app} from './framework';
 
 test('Example test', async () => {
   const dump = await automationClient.dumpVisualTree({testId: 'test-id-here'});

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -159,10 +159,10 @@ of testing againt the react tree, e2e-test-app compares the fully rendered XAML 
 correctness of ViewManagers.
 
 ```ts
-import {app} from './framework';
+import {dumpVisualTree} from './framework';
 
 test('Example test', async () => {
-  const dump = await automationClient.dumpVisualTree({testId: 'test-id-here'});
+  const dump = await dumpVisualTree('test-id-here');
   expect(dump).toMatchSnapshot();
 });
 ```

--- a/packages/e2e-test-app/.eslintrc.js
+++ b/packages/e2e-test-app/.eslintrc.js
@@ -2,8 +2,6 @@ module.exports = {
   extends: ['@rnw-scripts'],
   parserOptions: { tsconfigRootDir: __dirname },
   globals: {
-    $: 'readonly',
-    browser: 'readonly',
     expect: 'readonly',
     fail: 'readonly',
     rpcClient: 'readonly',

--- a/packages/e2e-test-app/jest.setup.js
+++ b/packages/e2e-test-app/jest.setup.js
@@ -23,7 +23,7 @@ global.jasmine.getEnv().addReporter({
       );
 
       const filename = path.join(screenshotDir, friendlySpecName);
-      await browser.saveScreenshot(filename);
+      await global.browser.saveScreenshot(filename);
     }
   },
 });

--- a/packages/e2e-test-app/test/DisplayNoneTest.test.ts
+++ b/packages/e2e-test-app/test/DisplayNoneTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, dumpVisualTree} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('Display:none Style');
@@ -14,19 +14,21 @@ beforeAll(async () => {
 describe('DisplayNoneTest', () => {
   /* Test case #1: display:none disabled */
   test('DisplayNoneDisabledTest', async () => {
-    const dump = await dumpVisualTree('textbox-container');
+    const dump = await app.dumpVisualTree('textbox-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Enable display:none once, update view*/
   test('DisplayNoneEnabledTest', async () => {
     await toggleDisplayNone();
-    const dump = await dumpVisualTree('textbox-container');
+    const dump = await app.dumpVisualTree('textbox-container');
     expect(dump).toMatchSnapshot();
   });
 });
 
 async function toggleDisplayNone() {
-  const showDisplayNoneToggle = await $('~toggle-display:none');
+  const showDisplayNoneToggle = await app.findElementByTestID(
+    'toggle-display:none',
+  );
   await showDisplayNoneToggle.click();
 }

--- a/packages/e2e-test-app/test/DisplayNoneTest.test.ts
+++ b/packages/e2e-test-app/test/DisplayNoneTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, app} from './framework';
+import {app, goToComponentExample, dumpVisualTree} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('Display:none Style');
@@ -14,14 +14,14 @@ beforeAll(async () => {
 describe('DisplayNoneTest', () => {
   /* Test case #1: display:none disabled */
   test('DisplayNoneDisabledTest', async () => {
-    const dump = await app.dumpVisualTree('textbox-container');
+    const dump = await dumpVisualTree('textbox-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Enable display:none once, update view*/
   test('DisplayNoneEnabledTest', async () => {
     await toggleDisplayNone();
-    const dump = await app.dumpVisualTree('textbox-container');
+    const dump = await dumpVisualTree('textbox-container');
     expect(dump).toMatchSnapshot();
   });
 });

--- a/packages/e2e-test-app/test/LegacyControlStyleTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyControlStyleTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, app} from './framework';
+import {app, goToComponentExample, dumpVisualTree} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyControlStyleTest');
@@ -14,21 +14,21 @@ beforeAll(async () => {
 describe('LegacyControlStyleTest', () => {
   /* Test case #1: Controls style with regular border */
   test('ControlStyleTestWithRegularBorder', async () => {
-    const dump = await app.dumpVisualTree('control-style-switch-view');
+    const dump = await dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Click button once, update controls style and round border*/
   test('ControlStyleTestWithRoundBorder', async () => {
     await toggleControlBorder();
-    const dump = await app.dumpVisualTree('control-style-switch-view');
+    const dump = await dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #3: Click button one more, return to #1*/
   test('ControlStyleTestWithRegularBorder #2', async () => {
     await toggleControlBorder();
-    const dump = await app.dumpVisualTree('control-style-switch-view');
+    const dump = await dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 });

--- a/packages/e2e-test-app/test/LegacyControlStyleTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyControlStyleTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, dumpVisualTree} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyControlStyleTest');
@@ -14,26 +14,26 @@ beforeAll(async () => {
 describe('LegacyControlStyleTest', () => {
   /* Test case #1: Controls style with regular border */
   test('ControlStyleTestWithRegularBorder', async () => {
-    const dump = await dumpVisualTree('control-style-switch-view');
+    const dump = await app.dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Click button once, update controls style and round border*/
   test('ControlStyleTestWithRoundBorder', async () => {
     await toggleControlBorder();
-    const dump = await dumpVisualTree('control-style-switch-view');
+    const dump = await app.dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #3: Click button one more, return to #1*/
   test('ControlStyleTestWithRegularBorder #2', async () => {
     await toggleControlBorder();
-    const dump = await dumpVisualTree('control-style-switch-view');
+    const dump = await app.dumpVisualTree('control-style-switch-view');
     expect(dump).toMatchSnapshot();
   });
 });
 
 async function toggleControlBorder() {
-  const showBorderToggle = await $('~show-border-toggle');
+  const showBorderToggle = await app.findElementByTestID('show-border-toggle');
   await showBorderToggle.click();
 }

--- a/packages/e2e-test-app/test/LegacyImageTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyImageTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, dumpVisualTree} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyImageTest');
@@ -14,37 +14,39 @@ beforeAll(async () => {
 describe('LegacyImageTest', () => {
   /* Test case #1: view and image displayed with no border and cornerRadius */
   test('ImageWithoutBorderTest', async () => {
-    const dump = await dumpVisualTree('image-container');
+    const dump = await app.dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Click button once, update view and image with round border*/
   test('ImageWithBorderTest', async () => {
     await toggleImageBorder();
-    const dump = await dumpVisualTree('image-container');
+    const dump = await app.dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #3: Click button one more, remove border from view and image but tree sturcture is different from #1*/
   test('ImageWithoutBorderTestOneMoreClick', async () => {
     await toggleImageBorder();
-    const dump = await dumpVisualTree('image-container');
+    const dump = await app.dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   test('ImageRTLTest', async () => {
     await toggleRTLMode();
-    const dump = await dumpVisualTree('image-container');
+    const dump = await app.dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 });
 
 async function toggleImageBorder() {
-  const imageBorderToggle = await $('~toggle-border-button');
+  const imageBorderToggle = await app.findElementByTestID(
+    'toggle-border-button',
+  );
   await imageBorderToggle.click();
 }
 
 async function toggleRTLMode() {
-  const rtlToggleButton = await $('~set-rtl-button');
+  const rtlToggleButton = await app.findElementByTestID('set-rtl-button');
   await rtlToggleButton.click();
 }

--- a/packages/e2e-test-app/test/LegacyImageTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyImageTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, app} from './framework';
+import {app, goToComponentExample, dumpVisualTree} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyImageTest');
@@ -14,27 +14,27 @@ beforeAll(async () => {
 describe('LegacyImageTest', () => {
   /* Test case #1: view and image displayed with no border and cornerRadius */
   test('ImageWithoutBorderTest', async () => {
-    const dump = await app.dumpVisualTree('image-container');
+    const dump = await dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #2: Click button once, update view and image with round border*/
   test('ImageWithBorderTest', async () => {
     await toggleImageBorder();
-    const dump = await app.dumpVisualTree('image-container');
+    const dump = await dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   /* Test case #3: Click button one more, remove border from view and image but tree sturcture is different from #1*/
   test('ImageWithoutBorderTestOneMoreClick', async () => {
     await toggleImageBorder();
-    const dump = await app.dumpVisualTree('image-container');
+    const dump = await dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 
   test('ImageRTLTest', async () => {
     await toggleRTLMode();
-    const dump = await app.dumpVisualTree('image-container');
+    const dump = await dumpVisualTree('image-container');
     expect(dump).toMatchSnapshot();
   });
 });

--- a/packages/e2e-test-app/test/LegacyLoginTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyLoginTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyLoginTest');
@@ -67,32 +67,34 @@ describe('LegacyLoginTest', () => {
 });
 
 async function setUsername(username: string) {
-  const usernameField = await $('~username-field');
+  const usernameField = await app.findElementByTestID('username-field');
   await usernameField.setValue(username);
 }
 
 async function setPassword(password: string) {
-  const passwordField = await $('~password-field');
+  const passwordField = await app.findElementByTestID('password-field');
   await passwordField.setValue(password);
 }
 
 async function appendPassword(password: string) {
-  const passwordField = await $('~password-field');
+  const passwordField = await app.findElementByTestID('password-field');
   await passwordField.addValue('End');
   await passwordField.addValue(password);
 }
 
 async function toggleShowPassword() {
-  const showPasswordToggle = await $('~show-password-toggle');
+  const showPasswordToggle = await app.findElementByTestID(
+    'show-password-toggle',
+  );
   await showPasswordToggle.click();
 }
 
 async function submitForm() {
-  const submitButton = await $('~submit-button');
+  const submitButton = await app.findElementByTestID('submit-button');
   await submitButton.click();
 }
 
 async function getLoginResult(): Promise<string> {
-  const loginResult = await $('~result-text');
+  const loginResult = await app.findElementByTestID('result-text');
   return await loginResult.getText();
 }

--- a/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
+++ b/packages/e2e-test-app/test/LegacyTextInputTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('LegacyTextInputTest');
@@ -86,21 +86,21 @@ describe('LegacyTextInputTest', () => {
 });
 
 async function textInputField() {
-  return await $('~textinput-field');
+  return await app.findElementByTestID('textinput-field');
 }
 
 async function autoCapsTextInputField() {
-  return await $('~auto-caps-textinput-field');
+  return await app.findElementByTestID('auto-caps-textinput-field');
 }
 
 async function multiLineTextInputField() {
-  return await $('~multi-line-textinput-field');
+  return await app.findElementByTestID('multi-line-textinput-field');
 }
 
 async function assertLogContains(text: string) {
-  const textLogComponent = await $('~textinput-log');
+  const textLogComponent = await app.findElementByTestID('textinput-log');
 
-  await browser.waitUntil(
+  await app.waitUntil(
     async () => {
       const loggedText = await textLogComponent.getText();
       return loggedText.split('\n').includes(text);
@@ -112,9 +112,9 @@ async function assertLogContains(text: string) {
 }
 
 async function assertLogContainsInOrder(expectedLines: string[]) {
-  const textLogComponent = await $('~textinput-log');
+  const textLogComponent = await app.findElementByTestID('textinput-log');
 
-  await browser.waitUntil(
+  await app.waitUntil(
     async () => {
       const loggedText = await textLogComponent.getText();
       const actualLines = loggedText.split('\n');

--- a/packages/e2e-test-app/test/TextComponentTest.test.ts
+++ b/packages/e2e-test-app/test/TextComponentTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, dumpVisualTree} from './framework';
+import {goToComponentExample, app} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('Text');
@@ -13,107 +13,107 @@ beforeAll(async () => {
 
 describe('TextTest', () => {
   test('Text transform', async () => {
-    const dump = await dumpVisualTree('text-transform');
+    const dump = await app.dumpVisualTree('text-transform');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text wrapping', async () => {
-    const dump = await dumpVisualTree('text-wrap');
+    const dump = await app.dumpVisualTree('text-wrap');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text padding', async () => {
-    const dump = await dumpVisualTree('text-padding');
+    const dump = await app.dumpVisualTree('text-padding');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text font family', async () => {
-    const dump = await dumpVisualTree('text-font-family');
+    const dump = await app.dumpVisualTree('text-font-family');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text size', async () => {
-    const dump = await dumpVisualTree('text-size');
+    const dump = await app.dumpVisualTree('text-size');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text color', async () => {
-    const dump = await dumpVisualTree('text-color');
+    const dump = await app.dumpVisualTree('text-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text decoration underline', async () => {
-    const dump = await dumpVisualTree('text-decoration-underline');
+    const dump = await app.dumpVisualTree('text-decoration-underline');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text decoration solid linethrough', async () => {
-    const dump = await dumpVisualTree('text-decoration-solid-linethru');
+    const dump = await app.dumpVisualTree('text-decoration-solid-linethru');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text color with children', async () => {
-    const dump = await dumpVisualTree('text-outer-color');
+    const dump = await app.dumpVisualTree('text-outer-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text alignment', async () => {
-    const dump = await dumpVisualTree('text-align');
+    const dump = await app.dumpVisualTree('text-align');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text unicode characters', async () => {
-    const dump = await dumpVisualTree('text-unicode');
+    const dump = await app.dumpVisualTree('text-unicode');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text line height', async () => {
-    const dump = await dumpVisualTree('text-line-height');
+    const dump = await app.dumpVisualTree('text-line-height');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text letter spacing', async () => {
-    const dump = await dumpVisualTree('text-letter-spacing');
+    const dump = await app.dumpVisualTree('text-letter-spacing');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text force one line', async () => {
-    const dump = await dumpVisualTree('text-one-line');
+    const dump = await app.dumpVisualTree('text-one-line');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text is selectable', async () => {
-    const dump = await dumpVisualTree('text-selectable');
+    const dump = await app.dumpVisualTree('text-selectable');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text selection color', async () => {
-    const dump = await dumpVisualTree('text-selection-color');
+    const dump = await app.dumpVisualTree('text-selection-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text shadows', async () => {
-    const dump = await dumpVisualTree('text-shadow');
+    const dump = await app.dumpVisualTree('text-shadow');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text ellipsize', async () => {
-    const dump = await dumpVisualTree('text-ellipsize');
+    const dump = await app.dumpVisualTree('text-ellipsize');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text font padding', async () => {
-    const dump = await dumpVisualTree('text-font-padding');
+    const dump = await app.dumpVisualTree('text-font-padding');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text border', async () => {
-    const dump = await dumpVisualTree('text-border');
+    const dump = await app.dumpVisualTree('text-border');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text background color', async () => {
-    const dump = await dumpVisualTree('text-background-color', {
+    const dump = await app.dumpVisualTree('text-background-color', {
       additionalProperties: ['TextHighlighters'],
     });
     expect(dump).toMatchSnapshot();

--- a/packages/e2e-test-app/test/TextComponentTest.test.ts
+++ b/packages/e2e-test-app/test/TextComponentTest.test.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {goToComponentExample, app} from './framework';
+import {goToComponentExample, dumpVisualTree} from './framework';
 
 beforeAll(async () => {
   await goToComponentExample('Text');
@@ -13,107 +13,107 @@ beforeAll(async () => {
 
 describe('TextTest', () => {
   test('Text transform', async () => {
-    const dump = await app.dumpVisualTree('text-transform');
+    const dump = await dumpVisualTree('text-transform');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text wrapping', async () => {
-    const dump = await app.dumpVisualTree('text-wrap');
+    const dump = await dumpVisualTree('text-wrap');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text padding', async () => {
-    const dump = await app.dumpVisualTree('text-padding');
+    const dump = await dumpVisualTree('text-padding');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text font family', async () => {
-    const dump = await app.dumpVisualTree('text-font-family');
+    const dump = await dumpVisualTree('text-font-family');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text size', async () => {
-    const dump = await app.dumpVisualTree('text-size');
+    const dump = await dumpVisualTree('text-size');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text color', async () => {
-    const dump = await app.dumpVisualTree('text-color');
+    const dump = await dumpVisualTree('text-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text decoration underline', async () => {
-    const dump = await app.dumpVisualTree('text-decoration-underline');
+    const dump = await dumpVisualTree('text-decoration-underline');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text decoration solid linethrough', async () => {
-    const dump = await app.dumpVisualTree('text-decoration-solid-linethru');
+    const dump = await dumpVisualTree('text-decoration-solid-linethru');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text color with children', async () => {
-    const dump = await app.dumpVisualTree('text-outer-color');
+    const dump = await dumpVisualTree('text-outer-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text alignment', async () => {
-    const dump = await app.dumpVisualTree('text-align');
+    const dump = await dumpVisualTree('text-align');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text unicode characters', async () => {
-    const dump = await app.dumpVisualTree('text-unicode');
+    const dump = await dumpVisualTree('text-unicode');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text line height', async () => {
-    const dump = await app.dumpVisualTree('text-line-height');
+    const dump = await dumpVisualTree('text-line-height');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text letter spacing', async () => {
-    const dump = await app.dumpVisualTree('text-letter-spacing');
+    const dump = await dumpVisualTree('text-letter-spacing');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text force one line', async () => {
-    const dump = await app.dumpVisualTree('text-one-line');
+    const dump = await dumpVisualTree('text-one-line');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text is selectable', async () => {
-    const dump = await app.dumpVisualTree('text-selectable');
+    const dump = await dumpVisualTree('text-selectable');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text selection color', async () => {
-    const dump = await app.dumpVisualTree('text-selection-color');
+    const dump = await dumpVisualTree('text-selection-color');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text shadows', async () => {
-    const dump = await app.dumpVisualTree('text-shadow');
+    const dump = await dumpVisualTree('text-shadow');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text ellipsize', async () => {
-    const dump = await app.dumpVisualTree('text-ellipsize');
+    const dump = await dumpVisualTree('text-ellipsize');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text font padding', async () => {
-    const dump = await app.dumpVisualTree('text-font-padding');
+    const dump = await dumpVisualTree('text-font-padding');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text border', async () => {
-    const dump = await app.dumpVisualTree('text-border');
+    const dump = await dumpVisualTree('text-border');
     expect(dump).toMatchSnapshot();
   });
 
   test('Text background color', async () => {
-    const dump = await app.dumpVisualTree('text-background-color', {
+    const dump = await dumpVisualTree('text-background-color', {
       additionalProperties: ['TextHighlighters'],
     });
     expect(dump).toMatchSnapshot();

--- a/packages/e2e-test-app/test/framework/AutomationClient.ts
+++ b/packages/e2e-test-app/test/framework/AutomationClient.ts
@@ -7,8 +7,6 @@
 
 /* global $:false, browser:false */
 
-import {dumpVisualTree} from './TreeDump';
-
 /**
  * Projection of a WebDriver Element, with functions corresponding to supported
  * WinAppDriver APIs.
@@ -47,8 +45,6 @@ export type AutomationElement = Pick<
  * This may not be 100% complete
  */
 export const app = {
-  dumpVisualTree,
-
   /**
    * Find an element by testID property
    */

--- a/packages/e2e-test-app/test/framework/AutomationClient.ts
+++ b/packages/e2e-test-app/test/framework/AutomationClient.ts
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+/* global $:false, browser:false */
+
+import {dumpVisualTree} from './TreeDump';
+
+/**
+ * Projection of a WebDriver Element, with functions corresponding to supported
+ * WinAppDriver APIs.
+ *
+ * See https://github.com/microsoft/WinAppDriver/blob/master/Docs/SupportedAPIs.md
+ */
+export type AutomationElement = Pick<
+  WebdriverIO.Element,
+  | 'addValue'
+  | 'clearValue'
+  | 'click'
+  | 'doubleClick'
+  | 'getAttribute'
+  | 'getLocation'
+  | 'getSize'
+  | 'getText'
+  | 'getValue'
+  | 'isDisplayed'
+  | 'isDisplayedInViewport'
+  | 'isEnabled'
+  | 'isEqual'
+  | 'isSelected'
+  | 'moveTo'
+  | 'saveScreenshot'
+  | 'setValue'
+  | 'touchAction'
+  | 'waitForDisplayed'
+  | 'waitForExist'
+>;
+
+/**
+ * WebDriverIO exposes a whole webdriver client, with loads of functionality
+ * that doesn't work or make sense on a desktop app. This facade exposes the
+ * bits that consistently work, in an easier API.
+ *
+ * This may not be 100% complete
+ */
+export const app = {
+  dumpVisualTree,
+
+  /**
+   * Find an element by testID property
+   */
+  findElementByTestID: (id: string): Promise<AutomationElement> => $(`~${id}`),
+
+  /**
+   * Find an element by Automation ID
+   *
+   * https://docs.microsoft.com/en-us/dotnet/api/system.windows.automation.automationelement.automationelementinformation.automationid?view=net-5.0
+   */
+  findElementByAutomationID: (id: string): Promise<AutomationElement> =>
+    $(`~${id}`),
+
+  /**
+   * Finds an element by the name of its class name (e.g. ListViewItem)
+   *
+   * https://docs.microsoft.com/en-us/dotnet/api/system.windows.automation.automationelement.automationelementinformation.classname?view=net-5.0
+   */
+  findElementByClassName: (className: string): Promise<AutomationElement> =>
+    $(className),
+
+  /**
+   * Find element by ControlType (e.g. Button, CheckBox)
+   *
+   * https://docs.microsoft.com/en-us/dotnet/api/system.windows.automation.controltype?view=net-5.0
+   */
+  findElementByControlType: (controlType: string): Promise<AutomationElement> =>
+    $(`<${controlType} />`),
+
+  /**
+   * Find element by a WinAppDriver compatible XPath Selector (e.g. '//Button[@AutomationId=\"MoreButton\"]')
+   */
+  findElementByXPath: (xpath: string): Promise<AutomationElement> => $(xpath),
+
+  setWindowSize: browser.setWindowSize.bind(browser),
+  setWindowPosition: browser.setWindowPosition.bind(browser),
+  getWindowPosition: browser.getWindowPosition.bind(browser),
+  getWindowSize: browser.getWindowSize.bind(browser),
+  switchWindow: browser.switchWindow.bind(browser),
+
+  waitUntil: browser.waitUntil.bind(browser),
+};

--- a/packages/e2e-test-app/test/framework/Navigation.ts
+++ b/packages/e2e-test-app/test/framework/Navigation.ts
@@ -30,7 +30,7 @@ async function goToExample(example: string) {
   const searchBox = await app.findElementByTestID('explorer_search');
   await searchBox.setValue(regexEscape(example));
 
-  const exampleButton = await app.findElementByTestID('example');
+  const exampleButton = await app.findElementByTestID(example);
   await exampleButton.click();
 
   // Make sure we've launched the example by waiting until the search box is

--- a/packages/e2e-test-app/test/framework/Navigation.ts
+++ b/packages/e2e-test-app/test/framework/Navigation.ts
@@ -5,11 +5,13 @@
  * @format
  */
 
+import {app} from './AutomationClient';
+
 /**
  * Visit an example on the RNTester Components tab
  */
 export async function goToComponentExample(example: string) {
-  const componentsTabButton = await $('~components-tab');
+  const componentsTabButton = await app.findElementByTestID('components-tab');
   await componentsTabButton.click();
   await goToExample(example);
 }
@@ -18,24 +20,24 @@ export async function goToComponentExample(example: string) {
  * Visit an example on the RNTester APIs tab
  */
 export async function goToApiExample(example: string) {
-  const componentsTabButton = await $('~apis-tab');
+  const componentsTabButton = await app.findElementByTestID('apis-tab');
   await componentsTabButton.click();
   await goToExample(example);
 }
 
 async function goToExample(example: string) {
   // Filter the list down to the one test, to improve the stability of selectors
-  const searchBox = await $('~explorer_search');
+  const searchBox = await app.findElementByTestID('explorer_search');
   await searchBox.setValue(regexEscape(example));
 
-  const exampleButton = await $(`~${example}`);
+  const exampleButton = await app.findElementByTestID('example');
   await exampleButton.click();
 
   // Make sure we've launched the example by waiting until the search box is
   // no longer present, but make sure we haven't crashed by checking that nav
   // buttons are still visible
-  await browser.waitUntil(async () => !(await exampleButton.isDisplayed()));
-  const componentsTab = await $('~components-tab');
+  await app.waitUntil(async () => !(await exampleButton.isDisplayed()));
+  const componentsTab = await app.findElementByTestID('components-tab');
   expect(await componentsTab.isDisplayed()).toBe(true);
 }
 

--- a/packages/e2e-test-app/test/framework/index.ts
+++ b/packages/e2e-test-app/test/framework/index.ts
@@ -5,5 +5,6 @@
  * @format
  */
 
-export * from './Navigation';
 export * from './AutomationClient';
+export * from './Navigation';
+export * from './TreeDump';

--- a/packages/e2e-test-app/test/framework/index.ts
+++ b/packages/e2e-test-app/test/framework/index.ts
@@ -6,4 +6,4 @@
  */
 
 export * from './Navigation';
-export * from './TreeDump';
+export * from './AutomationClient';


### PR DESCRIPTION
WebDriverIO exposes a whole webdriver client, with loads of functionality that doesn't work or make sense on a desktop app. This facade exposes the bits that are supported by WinAppDriver, in an easier API. It also lets us potentially decouple from WebDriverIO if we want to move to a differnt WebDriver client.

Currently being done in the test app, but will be extracted to a separate package after to allow use in apps outside the repo.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8517)