### PR TITLE
Fix autolinking to support solution files using LF instead of CRLF

### DIFF
--- a/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
+++ b/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix autolinking to support solution files using LF instead of CRLF",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
@@ -115,10 +115,14 @@ export function addProjectToSolution(
     );
   }
 
+  const originalSlnContents = fs.readFileSync(slnFile).toString();
+
+  const isCRLF = originalSlnContents.includes('\r\n');
+
   const slnLines = fs
     .readFileSync(slnFile)
     .toString()
-    .split('\r\n');
+    .split(isCRLF ? '\r\n' : '\n');
 
   let contentsChanged = false;
 
@@ -219,7 +223,7 @@ export function addProjectToSolution(
         );
       }
 
-      const slnContents = slnLines.join('\r\n');
+      const slnContents = slnLines.join(isCRLF ? '\r\n' : '\n');
       fs.writeFileSync(slnFile, slnContents, {
         encoding: 'utf8',
         flag: 'w',

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
@@ -119,10 +119,7 @@ export function addProjectToSolution(
 
   const isCRLF = originalSlnContents.includes('\r\n');
 
-  const slnLines = fs
-    .readFileSync(slnFile)
-    .toString()
-    .split(isCRLF ? '\r\n' : '\n');
+  const slnLines = originalSlnContents.split(isCRLF ? '\r\n' : '\n');
 
   let contentsChanged = false;
 


### PR DESCRIPTION
This PR fixes autolinking to properly handle modifying solution files
that have LF line endings (which can happen when cloning a repo that
didn't maintain the CRLF we use in our template).

Closes #8530