### PR TITLE
 Use Package Identity Name Instead of Package Family Name for Testing

### DIFF
--- a/change/jest-environment-winappdriver-6023bd5e-c1ba-4c1d-8400-91294717852e.json
+++ b/change/jest-environment-winappdriver-6023bd5e-c1ba-4c1d-8400-91294717852e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "Use Package Identity Name Instead of Package Family Name for Testing",
+  "packageName": "jest-environment-winappdriver",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/jest.config.js
+++ b/packages/e2e-test-app/jest.config.js
@@ -46,7 +46,7 @@ module.exports = {
   setupFilesAfterEnv: ['react-native-windows/jest/setup', './jest.setup.js'],
 
   testEnvironmentOptions: {
-    app: 'ReactUWPTestApp_8wekyb3d8bbwe!App',
+    app: 'ReactUWPTestApp',
     enableRpc: true,
     webdriverOptions: {
       // Level of logging verbosity: trace | debug | info | warn | error

--- a/packages/jest-environment-winappdriver/README.md
+++ b/packages/jest-environment-winappdriver/README.md
@@ -12,7 +12,7 @@ module.exports = {
   testEnvironment: 'jest-environment-winappdriver',
   maxWorkers: 1,
   testEnvironmentOptions: {
-    app: 'ReactUWPTestApp_8wekyb3d8bbwe!App',
+    app: 'ReactUWPTestApp',
     webdriverOptions: {
       logLevel: 'error',
       ...

--- a/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
+++ b/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {spawn, ChildProcess} from 'child_process';
+import {execSync, spawn, ChildProcess} from 'child_process';
 import fs from 'fs';
 
 import NodeEnvironment = require('jest-environment-node');
@@ -16,6 +16,10 @@ import {Config} from '@jest/types';
 import {waitForConnection, RpcClient} from 'node-rnw-rpc';
 
 export type EnvironmentOptions = {
+  /**
+   * The application to launch. Can be a path to an exe, or a package identity
+   * name (e.g. Microsoft.WindowsAlarms)
+   */
   app?: string;
   enableRpc?: boolean;
   rpcPort?: number;
@@ -51,7 +55,7 @@ class WinAppDriverEnvironment extends NodeEnvironment {
     const baseOptions: RemoteOptions = {
       port: 4723,
       capabilities: {
-        app: passedOptions.app,
+        app: resolveAppName(passedOptions.app),
         // @ts-ignore
         'ms:experimental-webdriver': true,
       },
@@ -139,6 +143,32 @@ async function spawnWinAppDriver(
       );
     });
   });
+}
+
+/**
+ * Convert a package identity of path to exe to the form expected by a WinAppDriver capability
+ */
+function resolveAppName(appName: string): string {
+  if (appName.endsWith('.exe')) {
+    return appName;
+  }
+
+  try {
+    const packageFamilyName = execSync(
+      `powershell (Get-AppxPackage -Name ${appName}).PackageFamilyName`,
+    )
+      .toString()
+      .trim();
+
+    if (packageFamilyName.length === 0) {
+      // Rethrown below
+      throw new Error();
+    }
+
+    return packageFamilyName;
+  } catch {
+    throw new Error(`Could not locate a package with identity "${appName}"`);
+  }
 }
 
 export {RpcClient} from 'node-rnw-rpc';

--- a/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
+++ b/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
@@ -146,7 +146,7 @@ async function spawnWinAppDriver(
 }
 
 /**
- * Convert a package identity of path to exe to the form expected by a WinAppDriver capability
+ * Convert a package identity or path to exe to the form expected by a WinAppDriver capability
  */
 function resolveAppName(appName: string): string {
   if (appName.endsWith('.exe')) {

--- a/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
+++ b/packages/jest-environment-winappdriver/src/WinAppDriverEnvironment.ts
@@ -165,7 +165,7 @@ function resolveAppName(appName: string): string {
       throw new Error();
     }
 
-    return packageFamilyName;
+    return `${packageFamilyName}!App`;
   } catch {
     throw new Error(`Could not locate a package with identity "${appName}"`);
   }


### PR DESCRIPTION
WinAppDriver expects an app passed to it as either a package family name, or a path to an exe. Package family names are confusing to work with, so instead use a package identity and do the conversion ourselves.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8518)