### PR TITLE
Provide more TS type information for ViewWindows

### DIFF
--- a/change/react-native-windows-397fc10d-00fc-436e-acbb-457e1ce17b5e.json
+++ b/change/react-native-windows-397fc10d-00fc-436e-acbb-457e1ce17b5e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Provide more TS type information for ViewWindows",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
+++ b/vnext/src/Libraries/Components/View/ViewWindowsProps.ts
@@ -5,7 +5,30 @@
  */
 
 import {IKeyboardProps} from '../Keyboard/KeyboardExtProps';
-import {ViewProps} from 'react-native';
+import {NativeSyntheticEvent, ViewProps} from 'react-native';
+
+export type INativeMouseEvent = {
+  target: number;
+  identifier: number;
+  pageX: number;
+  pageY: number;
+  locationX: number;
+  locationY: number;
+  timestamp: number;
+  pointerType: string;
+  force: number;
+  isLeftButton: boolean;
+  isRightButton: boolean;
+  isMiddleButton: boolean;
+  isBarrelButtonPressed: boolean;
+  isHorizontalScrollWheel: boolean;
+  isEraser: boolean;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+};
+
+export type IMouseEvent = NativeSyntheticEvent<INativeMouseEvent>;
 
 /**
  * @remarks
@@ -29,5 +52,29 @@ export interface IViewWindowsProps extends IKeyboardProps, ViewProps {
    * See https://github.com/ReactWindows/discussions-and-proposals/blob/harinik-accessibility/proposals/0000-accessibilityapis-lists.md
    */
   accessibilitySetSize?: number;
-  focusable?: boolean;
+
+  /**
+   * Specifies the Tooltip for the view
+   */
+  tooltip?: string;
+
+  /**
+   * Indicates the TabIndex to use for this view
+   */
+  tabIndex?: number;
+
+  /**
+   * Specifies if the control should show System focus visuals
+   */
+  enableFocusRing?: boolean;
+
+  /**
+   * Event fired when the mouse leaves the view
+   */
+  onMouseLeave?: (args: IMouseEvent) => void;
+
+  /**
+   * Event fired when the mouse enters the view
+   */
+  onMouseEnter?: (args: IMouseEvent) => void;
 }


### PR DESCRIPTION
This provides better type information for some of the additional properties that we've added to view in react-native-windows.

These properties are available by using `import {ViewWindows} from 'react-native-windows'` instead of `import {View} from 'react-native'`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8616)