### PR TITLE
[0.66] Adding Accessibility Prop accessibilityItemType on ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-b5400f80-1f0f-427d-b146-eccde1f97d33.json
+++ b/change/@office-iss-react-native-win32-b5400f80-1f0f-427d-b146-eccde1f97d33.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding ItemType prop on ViewWIn32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "safreibe@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -381,6 +381,7 @@ const ReactNativeViewConfig: ViewConfig = {
     accessibilityLabeledBy: true,
     accessibilityDescription: true,
     accessibilityControls: true,
+    accessibilityItemType: true,
     // Windows]
   },
 };

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -43,7 +43,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
   public render() {
     return (
       <ViewWin32>
-        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" />
+        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" accessibilityItemType="Comment" />
       <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
           <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -177,7 +177,6 @@ export type BasePropsWin32 = {
   */
   accessibilityControls?: React.RefObject<any>;
 
-
   /**
   * Identifies the ItemType property, which is a text string describing the type of the automation element.
   * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -175,7 +175,14 @@ export type BasePropsWin32 = {
   * This is mainly used for a Textbox with a Dropdown PeoplePicker-type list.  This allows an 
   * accessibility tool to query those other providers for properties and listen to their events.
   */
-   accessibilityControls?: React.RefObject<any>;    
+  accessibilityControls?: React.RefObject<any>;
+
+
+  /**
+  * Identifies the ItemType property, which is a text string describing the type of the automation element.
+  * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
+  */
+  accessibilityItemType?: string;   
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &


### PR DESCRIPTION
Backporting changes from #7796 and #8126 .

This accessibility prop is needed by some partners for the help of reading comments/replies.

I will backport this to .66/.65/.64/.63

UIA_ItemTypePropertyID -
Identifies the ItemType property, which is a text string describing the type of the automation element.
ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
When ItemType is supported, the string must match the application UI language or the operating system default UI language