### PR TITLE
Fire onMouseEnter/Leave events on pointer concluded

### DIFF
--- a/change/react-native-windows-63c7eafa-0398-42ec-a2db-6dc37804f31a.json
+++ b/change/react-native-windows-63c7eafa-0398-42ec-a2db-6dc37804f31a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fire onMouseEnter/Leave events on pointer conclude",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -193,9 +193,20 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
   if (m_pointers.size() == 0)
     m_touchId = 0;
 
-  m_xamlView.as<xaml::FrameworkElement>().ReleasePointerCapture(args.Pointer());
+  const auto frameworkElement = m_xamlView.as<xaml::FrameworkElement>();
+  auto wasCaptured = false;
+  if (frameworkElement.PointerCaptures()) {
+    for (auto pointer : frameworkElement.PointerCaptures()) {
+      wasCaptured |= pointer.PointerId() == args.Pointer().PointerId();
+    }
+  }
 
-  UpdatePointersInViews(args, tag, sourceElement);
+  frameworkElement.ReleasePointerCapture(args.Pointer());
+
+  // Updates the enter/leave state when pointer was previously captured
+  if (wasCaptured) {
+    UpdatePointersInViews(args, tag, sourceElement);
+  }
 }
 
 size_t TouchEventHandler::AddReactPointer(

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -194,6 +194,8 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
     m_touchId = 0;
 
   m_xamlView.as<xaml::FrameworkElement>().ReleasePointerCapture(args.Pointer());
+
+  UpdatePointersInViews(args, tag, sourceElement);
 }
 
 size_t TouchEventHandler::AddReactPointer(


### PR DESCRIPTION
See details of bug in #8525. Calling UpdatePointersInViews in the OnPointerConcluded callback fixes the issue.

Fixes #8525

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8526)