### PR TITLE
Fix logic to avoid launching packager

### DIFF
--- a/change/@react-native-windows-cli-dc9b1092-11ab-4867-8616-1ffbef340913.json
+++ b/change/@react-native-windows-cli-dc9b1092-11ab-4867-8616-1ffbef340913.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix logic to avoid launching packager",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -346,10 +346,7 @@ async function runWindowsInternal(
 }
 
 function shouldLaunchPackager(options: RunWindowsOptions): boolean {
-  return (
-    options.packager === true ||
-    (options.packager === undefined && options.release !== true)
-  );
+  return options.packager && options.launch && options.release !== true;
 }
 
 /*

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -41,7 +41,7 @@ export interface RunWindowsOptions {
   target?: string;
   remoteDebugging?: string;
   logging: boolean;
-  packager?: boolean;
+  packager: boolean;
   bundle: boolean;
   launch: boolean;
   autolink: boolean;
@@ -102,6 +102,7 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--no-packager',
     description: 'Do not launch packager while building',
+    default: false,
   },
   {
     name: '--bundle',

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -102,7 +102,6 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--no-packager',
     description: 'Do not launch packager while building',
-    default: false,
   },
   {
     name: '--bundle',


### PR DESCRIPTION
We do not want to launch the packager by default in release builds because the application is already bundled. Logic is present to avoid launching, conditioning on release mode, or if  ``--packager`` is specified.

Commander has some special handling around negation parameters. For a positive parameter, like `--foo`, the option will be set to undefined ifa default not present. If it is `--no-foo`, then `foo` will be set to true instead of undefined.

This effectively means there is not a way to test for `--packager` vs the absence of `--no-packager`, so the previous logic always assumed the user was explicitly asking for a packager.

This change moves the logic to instead launch the packer when the following conditions are met:
1. `--no-packager` is not set
2. `--no-launch` is not set
3. `--release` is not set

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8541)