### PR TITLE
Typecheck Playground Samples

### DIFF
--- a/packages/playground/Samples/accessible.tsx
+++ b/packages/playground/Samples/accessible.tsx
@@ -25,7 +25,7 @@ export default class Bootstrap extends React.Component<
     this.state = {displayText: 'Starting text. (THIRD ITEM)'};
   }
 
-  myElement = React.createRef();
+  myElement = React.createRef<TextInput>();
 
   render() {
     return (

--- a/packages/playground/Samples/rntester.tsx
+++ b/packages/playground/Samples/rntester.tsx
@@ -17,3 +17,5 @@
 require('react-native');
 
 require('@react-native-windows/tester/js/RNTesterApp');
+
+export {};

--- a/packages/playground/Samples/ticTacToe.tsx
+++ b/packages/playground/Samples/ticTacToe.tsx
@@ -41,7 +41,7 @@ export default class Bootstrap extends React.Component<
     const newSquares = this.state.squares.slice();
     const turn = this.whoseTurn();
     if (this.state.squares[i] || winner(this.state.squares)) {
-      return null;
+      return;
     }
     newSquares[i] = turn;
     this.setState({

--- a/packages/playground/just-task.js
+++ b/packages/playground/just-task.js
@@ -6,7 +6,7 @@
  */
 
 const fs = require('fs');
-const {task} = require('just-scripts');
+const {parallel, task} = require('just-scripts');
 
 // Use the shared base configuration
 require('@rnw-scripts/just-task');
@@ -14,3 +14,5 @@ require('@rnw-scripts/just-task');
 task('prepareBundleWin32', () => {
   fs.mkdirSync('windows/playground-win32/Bundle/Samples', {recursive: true});
 });
+
+task('lint', parallel('eslint', 'depcheck', 'ts'));

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@rnw-scripts/ts-config",
   "include": ["."],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "noEmit": true
+  }
 }


### PR DESCRIPTION
Fixes #8416

RNTester already type-checking as it does a build instead of transform

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8565)