### PR TITLE
[0.64] Add Functionality to setAccessibilityFocus Method

### DIFF
--- a/change/react-native-windows-85928af6-903b-4435-b317-7e7fde3dfc54.json
+++ b/change/react-native-windows-85928af6-903b-4435-b317-7e7fde3dfc54.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backport setAccessibilityFocus",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -121,6 +121,7 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
       vm->GetConstants(writer);
       writer.WriteObjectEnd();
     }
+    constants.Add(L"AccessibilityEventTypes", accessibilityEventTypes);
   }
 
   void createView(int64_t reactTag, std::string viewName, int64_t rootTag, React::JSValueObject &&props) noexcept {
@@ -323,8 +324,12 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
   }
 
   void sendAccessibilityEvent(int64_t reactTag, double eventType) noexcept {
-    assert(false);
-    // TODO
+    auto type = int(eventType);
+    if (type == accessibilityEventTypes["typeViewFocused"]) {
+      focus(reactTag);
+    } else {
+      assert(false);
+    }
   }
 
   void showPopupMenu(
@@ -499,6 +504,7 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
   std::vector<std::unique_ptr<IViewManager>> m_viewManagers;
   ShadowNodeRegistry m_nodeRegistry;
   std::shared_ptr<NativeUIManager> m_nativeUIManager;
+  const React::JSValueObject accessibilityEventTypes = React::JSValueObject{{"typeViewFocused", 8}};
 };
 
 UIManager::UIManager() : m_module(std::make_shared<UIManagerModule>()) {}


### PR DESCRIPTION
**_Why_**
Current implementation of setAccessibilityFocus method resulted in no action. Request to backport from partner. 

**_What_**
The RN setAccessibilityFocus API is intended to force the narrator focus to a specific element and then trigger narrator to announce that element.

**_How_**
Added source code to the sendAccessibilityEvent method inside PaperUIManager. New source code identifies the new element to focus on via its reactTag, focuses the element, and raises an automation event to alert narrator of the focus change. The RN setAccessibilityFocus API now calls the native method.

**_Testing_**
Tested by modifying a page in the playground app to call setAccessibilityFocus following the press of a button. The focus target was a second button. With narrator on, the first button was focused and pressed, triggering the API, and moving narrator focus to the second button. Its component type and accessibility label were then announced. I also ran the playground-win32 app to ensure that the functionality continues to work for XAML islands.

Backport #7268 to 0.64

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8594)