### PR TITLE
Stop Tagging 0.63 Builds

### DIFF
--- a/change/react-native-windows-288a5f41-0865-467a-83c0-2e53f5f0ede5.json
+++ b/change/react-native-windows-288a5f41-0865-467a-83c0-2e53f5f0ede5.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Stop Tagging 0.63 Builds",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -66,7 +66,7 @@
   },
   "beachball": {
     "defaultNpmTag": "v0.63-stable",
-    "gitTags": true,
+    "gitTags": false,
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
The only changes being made/accepted to 0.63 are for internal office usage, pending react-native-macos updates. Stop tagging new 0.63 release, so that patches stop showing up in the releases view.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8563)