### PR TITLE
Reenable babel-plugin-codegen (formerly babel-plugin-inline-viewconfigs)

### DIFF
--- a/packages/playground/babel.config.js
+++ b/packages/playground/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ['module:metro-react-native-babel-preset'],
-  // plugins: [require('../../vnext/src/babel-plugin-codegen')], #6570
+  plugins: [require('../../vnext/src/babel-plugin-codegen')],
 };


### PR DESCRIPTION
Fixes #6570

We hit an issue previously where an old codegen packaged caused this to need to be disabled. We have newer codegen, so try reenabling this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8534)