### PR TITLE
Expose launch args as high level automation option 

### DIFF
--- a/change/@react-native-windows-automation-82f03b0b-cdd1-4c44-b4c4-11eec17ef46b.json
+++ b/change/@react-native-windows-automation-82f03b0b-cdd1-4c44-b4c4-11eec17ef46b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Expose launch args as high level automation option",
+  "packageName": "@react-native-windows/automation",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation/README.md
+++ b/packages/@react-native-windows/automation/README.md
@@ -57,6 +57,11 @@ testEnvironmentOptions: {
   // or path to an .exe for an unpackaged application.
   app: 'Microsoft.WindowsAlarms',
 
+  /**
+   * Optional: Arguments to be passed to your application when launched
+   */
+  appArguments: '--bundle testBundle.js';
+
   // Optional: Explicit path to WinAppDriver. By default,
   // `@react-native-windows/automation` tries to use
   // "%PROGRAMFILES(X86)%\Windows Application Driver\WinAppDriver.exe"

--- a/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
+++ b/packages/@react-native-windows/automation/src/AutomationEnvironment.ts
@@ -25,6 +25,12 @@ export type EnvironmentOptions = {
    * name (e.g. Microsoft.WindowsAlarms)
    */
   app?: string;
+
+  /**
+   * Arguments to be passed to your application when launched
+   */
+  appArguments?: string;
+
   enableAutomationChannel?: boolean;
   automationChannelPort?: number;
   winAppDriverBin?: string;
@@ -69,6 +75,11 @@ export default class AutomationEnvironment extends NodeEnvironment {
       port: 4723,
       capabilities: {
         app: resolveAppName(passedOptions.app),
+
+        ...(passedOptions.appArguments && {
+          appArguments: passedOptions.appArguments,
+        }),
+
         // @ts-ignore
         'ms:experimental-webdriver': true,
       },


### PR DESCRIPTION
Fixes #8570

Win32 or unpackaged apps may need to be launched with specific args when running a test app, e.g. for FURN + rex scenarios. This can be passed via WinAppDriver capability, but is awfully hidden, requiring scouring WinAppDriver issues or source code. Expose it as a high-level option instead.