### PR TITLE
Generate nullable type for turbo module

### DIFF
--- a/change/@react-native-windows-codegen-ceaa24ec-f953-49ad-aab9-0ef29c09f64b.json
+++ b/change/@react-native-windows-codegen-ceaa24ec-f953-49ad-aab9-0ef29c09f64b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate nullable type for turbo module",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-2780fd2a-4fc6-4e8d-9675-2113fbcc7575.json
+++ b/change/react-native-windows-2780fd2a-4fc6-4e8d-9675-2113fbcc7575.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate nullable type for turbo module",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -69,7 +69,7 @@ function getPossibleMethodSignatures(
 ): string[] {
   const args = translateArgs(funcType.params);
   if (isMethodReturnPromise(funcType)) {
-    // Sadly, currently, the schema doesn't currently provide us information on the type of the promise.
+    // TODO: type of the promise could be provided in the future
     args.push('React::ReactPromise<React::JSValue> &&result');
   }
 
@@ -102,7 +102,7 @@ function renderProperties(
   properties: ReadonlyArray<NativeModulePropertyShape>,
   tuple: boolean,
 ): string {
-  // We skip the constants for now, since we dont have Spec file validation of them.
+  // TODO: generate code for constants
   return properties
     .filter(prop => prop.name !== 'getConstants')
     .map((prop, index) => {
@@ -120,7 +120,7 @@ function renderProperties(
       );
 
       if (isMethodReturnPromise(funcType)) {
-        // Sadly, currently, the schema doesn't currently provide us information on the type of the promise.
+        // TODO: type of the promise could be provided in the future
         traversedArgs.push('Promise<React::JSValue>');
       }
 

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -91,12 +91,10 @@ function translateParam(
 function translateSpecFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   'spec',
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, 'spec');
+      return `std::optional<${translateParam(
+        param.typeAnnotation.typeAnnotation,
+        'spec',
+      )}>`;
     default:
       return translateParam(param.typeAnnotation, 'spec');
   }
@@ -105,15 +103,10 @@ function translateSpecFunctionParam(param: NativeModuleParamShape): string {
 function translateCallbackParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   'template',
-      // )}>`;
-      return translateParam(
+      return `std::optional<${translateParam(
         param.typeAnnotation.typeAnnotation,
-        'callback-arg',
-      );
+        'template',
+      )}>`;
     default:
       return translateParam(param.typeAnnotation, 'callback-arg');
   }
@@ -122,12 +115,10 @@ function translateCallbackParam(param: NativeModuleParamShape): string {
 function translateFunctionParam(param: NativeModuleParamShape): string {
   switch (param.typeAnnotation.type) {
     case 'NullableTypeAnnotation':
-      // TODO: should be
-      // return `std::optional<${translateParam(
-      //   param.typeAnnotation.typeAnnotation,
-      //   'template',
-      // )}>`;
-      return translateParam(param.typeAnnotation.typeAnnotation, 'method-arg');
+      return `std::optional<${translateParam(
+        param.typeAnnotation.typeAnnotation,
+        'template',
+      )}>`;
     default:
       return translateParam(param.typeAnnotation, 'method-arg');
   }

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -53,8 +53,7 @@ function translateReturnType(
     case 'TypeAliasTypeAnnotation':
       return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
-      // TODO: should be `std::optional<${translateReturnType(type.typeAnnotation)}>`;
-      return translateReturnType(type.typeAnnotation);
+      return `std::optional<${translateReturnType(type.typeAnnotation)}>`;
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }

--- a/vnext/codegen/NativeActionSheetManagerSpec.g.h
+++ b/vnext/codegen/NativeActionSheetManagerSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 struct ActionSheetManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(React::JSValueObject, Callback<double>) noexcept>{0, L"showActionSheetWithOptions"},
-      Method<void(React::JSValueObject, Callback<React::JSValueObject>, Callback<bool, std::string>) noexcept>{1, L"showShareActionSheetWithOptions"},
+      Method<void(React::JSValueObject, Callback<React::JSValueObject>, Callback<bool, std::optional<std::string>>) noexcept>{1, L"showShareActionSheetWithOptions"},
   };
 
   template <class TModule>
@@ -31,8 +31,8 @@ struct ActionSheetManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "showShareActionSheetWithOptions",
-          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::string)> const & successCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::string)> const & successCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAppearanceSpec.g.h
+++ b/vnext/codegen/NativeAppearanceSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct AppearanceSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      SyncMethod<std::string() noexcept>{0, L"getColorScheme"},
+      SyncMethod<std::optional<std::string>() noexcept>{0, L"getColorScheme"},
       Method<void(std::string) noexcept>{1, L"addListener"},
       Method<void(double) noexcept>{2, L"removeListeners"},
   };
@@ -27,8 +27,8 @@ struct AppearanceSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getColorScheme",
-          "    REACT_SYNC_METHOD(getColorScheme) std::string getColorScheme() noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getColorScheme) static std::string getColorScheme() noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getColorScheme) std::optional<std::string> getColorScheme() noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getColorScheme) static std::optional<std::string> getColorScheme() noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addListener",

--- a/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
@@ -15,12 +15,12 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueArray, Callback<React::JSValueArray, React::JSValueArray>) noexcept>{0, L"multiGet"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{1, L"multiSet"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{2, L"multiMerge"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{3, L"multiRemove"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>, std::optional<React::JSValueArray>>) noexcept>{0, L"multiGet"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{1, L"multiSet"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{2, L"multiMerge"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{3, L"multiRemove"},
       Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<React::JSValueObject, React::JSValueArray>) noexcept>{5, L"getAllKeys"},
+      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<React::JSValueArray>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,23 +30,23 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(React::JSValueArray const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(React::JSValueArray const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
@@ -55,8 +55,8 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(React::JSValueObject const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(React::JSValueObject const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
@@ -15,12 +15,12 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueArray, Callback<React::JSValueArray, React::JSValueArray>) noexcept>{0, L"multiGet"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{1, L"multiSet"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{2, L"multiMerge"},
-      Method<void(React::JSValueArray, Callback<React::JSValueArray>) noexcept>{3, L"multiRemove"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>, std::optional<React::JSValueArray>>) noexcept>{0, L"multiGet"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{1, L"multiSet"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{2, L"multiMerge"},
+      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{3, L"multiRemove"},
       Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<React::JSValueObject, React::JSValueArray>) noexcept>{5, L"getAllKeys"},
+      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<React::JSValueArray>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,23 +30,23 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(React::JSValueArray const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(React::JSValueArray const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
@@ -55,8 +55,8 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(React::JSValueObject const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(React::JSValueObject const &, React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeDevLoadingViewSpec.g.h
+++ b/vnext/codegen/NativeDevLoadingViewSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct DevLoadingViewSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, double, double) noexcept>{0, L"showMessage"},
+      Method<void(std::string, std::optional<double>, std::optional<double>) noexcept>{0, L"showMessage"},
       Method<void() noexcept>{1, L"hide"},
   };
 
@@ -26,8 +26,8 @@ struct DevLoadingViewSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showMessage",
-          "    REACT_METHOD(showMessage) void showMessage(std::string message, double withColor, double withBackgroundColor) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showMessage) static void showMessage(std::string message, double withColor, double withBackgroundColor) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showMessage) void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showMessage) static void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "hide",

--- a/vnext/codegen/NativeIntentAndroidSpec.g.h
+++ b/vnext/codegen/NativeIntentAndroidSpec.g.h
@@ -19,7 +19,7 @@ struct IntentAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"canOpenURL"},
       Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"openURL"},
       Method<void(Promise<React::JSValue>) noexcept>{3, L"openSettings"},
-      Method<void(std::string, React::JSValueArray, Promise<React::JSValue>) noexcept>{4, L"sendIntent"},
+      Method<void(std::string, std::optional<React::JSValueArray>, Promise<React::JSValue>) noexcept>{4, L"sendIntent"},
   };
 
   template <class TModule>
@@ -49,8 +49,8 @@ struct IntentAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "sendIntent",
-          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, React::JSValueArray && extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, React::JSValueArray && extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, std::optional<React::JSValueArray> extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, std::optional<React::JSValueArray> extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
+++ b/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct JSCHeapCaptureSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, std::string) noexcept>{0, L"captureComplete"},
+      Method<void(std::string, std::optional<std::string>) noexcept>{0, L"captureComplete"},
   };
 
   template <class TModule>
@@ -25,8 +25,8 @@ struct JSCHeapCaptureSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "captureComplete",
-          "    REACT_METHOD(captureComplete) void captureComplete(std::string path, std::string error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(captureComplete) static void captureComplete(std::string path, std::string error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(captureComplete) void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(captureComplete) static void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
+++ b/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct JSCSamplingProfilerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(double, std::string, std::string) noexcept>{0, L"operationComplete"},
+      Method<void(double, std::optional<std::string>, std::optional<std::string>) noexcept>{0, L"operationComplete"},
   };
 
   template <class TModule>
@@ -25,8 +25,8 @@ struct JSCSamplingProfilerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "operationComplete",
-          "    REACT_METHOD(operationComplete) void operationComplete(double token, std::string result, std::string error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(operationComplete) static void operationComplete(double token, std::string result, std::string error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(operationComplete) void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(operationComplete) static void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeSegmentFetcherSpec.g.h
+++ b/vnext/codegen/NativeSegmentFetcherSpec.g.h
@@ -15,8 +15,8 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct SegmentFetcherSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(double, React::JSValue, Callback<React::JSValue>) noexcept>{0, L"fetchSegment"},
-      Method<void(double, React::JSValue, Callback<React::JSValue, std::string>) noexcept>{1, L"getSegment"},
+      Method<void(double, React::JSValue, Callback<std::optional<React::JSValue>>) noexcept>{0, L"fetchSegment"},
+      Method<void(double, React::JSValue, Callback<std::optional<React::JSValue>, std::optional<std::string>>) noexcept>{1, L"getSegment"},
   };
 
   template <class TModule>
@@ -26,13 +26,13 @@ struct SegmentFetcherSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "fetchSegment",
-          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, React::JSValue && options, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, React::JSValue && options, std::function<void(React::JSValue const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSegment",
-          "    REACT_METHOD(getSegment) void getSegment(double segmentId, React::JSValue && options, std::function<void(React::JSValue const &, std::string)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, React::JSValue && options, std::function<void(React::JSValue const &, std::string)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSegment) void getSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
@@ -17,7 +17,7 @@ struct StatusBarManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleS
   static constexpr auto methods = std::tuple{
       Method<void(double, bool) noexcept>{0, L"setColor"},
       Method<void(bool) noexcept>{1, L"setTranslucent"},
-      Method<void(std::string) noexcept>{2, L"setStyle"},
+      Method<void(std::optional<std::string>) noexcept>{2, L"setStyle"},
       Method<void(bool) noexcept>{3, L"setHidden"},
   };
 
@@ -38,8 +38,8 @@ struct StatusBarManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleS
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "setStyle",
-          "    REACT_METHOD(setStyle) void setStyle(std::string statusBarStyle) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setStyle) static void setStyle(std::string statusBarStyle) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "setHidden",

--- a/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
@@ -19,7 +19,7 @@ struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
       Method<void(bool) noexcept>{1, L"setNetworkActivityIndicatorVisible"},
       Method<void(std::string) noexcept>{2, L"addListener"},
       Method<void(double) noexcept>{3, L"removeListeners"},
-      Method<void(std::string, bool) noexcept>{4, L"setStyle"},
+      Method<void(std::optional<std::string>, bool) noexcept>{4, L"setStyle"},
       Method<void(bool, std::string) noexcept>{5, L"setHidden"},
   };
 
@@ -50,8 +50,8 @@ struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "setStyle",
-          "    REACT_METHOD(setStyle) void setStyle(std::string statusBarStyle, bool animated) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setStyle) static void setStyle(std::string statusBarStyle, bool animated) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "setHidden",

--- a/vnext/codegen/NativeUIManagerSpec.g.h
+++ b/vnext/codegen/NativeUIManagerSpec.g.h
@@ -18,27 +18,27 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       SyncMethod<React::JSValue(std::string) noexcept>{0, L"getConstantsForViewManager"},
       SyncMethod<React::JSValueArray() noexcept>{1, L"getDefaultEventTypes"},
       SyncMethod<React::JSValue(std::string) noexcept>{2, L"lazilyLoadView"},
-      Method<void(double, std::string, double, React::JSValue) noexcept>{3, L"createView"},
+      Method<void(std::optional<double>, std::string, double, React::JSValue) noexcept>{3, L"createView"},
       Method<void(double, std::string, React::JSValue) noexcept>{4, L"updateView"},
-      Method<void(double) noexcept>{5, L"focus"},
-      Method<void(double) noexcept>{6, L"blur"},
-      Method<void(double, React::JSValueArray, Callback<double, double, double, double, double>) noexcept>{7, L"findSubviewIn"},
-      Method<void(double, double, React::JSValueArray) noexcept>{8, L"dispatchViewManagerCommand"},
-      Method<void(double, Callback<double, double, double, double, double, double>) noexcept>{9, L"measure"},
-      Method<void(double, Callback<double, double, double, double>) noexcept>{10, L"measureInWindow"},
-      Method<void(double, double, Callback<React::JSValueArray>) noexcept>{11, L"viewIsDescendantOf"},
-      Method<void(double, double, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{12, L"measureLayout"},
-      Method<void(double, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{13, L"measureLayoutRelativeToParent"},
-      Method<void(double, bool) noexcept>{14, L"setJSResponder"},
+      Method<void(std::optional<double>) noexcept>{5, L"focus"},
+      Method<void(std::optional<double>) noexcept>{6, L"blur"},
+      Method<void(std::optional<double>, React::JSValueArray, Callback<double, double, double, double, double>) noexcept>{7, L"findSubviewIn"},
+      Method<void(std::optional<double>, double, std::optional<React::JSValueArray>) noexcept>{8, L"dispatchViewManagerCommand"},
+      Method<void(std::optional<double>, Callback<double, double, double, double, double, double>) noexcept>{9, L"measure"},
+      Method<void(std::optional<double>, Callback<double, double, double, double>) noexcept>{10, L"measureInWindow"},
+      Method<void(std::optional<double>, std::optional<double>, Callback<React::JSValueArray>) noexcept>{11, L"viewIsDescendantOf"},
+      Method<void(std::optional<double>, std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{12, L"measureLayout"},
+      Method<void(std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{13, L"measureLayoutRelativeToParent"},
+      Method<void(std::optional<double>, bool) noexcept>{14, L"setJSResponder"},
       Method<void() noexcept>{15, L"clearJSResponder"},
       Method<void(React::JSValue, Callback<>, Callback<React::JSValue>) noexcept>{16, L"configureNextLayoutAnimation"},
       Method<void(double) noexcept>{17, L"removeSubviewsFromContainerWithID"},
-      Method<void(double, double) noexcept>{18, L"replaceExistingNonRootView"},
-      Method<void(double, React::JSValueArray) noexcept>{19, L"setChildren"},
-      Method<void(double, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray) noexcept>{20, L"manageChildren"},
+      Method<void(std::optional<double>, std::optional<double>) noexcept>{18, L"replaceExistingNonRootView"},
+      Method<void(std::optional<double>, React::JSValueArray) noexcept>{19, L"setChildren"},
+      Method<void(std::optional<double>, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray) noexcept>{20, L"manageChildren"},
       Method<void(bool) noexcept>{21, L"setLayoutAnimationEnabledExperimental"},
-      Method<void(double, double) noexcept>{22, L"sendAccessibilityEvent"},
-      Method<void(double, React::JSValueArray, Callback<React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
+      Method<void(std::optional<double>, double) noexcept>{22, L"sendAccessibilityEvent"},
+      Method<void(std::optional<double>, React::JSValueArray, Callback<React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
       Method<void() noexcept>{24, L"dismissPopupMenu"},
   };
 
@@ -64,8 +64,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "createView",
-          "    REACT_METHOD(createView) void createView(double reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createView) static void createView(double reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createView) void createView(std::optional<double> reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createView) static void createView(std::optional<double> reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "updateView",
@@ -74,53 +74,53 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "focus",
-          "    REACT_METHOD(focus) void focus(double reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(focus) static void focus(double reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(focus) void focus(std::optional<double> reactTag) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(focus) static void focus(std::optional<double> reactTag) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "blur",
-          "    REACT_METHOD(blur) void blur(double reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(blur) static void blur(double reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(blur) void blur(std::optional<double> reactTag) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(blur) static void blur(std::optional<double> reactTag) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "findSubviewIn",
-          "    REACT_METHOD(findSubviewIn) void findSubviewIn(double reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(double reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(findSubviewIn) void findSubviewIn(std::optional<double> reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(std::optional<double> reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "dispatchViewManagerCommand",
-          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(double reactTag, double commandID, React::JSValueArray && commandArgs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(double reactTag, double commandID, React::JSValueArray && commandArgs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "measure",
-          "    REACT_METHOD(measure) void measure(double reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measure) static void measure(double reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measure) void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measure) static void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "measureInWindow",
-          "    REACT_METHOD(measureInWindow) void measureInWindow(double reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureInWindow) static void measureInWindow(double reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureInWindow) void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measureInWindow) static void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "viewIsDescendantOf",
-          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(double reactTag, double ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(double reactTag, double ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "measureLayout",
-          "    REACT_METHOD(measureLayout) void measureLayout(double reactTag, double ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayout) static void measureLayout(double reactTag, double ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayout) void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measureLayout) static void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "measureLayoutRelativeToParent",
-          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(double reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(double reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "setJSResponder",
-          "    REACT_METHOD(setJSResponder) void setJSResponder(double reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setJSResponder) static void setJSResponder(double reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setJSResponder) void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setJSResponder) static void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "clearJSResponder",
@@ -139,18 +139,18 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "replaceExistingNonRootView",
-          "    REACT_METHOD(replaceExistingNonRootView) void replaceExistingNonRootView(double reactTag, double newReactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(replaceExistingNonRootView) static void replaceExistingNonRootView(double reactTag, double newReactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(replaceExistingNonRootView) void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(replaceExistingNonRootView) static void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "setChildren",
-          "    REACT_METHOD(setChildren) void setChildren(double containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setChildren) static void setChildren(double containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setChildren) void setChildren(std::optional<double> containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setChildren) static void setChildren(std::optional<double> containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           20,
           "manageChildren",
-          "    REACT_METHOD(manageChildren) void manageChildren(double containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(manageChildren) static void manageChildren(double containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(manageChildren) void manageChildren(std::optional<double> containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(manageChildren) static void manageChildren(std::optional<double> containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           21,
           "setLayoutAnimationEnabledExperimental",
@@ -159,13 +159,13 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           22,
           "sendAccessibilityEvent",
-          "    REACT_METHOD(sendAccessibilityEvent) void sendAccessibilityEvent(double reactTag, double eventType) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendAccessibilityEvent) static void sendAccessibilityEvent(double reactTag, double eventType) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendAccessibilityEvent) void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendAccessibilityEvent) static void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "showPopupMenu",
-          "    REACT_METHOD(showPopupMenu) void showPopupMenu(double reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(double reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           24,
           "dismissPopupMenu",

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, React::JSValueArray, React::JSValueObject, double) noexcept>{0, L"connect"},
+      Method<void(std::string, std::optional<React::JSValueArray>, React::JSValueObject, double) noexcept>{0, L"connect"},
       Method<void(std::string, double) noexcept>{1, L"send"},
       Method<void(std::string, double) noexcept>{2, L"sendBinary"},
       Method<void(double) noexcept>{3, L"ping"},
@@ -31,8 +31,8 @@ struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "connect",
-          "    REACT_METHOD(connect) void connect(std::string url, React::JSValueArray && protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connect) static void connect(std::string url, React::JSValueArray && protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connect) void connect(std::string url, std::optional<React::JSValueArray> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<React::JSValueArray> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "send",


### PR DESCRIPTION
Use `std::optional<T>` where nullable types are used in turbo module specs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8601)