### PR TITLE
Generate aliased struct for turbo module

### DIFF
--- a/change/@react-native-windows-codegen-967f1b7b-9b13-42dd-9e2c-5878d2033ecf.json
+++ b/change/@react-native-windows-codegen-967f1b7b-9b13-42dd-9e2c-5878d2033ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate aliased struct for turbo module",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-6d7508de-686f-443e-a500-fd6df3e799a8.json
+++ b/change/react-native-windows-6d7508de-686f-443e-a500-fd6df3e799a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate aliased struct for turbo module",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -7,19 +7,14 @@
 'use strict';
 
 import {
-  NamedShape,
   NativeModuleFunctionTypeAnnotation,
-  NativeModuleParamTypeAnnotation,
   NativeModulePropertyShape,
-  NativeModuleReturnTypeAnnotation,
-  Nullable,
   SchemaType,
 } from 'react-native-tscodegen';
+import {translateArgs, translateSpecArgs} from './ParamTypes';
+import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
 type FilesOutput = Map<string, string>;
-type NativeModuleParamShape = NamedShape<
-  Nullable<NativeModuleParamTypeAnnotation>
->;
 
 const moduleTemplate = `
 /*
@@ -51,163 +46,6 @@ struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
 } // namespace ::_NAMESPACE_::
 `;
-
-function decorateType(type: string, forSpec: boolean): string {
-  return forSpec ? type : `${type} &&`;
-}
-
-function translateParam(
-  param: NativeModuleParamTypeAnnotation,
-  forSpec: boolean,
-): string {
-  // avoid: Property 'type' does not exist on type 'never'
-  const paramType = param.type;
-  switch (param.type) {
-    case 'StringTypeAnnotation':
-      return 'std::string';
-    case 'NumberTypeAnnotation':
-    case 'FloatTypeAnnotation':
-    case 'DoubleTypeAnnotation':
-      return 'double';
-    case 'Int32TypeAnnotation':
-      return 'int';
-    case 'BooleanTypeAnnotation':
-      return 'bool';
-    case 'FunctionTypeAnnotation': {
-      // TODO: type.params && type.returnTypeAnnotation
-      if (forSpec) {
-        return 'Callback<React::JSValue>';
-      } else {
-        return 'std::function<void(React::JSValue const &)> const &';
-      }
-    }
-    case 'ArrayTypeAnnotation':
-      // TODO: type.elementType
-      return decorateType('React::JSValueArray', forSpec);
-    case 'GenericObjectTypeAnnotation':
-      return decorateType('React::JSValueObject', forSpec);
-    case 'ObjectTypeAnnotation':
-      // TODO: we have more information here, and could create a more specific type
-      return decorateType('React::JSValueObject', forSpec);
-    case 'ReservedTypeAnnotation': {
-      // avoid: Property 'name' does not exist on type 'never'
-      const name = param.name;
-      // (#6597)
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (name !== 'RootTag')
-        throw new Error(`Unknown reserved function: ${name} in translateParam`);
-      return 'double';
-    }
-    case 'TypeAliasTypeAnnotation':
-      // TODO: print the real name after processing NativeModuleSchema::aliases
-      return decorateType('React::JSValueObject', forSpec);
-    default:
-      throw new Error(`Unhandled type in translateParam: ${paramType}`);
-  }
-}
-
-function translateSpecFunctionParam(param: NativeModuleParamShape): string {
-  switch (param.typeAnnotation.type) {
-    case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   true,
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, true);
-    default:
-      return translateParam(param.typeAnnotation, true);
-  }
-}
-
-function translateFunctionParam(param: NativeModuleParamShape): string {
-  switch (param.typeAnnotation.type) {
-    case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   false,
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, false);
-    default:
-      return translateParam(param.typeAnnotation, false);
-  }
-}
-
-function translateReturnType(
-  type: Nullable<NativeModuleReturnTypeAnnotation>,
-): string {
-  // avoid: Property 'type' does not exist on type 'never'
-  const returnType = type.type;
-  switch (type.type) {
-    case 'VoidTypeAnnotation':
-    case 'PromiseTypeAnnotation':
-      return 'void';
-    case 'StringTypeAnnotation':
-      return 'std::string';
-    case 'NumberTypeAnnotation':
-    case 'FloatTypeAnnotation':
-    case 'DoubleTypeAnnotation':
-      return 'double';
-    case 'Int32TypeAnnotation':
-      return 'int';
-    case 'BooleanTypeAnnotation':
-      return 'bool';
-    case 'ArrayTypeAnnotation':
-      // TODO: type.elementType
-      return 'React::JSValueArray';
-    case 'GenericObjectTypeAnnotation':
-      return 'React::JSValueObject';
-    case 'ObjectTypeAnnotation':
-      // TODO: we have more information here, and could create a more specific type
-      return 'React::JSValueObject';
-    case 'ReservedTypeAnnotation': {
-      // avoid: Property 'name' does not exist on type 'never'
-      const name = type.name;
-      // (#6597)
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (name !== 'RootTag')
-        throw new Error(
-          `Unknown reserved function: ${name} in translateReturnType`,
-        );
-      return 'double';
-    }
-    case 'TypeAliasTypeAnnotation':
-      // TODO: print the real name after processing NativeModuleSchema::aliases
-      return 'React::JSValueObject';
-    case 'NullableTypeAnnotation':
-      // TODO: should be `std::optional<${translateReturnType(type.typeAnnotation)}>`;
-      return translateReturnType(type.typeAnnotation);
-    default:
-      throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
-  }
-}
-
-function translateSpecReturnType(
-  type: Nullable<NativeModuleReturnTypeAnnotation>,
-) {
-  return translateReturnType(type);
-}
-
-function translateImplReturnType(
-  type: Nullable<NativeModuleReturnTypeAnnotation>,
-) {
-  return translateReturnType(type);
-}
-
-function translateSpecArgs(params: ReadonlyArray<NativeModuleParamShape>) {
-  return params.map(param => {
-    const translatedParam = translateSpecFunctionParam(param);
-    return `${translatedParam}`;
-  });
-}
-
-function translateArgs(params: ReadonlyArray<NativeModuleParamShape>) {
-  return params.map(param => {
-    const translatedParam = translateFunctionParam(param);
-    return `${translatedParam} ${param.name}`;
-  });
-}
 
 function isMethodSync(funcType: NativeModuleFunctionTypeAnnotation) {
   return (

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -160,6 +160,7 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         for (const aliasName of Object.keys(nativeModule.aliases)) {
           const aliasType = nativeModule.aliases[aliasName];
           traversedAliasedStructs = `${traversedAliasedStructs}
+  REACT_STRUCT(${aliasName})
   struct ${aliasName} {
 ${translateObjectBody(aliasType, '      ')}
   };

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -11,7 +11,7 @@ import {
   NativeModulePropertyShape,
   SchemaType,
 } from 'react-native-tscodegen';
-import {translateObjectBody} from './ObjectTypes';
+import {getAliasCppName, translateObjectBody} from './ObjectTypes';
 import {translateArgs, translateSpecArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
@@ -31,8 +31,8 @@ const moduleTemplate = `
 #include <tuple>
 
 namespace ::_NAMESPACE_:: {
-
-struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {::_MODULE_ALIASED_STRUCTS_::
+::_MODULE_ALIASED_STRUCTS_::
+struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
 ::_MODULE_PROPERTIES_TUPLE_::
   };
@@ -43,7 +43,7 @@ struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {:
 
 ::_MODULE_PROPERTIES_SPEC_ERRORS_::
   }
-};::_MODULE_ALIASED_STRUCT_DEFS_::
+};
 
 } // namespace ::_NAMESPACE_::
 `;
@@ -160,19 +160,11 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         for (const aliasName of Object.keys(nativeModule.aliases)) {
           const aliasType = nativeModule.aliases[aliasName];
           traversedAliasedStructs = `${traversedAliasedStructs}
-  struct ${aliasName} {
-${translateObjectBody(aliasType, '      ')}
-  };
+REACT_STRUCT(${getAliasCppName(aliasName)})
+struct ${getAliasCppName(aliasName)} {
+${translateObjectBody(aliasType, '    ')}
+};
 `;
-        }
-
-        let traversedAliasedStructDefs = '';
-        for (const aliasName of Object.keys(nativeModule.aliases)) {
-          traversedAliasedStructDefs = `${traversedAliasedStructDefs}
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(${preferredModuleName}Spec::${aliasName})`;
-        }
-        if (traversedAliasedStructDefs !== '') {
-          traversedAliasedStructDefs = `\n${traversedAliasedStructDefs}`;
         }
 
         const properties = nativeModule.spec.properties;
@@ -183,10 +175,6 @@ ${translateObjectBody(aliasType, '      ')}
           `Native${preferredModuleName}Spec.g.h`,
           moduleTemplate
             .replace(/::_MODULE_ALIASED_STRUCTS_::/g, traversedAliasedStructs)
-            .replace(
-              /::_MODULE_ALIASED_STRUCT_DEFS_::/g,
-              traversedAliasedStructDefs,
-            )
             .replace(/::_MODULE_PROPERTIES_TUPLE_::/g, traversedPropertyTuples)
             .replace(
               /::_MODULE_PROPERTIES_SPEC_ERRORS_::/g,

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -11,7 +11,11 @@ import {
   NativeModulePropertyShape,
   SchemaType,
 } from 'react-native-tscodegen';
-import {getAliasCppName, translateObjectBody} from './ObjectTypes';
+import {
+  getAliasCppName,
+  setPreferredModuleName,
+  translateObjectBody,
+} from './ObjectTypes';
 import {translateArgs, translateSpecArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
@@ -152,6 +156,7 @@ export function createNM2Generator({namespace}: {namespace: string}) {
       const preferredModuleName = moduleName.startsWith('Native')
         ? moduleName.substr(6)
         : moduleName;
+      setPreferredModuleName(preferredModuleName);
 
       if (nativeModule.type === 'NativeModule') {
         console.log(`Generating Native${preferredModuleName}Spec.g.h`);

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -13,6 +13,16 @@ import {
   Nullable,
 } from 'react-native-tscodegen';
 
+let preferredModuleName: string = '';
+
+export function setPreferredModuleName(moduleName: string): void {
+  preferredModuleName = moduleName;
+}
+
+export function getAliasCppName(typeName: string): string {
+  return `${preferredModuleName}Spec_${typeName}`;
+}
+
 function translateField(
   type: Nullable<NativeModuleBaseTypeAnnotation>,
 ): string {
@@ -49,7 +59,7 @@ function translateField(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      return type.name;
+      return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
       return `std::optional<${translateField(type.typeAnnotation)}>`;
     default:

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -49,8 +49,7 @@ function translateField(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      // TODO: print the real name after processing NativeModuleSchema::aliases
-      return 'React::JSValueObject';
+      return type.name;
     case 'NullableTypeAnnotation':
       return `std::optional<${translateField(type.typeAnnotation)}>`;
     default:

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -67,7 +67,9 @@ export function translateObjectBody(
       if (prop.optional && propType.type !== 'NullableTypeAnnotation') {
         propType = {type: 'NullableTypeAnnotation', typeAnnotation: propType};
       }
-      return `${prefix}${translateField(propType)} ${prop.name};`;
+      const first = `${prefix}REACT_FIELD(${prop.name})`;
+      const second = `${prefix}${translateField(propType)} ${prop.name};`;
+      return `${first}\n${second}`;
     })
     .join('\n');
 }

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {
+  NamedShape,
+  NativeModuleParamTypeAnnotation,
+  Nullable,
+} from 'react-native-tscodegen';
+
+type NativeModuleParamShape = NamedShape<
+  Nullable<NativeModuleParamTypeAnnotation>
+>;
+
+function decorateType(type: string, forSpec: boolean): string {
+  return forSpec ? type : `${type} &&`;
+}
+
+function translateParam(
+  param: NativeModuleParamTypeAnnotation,
+  forSpec: boolean,
+): string {
+  // avoid: Property 'type' does not exist on type 'never'
+  const paramType = param.type;
+  switch (param.type) {
+    case 'StringTypeAnnotation':
+      return 'std::string';
+    case 'NumberTypeAnnotation':
+    case 'FloatTypeAnnotation':
+    case 'DoubleTypeAnnotation':
+      return 'double';
+    case 'Int32TypeAnnotation':
+      return 'int';
+    case 'BooleanTypeAnnotation':
+      return 'bool';
+    case 'FunctionTypeAnnotation': {
+      // TODO: type.params && type.returnTypeAnnotation
+      if (forSpec) {
+        return 'Callback<React::JSValue>';
+      } else {
+        return 'std::function<void(React::JSValue const &)> const &';
+      }
+    }
+    case 'ArrayTypeAnnotation':
+      // TODO: type.elementType
+      return decorateType('React::JSValueArray', forSpec);
+    case 'GenericObjectTypeAnnotation':
+      return decorateType('React::JSValueObject', forSpec);
+    case 'ObjectTypeAnnotation':
+      // TODO: we have more information here, and could create a more specific type
+      return decorateType('React::JSValueObject', forSpec);
+    case 'ReservedTypeAnnotation': {
+      // avoid: Property 'name' does not exist on type 'never'
+      const name = param.name;
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (name !== 'RootTag')
+        throw new Error(`Unknown reserved function: ${name} in translateParam`);
+      return 'double';
+    }
+    case 'TypeAliasTypeAnnotation':
+      // TODO: print the real name after processing NativeModuleSchema::aliases
+      return decorateType('React::JSValueObject', forSpec);
+    default:
+      throw new Error(`Unhandled type in translateParam: ${paramType}`);
+  }
+}
+
+function translateSpecFunctionParam(param: NativeModuleParamShape): string {
+  switch (param.typeAnnotation.type) {
+    case 'NullableTypeAnnotation':
+      // TODO: should be
+      // return `std::optional<${translateParam(
+      //   param.typeAnnotation.typeAnnotation,
+      //   true,
+      // )}>`;
+      return translateParam(param.typeAnnotation.typeAnnotation, true);
+    default:
+      return translateParam(param.typeAnnotation, true);
+  }
+}
+
+function translateFunctionParam(param: NativeModuleParamShape): string {
+  switch (param.typeAnnotation.type) {
+    case 'NullableTypeAnnotation':
+      // TODO: should be
+      // return `std::optional<${translateParam(
+      //   param.typeAnnotation.typeAnnotation,
+      //   false,
+      // )}>`;
+      return translateParam(param.typeAnnotation.typeAnnotation, false);
+    default:
+      return translateParam(param.typeAnnotation, false);
+  }
+}
+
+export function translateSpecArgs(
+  params: ReadonlyArray<NativeModuleParamShape>,
+) {
+  return params.map(param => {
+    const translatedParam = translateSpecFunctionParam(param);
+    return `${translatedParam}`;
+  });
+}
+
+export function translateArgs(params: ReadonlyArray<NativeModuleParamShape>) {
+  return params.map(param => {
+    const translatedParam = translateFunctionParam(param);
+    return `${translatedParam} ${param.name}`;
+  });
+}

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -63,8 +63,7 @@ function translateParam(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      // TODO: print the real name after processing NativeModuleSchema::aliases
-      return decorateType('React::JSValueObject', forSpec);
+      return decorateType(param.name, forSpec);
     default:
       throw new Error(`Unhandled type in translateParam: ${paramType}`);
   }
@@ -73,10 +72,12 @@ function translateParam(
 function translateSpecFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      return `std::optional<${translateParam(
-        param.typeAnnotation.typeAnnotation,
-        true,
-      )}>`;
+      // TODO: should be
+      // return `std::optional<${translateParam(
+      //   param.typeAnnotation.typeAnnotation,
+      //   true,
+      // )}>`;
+      return translateParam(param.typeAnnotation.typeAnnotation, true);
     default:
       return translateParam(param.typeAnnotation, true);
   }
@@ -85,10 +86,12 @@ function translateSpecFunctionParam(param: NativeModuleParamShape): string {
 function translateFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      return `std::optional<${translateParam(
-        param.typeAnnotation.typeAnnotation,
-        false,
-      )}>`;
+      // TODO: should be
+      // return `std::optional<${translateParam(
+      //   param.typeAnnotation.typeAnnotation,
+      //   false,
+      // )}>`;
+      return translateParam(param.typeAnnotation.typeAnnotation, false);
     default:
       return translateParam(param.typeAnnotation, false);
   }

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -73,12 +73,10 @@ function translateParam(
 function translateSpecFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   true,
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, true);
+      return `std::optional<${translateParam(
+        param.typeAnnotation.typeAnnotation,
+        true,
+      )}>`;
     default:
       return translateParam(param.typeAnnotation, true);
   }
@@ -87,12 +85,10 @@ function translateSpecFunctionParam(param: NativeModuleParamShape): string {
 function translateFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   false,
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, false);
+      return `std::optional<${translateParam(
+        param.typeAnnotation.typeAnnotation,
+        false,
+      )}>`;
     default:
       return translateParam(param.typeAnnotation, false);
   }

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -11,6 +11,7 @@ import {
   NativeModuleParamTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
+import {getAliasCppName} from './ObjectTypes';
 
 type NativeModuleParamShape = NamedShape<
   Nullable<NativeModuleParamTypeAnnotation>
@@ -63,7 +64,7 @@ function translateParam(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      return decorateType(param.name, forSpec);
+      return decorateType(getAliasCppName(param.name), forSpec);
     default:
       throw new Error(`Unhandled type in translateParam: ${paramType}`);
   }

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {
+  NativeModuleReturnTypeAnnotation,
+  Nullable,
+} from 'react-native-tscodegen';
+
+function translateReturnType(
+  type: Nullable<NativeModuleReturnTypeAnnotation>,
+): string {
+  // avoid: Property 'type' does not exist on type 'never'
+  const returnType = type.type;
+  switch (type.type) {
+    case 'VoidTypeAnnotation':
+    case 'PromiseTypeAnnotation':
+      return 'void';
+    case 'StringTypeAnnotation':
+      return 'std::string';
+    case 'NumberTypeAnnotation':
+    case 'FloatTypeAnnotation':
+    case 'DoubleTypeAnnotation':
+      return 'double';
+    case 'Int32TypeAnnotation':
+      return 'int';
+    case 'BooleanTypeAnnotation':
+      return 'bool';
+    case 'ArrayTypeAnnotation':
+      // TODO: type.elementType
+      return 'React::JSValueArray';
+    case 'GenericObjectTypeAnnotation':
+      return 'React::JSValueObject';
+    case 'ObjectTypeAnnotation':
+      // TODO: we have more information here, and could create a more specific type
+      return 'React::JSValueObject';
+    case 'ReservedTypeAnnotation': {
+      // avoid: Property 'name' does not exist on type 'never'
+      const name = type.name;
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (name !== 'RootTag')
+        throw new Error(
+          `Unknown reserved function: ${name} in translateReturnType`,
+        );
+      return 'double';
+    }
+    case 'TypeAliasTypeAnnotation':
+      // TODO: print the real name after processing NativeModuleSchema::aliases
+      return 'React::JSValueObject';
+    case 'NullableTypeAnnotation':
+      // TODO: should be `std::optional<${translateReturnType(type.typeAnnotation)}>`;
+      return translateReturnType(type.typeAnnotation);
+    default:
+      throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
+  }
+}
+
+export function translateSpecReturnType(
+  type: Nullable<NativeModuleReturnTypeAnnotation>,
+) {
+  return translateReturnType(type);
+}
+
+export function translateImplReturnType(
+  type: Nullable<NativeModuleReturnTypeAnnotation>,
+) {
+  return translateReturnType(type);
+}

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -10,6 +10,7 @@ import {
   NativeModuleReturnTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
+import {getAliasCppName} from './ObjectTypes';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
@@ -50,7 +51,7 @@ function translateReturnType(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      return type.name;
+      return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
       // TODO: should be `std::optional<${translateReturnType(type.typeAnnotation)}>`;
       return translateReturnType(type.typeAnnotation);

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -50,10 +50,10 @@ function translateReturnType(
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
-      // TODO: print the real name after processing NativeModuleSchema::aliases
-      return 'React::JSValueObject';
+      return type.name;
     case 'NullableTypeAnnotation':
-      return `std::optional<${translateReturnType(type.typeAnnotation)}>`;
+      // TODO: should be `std::optional<${translateReturnType(type.typeAnnotation)}>`;
+      return translateReturnType(type.typeAnnotation);
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -21,13 +21,17 @@
 // Please skip below to read about REACT_STRUCT and REACT_FIELD macros.
 //
 
-#define INTERNAL_REACT_STRUCT(structType)                                                  \
+#define INTERNAL_REACT_STRUCT_GETSTRUCTINFO(structType)                                    \
   struct structType;                                                                       \
   inline winrt::Microsoft::ReactNative::FieldMap GetStructInfo(structType *) noexcept {    \
     winrt::Microsoft::ReactNative::FieldMap fieldMap{};                                    \
     winrt::Microsoft::ReactNative::CollectStructFields<structType, __COUNTER__>(fieldMap); \
     return fieldMap;                                                                       \
   }
+
+#define INTERNAL_REACT_STRUCT(structType)                                                  \
+  struct structType;                                                                       \
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(structType)
 
 #define INTERNAL_REACT_FIELD_2_ARGS(field, fieldName)                      \
   template <class TClass>                                                  \

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -21,17 +21,13 @@
 // Please skip below to read about REACT_STRUCT and REACT_FIELD macros.
 //
 
-#define INTERNAL_REACT_STRUCT_GETSTRUCTINFO(structType)                                    \
+#define INTERNAL_REACT_STRUCT(structType)                                                  \
   struct structType;                                                                       \
   inline winrt::Microsoft::ReactNative::FieldMap GetStructInfo(structType *) noexcept {    \
     winrt::Microsoft::ReactNative::FieldMap fieldMap{};                                    \
     winrt::Microsoft::ReactNative::CollectStructFields<structType, __COUNTER__>(fieldMap); \
     return fieldMap;                                                                       \
   }
-
-#define INTERNAL_REACT_STRUCT(structType) \
-  struct structType;                      \
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(structType)
 
 #define INTERNAL_REACT_FIELD_2_ARGS(field, fieldName)                      \
   template <class TClass>                                                  \

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -29,8 +29,8 @@
     return fieldMap;                                                                       \
   }
 
-#define INTERNAL_REACT_STRUCT(structType)                                                  \
-  struct structType;                                                                       \
+#define INTERNAL_REACT_STRUCT(structType) \
+  struct structType;                      \
   INTERNAL_REACT_STRUCT_GETSTRUCTINFO(structType)
 
 #define INTERNAL_REACT_FIELD_2_ARGS(field, fieldName)                      \

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(Args)
   struct Args {
       REACT_FIELD(title)
       std::optional<std::string> title;
@@ -49,5 +48,7 @@ struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(alertWithArgs) static void alertWithArgs(Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AlertManagerSpec::Args)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_Args)
-struct Spec_Args {
+REACT_STRUCT(AlertManagerSpec_Args)
+struct AlertManagerSpec_Args {
     REACT_FIELD(title)
     std::optional<std::string> title;
     REACT_FIELD(message)
@@ -35,7 +35,7 @@ struct Spec_Args {
 
 struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Spec_Args, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
+      Method<void(AlertManagerSpec_Args, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
   };
 
   template <class TModule>
@@ -45,8 +45,8 @@ struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "alertWithArgs",
-          "    REACT_METHOD(alertWithArgs) void alertWithArgs(Spec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(Spec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(alertWithArgs) void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -14,8 +14,19 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct Args {
+      std::optional<std::string> title;
+      std::optional<std::string> message;
+      std::optional<React::JSValueArray> buttons;
+      std::optional<std::string> type;
+      std::optional<std::string> defaultValue;
+      std::optional<std::string> cancelButtonKey;
+      std::optional<std::string> destructiveButtonKey;
+      std::optional<std::string> keyboardType;
+  };
+
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
+      Method<void(Args, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
   };
 
   template <class TModule>
@@ -25,8 +36,8 @@ struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "alertWithArgs",
-          "    REACT_METHOD(alertWithArgs) void alertWithArgs(React::JSValueObject && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(React::JSValueObject && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(alertWithArgs) void alertWithArgs(Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -14,14 +14,23 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(Args)
   struct Args {
+      REACT_FIELD(title)
       std::optional<std::string> title;
+      REACT_FIELD(message)
       std::optional<std::string> message;
+      REACT_FIELD(buttons)
       std::optional<React::JSValueArray> buttons;
+      REACT_FIELD(type)
       std::optional<std::string> type;
+      REACT_FIELD(defaultValue)
       std::optional<std::string> defaultValue;
+      REACT_FIELD(cancelButtonKey)
       std::optional<std::string> cancelButtonKey;
+      REACT_FIELD(destructiveButtonKey)
       std::optional<std::string> destructiveButtonKey;
+      REACT_FIELD(keyboardType)
       std::optional<std::string> keyboardType;
   };
 

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -13,28 +13,29 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct Args {
-      REACT_FIELD(title)
-      std::optional<std::string> title;
-      REACT_FIELD(message)
-      std::optional<std::string> message;
-      REACT_FIELD(buttons)
-      std::optional<React::JSValueArray> buttons;
-      REACT_FIELD(type)
-      std::optional<std::string> type;
-      REACT_FIELD(defaultValue)
-      std::optional<std::string> defaultValue;
-      REACT_FIELD(cancelButtonKey)
-      std::optional<std::string> cancelButtonKey;
-      REACT_FIELD(destructiveButtonKey)
-      std::optional<std::string> destructiveButtonKey;
-      REACT_FIELD(keyboardType)
-      std::optional<std::string> keyboardType;
-  };
+REACT_STRUCT(Spec_Args)
+struct Spec_Args {
+    REACT_FIELD(title)
+    std::optional<std::string> title;
+    REACT_FIELD(message)
+    std::optional<std::string> message;
+    REACT_FIELD(buttons)
+    std::optional<React::JSValueArray> buttons;
+    REACT_FIELD(type)
+    std::optional<std::string> type;
+    REACT_FIELD(defaultValue)
+    std::optional<std::string> defaultValue;
+    REACT_FIELD(cancelButtonKey)
+    std::optional<std::string> cancelButtonKey;
+    REACT_FIELD(destructiveButtonKey)
+    std::optional<std::string> destructiveButtonKey;
+    REACT_FIELD(keyboardType)
+    std::optional<std::string> keyboardType;
+};
 
+struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Args, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
+      Method<void(Spec_Args, Callback<React::JSValue>) noexcept>{0, L"alertWithArgs"},
   };
 
   template <class TModule>
@@ -44,11 +45,9 @@ struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "alertWithArgs",
-          "    REACT_METHOD(alertWithArgs) void alertWithArgs(Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(alertWithArgs) void alertWithArgs(Spec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(Spec_Args && args, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AlertManagerSpec::Args)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -14,13 +14,11 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(EndResult)
   struct EndResult {
       REACT_FIELD(finished)
       bool finished;
   };
 
-  REACT_STRUCT(EventMapping)
   struct EventMapping {
       REACT_FIELD(nativeEventPath)
       React::JSValueArray nativeEventPath;
@@ -169,5 +167,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedModuleSpec::EndResult)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedModuleSpec::EventMapping)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -13,19 +13,21 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(Spec_EndResult)
+struct Spec_EndResult {
+    REACT_FIELD(finished)
+    bool finished;
+};
+
+REACT_STRUCT(Spec_EventMapping)
+struct Spec_EventMapping {
+    REACT_FIELD(nativeEventPath)
+    React::JSValueArray nativeEventPath;
+    REACT_FIELD(animatedValueTag)
+    std::optional<double> animatedValueTag;
+};
+
 struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct EndResult {
-      REACT_FIELD(finished)
-      bool finished;
-  };
-
-  struct EventMapping {
-      REACT_FIELD(nativeEventPath)
-      React::JSValueArray nativeEventPath;
-      REACT_FIELD(animatedValueTag)
-      std::optional<double> animatedValueTag;
-  };
-
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
@@ -45,7 +47,7 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, EventMapping) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, Spec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -148,8 +150,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",
@@ -167,8 +169,5 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedModuleSpec::EndResult)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedModuleSpec::EventMapping)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -14,12 +14,17 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(EndResult)
   struct EndResult {
+      REACT_FIELD(finished)
       bool finished;
   };
 
+  REACT_STRUCT(EventMapping)
   struct EventMapping {
+      REACT_FIELD(nativeEventPath)
       React::JSValueArray nativeEventPath;
+      REACT_FIELD(animatedValueTag)
       std::optional<double> animatedValueTag;
   };
 

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -14,6 +14,15 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct EndResult {
+      bool finished;
+  };
+
+  struct EventMapping {
+      React::JSValueArray nativeEventPath;
+      std::optional<double> animatedValueTag;
+  };
+
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
@@ -33,7 +42,7 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, React::JSValueObject) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -136,8 +145,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, React::JSValueObject && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, React::JSValueObject && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -13,14 +13,14 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_EndResult)
-struct Spec_EndResult {
+REACT_STRUCT(AnimatedModuleSpec_EndResult)
+struct AnimatedModuleSpec_EndResult {
     REACT_FIELD(finished)
     bool finished;
 };
 
-REACT_STRUCT(Spec_EventMapping)
-struct Spec_EventMapping {
+REACT_STRUCT(AnimatedModuleSpec_EventMapping)
+struct AnimatedModuleSpec_EventMapping {
     REACT_FIELD(nativeEventPath)
     React::JSValueArray nativeEventPath;
     REACT_FIELD(animatedValueTag)
@@ -47,7 +47,7 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, Spec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, AnimatedModuleSpec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -150,8 +150,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -14,6 +14,15 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct EndResult {
+      bool finished;
+  };
+
+  struct EventMapping {
+      React::JSValueArray nativeEventPath;
+      std::optional<double> animatedValueTag;
+  };
+
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
@@ -33,7 +42,7 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, React::JSValueObject) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -136,8 +145,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, React::JSValueObject && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, React::JSValueObject && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -14,13 +14,11 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(EndResult)
   struct EndResult {
       REACT_FIELD(finished)
       bool finished;
   };
 
-  REACT_STRUCT(EventMapping)
   struct EventMapping {
       REACT_FIELD(nativeEventPath)
       React::JSValueArray nativeEventPath;
@@ -169,5 +167,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedTurboModuleSpec::EndResult)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedTurboModuleSpec::EventMapping)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -13,14 +13,14 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_EndResult)
-struct Spec_EndResult {
+REACT_STRUCT(AnimatedTurboModuleSpec_EndResult)
+struct AnimatedTurboModuleSpec_EndResult {
     REACT_FIELD(finished)
     bool finished;
 };
 
-REACT_STRUCT(Spec_EventMapping)
-struct Spec_EventMapping {
+REACT_STRUCT(AnimatedTurboModuleSpec_EventMapping)
+struct AnimatedTurboModuleSpec_EventMapping {
     REACT_FIELD(nativeEventPath)
     React::JSValueArray nativeEventPath;
     REACT_FIELD(animatedValueTag)
@@ -47,7 +47,7 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, Spec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, AnimatedTurboModuleSpec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -150,8 +150,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -13,19 +13,21 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(Spec_EndResult)
+struct Spec_EndResult {
+    REACT_FIELD(finished)
+    bool finished;
+};
+
+REACT_STRUCT(Spec_EventMapping)
+struct Spec_EventMapping {
+    REACT_FIELD(nativeEventPath)
+    React::JSValueArray nativeEventPath;
+    REACT_FIELD(animatedValueTag)
+    std::optional<double> animatedValueTag;
+};
+
 struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct EndResult {
-      REACT_FIELD(finished)
-      bool finished;
-  };
-
-  struct EventMapping {
-      REACT_FIELD(nativeEventPath)
-      React::JSValueArray nativeEventPath;
-      REACT_FIELD(animatedValueTag)
-      std::optional<double> animatedValueTag;
-  };
-
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
@@ -45,7 +47,7 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
       Method<void(double, double) noexcept>{15, L"disconnectAnimatedNodeFromView"},
       Method<void(double) noexcept>{16, L"restoreDefaultValues"},
       Method<void(double) noexcept>{17, L"dropAnimatedNode"},
-      Method<void(double, std::string, EventMapping) noexcept>{18, L"addAnimatedEventToView"},
+      Method<void(double, std::string, Spec_EventMapping) noexcept>{18, L"addAnimatedEventToView"},
       Method<void(double, std::string, double) noexcept>{19, L"removeAnimatedEventFromView"},
       Method<void(std::string) noexcept>{20, L"addListener"},
       Method<void(double) noexcept>{21, L"removeListeners"},
@@ -148,8 +150,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, Spec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "removeAnimatedEventFromView",
@@ -167,8 +169,5 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedTurboModuleSpec::EndResult)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(AnimatedTurboModuleSpec::EventMapping)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -14,12 +14,17 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(EndResult)
   struct EndResult {
+      REACT_FIELD(finished)
       bool finished;
   };
 
+  REACT_STRUCT(EventMapping)
   struct EventMapping {
+      REACT_FIELD(nativeEventPath)
       React::JSValueArray nativeEventPath;
+      REACT_FIELD(animatedValueTag)
       std::optional<double> animatedValueTag;
   };
 

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -13,42 +13,45 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(Spec_DisplayMetrics)
+struct Spec_DisplayMetrics {
+    REACT_FIELD(width)
+    double width;
+    REACT_FIELD(height)
+    double height;
+    REACT_FIELD(scale)
+    double scale;
+    REACT_FIELD(fontScale)
+    double fontScale;
+};
+
+REACT_STRUCT(Spec_DisplayMetricsAndroid)
+struct Spec_DisplayMetricsAndroid {
+    REACT_FIELD(width)
+    double width;
+    REACT_FIELD(height)
+    double height;
+    REACT_FIELD(scale)
+    double scale;
+    REACT_FIELD(fontScale)
+    double fontScale;
+    REACT_FIELD(densityDpi)
+    double densityDpi;
+};
+
+REACT_STRUCT(Spec_DimensionsPayload)
+struct Spec_DimensionsPayload {
+    REACT_FIELD(window)
+    std::optional<Spec_DisplayMetrics> window;
+    REACT_FIELD(screen)
+    std::optional<Spec_DisplayMetrics> screen;
+    REACT_FIELD(windowPhysicalPixels)
+    std::optional<Spec_DisplayMetricsAndroid> windowPhysicalPixels;
+    REACT_FIELD(screenPhysicalPixels)
+    std::optional<Spec_DisplayMetricsAndroid> screenPhysicalPixels;
+};
+
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct DisplayMetrics {
-      REACT_FIELD(width)
-      double width;
-      REACT_FIELD(height)
-      double height;
-      REACT_FIELD(scale)
-      double scale;
-      REACT_FIELD(fontScale)
-      double fontScale;
-  };
-
-  struct DisplayMetricsAndroid {
-      REACT_FIELD(width)
-      double width;
-      REACT_FIELD(height)
-      double height;
-      REACT_FIELD(scale)
-      double scale;
-      REACT_FIELD(fontScale)
-      double fontScale;
-      REACT_FIELD(densityDpi)
-      double densityDpi;
-  };
-
-  struct DimensionsPayload {
-      REACT_FIELD(window)
-      std::optional<DisplayMetrics> window;
-      REACT_FIELD(screen)
-      std::optional<DisplayMetrics> screen;
-      REACT_FIELD(windowPhysicalPixels)
-      std::optional<DisplayMetricsAndroid> windowPhysicalPixels;
-      REACT_FIELD(screenPhysicalPixels)
-      std::optional<DisplayMetricsAndroid> screenPhysicalPixels;
-  };
-
   static constexpr auto methods = std::tuple{
 
   };
@@ -60,9 +63,5 @@ struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DisplayMetrics)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DisplayMetricsAndroid)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DimensionsPayload)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_DisplayMetrics)
-struct Spec_DisplayMetrics {
+REACT_STRUCT(DeviceInfoSpec_DisplayMetrics)
+struct DeviceInfoSpec_DisplayMetrics {
     REACT_FIELD(width)
     double width;
     REACT_FIELD(height)
@@ -25,8 +25,8 @@ struct Spec_DisplayMetrics {
     double fontScale;
 };
 
-REACT_STRUCT(Spec_DisplayMetricsAndroid)
-struct Spec_DisplayMetricsAndroid {
+REACT_STRUCT(DeviceInfoSpec_DisplayMetricsAndroid)
+struct DeviceInfoSpec_DisplayMetricsAndroid {
     REACT_FIELD(width)
     double width;
     REACT_FIELD(height)
@@ -39,16 +39,16 @@ struct Spec_DisplayMetricsAndroid {
     double densityDpi;
 };
 
-REACT_STRUCT(Spec_DimensionsPayload)
-struct Spec_DimensionsPayload {
+REACT_STRUCT(DeviceInfoSpec_DimensionsPayload)
+struct DeviceInfoSpec_DimensionsPayload {
     REACT_FIELD(window)
-    std::optional<Spec_DisplayMetrics> window;
+    std::optional<DeviceInfoSpec_DisplayMetrics> window;
     REACT_FIELD(screen)
-    std::optional<Spec_DisplayMetrics> screen;
+    std::optional<DeviceInfoSpec_DisplayMetrics> screen;
     REACT_FIELD(windowPhysicalPixels)
-    std::optional<Spec_DisplayMetricsAndroid> windowPhysicalPixels;
+    std::optional<DeviceInfoSpec_DisplayMetricsAndroid> windowPhysicalPixels;
     REACT_FIELD(screenPhysicalPixels)
-    std::optional<Spec_DisplayMetricsAndroid> screenPhysicalPixels;
+    std::optional<DeviceInfoSpec_DisplayMetricsAndroid> screenPhysicalPixels;
 };
 
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(DisplayMetrics)
   struct DisplayMetrics {
       REACT_FIELD(width)
       double width;
@@ -26,7 +25,6 @@ struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       double fontScale;
   };
 
-  REACT_STRUCT(DisplayMetricsAndroid)
   struct DisplayMetricsAndroid {
       REACT_FIELD(width)
       double width;
@@ -40,7 +38,6 @@ struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       double densityDpi;
   };
 
-  REACT_STRUCT(DimensionsPayload)
   struct DimensionsPayload {
       REACT_FIELD(window)
       std::optional<DisplayMetrics> window;
@@ -63,5 +60,9 @@ struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DisplayMetrics)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DisplayMetricsAndroid)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DeviceInfoSpec::DimensionsPayload)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -14,6 +14,28 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct DisplayMetrics {
+      double width;
+      double height;
+      double scale;
+      double fontScale;
+  };
+
+  struct DisplayMetricsAndroid {
+      double width;
+      double height;
+      double scale;
+      double fontScale;
+      double densityDpi;
+  };
+
+  struct DimensionsPayload {
+      std::optional<DisplayMetrics> window;
+      std::optional<DisplayMetrics> screen;
+      std::optional<DisplayMetricsAndroid> windowPhysicalPixels;
+      std::optional<DisplayMetricsAndroid> screenPhysicalPixels;
+  };
+
   static constexpr auto methods = std::tuple{
 
   };

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -14,25 +14,41 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(DisplayMetrics)
   struct DisplayMetrics {
+      REACT_FIELD(width)
       double width;
+      REACT_FIELD(height)
       double height;
+      REACT_FIELD(scale)
       double scale;
+      REACT_FIELD(fontScale)
       double fontScale;
   };
 
+  REACT_STRUCT(DisplayMetricsAndroid)
   struct DisplayMetricsAndroid {
+      REACT_FIELD(width)
       double width;
+      REACT_FIELD(height)
       double height;
+      REACT_FIELD(scale)
       double scale;
+      REACT_FIELD(fontScale)
       double fontScale;
+      REACT_FIELD(densityDpi)
       double densityDpi;
   };
 
+  REACT_STRUCT(DimensionsPayload)
   struct DimensionsPayload {
+      REACT_FIELD(window)
       std::optional<DisplayMetrics> window;
+      REACT_FIELD(screen)
       std::optional<DisplayMetrics> screen;
+      REACT_FIELD(windowPhysicalPixels)
       std::optional<DisplayMetricsAndroid> windowPhysicalPixels;
+      REACT_FIELD(screenPhysicalPixels)
       std::optional<DisplayMetricsAndroid> screenPhysicalPixels;
   };
 

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(DialogOptions)
   struct DialogOptions {
       REACT_FIELD(title)
       std::optional<std::string> title;
@@ -47,5 +46,7 @@ struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
           "    REACT_METHOD(showAlert) static void showAlert(DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DialogManagerAndroidSpec::DialogOptions)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -14,13 +14,21 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(DialogOptions)
   struct DialogOptions {
+      REACT_FIELD(title)
       std::optional<std::string> title;
+      REACT_FIELD(message)
       std::optional<std::string> message;
+      REACT_FIELD(buttonPositive)
       std::optional<std::string> buttonPositive;
+      REACT_FIELD(buttonNegative)
       std::optional<std::string> buttonNegative;
+      REACT_FIELD(buttonNeutral)
       std::optional<std::string> buttonNeutral;
+      REACT_FIELD(items)
       std::optional<React::JSValueArray> items;
+      REACT_FIELD(cancelable)
       std::optional<bool> cancelable;
   };
 

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -14,8 +14,18 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct DialogOptions {
+      std::optional<std::string> title;
+      std::optional<std::string> message;
+      std::optional<std::string> buttonPositive;
+      std::optional<std::string> buttonNegative;
+      std::optional<std::string> buttonNeutral;
+      std::optional<React::JSValueArray> items;
+      std::optional<bool> cancelable;
+  };
+
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
+      Method<void(DialogOptions, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
   };
 
   template <class TModule>
@@ -25,8 +35,8 @@ struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showAlert",
-          "    REACT_METHOD(showAlert) void showAlert(React::JSValueObject && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showAlert) static void showAlert(React::JSValueObject && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showAlert) void showAlert(DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showAlert) static void showAlert(DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_DialogOptions)
-struct Spec_DialogOptions {
+REACT_STRUCT(DialogManagerAndroidSpec_DialogOptions)
+struct DialogManagerAndroidSpec_DialogOptions {
     REACT_FIELD(title)
     std::optional<std::string> title;
     REACT_FIELD(message)
@@ -33,7 +33,7 @@ struct Spec_DialogOptions {
 
 struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Spec_DialogOptions, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
+      Method<void(DialogManagerAndroidSpec_DialogOptions, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
   };
 
   template <class TModule>
@@ -43,8 +43,8 @@ struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showAlert",
-          "    REACT_METHOD(showAlert) void showAlert(Spec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showAlert) static void showAlert(Spec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showAlert) void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showAlert) static void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -13,26 +13,27 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct DialogOptions {
-      REACT_FIELD(title)
-      std::optional<std::string> title;
-      REACT_FIELD(message)
-      std::optional<std::string> message;
-      REACT_FIELD(buttonPositive)
-      std::optional<std::string> buttonPositive;
-      REACT_FIELD(buttonNegative)
-      std::optional<std::string> buttonNegative;
-      REACT_FIELD(buttonNeutral)
-      std::optional<std::string> buttonNeutral;
-      REACT_FIELD(items)
-      std::optional<React::JSValueArray> items;
-      REACT_FIELD(cancelable)
-      std::optional<bool> cancelable;
-  };
+REACT_STRUCT(Spec_DialogOptions)
+struct Spec_DialogOptions {
+    REACT_FIELD(title)
+    std::optional<std::string> title;
+    REACT_FIELD(message)
+    std::optional<std::string> message;
+    REACT_FIELD(buttonPositive)
+    std::optional<std::string> buttonPositive;
+    REACT_FIELD(buttonNegative)
+    std::optional<std::string> buttonNegative;
+    REACT_FIELD(buttonNeutral)
+    std::optional<std::string> buttonNeutral;
+    REACT_FIELD(items)
+    std::optional<React::JSValueArray> items;
+    REACT_FIELD(cancelable)
+    std::optional<bool> cancelable;
+};
 
+struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(DialogOptions, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
+      Method<void(Spec_DialogOptions, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"showAlert"},
   };
 
   template <class TModule>
@@ -42,11 +43,9 @@ struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showAlert",
-          "    REACT_METHOD(showAlert) void showAlert(DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showAlert) static void showAlert(DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showAlert) void showAlert(Spec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showAlert) static void showAlert(Spec_DialogOptions && config, std::function<void(React::JSValue const &)> const & onError, std::function<void(React::JSValue const &)> const & onAction) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(DialogManagerAndroidSpec::DialogOptions)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -14,22 +14,37 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(StackFrame)
   struct StackFrame {
+      REACT_FIELD(column)
       std::optional<double> column;
+      REACT_FIELD(file)
       std::optional<std::string> file;
+      REACT_FIELD(lineNumber)
       std::optional<double> lineNumber;
+      REACT_FIELD(methodName)
       std::string methodName;
+      REACT_FIELD(collapse)
       std::optional<bool> collapse;
   };
 
+  REACT_STRUCT(ExceptionData)
   struct ExceptionData {
+      REACT_FIELD(message)
       std::string message;
+      REACT_FIELD(originalMessage)
       std::optional<std::string> originalMessage;
+      REACT_FIELD(name)
       std::optional<std::string> name;
+      REACT_FIELD(componentStack)
       std::optional<std::string> componentStack;
+      REACT_FIELD(stack)
       React::JSValueArray stack;
+      REACT_FIELD(id)
       double id;
+      REACT_FIELD(isFatal)
       bool isFatal;
+      REACT_FIELD(extraData)
       std::optional<React::JSValueObject> extraData;
   };
 

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_StackFrame)
-struct Spec_StackFrame {
+REACT_STRUCT(ExceptionsManagerSpec_StackFrame)
+struct ExceptionsManagerSpec_StackFrame {
     REACT_FIELD(column)
     std::optional<double> column;
     REACT_FIELD(file)
@@ -27,8 +27,8 @@ struct Spec_StackFrame {
     std::optional<bool> collapse;
 };
 
-REACT_STRUCT(Spec_ExceptionData)
-struct Spec_ExceptionData {
+REACT_STRUCT(ExceptionsManagerSpec_ExceptionData)
+struct ExceptionsManagerSpec_ExceptionData {
     REACT_FIELD(message)
     std::string message;
     REACT_FIELD(originalMessage)
@@ -51,7 +51,7 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(std::string, React::JSValueArray, double) noexcept>{0, L"reportFatalException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{1, L"reportSoftException"},
-      Method<void(Spec_ExceptionData) noexcept>{2, L"reportException"},
+      Method<void(ExceptionsManagerSpec_ExceptionData) noexcept>{2, L"reportException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{3, L"updateExceptionMessage"},
       Method<void() noexcept>{4, L"dismissRedbox"},
   };
@@ -73,8 +73,8 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "reportException",
-          "    REACT_METHOD(reportException) void reportException(Spec_ExceptionData && data) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportException) static void reportException(Spec_ExceptionData && data) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportException) void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(reportException) static void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateExceptionMessage",

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -13,43 +13,45 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(Spec_StackFrame)
+struct Spec_StackFrame {
+    REACT_FIELD(column)
+    std::optional<double> column;
+    REACT_FIELD(file)
+    std::optional<std::string> file;
+    REACT_FIELD(lineNumber)
+    std::optional<double> lineNumber;
+    REACT_FIELD(methodName)
+    std::string methodName;
+    REACT_FIELD(collapse)
+    std::optional<bool> collapse;
+};
+
+REACT_STRUCT(Spec_ExceptionData)
+struct Spec_ExceptionData {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(originalMessage)
+    std::optional<std::string> originalMessage;
+    REACT_FIELD(name)
+    std::optional<std::string> name;
+    REACT_FIELD(componentStack)
+    std::optional<std::string> componentStack;
+    REACT_FIELD(stack)
+    React::JSValueArray stack;
+    REACT_FIELD(id)
+    double id;
+    REACT_FIELD(isFatal)
+    bool isFatal;
+    REACT_FIELD(extraData)
+    std::optional<React::JSValueObject> extraData;
+};
+
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct StackFrame {
-      REACT_FIELD(column)
-      std::optional<double> column;
-      REACT_FIELD(file)
-      std::optional<std::string> file;
-      REACT_FIELD(lineNumber)
-      std::optional<double> lineNumber;
-      REACT_FIELD(methodName)
-      std::string methodName;
-      REACT_FIELD(collapse)
-      std::optional<bool> collapse;
-  };
-
-  struct ExceptionData {
-      REACT_FIELD(message)
-      std::string message;
-      REACT_FIELD(originalMessage)
-      std::optional<std::string> originalMessage;
-      REACT_FIELD(name)
-      std::optional<std::string> name;
-      REACT_FIELD(componentStack)
-      std::optional<std::string> componentStack;
-      REACT_FIELD(stack)
-      React::JSValueArray stack;
-      REACT_FIELD(id)
-      double id;
-      REACT_FIELD(isFatal)
-      bool isFatal;
-      REACT_FIELD(extraData)
-      std::optional<React::JSValueObject> extraData;
-  };
-
   static constexpr auto methods = std::tuple{
       Method<void(std::string, React::JSValueArray, double) noexcept>{0, L"reportFatalException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{1, L"reportSoftException"},
-      Method<void(ExceptionData) noexcept>{2, L"reportException"},
+      Method<void(Spec_ExceptionData) noexcept>{2, L"reportException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{3, L"updateExceptionMessage"},
       Method<void() noexcept>{4, L"dismissRedbox"},
   };
@@ -71,8 +73,8 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "reportException",
-          "    REACT_METHOD(reportException) void reportException(ExceptionData && data) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportException) static void reportException(ExceptionData && data) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportException) void reportException(Spec_ExceptionData && data) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(reportException) static void reportException(Spec_ExceptionData && data) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateExceptionMessage",
@@ -85,8 +87,5 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(dismissRedbox) static void dismissRedbox() noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ExceptionsManagerSpec::StackFrame)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ExceptionsManagerSpec::ExceptionData)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(StackFrame)
   struct StackFrame {
       REACT_FIELD(column)
       std::optional<double> column;
@@ -28,7 +27,6 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       std::optional<bool> collapse;
   };
 
-  REACT_STRUCT(ExceptionData)
   struct ExceptionData {
       REACT_FIELD(message)
       std::string message;
@@ -87,5 +85,8 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(dismissRedbox) static void dismissRedbox() noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ExceptionsManagerSpec::StackFrame)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ExceptionsManagerSpec::ExceptionData)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -14,10 +14,29 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct StackFrame {
+      std::optional<double> column;
+      std::optional<std::string> file;
+      std::optional<double> lineNumber;
+      std::string methodName;
+      std::optional<bool> collapse;
+  };
+
+  struct ExceptionData {
+      std::string message;
+      std::optional<std::string> originalMessage;
+      std::optional<std::string> name;
+      std::optional<std::string> componentStack;
+      React::JSValueArray stack;
+      double id;
+      bool isFatal;
+      std::optional<React::JSValueObject> extraData;
+  };
+
   static constexpr auto methods = std::tuple{
       Method<void(std::string, React::JSValueArray, double) noexcept>{0, L"reportFatalException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{1, L"reportSoftException"},
-      Method<void(React::JSValueObject) noexcept>{2, L"reportException"},
+      Method<void(ExceptionData) noexcept>{2, L"reportException"},
       Method<void(std::string, React::JSValueArray, double) noexcept>{3, L"updateExceptionMessage"},
       Method<void() noexcept>{4, L"dismissRedbox"},
   };
@@ -39,8 +58,8 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "reportException",
-          "    REACT_METHOD(reportException) void reportException(React::JSValueObject && data) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportException) static void reportException(React::JSValueObject && data) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportException) void reportException(ExceptionData && data) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(reportException) static void reportException(ExceptionData && data) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateExceptionMessage",

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(Options)
   struct Options {
       REACT_FIELD(offset)
       React::JSValueObject offset;
@@ -43,5 +42,7 @@ struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
           "    REACT_METHOD(cropImage) static void cropImage(std::string uri, Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ImageEditorSpec::Options)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -13,22 +13,23 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct Options {
-      REACT_FIELD(offset)
-      React::JSValueObject offset;
-      REACT_FIELD(size)
-      React::JSValueObject size;
-      REACT_FIELD(displaySize)
-      std::optional<React::JSValueObject> displaySize;
-      REACT_FIELD(resizeMode)
-      std::optional<std::string> resizeMode;
-      REACT_FIELD(allowExternalStorage)
-      std::optional<bool> allowExternalStorage;
-  };
+REACT_STRUCT(Spec_Options)
+struct Spec_Options {
+    REACT_FIELD(offset)
+    React::JSValueObject offset;
+    REACT_FIELD(size)
+    React::JSValueObject size;
+    REACT_FIELD(displaySize)
+    std::optional<React::JSValueObject> displaySize;
+    REACT_FIELD(resizeMode)
+    std::optional<std::string> resizeMode;
+    REACT_FIELD(allowExternalStorage)
+    std::optional<bool> allowExternalStorage;
+};
 
+struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Options, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
+      Method<void(std::string, Spec_Options, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
   };
 
   template <class TModule>
@@ -38,11 +39,9 @@ struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "cropImage",
-          "    REACT_METHOD(cropImage) void cropImage(std::string uri, Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cropImage) void cropImage(std::string uri, Spec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, Spec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(ImageEditorSpec::Options)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -14,8 +14,16 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct Options {
+      React::JSValueObject offset;
+      React::JSValueObject size;
+      std::optional<React::JSValueObject> displaySize;
+      std::optional<std::string> resizeMode;
+      std::optional<bool> allowExternalStorage;
+  };
+
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, React::JSValueObject, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
+      Method<void(std::string, Options, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
   };
 
   template <class TModule>
@@ -25,8 +33,8 @@ struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "cropImage",
-          "    REACT_METHOD(cropImage) void cropImage(std::string uri, React::JSValueObject && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, React::JSValueObject && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cropImage) void cropImage(std::string uri, Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_Options)
-struct Spec_Options {
+REACT_STRUCT(ImageEditorSpec_Options)
+struct ImageEditorSpec_Options {
     REACT_FIELD(offset)
     React::JSValueObject offset;
     REACT_FIELD(size)
@@ -29,7 +29,7 @@ struct Spec_Options {
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Spec_Options, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
+      Method<void(std::string, ImageEditorSpec_Options, Callback<React::JSValue>, Callback<React::JSValue>) noexcept>{0, L"cropImage"},
   };
 
   template <class TModule>
@@ -39,8 +39,8 @@ struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "cropImage",
-          "    REACT_METHOD(cropImage) void cropImage(std::string uri, Spec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, Spec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cropImage) void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(React::JSValue const &)> const & successCallback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -14,11 +14,17 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(Options)
   struct Options {
+      REACT_FIELD(offset)
       React::JSValueObject offset;
+      REACT_FIELD(size)
       React::JSValueObject size;
+      REACT_FIELD(displaySize)
       std::optional<React::JSValueObject> displaySize;
+      REACT_FIELD(resizeMode)
       std::optional<std::string> resizeMode;
+      REACT_FIELD(allowExternalStorage)
       std::optional<bool> allowExternalStorage;
   };
 

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -13,8 +13,8 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(Spec_Permissions)
-struct Spec_Permissions {
+REACT_STRUCT(PushNotificationManagerIOSSpec_Permissions)
+struct PushNotificationManagerIOSSpec_Permissions {
     REACT_FIELD(alert)
     bool alert;
     REACT_FIELD(badge)
@@ -23,8 +23,8 @@ struct Spec_Permissions {
     bool sound;
 };
 
-REACT_STRUCT(Spec_Notification)
-struct Spec_Notification {
+REACT_STRUCT(PushNotificationManagerIOSSpec_Notification)
+struct PushNotificationManagerIOSSpec_Notification {
     REACT_FIELD(alertTitle)
     std::optional<std::string> alertTitle;
     REACT_FIELD(fireDate)
@@ -53,8 +53,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       Method<void(React::JSValueObject, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
       Method<void() noexcept>{4, L"abandonPermissions"},
       Method<void(Callback<React::JSValue>) noexcept>{5, L"checkPermissions"},
-      Method<void(Spec_Notification) noexcept>{6, L"presentLocalNotification"},
-      Method<void(Spec_Notification) noexcept>{7, L"scheduleLocalNotification"},
+      Method<void(PushNotificationManagerIOSSpec_Notification) noexcept>{6, L"presentLocalNotification"},
+      Method<void(PushNotificationManagerIOSSpec_Notification) noexcept>{7, L"scheduleLocalNotification"},
       Method<void() noexcept>{8, L"cancelAllLocalNotifications"},
       Method<void(React::JSValueObject) noexcept>{9, L"cancelLocalNotifications"},
       Method<void(Promise<React::JSValue>) noexcept>{10, L"getInitialNotification"},
@@ -104,13 +104,13 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "presentLocalNotification",
-          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "scheduleLocalNotification",
-          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "cancelAllLocalNotifications",

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -14,21 +14,35 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  REACT_STRUCT(Permissions)
   struct Permissions {
+      REACT_FIELD(alert)
       bool alert;
+      REACT_FIELD(badge)
       bool badge;
+      REACT_FIELD(sound)
       bool sound;
   };
 
+  REACT_STRUCT(Notification)
   struct Notification {
+      REACT_FIELD(alertTitle)
       std::optional<std::string> alertTitle;
+      REACT_FIELD(fireDate)
       std::optional<double> fireDate;
+      REACT_FIELD(alertBody)
       std::optional<std::string> alertBody;
+      REACT_FIELD(alertAction)
       std::optional<std::string> alertAction;
+      REACT_FIELD(userInfo)
       std::optional<React::JSValueObject> userInfo;
+      REACT_FIELD(category)
       std::optional<std::string> category;
+      REACT_FIELD(repeatInterval)
       std::optional<std::string> repeatInterval;
+      REACT_FIELD(applicationIconBadgeNumber)
       std::optional<double> applicationIconBadgeNumber;
+      REACT_FIELD(isSilent)
       std::optional<bool> isSilent;
   };
 

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -14,6 +14,24 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  struct Permissions {
+      bool alert;
+      bool badge;
+      bool sound;
+  };
+
+  struct Notification {
+      std::optional<std::string> alertTitle;
+      std::optional<double> fireDate;
+      std::optional<std::string> alertBody;
+      std::optional<std::string> alertAction;
+      std::optional<React::JSValueObject> userInfo;
+      std::optional<std::string> category;
+      std::optional<std::string> repeatInterval;
+      std::optional<double> applicationIconBadgeNumber;
+      std::optional<bool> isSilent;
+  };
+
   static constexpr auto methods = std::tuple{
       Method<void(std::string, std::string) noexcept>{0, L"onFinishRemoteNotification"},
       Method<void(double) noexcept>{1, L"setApplicationIconBadgeNumber"},
@@ -21,8 +39,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       Method<void(React::JSValueObject, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
       Method<void() noexcept>{4, L"abandonPermissions"},
       Method<void(Callback<React::JSValue>) noexcept>{5, L"checkPermissions"},
-      Method<void(React::JSValueObject) noexcept>{6, L"presentLocalNotification"},
-      Method<void(React::JSValueObject) noexcept>{7, L"scheduleLocalNotification"},
+      Method<void(Notification) noexcept>{6, L"presentLocalNotification"},
+      Method<void(Notification) noexcept>{7, L"scheduleLocalNotification"},
       Method<void() noexcept>{8, L"cancelAllLocalNotifications"},
       Method<void(React::JSValueObject) noexcept>{9, L"cancelLocalNotifications"},
       Method<void(Promise<React::JSValue>) noexcept>{10, L"getInitialNotification"},
@@ -72,13 +90,13 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "presentLocalNotification",
-          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(React::JSValueObject && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(React::JSValueObject && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "scheduleLocalNotification",
-          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(React::JSValueObject && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(React::JSValueObject && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "cancelAllLocalNotifications",

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -14,7 +14,6 @@
 namespace Microsoft::ReactNativeSpecs {
 
 struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  REACT_STRUCT(Permissions)
   struct Permissions {
       REACT_FIELD(alert)
       bool alert;
@@ -24,7 +23,6 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       bool sound;
   };
 
-  REACT_STRUCT(Notification)
   struct Notification {
       REACT_FIELD(alertTitle)
       std::optional<std::string> alertTitle;
@@ -163,5 +161,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
+
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(PushNotificationManagerIOSSpec::Permissions)
+  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(PushNotificationManagerIOSSpec::Notification)
 
 } // namespace Microsoft::ReactNativeSpecs

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -13,37 +13,39 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(Spec_Permissions)
+struct Spec_Permissions {
+    REACT_FIELD(alert)
+    bool alert;
+    REACT_FIELD(badge)
+    bool badge;
+    REACT_FIELD(sound)
+    bool sound;
+};
+
+REACT_STRUCT(Spec_Notification)
+struct Spec_Notification {
+    REACT_FIELD(alertTitle)
+    std::optional<std::string> alertTitle;
+    REACT_FIELD(fireDate)
+    std::optional<double> fireDate;
+    REACT_FIELD(alertBody)
+    std::optional<std::string> alertBody;
+    REACT_FIELD(alertAction)
+    std::optional<std::string> alertAction;
+    REACT_FIELD(userInfo)
+    std::optional<React::JSValueObject> userInfo;
+    REACT_FIELD(category)
+    std::optional<std::string> category;
+    REACT_FIELD(repeatInterval)
+    std::optional<std::string> repeatInterval;
+    REACT_FIELD(applicationIconBadgeNumber)
+    std::optional<double> applicationIconBadgeNumber;
+    REACT_FIELD(isSilent)
+    std::optional<bool> isSilent;
+};
+
 struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  struct Permissions {
-      REACT_FIELD(alert)
-      bool alert;
-      REACT_FIELD(badge)
-      bool badge;
-      REACT_FIELD(sound)
-      bool sound;
-  };
-
-  struct Notification {
-      REACT_FIELD(alertTitle)
-      std::optional<std::string> alertTitle;
-      REACT_FIELD(fireDate)
-      std::optional<double> fireDate;
-      REACT_FIELD(alertBody)
-      std::optional<std::string> alertBody;
-      REACT_FIELD(alertAction)
-      std::optional<std::string> alertAction;
-      REACT_FIELD(userInfo)
-      std::optional<React::JSValueObject> userInfo;
-      REACT_FIELD(category)
-      std::optional<std::string> category;
-      REACT_FIELD(repeatInterval)
-      std::optional<std::string> repeatInterval;
-      REACT_FIELD(applicationIconBadgeNumber)
-      std::optional<double> applicationIconBadgeNumber;
-      REACT_FIELD(isSilent)
-      std::optional<bool> isSilent;
-  };
-
   static constexpr auto methods = std::tuple{
       Method<void(std::string, std::string) noexcept>{0, L"onFinishRemoteNotification"},
       Method<void(double) noexcept>{1, L"setApplicationIconBadgeNumber"},
@@ -51,8 +53,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       Method<void(React::JSValueObject, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
       Method<void() noexcept>{4, L"abandonPermissions"},
       Method<void(Callback<React::JSValue>) noexcept>{5, L"checkPermissions"},
-      Method<void(Notification) noexcept>{6, L"presentLocalNotification"},
-      Method<void(Notification) noexcept>{7, L"scheduleLocalNotification"},
+      Method<void(Spec_Notification) noexcept>{6, L"presentLocalNotification"},
+      Method<void(Spec_Notification) noexcept>{7, L"scheduleLocalNotification"},
       Method<void() noexcept>{8, L"cancelAllLocalNotifications"},
       Method<void(React::JSValueObject) noexcept>{9, L"cancelLocalNotifications"},
       Method<void(Promise<React::JSValue>) noexcept>{10, L"getInitialNotification"},
@@ -102,13 +104,13 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "presentLocalNotification",
-          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "scheduleLocalNotification",
-          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(Spec_Notification && notification) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "cancelAllLocalNotifications",
@@ -161,8 +163,5 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
           "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
   }
 };
-
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(PushNotificationManagerIOSSpec::Permissions)
-  INTERNAL_REACT_STRUCT_GETSTRUCTINFO(PushNotificationManagerIOSSpec::Notification)
 
 } // namespace Microsoft::ReactNativeSpecs


### PR DESCRIPTION
From react-native 0.64, react-native-codegen allows defining aliases for object literal types. This change reflect it on the codegen.

~~I don't know why `Microsoft.ReactNative.sln` still compiles as these new structs are used in the spec but implementations are not changed.~~
It is interesting that no module implementations are using `REACT_STRUCT` except `Alert` and `DeviceInfo`. `Alert` doesn't check the spec class when registering. `DeviceInfo` doesn't contain constants in the spec. I will fix them in separate commits.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8520)