### PR TITLE
Issue#8397: Hermes profiler needs more work to function in win32 unpackaged apps

### DIFF
--- a/change/react-native-windows-94cfe0bf-1f44-4ee0-9e13-50c52c85610d.json
+++ b/change/react-native-windows-94cfe0bf-1f44-4ee0-9e13-50c52c85610d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Issue#8397 Hermes profiler needs more work to function in win32 unpackaged apps Essentially, we are adding a new function to fetch the application data directory which works with both packaged and unpackaged apps, and consuming it in Hermes sampling profiler.",
+  "packageName": "react-native-windows",
+  "email": "anandrag@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/HermesSamplingProfiler.cpp
+++ b/vnext/Shared/HermesSamplingProfiler.cpp
@@ -7,8 +7,8 @@
 #include <chrono>
 #include <future>
 
-#include "Utils.h"
 #include "HermesSamplingProfiler.h"
+#include "Utils.h"
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -10,40 +10,57 @@
 #include <appmodel.h>
 #include <winrt/Windows.Storage.h>
 
+#include <sstream>
+
 using std::string;
 
 namespace Microsoft::React {
+
+namespace {
+std::future<std::string> getPackagedApplicationDataPath(const wchar_t *childFolder) {
+  auto localFolder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder();
+  if (!childFolder) {
+    co_return winrt::to_string(localFolder.Path());
+  } else {
+    auto subfolder = co_await localFolder.CreateFolderAsync(
+        childFolder, winrt::Windows::Storage::CreationCollisionOption::OpenIfExists);
+    co_return winrt::to_string(subfolder.Path());
+  }
+}
+
+std::future<std::string> getUnPackagedApplicationDataPath(const wchar_t *childFolder) {
+  wchar_t *pwzAppDataPath = NULL;
+  if (SHGetKnownFolderPath(
+          FOLDERID_AppDataProgramData,
+          KF_FLAG_CREATE,
+          static_cast<HANDLE>(NULL),
+          &pwzAppDataPath) != S_OK)
+    std::abort();
+
+  auto appDataPath = winrt::to_string(pwzAppDataPath);
+  CoTaskMemFree(pwzAppDataPath);
+
+  if (!childFolder) {
+    co_return appDataPath;
+  } else {
+    std::ostringstream os;
+    os << appDataPath << "\\" << winrt::to_string(childFolder);
+    auto childFolderPath = os.str();
+    if (!CreateDirectoryA(childFolderPath.c_str(), NULL) && GetLastError() != ERROR_ALREADY_EXISTS)
+      std::abort();
+    co_return childFolderPath;
+  }
+}
+} // namespace
 
 std::future<std::string> getApplicationDataPath(const wchar_t *childFolder) {
   uint32_t length{0};
   bool isPackagedApp = GetCurrentPackageFullName(&length, nullptr) != APPMODEL_ERROR_NO_PACKAGE;
   std::string appDataPath;
-  if (isPackagedApp) {
-    if (!childFolder) {
-      co_return winrt::to_string(winrt::Windows::Storage::ApplicationData::Current().LocalFolder().Path());
-    } else {
-      auto subfolder = co_await winrt::Windows::Storage::ApplicationData::Current().LocalFolder().CreateFolderAsync(
-          childFolder, winrt::Windows::Storage::CreationCollisionOption::OpenIfExists);
-      co_return winrt::to_string(subfolder.Path());
-    }
+  if (false) {
+    co_return co_await getPackagedApplicationDataPath(childFolder);
   } else {
-    wchar_t wzAppData[MAX_PATH]{};
-    if (CALL_INDIRECT(
-            L"shell32.dll", SHGetFolderPathW, nullptr, CSIDL_LOCAL_APPDATA, nullptr, SHGFP_TYPE_CURRENT, wzAppData) !=
-        S_OK) {
-      std::abort(); // We don't expect this to happen ever ..
-    }
-    appDataPath = winrt::to_string(wzAppData);
-    if (!childFolder) {
-      co_return appDataPath;
-    } else {
-      std::ostringstream os;
-      os << appDataPath << "\\" << winrt::to_string(childFolder);
-      auto childFolderPath = os.str();
-      if (!CreateDirectoryA(childFolderPath.c_str(), NULL))
-        std::abort();
-      co_return childFolderPath;
-    }
+    co_return co_await getUnPackagedApplicationDataPath(childFolder);
   }
 }
 

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -30,11 +30,8 @@ std::future<std::string> getPackagedApplicationDataPath(const wchar_t *childFold
 
 std::future<std::string> getUnPackagedApplicationDataPath(const wchar_t *childFolder) {
   wchar_t *pwzAppDataPath = NULL;
-  if (SHGetKnownFolderPath(
-          FOLDERID_AppDataProgramData,
-          KF_FLAG_CREATE,
-          static_cast<HANDLE>(NULL),
-          &pwzAppDataPath) != S_OK)
+  if (SHGetKnownFolderPath(FOLDERID_AppDataProgramData, KF_FLAG_CREATE, static_cast<HANDLE>(NULL), &pwzAppDataPath) !=
+      S_OK)
     std::abort();
 
   auto appDataPath = winrt::to_string(pwzAppDataPath);

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -4,11 +4,11 @@
 #include "Utils.h"
 #include <regex>
 
-#include <winrt/Windows.Storage.h>
-#include <appmodel.h>
+#include <DesktopWindowBridge.h>
 #include <ShlObj.h>
 #include <Shlwapi.h>
-#include <DesktopWindowBridge.h>
+#include <appmodel.h>
+#include <winrt/Windows.Storage.h>
 
 using std::string;
 

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -30,8 +30,13 @@ std::future<std::string> getPackagedApplicationDataPath(const wchar_t *childFold
 
 std::future<std::string> getUnPackagedApplicationDataPath(const wchar_t *childFolder) {
   wchar_t *pwzAppDataPath = NULL;
-  if (SHGetKnownFolderPath(FOLDERID_AppDataProgramData, KF_FLAG_CREATE, static_cast<HANDLE>(NULL), &pwzAppDataPath) !=
-      S_OK)
+  if (CALL_INDIRECT(
+          L"shell32.dll",
+          SHGetKnownFolderPath,
+          FOLDERID_AppDataProgramData,
+          KF_FLAG_CREATE,
+          static_cast<HANDLE>(NULL),
+          &pwzAppDataPath) != S_OK)
     std::abort();
 
   auto appDataPath = winrt::to_string(pwzAppDataPath);

--- a/vnext/Shared/Utils.h
+++ b/vnext/Shared/Utils.h
@@ -19,4 +19,6 @@ struct Url {
   std::string Target();
 };
 
+std::future<std::string> getApplicationDataPath(const wchar_t *childfolder);
+
 } // namespace Microsoft::React

--- a/vnext/Shared/Utils.h
+++ b/vnext/Shared/Utils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <future>
 #include <string>
 
 namespace Microsoft::React {


### PR DESCRIPTION
Essentially, we are adding a new function to fetch the application data directory which works with both packaged and unpackaged apps, and consuming it in Hermes sampling profiler.

This change needs to be ported to RN66.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8615)