### PR TITLE
Export AutomationElement type

### DIFF
--- a/change/@react-native-windows-automation-0bb4044e-9656-4374-9679-1a1c6e2c6e3f.json
+++ b/change/@react-native-windows-automation-0bb4044e-9656-4374-9679-1a1c6e2c6e3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export AutomationElement type",
+  "packageName": "@react-native-windows/automation",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation/.eslintrc.js
+++ b/packages/@react-native-windows/automation/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['@rnw-scripts'],
   parserOptions: {tsconfigRootDir : __dirname},
+  
+  // Workaround "export type" being unsupported with prettier 1.x
+  ignorePatterns: ['index.ts'],
 };

--- a/packages/@react-native-windows/automation/src/index.ts
+++ b/packages/@react-native-windows/automation/src/index.ts
@@ -6,7 +6,8 @@
  */
 
 import AutomationEnvironment from './AutomationEnvironment';
-import {app} from './AutomationClient';
+import {app, AutomationElement} from './AutomationClient';
 
 export {app};
+export type {AutomationElement}
 export default AutomationEnvironment;


### PR DESCRIPTION
This is a high-level type that can be useful to use as a return type for helpers in app-code. Export it from the @react-native-windows/automation entry-point.
