### PR TITLE
Adding Accessibility Prop accessibilityItemType on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-6c132fce-6826-4199-99d7-2fd4111db44c.json
+++ b/change/@office-iss-react-native-win32-6c132fce-6826-4199-99d7-2fd4111db44c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding accessibilityItemType property to ViewWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -381,6 +381,7 @@ const ReactNativeViewConfig: ViewConfig = {
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
     accessibilityControls: true,
+    accessibilityItemType: true,
     // Windows]
   },
 };

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -43,7 +43,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
   public render() {
     return (
       <ViewWin32>
-        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" />
+        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" accessibilityItemType="Comment" />
       <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
           <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -176,6 +176,12 @@ export type BasePropsWin32 = {
   * accessibility tool to query those other providers for properties and listen to their events.
   */
    accessibilityControls?: React.RefObject<any>;    
+
+   /**
+    * Identifies the ItemType property, which is a text string describing the type of the automation element.
+    * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
+    */
+   accessibilityItemType?: string;
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -17,8 +17,8 @@ const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityState'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
-  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'> &
-  'accessibilityItemType';
+  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
+  //'accessibilityItemType';
 
 type ViewWin32Type = React.ForwardRefExoticComponent<
 IViewWin32Props & React.RefAttributes<View>

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -18,7 +18,6 @@ type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibility
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityState'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
-  //'accessibilityItemType';
 
 type ViewWin32Type = React.ForwardRefExoticComponent<
 IViewWin32Props & React.RefAttributes<View>

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -17,7 +17,8 @@ const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityState'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
-  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
+  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'> &
+  'accessibilityItemType';
 
 type ViewWin32Type = React.ForwardRefExoticComponent<
 IViewWin32Props & React.RefAttributes<View>


### PR DESCRIPTION
This accessibility prop is needed by some partners for the help of reading comments/replies.

I will backport this to .65/.64/.63

**[UIA_ItemTypePropertyID](https://docs.microsoft.com/en-us/windows/win32/winauto/uiauto-automation-element-propids)** - 
Identifies the ItemType property, which is a text string describing the type of the automation element.
ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
When ItemType is supported, the string must match the application UI language or the operating system default UI language.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8543)