### PR TITLE
[0.64] Allow injection of custom UI thread

### DIFF
--- a/change/@office-iss-react-native-win32-2f74a1fc-d190-4395-a600-69abbc3095ab.json
+++ b/change/@office-iss-react-native-win32-2f74a1fc-d190-4395-a600-69abbc3095ab.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix exception in View when props are undefined",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-84f792cf-76b2-4a3a-bff8-2915916225ad.json
+++ b/change/react-native-windows-84f792cf-76b2-4a3a-bff8-2915916225ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow injection of custom UI thread",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -33,7 +33,7 @@ const View: React.AbstractComponent<
   // [Win32
   invariant(
     // $FlowFixMe Wanting to catch untyped usages
-    props.acceptsKeyboardFocus === undefined,
+    props && props.acceptsKeyboardFocus === undefined,
     'Support for the "acceptsKeyboardFocus" property has been removed in favor of "focusable"',
   );
   // Win32]

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -31,11 +31,13 @@ export const ViewWin32 = React.forwardRef(
      * Check for raw text in the DOM.
      */
     if (__DEV__) {
-      React.Children.toArray(props.children).forEach(item => {
-        if (typeof item === 'string') {
-          console.error(`Unexpected text node: ${item}. A text node cannot be a child of a <View>.`);
-        }
-      });
+      if (props) {
+        React.Children.toArray(props.children).forEach(item => {
+          if (typeof item === 'string') {
+            console.error(`Unexpected text node: ${item}. A text node cannot be a child of a <View>.`);
+          }
+        });
+      }
     }
 
     /**

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -10,8 +10,8 @@ using namespace Windows::Foundation;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-// Implements ISimpleDispatch on top of a custom IReactDispatcher provided by the application
-struct WrappedReactDispatcher : public Mso::UnknownObject<Mso::React::ISimpleDispatch> {
+// Implements IDispatchQueue2 on top of a custom IReactDispatcher provided by the application
+struct WrappedReactDispatcher : public Mso::UnknownObject<Mso::React::IDispatchQueue2> {
   WrappedReactDispatcher(const winrt::Microsoft::ReactNative::IReactDispatcher &dispatcher) noexcept
       : m_dispatcher(dispatcher) {}
 
@@ -53,14 +53,14 @@ void ReactDispatcher::InvokeElsePost(Mso::DispatchTask &&task) const noexcept {
   return make<ReactDispatcher>(Mso::DispatchQueue{});
 }
 
-/*static*/ Mso::CntPtr<Mso::React::ISimpleDispatch> ReactDispatcher::GetUISimpleDispatch(
+/*static*/ Mso::CntPtr<Mso::React::IDispatchQueue2> ReactDispatcher::GetUIDispatchQueue2(
     IReactPropertyBag const &properties) noexcept {
   auto iReactDispatcher = GetUIDispatcher(properties);
 
   if (!iReactDispatcher)
     return nullptr;
 
-  if (auto simpleDispatcher = iReactDispatcher.try_as<ISimpleDispatch>())
+  if (auto simpleDispatcher = iReactDispatcher.try_as<IDispatchQueue2>())
     return simpleDispatcher.get();
 
   return Mso::Make<WrappedReactDispatcher>(iReactDispatcher);

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -8,8 +8,8 @@
 
 namespace Mso::React {
 
-MSO_GUID(ISimpleDispatch, "a8d9db25-3d16-4476-ae65-682fcee1260c")
-struct ISimpleDispatch : ::IUnknown {
+MSO_GUID(IDispatchQueue2, "a8d9db25-3d16-4476-ae65-682fcee1260c")
+struct IDispatchQueue2 : ::IUnknown {
   //! Post the task to the end of the queue for asynchronous invocation.
   virtual void Post(Mso::DispatchTask &&task) const noexcept = 0;
 
@@ -22,7 +22,7 @@ struct ISimpleDispatch : ::IUnknown {
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::React::ISimpleDispatch> {
+struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::React::IDispatchQueue2> {
   ReactDispatcher() = default;
   ReactDispatcher(Mso::DispatchQueue &&queue) noexcept;
 
@@ -31,7 +31,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
 
   static IReactDispatcher CreateSerialDispatcher() noexcept;
 
-  static Mso::CntPtr<ISimpleDispatch> GetUISimpleDispatch(IReactPropertyBag const &properties) noexcept;
+  static Mso::CntPtr<IDispatchQueue2> GetUIDispatchQueue2(IReactPropertyBag const &properties) noexcept;
   static IReactDispatcher UIThreadDispatcher() noexcept;
   static IReactPropertyName UIDispatcherProperty() noexcept;
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -6,9 +6,22 @@
 #include <dispatchQueue/dispatchQueue.h>
 #include <winrt/Microsoft.ReactNative.h>
 
+namespace Mso::React {
+
+struct __declspec(uuid("a8d9db25-3d16-4476-ae65-682fcee1260c")) ISimpleDispatch : ::IUnknown {
+  //! Post the task to the end of the queue for asynchronous invocation.
+  virtual void Post(Mso::DispatchTask &&task) const noexcept = 0;
+
+  //! Invoke the task immediately if the queue uses the current thread. Otherwise, post it.
+  //! The immediate execution ignores the suspend or shutdown states.
+  virtual void InvokeElsePost(Mso::DispatchTask &&task) const noexcept = 0;
+};
+
+} // namespace Mso::React
+
 namespace winrt::Microsoft::ReactNative::implementation {
 
-struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IReactDispatcher>> {
+struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::React::ISimpleDispatch> {
   ReactDispatcher() = default;
   ReactDispatcher(Mso::DispatchQueue &&queue) noexcept;
 
@@ -17,14 +30,16 @@ struct ReactDispatcher : implements<ReactDispatcher, winrt::default_interface<IR
 
   static IReactDispatcher CreateSerialDispatcher() noexcept;
 
-  static Mso::DispatchQueue GetUIDispatchQueue(IReactPropertyBag const &properties) noexcept;
-
+  static winrt::com_ptr<ISimpleDispatch> GetUISimpleDispatch(IReactPropertyBag const &properties) noexcept;
   static IReactDispatcher UIThreadDispatcher() noexcept;
   static IReactPropertyName UIDispatcherProperty() noexcept;
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
   static IReactPropertyName JSDispatcherProperty() noexcept;
+
+  void Post(Mso::DispatchTask &&task) const noexcept override;
+  void InvokeElsePost(Mso::DispatchTask &&task) const noexcept override;
 
  private:
   Mso::DispatchQueue m_queue;

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -8,7 +8,8 @@
 
 namespace Mso::React {
 
-struct __declspec(uuid("a8d9db25-3d16-4476-ae65-682fcee1260c")) ISimpleDispatch : ::IUnknown {
+MSO_GUID(ISimpleDispatch, "a8d9db25-3d16-4476-ae65-682fcee1260c")
+struct ISimpleDispatch : ::IUnknown {
   //! Post the task to the end of the queue for asynchronous invocation.
   virtual void Post(Mso::DispatchTask &&task) const noexcept = 0;
 
@@ -30,7 +31,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
 
   static IReactDispatcher CreateSerialDispatcher() noexcept;
 
-  static winrt::com_ptr<ISimpleDispatch> GetUISimpleDispatch(IReactPropertyBag const &properties) noexcept;
+  static Mso::CntPtr<ISimpleDispatch> GetUISimpleDispatch(IReactPropertyBag const &properties) noexcept;
   static IReactDispatcher UIThreadDispatcher() noexcept;
   static IReactPropertyName UIDispatcherProperty() noexcept;
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
@@ -16,7 +16,7 @@ namespace react::uwp {
 
 AppearanceChangeListener::AppearanceChangeListener(
     const Mso::React::IReactContext &context,
-    const Mso::React::ISimpleDispatch &uiQueue) noexcept
+    const Mso::React::IDispatchQueue2 &uiQueue) noexcept
     : m_queue(&uiQueue), m_context(&context) {
   if (auto currentApp = xaml::TryGetCurrentApplication()) {
     m_currentTheme = currentApp.RequestedTheme();

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
@@ -16,11 +16,8 @@ namespace react::uwp {
 
 AppearanceChangeListener::AppearanceChangeListener(
     const Mso::React::IReactContext &context,
-    Mso::DispatchQueue const &uiQueue) noexcept
-    : Mso::ActiveObject<>(uiQueue), m_context(&context) {
-  // Ensure we're constructed on the UI thread
-  VerifyElseCrash(uiQueue.HasThreadAccess());
-
+    const Mso::React::ISimpleDispatch &uiQueue) noexcept
+    : m_queue(&uiQueue), m_context(&context) {
   if (auto currentApp = xaml::TryGetCurrentApplication()) {
     m_currentTheme = currentApp.RequestedTheme();
 
@@ -29,7 +26,11 @@ AppearanceChangeListener::AppearanceChangeListener(
     m_revoker = m_uiSettings.ColorValuesChanged(
         winrt::auto_revoke, [weakThis{Mso::WeakPtr(this)}](const auto & /*sender*/, const auto & /*args*/) noexcept {
           if (auto strongThis = weakThis.GetStrongPtr()) {
-            strongThis->InvokeInQueueStrong([strongThis]() noexcept { strongThis->OnColorValuesChanged(); });
+            strongThis->m_queue->Post([weakThis]() noexcept {
+              if (auto strongThis = weakThis.GetStrongPtr()) {
+                strongThis->OnColorValuesChanged();
+              }
+            });
           }
         });
   }

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -23,14 +23,14 @@ class AppearanceChangeListener final : public Mso::RefCountedObject<Mso::RefCoun
  public:
   AppearanceChangeListener(
       const Mso::React::IReactContext &context,
-      const Mso::React::ISimpleDispatch &uiQueue) noexcept;
+      const Mso::React::IDispatchQueue2 &uiQueue) noexcept;
   const char *GetColorScheme() const noexcept;
 
  private:
   static const char *ToString(ApplicationTheme theme) noexcept;
   void OnColorValuesChanged() noexcept;
 
-  Mso::CntPtr<const Mso::React::ISimpleDispatch> m_queue;
+  Mso::CntPtr<const Mso::React::IDispatchQueue2> m_queue;
   UISettings m_uiSettings;
   UISettings::ColorValuesChanged_revoker m_revoker;
   std::atomic<ApplicationTheme> m_currentTheme;

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -3,30 +3,34 @@
 
 #pragma once
 
-#include <activeObject/activeObject.h>
 #include <cxxreact/CxxModule.h>
 #include <eventWaitHandle/eventWaitHandle.h>
 
 #include <winrt/Windows.UI.ViewManagement.h>
 
+#include <IReactDispatcher.h>
 #include <React.h>
+#include <object/refCountedObject.h>
 #include "IReactInstance.h"
 
 namespace react::uwp {
 
 // Listens for the current theme on the UI thread, storing the most recent. Will emit JS events on Appearance change.
-class AppearanceChangeListener final : public Mso::ActiveObject<> {
+class AppearanceChangeListener final : public Mso::RefCountedObject<Mso::RefCountStrategy::WeakRef, Mso::IRefCounted> {
   using ApplicationTheme = xaml::ApplicationTheme;
   using UISettings = winrt::Windows::UI::ViewManagement::UISettings;
 
  public:
-  AppearanceChangeListener(const Mso::React::IReactContext &context, Mso::DispatchQueue const &uiQueue) noexcept;
+  AppearanceChangeListener(
+      const Mso::React::IReactContext &context,
+      const Mso::React::ISimpleDispatch &uiQueue) noexcept;
   const char *GetColorScheme() const noexcept;
 
  private:
   static const char *ToString(ApplicationTheme theme) noexcept;
   void OnColorValuesChanged() noexcept;
 
+  Mso::CntPtr<const Mso::React::ISimpleDispatch> m_queue;
   UISettings m_uiSettings;
   UISettings::ColorValuesChanged_revoker m_revoker;
   std::atomic<ApplicationTheme> m_currentTheme;

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -5,6 +5,7 @@
 #include "ReactCoreInjection.h"
 #include "ReactCoreInjection.g.cpp"
 #include "ReactViewOptions.g.cpp"
+#include <future/futureWinRT.h>
 #include "IReactContext.h"
 #include "ReactContext.h"
 #include "ReactInstanceWin.h"
@@ -86,16 +87,18 @@ ReactViewHost::ReactViewHost(
 
 // ReactViewOptions ReactViewHost::Options() noexcept;
 // ReactNative::ReactNativeHost ReactViewHost::ReactHost() noexcept {}
-void ReactViewHost::ReloadViewInstance() noexcept {
-  m_viewHost->ReloadViewInstance();
+winrt::Windows::Foundation::IAsyncAction ReactViewHost::ReloadViewInstance() noexcept {
+  return make<Mso::AsyncActionFutureAdapter>(m_viewHost->ReloadViewInstance());
 }
 
-void ReactViewHost::ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept {
-  m_viewHost->ReloadViewInstanceWithOptions(options.as<ReactViewOptions>()->CreateViewOptions());
+winrt::Windows::Foundation::IAsyncAction ReactViewHost::ReloadViewInstanceWithOptions(
+    ReactNative::ReactViewOptions options) noexcept {
+  return make<Mso::AsyncActionFutureAdapter>(
+      m_viewHost->ReloadViewInstanceWithOptions(options.as<ReactViewOptions>()->CreateViewOptions()));
 }
 
-void ReactViewHost::UnloadViewInstance() noexcept {
-  m_viewHost->UnloadViewInstance();
+winrt::Windows::Foundation::IAsyncAction ReactViewHost::UnloadViewInstance() noexcept {
+  return make<Mso::AsyncActionFutureAdapter>(m_viewHost->UnloadViewInstance());
 }
 
 //! This class ensures that we access ReactRootView from UI thread.
@@ -151,10 +154,16 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   }
 };
 
-void ReactViewHost::AttachViewInstance(ReactNative::IReactViewInstance viewInstance) noexcept {
-  m_viewHost->AttachViewInstance(*Mso::Make<ReactViewInstance>(viewInstance, m_uiDispatcher));
+winrt::Windows::Foundation::IAsyncAction ReactViewHost::AttachViewInstance(
+    ReactNative::IReactViewInstance viewInstance) noexcept {
+  return make<Mso::AsyncActionFutureAdapter>(
+      m_viewHost->AttachViewInstance(*Mso::Make<ReactViewInstance>(viewInstance, m_uiDispatcher)));
 }
 
-void ReactViewHost::DetachViewInstance() noexcept {}
+winrt::Windows::Foundation::IAsyncAction ReactViewHost::DetachViewInstance() noexcept {
+  Mso::Promise<void> promise;
+  promise.SetValue();
+  return make<Mso::AsyncActionFutureAdapter>(promise.AsFuture());
+}
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -53,12 +53,11 @@ struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
       Mso::React::IReactViewHost &viewHost,
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
-  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstance() noexcept;
-  /*Windows::Foundation::IAsyncAction */ void ReloadViewInstanceWithOptions(
-      ReactNative::ReactViewOptions options) noexcept;
-  /*Windows::Foundation::IAsyncAction */ void UnloadViewInstance() noexcept;
-  /*Windows::Foundation::IAsyncAction */ void AttachViewInstance(IReactViewInstance viewInstance) noexcept;
-  /*Windows::Foundation::IAsyncAction */ void DetachViewInstance() noexcept;
+  Windows::Foundation::IAsyncAction ReloadViewInstance() noexcept;
+  Windows::Foundation::IAsyncAction ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
+  Windows::Foundation::IAsyncAction UnloadViewInstance() noexcept;
+  Windows::Foundation::IAsyncAction AttachViewInstance(IReactViewInstance viewInstance) noexcept;
+  Windows::Foundation::IAsyncAction DetachViewInstance() noexcept;
 
  private:
   Mso::CntPtr<Mso::React::IReactViewHost> m_viewHost;

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -50,19 +50,19 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
     interface IReactViewHost
   {
     DOC_STRING("Reloads the IReactViewInstance if it is attached.")
-      /*Windows.Foundation.IAsyncAction*/ void ReloadViewInstance();
+      Windows.Foundation.IAsyncAction ReloadViewInstance();
 
     DOC_STRING("Reloads IReactViewInstance if it is attached with a new set of options.")
-      /*Windows.Foundation.IAsyncAction*/ void ReloadViewInstanceWithOptions(ReactViewOptions options);
+      Windows.Foundation.IAsyncAction ReloadViewInstanceWithOptions(ReactViewOptions options);
 
     DOC_STRING("Unloads the attached IReactViewInstance.")
-      /*Windows.Foundation.IAsyncAction*/ void UnloadViewInstance();
+      Windows.Foundation.IAsyncAction UnloadViewInstance();
 
     DOC_STRING("Attaches IReactViewInstance to the IReactViewHost.")
-      /*Windows.Foundation.IAsyncAction*/ void AttachViewInstance(IReactViewInstance viewInstance);
+      Windows.Foundation.IAsyncAction AttachViewInstance(IReactViewInstance viewInstance);
 
     DOC_STRING("Detaches IReactViewInstance from the IReactViewHost.")
-      /*Windows.Foundation.IAsyncAction*/ void DetachViewInstance();
+      Windows.Foundation.IAsyncAction DetachViewInstance();
   }
 
   [experimental]

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -641,9 +641,9 @@ void ReactInstanceWin::InitNativeMessageThread() noexcept {
 void ReactInstanceWin::InitUIMessageThread() noexcept {
   // Native queue was already given us in constructor.
 
-  m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUISimpleDispatch(m_options.Properties);
+  m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatchQueue2(m_options.Properties);
   VerifyElseCrashSz(m_uiQueue, "No UI Dispatcher provided");
-  m_uiMessageThread.Exchange(std::make_shared<MessageSimpleDispatchQueue>(
+  m_uiMessageThread.Exchange(std::make_shared<MessageDispatchQueue2>(
       *m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
   auto batchingUIThread = react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -335,161 +335,167 @@ void ReactInstanceWin::Initialize() noexcept {
   });
 #endif
 
-  Mso::PostFuture(m_uiQueue, [weakThis = Mso::WeakPtr{this}]() noexcept {
-
-#ifndef CORE_ABI
+  m_uiQueue->Post([this, weakThis = Mso::WeakPtr{this}]() noexcept {
     // Objects that must be created on the UI thread
     if (auto strongThis = weakThis.GetStrongPtr()) {
+#ifndef CORE_ABI
       strongThis->m_appTheme = std::make_shared<react::uwp::AppTheme>(
           strongThis->GetReactContext(), strongThis->m_uiMessageThread.LoadWithLock());
       Microsoft::ReactNative::I18nManager::InitI18nInfo(
           winrt::Microsoft::ReactNative::ReactPropertyBag(strongThis->Options().Properties));
       strongThis->m_appearanceListener =
-          Mso::Make<react::uwp::AppearanceChangeListener>(strongThis->GetReactContext(), strongThis->m_uiQueue);
+          Mso::Make<react::uwp::AppearanceChangeListener>(strongThis->GetReactContext(), *(strongThis->m_uiQueue));
       Microsoft::ReactNative::DeviceInfoHolder::InitDeviceInfoHolder(
           winrt::Microsoft::ReactNative::ReactPropertyBag(strongThis->Options().Properties));
-    }
 #endif
-  }).Then(Queue(), [this, weakThis = Mso::WeakPtr{this}]() noexcept {
-    if (auto strongThis = weakThis.GetStrongPtr()) {
-      // auto cxxModulesProviders = GetCxxModuleProviders();
 
-      auto devSettings = std::make_shared<facebook::react::DevSettings>();
-      devSettings->useJITCompilation = m_options.EnableJITCompilation;
-      devSettings->sourceBundleHost = SourceBundleHost();
-      devSettings->sourceBundlePort = SourceBundlePort();
-      devSettings->debugBundlePath = DebugBundlePath();
-      devSettings->liveReloadCallback = GetLiveReloadCallback();
-      devSettings->errorCallback = GetErrorCallback();
-      devSettings->loggingCallback = GetLoggingCallback();
-      m_redboxHandler = devSettings->redboxHandler = std::move(GetRedBoxHandler());
-      devSettings->useDirectDebugger = m_useDirectDebugger;
-      devSettings->debuggerBreakOnNextLine = m_debuggerBreakOnNextLine;
-      devSettings->debuggerPort = m_options.DeveloperSettings.DebuggerPort;
-      devSettings->debuggerRuntimeName = m_options.DeveloperSettings.DebuggerRuntimeName;
-      devSettings->useWebDebugger = m_useWebDebugger;
-      devSettings->useFastRefresh = m_isFastReloadEnabled;
-      // devSettings->memoryTracker = GetMemoryTracker();
-      devSettings->bundleRootPath = BundleRootPath();
+      strongThis->Queue().Post([this, weakThis]() noexcept {
+        if (auto strongThis = weakThis.GetStrongPtr()) {
+          // auto cxxModulesProviders = GetCxxModuleProviders();
 
-      devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
-      devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
+          auto devSettings = std::make_shared<facebook::react::DevSettings>();
+          devSettings->useJITCompilation = m_options.EnableJITCompilation;
+          devSettings->sourceBundleHost = SourceBundleHost();
+          devSettings->sourceBundlePort = SourceBundlePort();
+          devSettings->debugBundlePath = DebugBundlePath();
+          devSettings->liveReloadCallback = GetLiveReloadCallback();
+          devSettings->errorCallback = GetErrorCallback();
+          devSettings->loggingCallback = GetLoggingCallback();
+          m_redboxHandler = devSettings->redboxHandler = std::move(GetRedBoxHandler());
+          devSettings->useDirectDebugger = m_useDirectDebugger;
+          devSettings->debuggerBreakOnNextLine = m_debuggerBreakOnNextLine;
+          devSettings->debuggerPort = m_options.DeveloperSettings.DebuggerPort;
+          devSettings->debuggerRuntimeName = m_options.DeveloperSettings.DebuggerRuntimeName;
+          devSettings->useWebDebugger = m_useWebDebugger;
+          devSettings->useFastRefresh = m_isFastReloadEnabled;
+          // devSettings->memoryTracker = GetMemoryTracker();
+          devSettings->bundleRootPath = BundleRootPath();
+
+          devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
+          devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
 
 #ifndef CORE_ABI
-      devSettings->showDevMenuCallback = [weakThis]() noexcept {
-        if (auto strongThis = weakThis.GetStrongPtr()) {
-          strongThis->m_uiQueue.Post([context = strongThis->m_reactContext]() {
-            Microsoft::ReactNative::DevMenuManager::Show(context->Properties());
-          });
-        }
-      };
+          devSettings->showDevMenuCallback = [weakThis]() noexcept {
+            if (auto strongThis = weakThis.GetStrongPtr()) {
+              strongThis->m_uiQueue->Post([context = strongThis->m_reactContext]() {
+                Microsoft::ReactNative::DevMenuManager::Show(context->Properties());
+              });
+            }
+          };
 #endif
 
-      // Now that ReactNativeWindows is building outside devmain, it is missing
-      // fix given by PR https://github.com/microsoft/react-native-windows/pull/2624 causing
-      // regression. We're turning off console redirection till the fix is available in devmain.
-      // Bug https://office.visualstudio.com/DefaultCollection/OC/_workitems/edit/3441551 is tracking this
-      devSettings->debuggerConsoleRedirection = false; // JSHost::ChangeGate::ChakraCoreDebuggerConsoleRedirection();
+          // Now that ReactNativeWindows is building outside devmain, it is missing
+          // fix given by PR https://github.com/microsoft/react-native-windows/pull/2624 causing
+          // regression. We're turning off console redirection till the fix is available in devmain.
+          // Bug https://office.visualstudio.com/DefaultCollection/OC/_workitems/edit/3441551 is tracking this
+          devSettings->debuggerConsoleRedirection =
+              false; // JSHost::ChangeGate::ChakraCoreDebuggerConsoleRedirection();
 
 #ifdef CORE_ABI
-      std::vector<facebook::react::NativeModuleDescription> cxxModules;
+          std::vector<facebook::react::NativeModuleDescription> cxxModules;
 #else
-      // Acquire default modules and then populate with custom modules.
-      // Note that some of these have custom thread affinity.
-      std::vector<facebook::react::NativeModuleDescription> cxxModules = react::uwp::GetCoreModules(
-          m_batchingUIThread,
-          m_jsMessageThread.Load(),
-          std::move(m_appTheme),
-          std::move(m_appearanceListener),
-          m_reactContext);
+          // Acquire default modules and then populate with custom modules.
+          // Note that some of these have custom thread affinity.
+          std::vector<facebook::react::NativeModuleDescription> cxxModules = react::uwp::GetCoreModules(
+              m_batchingUIThread,
+              m_jsMessageThread.Load(),
+              std::move(m_appTheme),
+              std::move(m_appearanceListener),
+              m_reactContext);
 #endif
 
-      auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();
+          auto nmp = std::make_shared<winrt::Microsoft::ReactNative::NativeModulesProvider>();
 
-      LoadModules(nmp, m_options.TurboModuleProvider);
+          LoadModules(nmp, m_options.TurboModuleProvider);
 
-      auto modules = nmp->GetModules(m_reactContext, m_jsMessageThread.Load());
-      cxxModules.insert(
-          cxxModules.end(), std::make_move_iterator(modules.begin()), std::make_move_iterator(modules.end()));
+          auto modules = nmp->GetModules(m_reactContext, m_jsMessageThread.Load());
+          cxxModules.insert(
+              cxxModules.end(), std::make_move_iterator(modules.begin()), std::make_move_iterator(modules.end()));
 
-      if (m_options.ModuleProvider != nullptr) {
-        std::vector<facebook::react::NativeModuleDescription> customCxxModules =
-            m_options.ModuleProvider->GetModules(m_reactContext, m_jsMessageThread.Load());
-        cxxModules.insert(std::end(cxxModules), std::begin(customCxxModules), std::end(customCxxModules));
-      }
+          if (m_options.ModuleProvider != nullptr) {
+            std::vector<facebook::react::NativeModuleDescription> customCxxModules =
+                m_options.ModuleProvider->GetModules(m_reactContext, m_jsMessageThread.Load());
+            cxxModules.insert(std::end(cxxModules), std::begin(customCxxModules), std::end(customCxxModules));
+          }
 
-      if (m_options.UseJsi) {
-        std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
-        std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
+          if (m_options.UseJsi) {
+            std::unique_ptr<facebook::jsi::ScriptStore> scriptStore = nullptr;
+            std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
-        switch (m_options.JsiEngine) {
-          case JSIEngine::Hermes:
+            switch (m_options.JsiEngine) {
+              case JSIEngine::Hermes:
 #if defined(USE_HERMES)
-            devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
-            devSettings->inlineSourceMap = false;
-            break;
+                devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::HermesRuntimeHolder>();
+                devSettings->inlineSourceMap = false;
+                break;
 #endif
-          case JSIEngine::V8:
+              case JSIEngine::V8:
 #if defined(USE_V8)
 #ifndef CORE_ABI
-            preparedScriptStore =
-                std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
+                preparedScriptStore =
+                    std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationLocalFolder());
 #endif // CORE_ABI
-            devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
-                devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
-            break;
+                devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
+                    devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
+                break;
 #endif // USE_V8
-          case JSIEngine::Chakra:
+              case JSIEngine::Chakra:
 #ifndef CORE_ABI
-            if (m_options.EnableByteCodeCaching || !m_options.ByteCodeFileUri.empty()) {
-              scriptStore = std::make_unique<react::uwp::UwpScriptStore>();
-              preparedScriptStore =
-                  std::make_unique<react::uwp::UwpPreparedScriptStore>(winrt::to_hstring(m_options.ByteCodeFileUri));
-            }
+                if (m_options.EnableByteCodeCaching || !m_options.ByteCodeFileUri.empty()) {
+                  scriptStore = std::make_unique<react::uwp::UwpScriptStore>();
+                  preparedScriptStore = std::make_unique<react::uwp::UwpPreparedScriptStore>(
+                      winrt::to_hstring(m_options.ByteCodeFileUri));
+                }
 #endif
-            devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
-                devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
-            break;
+                devSettings->jsiRuntimeHolder = std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(
+                    devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
+                break;
+            }
+
+            m_jsiRuntimeHolder = devSettings->jsiRuntimeHolder;
+          }
+
+          try {
+            // We need to keep the instance wrapper alive as its destruction shuts down the native queue.
+            m_options.TurboModuleProvider->SetReactContext(
+                winrt::make<implementation::ReactContext>(Mso::Copy(m_reactContext)));
+            auto bundleRootPath = devSettings->bundleRootPath;
+            auto instanceWrapper = facebook::react::CreateReactInstance(
+                std::shared_ptr<facebook::react::Instance>(strongThis->m_instance.Load()),
+                std::move(bundleRootPath), // bundleRootPath
+                std::move(cxxModules),
+                m_options.TurboModuleProvider,
+                std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
+                m_jsMessageThread.Load(),
+                Mso::Copy(m_batchingUIThread),
+                std::move(devSettings));
+
+            m_instanceWrapper.Exchange(std::move(instanceWrapper));
+
+            LoadJSBundles();
+
+            if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
+              folly::dynamic params = folly::dynamic::array(
+                  STRING(RN_PLATFORM),
+                  DebugBundlePath(),
+                  SourceBundleHost(),
+                  SourceBundlePort(),
+                  m_isFastReloadEnabled);
+              m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
+            }
+
+          } catch (std::exception &e) {
+            OnErrorWithMessage(e.what());
+            OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
+          } catch (winrt::hresult_error const &e) {
+            OnErrorWithMessage(Microsoft::Common::Unicode::Utf16ToUtf8(e.message().c_str(), e.message().size()));
+            OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
+          } catch (...) {
+            OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
+          }
         }
-
-        m_jsiRuntimeHolder = devSettings->jsiRuntimeHolder;
-      }
-
-      try {
-        // We need to keep the instance wrapper alive as its destruction shuts down the native queue.
-        m_options.TurboModuleProvider->SetReactContext(
-            winrt::make<implementation::ReactContext>(Mso::Copy(m_reactContext)));
-        auto bundleRootPath = devSettings->bundleRootPath;
-        auto instanceWrapper = facebook::react::CreateReactInstance(
-            std::shared_ptr<facebook::react::Instance>(strongThis->m_instance.Load()),
-            std::move(bundleRootPath), // bundleRootPath
-            std::move(cxxModules),
-            m_options.TurboModuleProvider,
-            std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
-            m_jsMessageThread.Load(),
-            Mso::Copy(m_batchingUIThread),
-            std::move(devSettings));
-
-        m_instanceWrapper.Exchange(std::move(instanceWrapper));
-
-        LoadJSBundles();
-
-        if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
-          folly::dynamic params = folly::dynamic::array(
-              STRING(RN_PLATFORM), DebugBundlePath(), SourceBundleHost(), SourceBundlePort(), m_isFastReloadEnabled);
-          m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
-        }
-
-      } catch (std::exception &e) {
-        OnErrorWithMessage(e.what());
-        OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
-      } catch (winrt::hresult_error const &e) {
-        OnErrorWithMessage(Microsoft::Common::Unicode::Utf16ToUtf8(e.message().c_str(), e.message().size()));
-        OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
-      } catch (...) {
-        OnErrorWithMessage("UwpReactInstance: Failed to create React Instance.");
-      }
-    }
+      });
+    };
   });
 }
 
@@ -634,10 +640,11 @@ void ReactInstanceWin::InitNativeMessageThread() noexcept {
 
 void ReactInstanceWin::InitUIMessageThread() noexcept {
   // Native queue was already given us in constructor.
-  m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUIDispatchQueue(m_options.Properties);
+
+  m_uiQueue = winrt::Microsoft::ReactNative::implementation::ReactDispatcher::GetUISimpleDispatch(m_options.Properties);
   VerifyElseCrashSz(m_uiQueue, "No UI Dispatcher provided");
-  m_uiMessageThread.Exchange(
-      std::make_shared<MessageDispatchQueue>(m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
+  m_uiMessageThread.Exchange(std::make_shared<MessageSimpleDispatchQueue>(
+      *m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
   auto batchingUIThread = react::uwp::MakeBatchingQueueThread(m_uiMessageThread.Load());
   m_batchingUIThread = batchingUIThread;
@@ -722,7 +729,7 @@ std::shared_ptr<IRedBoxHandler> ReactInstanceWin::GetRedBoxHandler() noexcept {
 #ifndef CORE_ABI
   } else if (UseDeveloperSupport()) {
     auto localWkReactHost = m_weakReactHost;
-    return CreateDefaultRedBoxHandler(std::move(localWkReactHost), Mso::Copy(m_uiQueue));
+    return CreateDefaultRedBoxHandler(std::move(localWkReactHost), *m_uiQueue);
 #endif
   } else {
     return {};

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -180,7 +180,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
 #endif
-  Mso::CntPtr<Mso::React::ISimpleDispatch> m_uiQueue;
+  Mso::CntPtr<Mso::React::IDispatchQueue2> m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 
   std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -180,7 +180,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
 #endif
-  winrt::com_ptr<Mso::React::ISimpleDispatch> m_uiQueue;
+  Mso::CntPtr<Mso::React::ISimpleDispatch> m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 
   std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "IReactDispatcher.h"
 #include "IReactInstanceInternal.h"
 #include "ReactContext.h"
 #include "ReactNativeHeaders.h"
@@ -179,7 +180,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
 #endif
-  Mso::DispatchQueue m_uiQueue;
+  Mso::CntPtr<Mso::React::ISimpleDispatch> m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 
   std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -180,7 +180,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   std::shared_ptr<react::uwp::AppTheme> m_appTheme;
   Mso::CntPtr<react::uwp::AppearanceChangeListener> m_appearanceListener;
 #endif
-  Mso::CntPtr<Mso::React::ISimpleDispatch> m_uiQueue;
+  winrt::com_ptr<Mso::React::ISimpleDispatch> m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 
   std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -403,7 +403,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultRedBoxHandler>, IRedBoxHandler {
   DefaultRedBoxHandler(
       Mso::WeakPtr<Mso::React::IReactHost> &&weakReactHost,
-      const Mso::React::ISimpleDispatch &uiQueue) noexcept
+      const Mso::React::IDispatchQueue2 &uiQueue) noexcept
       : m_weakReactHost{std::move(weakReactHost)}, m_uiQueue{&uiQueue} {}
 
   ~DefaultRedBoxHandler() {
@@ -522,7 +522,7 @@ struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultR
   }
 
  private:
-  Mso::CntPtr<const Mso::React::ISimpleDispatch> m_uiQueue;
+  Mso::CntPtr<const Mso::React::IDispatchQueue2> m_uiQueue;
   bool m_showingRedBox{false}; // Access from UI Thread only
   std::mutex m_lockRedBox;
   std::vector<std::shared_ptr<RedBox>> m_redBoxes; // Protected by m_lockRedBox
@@ -570,7 +570,7 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
 
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
-    const Mso::React::ISimpleDispatch &uiQueue) noexcept {
+    const Mso::React::IDispatchQueue2 &uiQueue) noexcept {
 #ifndef CORE_ABI
   return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), uiQueue);
 #else

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -401,8 +401,10 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
  * This class is implemented such that the methods on IRedBoxHandler are thread safe.
  */
 struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultRedBoxHandler>, IRedBoxHandler {
-  DefaultRedBoxHandler(Mso::WeakPtr<Mso::React::IReactHost> &&weakReactHost, Mso::DispatchQueue &&uiQueue) noexcept
-      : m_weakReactHost{std::move(weakReactHost)}, m_uiQueue{std::move(uiQueue)} {}
+  DefaultRedBoxHandler(
+      Mso::WeakPtr<Mso::React::IReactHost> &&weakReactHost,
+      const Mso::React::ISimpleDispatch &uiQueue) noexcept
+      : m_weakReactHost{std::move(weakReactHost)}, m_uiQueue{&uiQueue} {}
 
   ~DefaultRedBoxHandler() {
     // Hide any currently showing redBoxes
@@ -411,7 +413,7 @@ struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultR
       std::scoped_lock lock{m_lockRedBox};
       std::swap(m_redBoxes, redBoxes);
     }
-    m_uiQueue.Post([redBoxes = std::move(redBoxes)]() {
+    m_uiQueue->Post([redBoxes = std::move(redBoxes)]() {
       for (const auto &redBox : redBoxes) {
         redBox->Dismiss();
       }
@@ -465,14 +467,14 @@ struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultR
     }
 
     if (redbox) {
-      m_uiQueue.Post([redboxCaptured = std::move(redbox), errorInfo = std::move(info)]() {
+      m_uiQueue->Post([redboxCaptured = std::move(redbox), errorInfo = std::move(info)]() {
         redboxCaptured->UpdateError(std::move(errorInfo));
       });
     }
   }
 
   virtual void dismissRedbox() override {
-    m_uiQueue.Post([wkthis = std::weak_ptr(shared_from_this())]() {
+    m_uiQueue->Post([wkthis = std::weak_ptr(shared_from_this())]() {
       if (auto pthis = wkthis.lock()) {
         std::scoped_lock lock{pthis->m_lockRedBox};
         if (!pthis->m_redBoxes.empty())
@@ -516,11 +518,11 @@ struct DefaultRedBoxHandler final : public std::enable_shared_from_this<DefaultR
       return;
     m_showingRedBox = true;
 
-    m_uiQueue.Post([redboxCaptured = std::move(redbox)]() { redboxCaptured->ShowNewJSError(); });
+    m_uiQueue->Post([redboxCaptured = std::move(redbox)]() { redboxCaptured->ShowNewJSError(); });
   }
 
  private:
-  const Mso::DispatchQueue m_uiQueue;
+  Mso::CntPtr<const Mso::React::ISimpleDispatch> m_uiQueue;
   bool m_showingRedBox{false}; // Access from UI Thread only
   std::mutex m_lockRedBox;
   std::vector<std::shared_ptr<RedBox>> m_redBoxes; // Protected by m_lockRedBox
@@ -568,9 +570,9 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
 
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
-    Mso::DispatchQueue &&uiQueue) noexcept {
+    const Mso::React::ISimpleDispatch &uiQueue) noexcept {
 #ifndef CORE_ABI
-  return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), std::move(uiQueue));
+  return std::make_shared<DefaultRedBoxHandler>(std::move(weakReactHost), uiQueue);
 #else
   return nullptr;
 #endif

--- a/vnext/Microsoft.ReactNative/RedBox.h
+++ b/vnext/Microsoft.ReactNative/RedBox.h
@@ -13,5 +13,5 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
 
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
-    const Mso::React::ISimpleDispatch &uiQueue) noexcept;
+    const Mso::React::IDispatchQueue2 &uiQueue) noexcept;
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBox.h
+++ b/vnext/Microsoft.ReactNative/RedBox.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 #include <DevSettings.h>
+#include "IReactDispatcher.h"
 #include "IRedBoxHandler.h"
 #include "ReactHost/React.h"
 
@@ -12,5 +13,5 @@ std::shared_ptr<IRedBoxHandler> CreateRedBoxHandler(
 
 std::shared_ptr<IRedBoxHandler> CreateDefaultRedBoxHandler(
     Mso::WeakPtr<IReactHost> &&weakReactHost,
-    Mso::DispatchQueue &&uiQueue) noexcept;
+    const Mso::React::ISimpleDispatch &uiQueue) noexcept;
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
@@ -34,7 +34,7 @@ struct DefaultRedBoxHandler : winrt::implements<DefaultRedBoxHandler, IRedBoxHan
     auto hostImpl = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeHost>(host);
     Mso::WeakPtr<Mso::React::IReactHost> wkHost(hostImpl->ReactHost());
     m_redBoxHandler = Mso::React::CreateDefaultRedBoxHandler(
-        std::move(wkHost), *ReactDispatcher::GetUISimpleDispatch(host.InstanceSettings().Properties()));
+        std::move(wkHost), *ReactDispatcher::GetUIDispatchQueue2(host.InstanceSettings().Properties()));
   }
 
   void ShowNewError(IRedBoxErrorInfo const &info, RedBoxErrorType type) noexcept {

--- a/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
+++ b/vnext/Microsoft.ReactNative/RedBoxHandler.cpp
@@ -34,7 +34,7 @@ struct DefaultRedBoxHandler : winrt::implements<DefaultRedBoxHandler, IRedBoxHan
     auto hostImpl = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactNativeHost>(host);
     Mso::WeakPtr<Mso::React::IReactHost> wkHost(hostImpl->ReactHost());
     m_redBoxHandler = Mso::React::CreateDefaultRedBoxHandler(
-        std::move(wkHost), ReactDispatcher::GetUIDispatchQueue(host.InstanceSettings().Properties()));
+        std::move(wkHost), *ReactDispatcher::GetUISimpleDispatch(host.InstanceSettings().Properties()));
   }
 
   void ShowNewError(IRedBoxErrorInfo const &info, RedBoxErrorType type) noexcept {

--- a/vnext/Shared/Threading/BatchingQueueThread.h
+++ b/vnext/Shared/Threading/BatchingQueueThread.h
@@ -50,6 +50,8 @@ struct BatchingQueueThread final : facebook::react::BatchingMessageQueueThread {
 
  private:
   std::mutex m_mutex;
+  std::mutex m_mutexQuitting;
+  bool m_quitting{false};
   std::shared_ptr<facebook::react::CallInvoker> m_callInvoker;
   std::shared_ptr<BatchingQueueCallInvoker> m_batchingQueueCallInvoker;
 };

--- a/vnext/Shared/Threading/MessageDispatchQueue.cpp
+++ b/vnext/Shared/Threading/MessageDispatchQueue.cpp
@@ -89,11 +89,11 @@ void MessageDispatchQueue::quitSynchronous() {
 }
 
 //=============================================================================================
-// MessageSimpleDispatchQueue implementation.
+// MessageDispatchQueue2 implementation.
 //=============================================================================================
 
-MessageSimpleDispatchQueue::MessageSimpleDispatchQueue(
-    Mso::React::ISimpleDispatch &dispatchQueue,
+MessageDispatchQueue2::MessageDispatchQueue2(
+    Mso::React::IDispatchQueue2 &dispatchQueue,
     Mso::Functor<void(const Mso::ErrorCode &)> &&errorHandler,
     Mso::Promise<void> &&whenQuit) noexcept
     : m_stopped{false},
@@ -101,9 +101,9 @@ MessageSimpleDispatchQueue::MessageSimpleDispatchQueue(
       m_whenQuit{std::move(whenQuit)},
       m_dispatchQueue{&dispatchQueue} {}
 
-MessageSimpleDispatchQueue::~MessageSimpleDispatchQueue() noexcept {}
+MessageDispatchQueue2::~MessageDispatchQueue2() noexcept {}
 
-void MessageSimpleDispatchQueue::runOnQueue(std::function<void()> &&func) {
+void MessageDispatchQueue2::runOnQueue(std::function<void()> &&func) {
   if (m_stopped) {
     return;
   }
@@ -115,7 +115,7 @@ void MessageSimpleDispatchQueue::runOnQueue(std::function<void()> &&func) {
   });
 }
 
-void MessageSimpleDispatchQueue::tryFunc(const std::function<void()> &func) noexcept {
+void MessageDispatchQueue2::tryFunc(const std::function<void()> &func) noexcept {
   try {
     func();
   } catch (const std::exception & /*ex*/) {
@@ -125,7 +125,7 @@ void MessageSimpleDispatchQueue::tryFunc(const std::function<void()> &func) noex
   }
 }
 
-void MessageSimpleDispatchQueue::runSync(const Mso::VoidFunctorRef &func) noexcept {
+void MessageDispatchQueue2::runSync(const Mso::VoidFunctorRef &func) noexcept {
   Mso::ManualResetEvent callbackFinished{};
 
   m_dispatchQueue->InvokeElsePost(Mso::MakeDispatchTask(
@@ -141,7 +141,7 @@ void MessageSimpleDispatchQueue::runSync(const Mso::VoidFunctorRef &func) noexce
 
 // runOnQueueSync and quitSynchronous are dangerous.  They should only be
 // used for initialization and cleanup.
-void MessageSimpleDispatchQueue::runOnQueueSync(std::function<void()> &&func) {
+void MessageDispatchQueue2::runOnQueueSync(std::function<void()> &&func) {
   if (m_stopped) {
     return;
   }
@@ -154,7 +154,7 @@ void MessageSimpleDispatchQueue::runOnQueueSync(std::function<void()> &&func) {
 }
 
 // Once quitSynchronous() returns, no further work should run on the queue.
-void MessageSimpleDispatchQueue::quitSynchronous() {
+void MessageDispatchQueue2::quitSynchronous() {
   m_stopped = true;
   runSync([]() noexcept {});
 

--- a/vnext/Shared/Threading/MessageDispatchQueue.cpp
+++ b/vnext/Shared/Threading/MessageDispatchQueue.cpp
@@ -96,9 +96,10 @@ MessageSimpleDispatchQueue::MessageSimpleDispatchQueue(
     Mso::React::ISimpleDispatch &dispatchQueue,
     Mso::Functor<void(const Mso::ErrorCode &)> &&errorHandler,
     Mso::Promise<void> &&whenQuit) noexcept
-    : m_stopped{false}, m_errorHandler{std::move(errorHandler)}, m_whenQuit{std::move(whenQuit)} {
-  m_dispatchQueue.copy_from(&dispatchQueue);
-}
+    : m_stopped{false},
+      m_errorHandler{std::move(errorHandler)},
+      m_whenQuit{std::move(whenQuit)},
+      m_dispatchQueue{&dispatchQueue} {}
 
 MessageSimpleDispatchQueue::~MessageSimpleDispatchQueue() noexcept {}
 

--- a/vnext/Shared/Threading/MessageDispatchQueue.h
+++ b/vnext/Shared/Threading/MessageDispatchQueue.h
@@ -45,7 +45,7 @@ struct MessageDispatchQueue : facebook::react::MessageQueueThread, std::enable_s
 };
 
 struct MessageDispatchQueue2 : facebook::react::MessageQueueThread,
-                                    std::enable_shared_from_this<MessageDispatchQueue2> {
+                               std::enable_shared_from_this<MessageDispatchQueue2> {
   MessageDispatchQueue2(
       Mso::React::IDispatchQueue2 &dispatchQueue,
       Mso::Functor<void(const Mso::ErrorCode &)> &&errorHandler,

--- a/vnext/Shared/Threading/MessageDispatchQueue.h
+++ b/vnext/Shared/Threading/MessageDispatchQueue.h
@@ -44,14 +44,14 @@ struct MessageDispatchQueue : facebook::react::MessageQueueThread, std::enable_s
   const Mso::Promise<void> m_whenQuit;
 };
 
-struct MessageSimpleDispatchQueue : facebook::react::MessageQueueThread,
-                                    std::enable_shared_from_this<MessageSimpleDispatchQueue> {
-  MessageSimpleDispatchQueue(
-      Mso::React::ISimpleDispatch &dispatchQueue,
+struct MessageDispatchQueue2 : facebook::react::MessageQueueThread,
+                                    std::enable_shared_from_this<MessageDispatchQueue2> {
+  MessageDispatchQueue2(
+      Mso::React::IDispatchQueue2 &dispatchQueue,
       Mso::Functor<void(const Mso::ErrorCode &)> &&errorHandler,
       Mso::Promise<void> &&whenQuit = nullptr) noexcept;
 
-  ~MessageSimpleDispatchQueue() noexcept override;
+  ~MessageDispatchQueue2() noexcept override;
 
  public: // FastMessageQueueThread implementation
   void runOnQueue(std::function<void()> &&func) override;
@@ -69,7 +69,7 @@ struct MessageSimpleDispatchQueue : facebook::react::MessageQueueThread,
 
  private:
   std::atomic<bool> m_stopped;
-  Mso::CntPtr<Mso::React::ISimpleDispatch> m_dispatchQueue;
+  Mso::CntPtr<Mso::React::IDispatchQueue2> m_dispatchQueue;
   Mso::Functor<void(const Mso::ErrorCode &)> m_errorHandler;
   const Mso::Promise<void> m_whenQuit;
 };

--- a/vnext/Shared/Threading/MessageDispatchQueue.h
+++ b/vnext/Shared/Threading/MessageDispatchQueue.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <IReactDispatcher.h>
 #include <cxxreact/MessageQueueThread.h>
 #include <functional/FunctorRef.h>
 #include <future/Future.h>
@@ -39,6 +40,36 @@ struct MessageDispatchQueue : facebook::react::MessageQueueThread, std::enable_s
  private:
   std::atomic<bool> m_stopped;
   Mso::DispatchQueue m_dispatchQueue;
+  Mso::Functor<void(const Mso::ErrorCode &)> m_errorHandler;
+  const Mso::Promise<void> m_whenQuit;
+};
+
+struct MessageSimpleDispatchQueue : facebook::react::MessageQueueThread,
+                                    std::enable_shared_from_this<MessageSimpleDispatchQueue> {
+  MessageSimpleDispatchQueue(
+      Mso::React::ISimpleDispatch &dispatchQueue,
+      Mso::Functor<void(const Mso::ErrorCode &)> &&errorHandler,
+      Mso::Promise<void> &&whenQuit = nullptr) noexcept;
+
+  ~MessageSimpleDispatchQueue() noexcept override;
+
+ public: // FastMessageQueueThread implementation
+  void runOnQueue(std::function<void()> &&func) override;
+
+  // runOnQueueSync and quitSynchronous are dangerous.  They should only be
+  // used for initialization and cleanup.
+  void runOnQueueSync(std::function<void()> &&func) override;
+
+  // Once quitSynchronous() returns, no further work should run on the queue.
+  void quitSynchronous() override;
+
+ private:
+  void runSync(const Mso::VoidFunctorRef &func) noexcept;
+  void tryFunc(const std::function<void()> &func) noexcept;
+
+ private:
+  std::atomic<bool> m_stopped;
+  Mso::CntPtr<Mso::React::ISimpleDispatch> m_dispatchQueue;
   Mso::Functor<void(const Mso::ErrorCode &)> m_errorHandler;
   const Mso::Promise<void> m_whenQuit;
 };


### PR DESCRIPTION
Currently bad things happen if someone tries to set a custom implementation of IReactDispatcher to InstanceSettings.UIDispatcher.

This fixes an assumed cast to an internal object, and replaces it with a small internal interface that we can QI for.  If that interface exists we will use that internally.  Otherwise, we can implement that interface on top of an app provided IReactDispatcher.

Making this PR against 0.64 since I'm testing it against a 0.64 providing an custom IReactDispatcher internally.  We will need this backported to 0.64 anyway for Office's effort to get onto the public ABI.

Note, I am also backporting #8026 since I hit that issue while testing this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8521)