### PR TITLE
Fix race condition when building customer projects

### DIFF
--- a/change/react-native-windows-9c592c92-59e0-41c3-b4ad-717dc10aa396.json
+++ b/change/react-native-windows-9c592c92-59e0-41c3-b4ad-717dc10aa396.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix race condition when building customer projects",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -278,16 +278,19 @@
     <Error Condition="!Exists('$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets'))" />
   </Target>
   <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
-    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')" />
-    <DownloadFile Condition="!Exists('$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip')"
+    <PropertyGroup>
+      <FollyZipDir>$(IntDir)\.follyzip</FollyZipDir>
+    </PropertyGroup>
+    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyZipDir)\folly-$(FollyVersion).zip')" />
+    <DownloadFile Condition="!Exists('$(FollyZipDir)\folly-$(FollyVersion).zip')"
       SourceUrl="https://github.com/facebook/folly/archive/v$(FollyVersion).zip"
       DestinationFileName="folly-$(FollyVersion).zip"
-      DestinationFolder="$(FollyDir)..\.follyzip"
+      DestinationFolder="$(FollyZipDir)"
       Retries="10"/>
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
     <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
-    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyDir)..\.follyzip\folly-$(FollyVersion).zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
+    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyZipDir)\folly-$(FollyVersion).zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
   </Target>
   <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
     <Message Importance="High" Text="Generating $([MSBuild]::NormalizePath($(FollyDir)..))\cgmanifest.json." Condition="!Exists('$([MSBuild]::NormalizePath($(FollyDir)..))\cgmanifest.json')" />


### PR DESCRIPTION
Our CI has caught 2 runs where metro was trying to read folly.zip file while it was being downloaded.
This change moves the zip file into the intermediate msbuild output folder rather than the node_modules folder where Metro bunderl is snooping around.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8562)