### PR TITLE
[0.63] Adding Accessibility Prop accessibilityItemType on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-2021-09-02-12-08-11-sammy-63_A11yItemType.json
+++ b/change/@office-iss-react-native-win32-2021-09-02-12-08-11-sammy-63_A11yItemType.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding accessibilityItemType to ViewWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-02T19:08:11.049Z"
+}

--- a/packages/react-native-win32/docs/api/react-native-win32.basepropswin32.md
+++ b/packages/react-native-win32/docs/api/react-native-win32.basepropswin32.md
@@ -14,5 +14,6 @@ export declare type BasePropsWin32 = {
     accessibilityDescribedBy?: React.RefObject<any>;
     accessibilityLabeledBy?: React.RefObject<any>;
     accessibilityControls?: React.RefObject<any>;
+    accessibilityItemType?: string;
 };
 ```

--- a/packages/react-native-win32/etc/react-native-win32.api.md
+++ b/packages/react-native-win32/etc/react-native-win32.api.md
@@ -57,6 +57,7 @@ export type BasePropsWin32 = {
     accessibilityDescribedBy?: React_2.RefObject<any>;
     accessibilityLabeledBy?: React_2.RefObject<any>;
     accessibilityControls?: React_2.RefObject<any>;
+    accessibilityItemType?: string;
 };
 
 // Warning: (ae-forgotten-export) The symbol "IButtonWin32State" needs to be exported by the entry point typings-index.d.ts

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -379,6 +379,7 @@ const ReactNativeViewConfig = {
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
     accessibilityControls: true,
+    accessibilityItemType: true,
     // Windows]
   },
 };

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -43,7 +43,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
   public render() {
     return (
       <ViewWin32>
-        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" />
+        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" accessibilityItemType="Comment" />
       <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
           <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -175,7 +175,13 @@ export type BasePropsWin32 = {
   * This is mainly used for a Textbox with a Dropdown PeoplePicker-type list.  This allows an 
   * accessibility tool to query those other providers for properties and listen to their events.
   */
-   accessibilityControls?: React.RefObject<any>;     
+   accessibilityControls?: React.RefObject<any>;
+
+  /**
+  * Identifies the ItemType property, which is a text string describing the type of the automation element.
+  * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
+  */
+   accessibilityItemType?: string;
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -17,8 +17,7 @@ const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityState'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
-  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'> &
-  'accessibilityItemType';
+  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
 
 type ViewWin32Type = React.ForwardRefExoticComponent<
 IViewWin32Props & React.RefAttributes<View>

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.tsx
@@ -17,7 +17,8 @@ const setAndForwardRef = require('../../Utilities/setAndForwardRef');
 type InnerViewWin32Props = UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityRole'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityState'> &
   UseFrom<IViewWin32Props, RN.ViewProps, 'accessibilityActions'> &
-  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'>;
+  UseFrom<IViewWin32Props, RN.ViewProps, 'onAccessibilityAction'> &
+  'accessibilityItemType';
 
 type ViewWin32Type = React.ForwardRefExoticComponent<
 IViewWin32Props & React.RefAttributes<View>


### PR DESCRIPTION
This accessibility prop is needed by some partners for the help of reading comments/replies.

I will backport this to .65/.64/.63

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8546)