### PR TITLE
Generate `std::vector<T>` for array types in turbo modules

### DIFF
--- a/change/@react-native-windows-codegen-4fdc254b-a8bb-45fa-a4cc-df410c4a2137.json
+++ b/change/@react-native-windows-codegen-4fdc254b-a8bb-45fa-a4cc-df410c4a2137.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate `std::vector<T>` for array types in turbo modules",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-6d6555c7-4800-429b-ba40-8dd3b679a2b4.json
+++ b/change/react-native-windows-6d6555c7-4800-429b-ba40-8dd3b679a2b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate `std::vector<T>` for array types in turbo modules",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -40,8 +40,11 @@ function translateField(
     case 'BooleanTypeAnnotation':
       return 'bool';
     case 'ArrayTypeAnnotation':
-      // TODO: type.elementType
-      return 'React::JSValueArray';
+      if (type.elementType) {
+        return `std::vector<${translateField(type.elementType)}>`;
+      } else {
+        return `React::JSValueArray`;
+      }
     case 'GenericObjectTypeAnnotation':
       return 'React::JSValue';
     case 'ObjectTypeAnnotation':

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -32,8 +32,11 @@ function translateReturnType(
     case 'BooleanTypeAnnotation':
       return 'bool';
     case 'ArrayTypeAnnotation':
-      // TODO: type.elementType
-      return 'React::JSValueArray';
+      if (type.elementType) {
+        return `std::vector<${translateReturnType(type.elementType)}>`;
+      } else {
+        return 'React::JSValueArray';
+      }
     case 'GenericObjectTypeAnnotation':
       return 'React::JSValue';
     case 'ObjectTypeAnnotation':

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -20,7 +20,7 @@ struct AlertManagerSpec_Args {
     REACT_FIELD(message)
     std::optional<std::string> message;
     REACT_FIELD(buttons)
-    std::optional<React::JSValueArray> buttons;
+    std::optional<std::vector<React::JSValue>> buttons;
     REACT_FIELD(type)
     std::optional<std::string> type;
     REACT_FIELD(defaultValue)

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -22,7 +22,7 @@ struct AnimatedModuleSpec_EndResult {
 REACT_STRUCT(AnimatedModuleSpec_EventMapping)
 struct AnimatedModuleSpec_EventMapping {
     REACT_FIELD(nativeEventPath)
-    React::JSValueArray nativeEventPath;
+    std::vector<std::string> nativeEventPath;
     REACT_FIELD(animatedValueTag)
     std::optional<double> animatedValueTag;
 };

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -22,7 +22,7 @@ struct AnimatedTurboModuleSpec_EndResult {
 REACT_STRUCT(AnimatedTurboModuleSpec_EventMapping)
 struct AnimatedTurboModuleSpec_EventMapping {
     REACT_FIELD(nativeEventPath)
-    React::JSValueArray nativeEventPath;
+    std::vector<std::string> nativeEventPath;
     REACT_FIELD(animatedValueTag)
     std::optional<double> animatedValueTag;
 };

--- a/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
@@ -15,12 +15,12 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>, std::optional<React::JSValueArray>>) noexcept>{0, L"multiGet"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{1, L"multiSet"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{2, L"multiMerge"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{3, L"multiRemove"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{1, L"multiSet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{2, L"multiMerge"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{3, L"multiRemove"},
       Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<React::JSValueArray>>) noexcept>{5, L"getAllKeys"},
+      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,23 +30,23 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
@@ -55,8 +55,8 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
@@ -15,12 +15,12 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>, std::optional<React::JSValueArray>>) noexcept>{0, L"multiGet"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{1, L"multiSet"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{2, L"multiMerge"},
-      Method<void(React::JSValueArray, Callback<std::optional<React::JSValueArray>>) noexcept>{3, L"multiRemove"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{1, L"multiSet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{2, L"multiMerge"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{3, L"multiRemove"},
       Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<React::JSValueArray>>) noexcept>{5, L"getAllKeys"},
+      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,23 +30,23 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(React::JSValueArray && kvPairs, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(React::JSValueArray && keys, std::function<void(std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
@@ -55,8 +55,8 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<React::JSValueArray>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeBlobModuleSpec.g.h
+++ b/vnext/codegen/NativeBlobModuleSpec.g.h
@@ -19,7 +19,7 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(double) noexcept>{1, L"addWebSocketHandler"},
       Method<void(double) noexcept>{2, L"removeWebSocketHandler"},
       Method<void(React::JSValue, double) noexcept>{3, L"sendOverSocket"},
-      Method<void(React::JSValueArray, std::string) noexcept>{4, L"createFromParts"},
+      Method<void(std::vector<React::JSValue>, std::string) noexcept>{4, L"createFromParts"},
       Method<void(std::string) noexcept>{5, L"release"},
   };
 
@@ -50,8 +50,8 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "createFromParts",
-          "    REACT_METHOD(createFromParts) void createFromParts(React::JSValueArray && parts, std::string withId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createFromParts) static void createFromParts(React::JSValueArray && parts, std::string withId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createFromParts) void createFromParts(std::vector<React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createFromParts) static void createFromParts(std::vector<React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "release",

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -26,7 +26,7 @@ struct DialogManagerAndroidSpec_DialogOptions {
     REACT_FIELD(buttonNeutral)
     std::optional<std::string> buttonNeutral;
     REACT_FIELD(items)
-    std::optional<React::JSValueArray> items;
+    std::optional<std::vector<std::string>> items;
     REACT_FIELD(cancelable)
     std::optional<bool> cancelable;
 };

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -38,7 +38,7 @@ struct ExceptionsManagerSpec_ExceptionData {
     REACT_FIELD(componentStack)
     std::optional<std::string> componentStack;
     REACT_FIELD(stack)
-    React::JSValueArray stack;
+    std::vector<ExceptionsManagerSpec_StackFrame> stack;
     REACT_FIELD(id)
     double id;
     REACT_FIELD(isFatal)
@@ -49,10 +49,10 @@ struct ExceptionsManagerSpec_ExceptionData {
 
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, React::JSValueArray, double) noexcept>{0, L"reportFatalException"},
-      Method<void(std::string, React::JSValueArray, double) noexcept>{1, L"reportSoftException"},
+      Method<void(std::string, std::vector<ExceptionsManagerSpec_StackFrame>, double) noexcept>{0, L"reportFatalException"},
+      Method<void(std::string, std::vector<ExceptionsManagerSpec_StackFrame>, double) noexcept>{1, L"reportSoftException"},
       Method<void(ExceptionsManagerSpec_ExceptionData) noexcept>{2, L"reportException"},
-      Method<void(std::string, React::JSValueArray, double) noexcept>{3, L"updateExceptionMessage"},
+      Method<void(std::string, std::vector<ExceptionsManagerSpec_StackFrame>, double) noexcept>{3, L"updateExceptionMessage"},
       Method<void() noexcept>{4, L"dismissRedbox"},
   };
 
@@ -63,13 +63,13 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "reportFatalException",
-          "    REACT_METHOD(reportFatalException) void reportFatalException(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportFatalException) static void reportFatalException(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportFatalException) void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(reportFatalException) static void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "reportSoftException",
-          "    REACT_METHOD(reportSoftException) void reportSoftException(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportSoftException) static void reportSoftException(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportSoftException) void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(reportSoftException) static void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "reportException",
@@ -78,8 +78,8 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateExceptionMessage",
-          "    REACT_METHOD(updateExceptionMessage) void updateExceptionMessage(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateExceptionMessage) static void updateExceptionMessage(std::string message, React::JSValueArray && stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateExceptionMessage) void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(updateExceptionMessage) static void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "dismissRedbox",

--- a/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
@@ -19,7 +19,7 @@ struct ImageLoaderAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"getSize"},
       Method<void(std::string, React::JSValue, Promise<React::JSValue>) noexcept>{2, L"getSizeWithHeaders"},
       Method<void(std::string, double, Promise<React::JSValue>) noexcept>{3, L"prefetchImage"},
-      Method<void(React::JSValueArray, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
+      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
   };
 
   template <class TModule>
@@ -49,8 +49,8 @@ struct ImageLoaderAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(React::JSValueArray && uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(React::JSValueArray && uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeImageLoaderIOSSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderIOSSpec.g.h
@@ -19,7 +19,7 @@ struct ImageLoaderIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(std::string, React::JSValue, Promise<React::JSValue>) noexcept>{1, L"getSizeWithHeaders"},
       Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"prefetchImage"},
       Method<void(std::string, std::string, double, Promise<React::JSValue>) noexcept>{3, L"prefetchImageWithMetadata"},
-      Method<void(React::JSValueArray, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
+      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
   };
 
   template <class TModule>
@@ -49,8 +49,8 @@ struct ImageLoaderIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(React::JSValueArray && uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(React::JSValueArray && uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativePermissionsAndroidSpec.g.h
+++ b/vnext/codegen/NativePermissionsAndroidSpec.g.h
@@ -18,7 +18,7 @@ struct PermissionsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(std::string, Promise<React::JSValue>) noexcept>{0, L"checkPermission"},
       Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"requestPermission"},
       Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"shouldShowRequestPermissionRationale"},
-      Method<void(React::JSValueArray, Promise<React::JSValue>) noexcept>{3, L"requestMultiplePermissions"},
+      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{3, L"requestMultiplePermissions"},
   };
 
   template <class TModule>
@@ -43,8 +43,8 @@ struct PermissionsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestMultiplePermissions",
-          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(React::JSValueArray && permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(React::JSValueArray && permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(std::vector<std::string> const & permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(std::vector<std::string> const & permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -60,8 +60,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       Method<void(Promise<React::JSValue>) noexcept>{10, L"getInitialNotification"},
       Method<void(Callback<PushNotificationManagerIOSSpec_Notification>) noexcept>{11, L"getScheduledLocalNotifications"},
       Method<void() noexcept>{12, L"removeAllDeliveredNotifications"},
-      Method<void(React::JSValueArray) noexcept>{13, L"removeDeliveredNotifications"},
-      Method<void(Callback<React::JSValueArray>) noexcept>{14, L"getDeliveredNotifications"},
+      Method<void(std::vector<std::string>) noexcept>{13, L"removeDeliveredNotifications"},
+      Method<void(Callback<std::vector<PushNotificationManagerIOSSpec_Notification>>) noexcept>{14, L"getDeliveredNotifications"},
       Method<void(Callback<double>) noexcept>{15, L"getAuthorizationStatus"},
       Method<void(std::string) noexcept>{16, L"addListener"},
       Method<void(double) noexcept>{17, L"removeListeners"},
@@ -139,13 +139,13 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "removeDeliveredNotifications",
-          "    REACT_METHOD(removeDeliveredNotifications) void removeDeliveredNotifications(React::JSValueArray && identifiers) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeDeliveredNotifications) static void removeDeliveredNotifications(React::JSValueArray && identifiers) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeDeliveredNotifications) void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(removeDeliveredNotifications) static void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "getDeliveredNotifications",
-          "    REACT_METHOD(getDeliveredNotifications) void getDeliveredNotifications(std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getDeliveredNotifications) static void getDeliveredNotifications(std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getDeliveredNotifications) void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getDeliveredNotifications) static void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "getAuthorizationStatus",

--- a/vnext/codegen/NativeSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeSettingsManagerSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(React::JSValue) noexcept>{0, L"setValues"},
-      Method<void(React::JSValueArray) noexcept>{1, L"deleteValues"},
+      Method<void(std::vector<std::string>) noexcept>{1, L"deleteValues"},
   };
 
   template <class TModule>
@@ -31,8 +31,8 @@ struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "deleteValues",
-          "    REACT_METHOD(deleteValues) void deleteValues(React::JSValueArray && values) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(deleteValues) static void deleteValues(React::JSValueArray && values) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(deleteValues) void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(deleteValues) static void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeUIManagerSpec.g.h
+++ b/vnext/codegen/NativeUIManagerSpec.g.h
@@ -16,17 +16,17 @@ namespace Microsoft::ReactNativeSpecs {
 struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       SyncMethod<React::JSValue(std::string) noexcept>{0, L"getConstantsForViewManager"},
-      SyncMethod<React::JSValueArray() noexcept>{1, L"getDefaultEventTypes"},
+      SyncMethod<std::vector<std::string>() noexcept>{1, L"getDefaultEventTypes"},
       SyncMethod<React::JSValue(std::string) noexcept>{2, L"lazilyLoadView"},
       Method<void(std::optional<double>, std::string, double, React::JSValue) noexcept>{3, L"createView"},
       Method<void(double, std::string, React::JSValue) noexcept>{4, L"updateView"},
       Method<void(std::optional<double>) noexcept>{5, L"focus"},
       Method<void(std::optional<double>) noexcept>{6, L"blur"},
-      Method<void(std::optional<double>, React::JSValueArray, Callback<double, double, double, double, double>) noexcept>{7, L"findSubviewIn"},
+      Method<void(std::optional<double>, std::vector<double>, Callback<double, double, double, double, double>) noexcept>{7, L"findSubviewIn"},
       Method<void(std::optional<double>, double, std::optional<React::JSValueArray>) noexcept>{8, L"dispatchViewManagerCommand"},
       Method<void(std::optional<double>, Callback<double, double, double, double, double, double>) noexcept>{9, L"measure"},
       Method<void(std::optional<double>, Callback<double, double, double, double>) noexcept>{10, L"measureInWindow"},
-      Method<void(std::optional<double>, std::optional<double>, Callback<React::JSValueArray>) noexcept>{11, L"viewIsDescendantOf"},
+      Method<void(std::optional<double>, std::optional<double>, Callback<std::vector<bool>>) noexcept>{11, L"viewIsDescendantOf"},
       Method<void(std::optional<double>, std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{12, L"measureLayout"},
       Method<void(std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{13, L"measureLayoutRelativeToParent"},
       Method<void(std::optional<double>, bool) noexcept>{14, L"setJSResponder"},
@@ -34,11 +34,11 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void(React::JSValue, Callback<>, Callback<React::JSValue>) noexcept>{16, L"configureNextLayoutAnimation"},
       Method<void(double) noexcept>{17, L"removeSubviewsFromContainerWithID"},
       Method<void(std::optional<double>, std::optional<double>) noexcept>{18, L"replaceExistingNonRootView"},
-      Method<void(std::optional<double>, React::JSValueArray) noexcept>{19, L"setChildren"},
-      Method<void(std::optional<double>, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray, React::JSValueArray) noexcept>{20, L"manageChildren"},
+      Method<void(std::optional<double>, std::vector<double>) noexcept>{19, L"setChildren"},
+      Method<void(std::optional<double>, std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>) noexcept>{20, L"manageChildren"},
       Method<void(bool) noexcept>{21, L"setLayoutAnimationEnabledExperimental"},
       Method<void(std::optional<double>, double) noexcept>{22, L"sendAccessibilityEvent"},
-      Method<void(std::optional<double>, React::JSValueArray, Callback<React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
+      Method<void(std::optional<double>, std::vector<std::string>, Callback<React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
       Method<void() noexcept>{24, L"dismissPopupMenu"},
   };
 
@@ -54,8 +54,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getDefaultEventTypes",
-          "    REACT_SYNC_METHOD(getDefaultEventTypes) React::JSValueArray getDefaultEventTypes() noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getDefaultEventTypes) static React::JSValueArray getDefaultEventTypes() noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getDefaultEventTypes) std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getDefaultEventTypes) static std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "lazilyLoadView",
@@ -84,8 +84,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "findSubviewIn",
-          "    REACT_METHOD(findSubviewIn) void findSubviewIn(std::optional<double> reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(std::optional<double> reactTag, React::JSValueArray && point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(findSubviewIn) void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "dispatchViewManagerCommand",
@@ -104,8 +104,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "viewIsDescendantOf",
-          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValueArray const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "measureLayout",
@@ -144,13 +144,13 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "setChildren",
-          "    REACT_METHOD(setChildren) void setChildren(std::optional<double> containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setChildren) static void setChildren(std::optional<double> containerTag, React::JSValueArray && reactTags) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setChildren) void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setChildren) static void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           20,
           "manageChildren",
-          "    REACT_METHOD(manageChildren) void manageChildren(std::optional<double> containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(manageChildren) static void manageChildren(std::optional<double> containerTag, React::JSValueArray && moveFromIndices, React::JSValueArray && moveToIndices, React::JSValueArray && addChildReactTags, React::JSValueArray && addAtIndices, React::JSValueArray && removeAtIndices) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(manageChildren) void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(manageChildren) static void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           21,
           "setLayoutAnimationEnabledExperimental",
@@ -164,8 +164,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "showPopupMenu",
-          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, React::JSValueArray && items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           24,
           "dismissPopupMenu",

--- a/vnext/codegen/NativeVibrationSpec.g.h
+++ b/vnext/codegen/NativeVibrationSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 struct VibrationSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(double) noexcept>{0, L"vibrate"},
-      Method<void(React::JSValueArray, double) noexcept>{1, L"vibrateByPattern"},
+      Method<void(std::vector<double>, double) noexcept>{1, L"vibrateByPattern"},
       Method<void() noexcept>{2, L"cancel"},
   };
 
@@ -32,8 +32,8 @@ struct VibrationSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "vibrateByPattern",
-          "    REACT_METHOD(vibrateByPattern) void vibrateByPattern(React::JSValueArray && pattern, double repeat) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(vibrateByPattern) static void vibrateByPattern(React::JSValueArray && pattern, double repeat) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(vibrateByPattern) void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(vibrateByPattern) static void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "cancel",

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, std::optional<React::JSValueArray>, React::JSValueObject, double) noexcept>{0, L"connect"},
+      Method<void(std::string, std::optional<std::vector<std::string>>, React::JSValueObject, double) noexcept>{0, L"connect"},
       Method<void(std::string, double) noexcept>{1, L"send"},
       Method<void(std::string, double) noexcept>{2, L"sendBinary"},
       Method<void(double) noexcept>{3, L"ping"},
@@ -31,8 +31,8 @@ struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "connect",
-          "    REACT_METHOD(connect) void connect(std::string url, std::optional<React::JSValueArray> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<React::JSValueArray> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connect) void connect(std::string url, std::optional<std::vector<std::string>> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<std::vector<std::string>> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "send",


### PR DESCRIPTION
Generate `std::vector<T>` for array types in turbo modules. For array that doesn't have an element type in the spec, `React::JSArrayValue` is used.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8606)