### PR TITLE
Generate anonymous objects for turbo module

### DIFF
--- a/change/@react-native-windows-codegen-35c7ec51-4ff3-4dfc-abd9-4a23a2e988d5.json
+++ b/change/@react-native-windows-codegen-35c7ec51-4ff3-4dfc-abd9-4a23a2e988d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate anonymous objects in correct order for turbo module",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-ea9cb68a-e7bd-4c3f-91c0-2bd67f436916.json
+++ b/change/react-native-windows-ea9cb68a-e7bd-4c3f-91c0-2bd67f436916.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Generate anonymous objects in correct order for turbo module",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {
+  NativeModuleBaseTypeAnnotation,
+  NativeModuleObjectTypeAnnotation,
+  NamedShape,
+  Nullable,
+} from 'react-native-tscodegen';
+import {AliasMap, getAliasCppName} from './AliasManaging';
+import {translateField} from './ObjectTypes';
+
+function translateObjectBody(
+  type: NativeModuleObjectTypeAnnotation,
+  aliases: AliasMap,
+  baseAliasName: string,
+  prefix: string,
+) {
+  return type.properties
+    .map((prop: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>) => {
+      let propType = prop.typeAnnotation;
+      if (prop.optional && propType.type !== 'NullableTypeAnnotation') {
+        propType = {type: 'NullableTypeAnnotation', typeAnnotation: propType};
+      }
+      const first = `${prefix}REACT_FIELD(${prop.name})`;
+      const second = `${prefix}${translateField(
+        propType,
+        aliases,
+        `${baseAliasName}_${prop.name}`,
+      )} ${prop.name};`;
+      return `${first}\n${second}`;
+    })
+    .join('\n');
+}
+
+export function createAliasMap(nativeModuleAliases: {
+  [name: string]: NativeModuleObjectTypeAnnotation;
+}): AliasMap {
+  const aliases: AliasMap = {};
+  for (const aliasName of Object.keys(nativeModuleAliases)) {
+    aliases[aliasName] = nativeModuleAliases[aliasName];
+  }
+  return aliases;
+}
+
+export function generateAliases(aliases: AliasMap): string {
+  const aliasOrder: string[] = [];
+  const aliasCode: {[name: string]: string} = {};
+  const aliasJobs: string[] = Object.keys(aliases);
+
+  while (aliasJobs.length > 0) {
+    const aliasName = <string>aliasJobs.shift();
+    const aliasType = <NativeModuleObjectTypeAnnotation>aliases[aliasName];
+    aliasCode[aliasName] = `
+REACT_STRUCT(${getAliasCppName(aliasName)})
+struct ${getAliasCppName(aliasName)} {
+${translateObjectBody(aliasType, aliases, aliasName, '    ')}
+};
+`;
+    aliasOrder.push(aliasName);
+  }
+
+  let traversedAliasedStructs = '';
+  for (const aliasName of aliasOrder) {
+    traversedAliasedStructs = `${traversedAliasedStructs}${aliasCode[aliasName]}`;
+  }
+  return traversedAliasedStructs;
+}

--- a/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
@@ -41,9 +41,9 @@ function translateObjectBody(
 export function createAliasMap(nativeModuleAliases: {
   [name: string]: NativeModuleObjectTypeAnnotation;
 }): AliasMap {
-  const aliases: AliasMap = {};
+  const aliases: AliasMap = {types: {}};
   for (const aliasName of Object.keys(nativeModuleAliases)) {
-    aliases[aliasName] = nativeModuleAliases[aliasName];
+    aliases.types[aliasName] = nativeModuleAliases[aliasName];
   }
   return aliases;
 }
@@ -51,11 +51,13 @@ export function createAliasMap(nativeModuleAliases: {
 export function generateAliases(aliases: AliasMap): string {
   const aliasOrder: string[] = [];
   const aliasCode: {[name: string]: string} = {};
-  const aliasJobs: string[] = Object.keys(aliases);
+  aliases.jobs = Object.keys(aliases.types);
 
-  while (aliasJobs.length > 0) {
-    const aliasName = <string>aliasJobs.shift();
-    const aliasType = <NativeModuleObjectTypeAnnotation>aliases[aliasName];
+  while (aliases.jobs.length > 0) {
+    const aliasName = <string>aliases.jobs.shift();
+    const aliasType = <NativeModuleObjectTypeAnnotation>(
+      aliases.types[aliasName]
+    );
     aliasCode[aliasName] = `
 REACT_STRUCT(${getAliasCppName(aliasName)})
 struct ${getAliasCppName(aliasName)} {

--- a/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
@@ -71,11 +71,22 @@ function generateNestedAliasesInCorrectOrder(
   aliasCode: AliasCodeMap,
   aliasOrder: string[],
 ): void {
+  // retrieve and clean all ungenerated aliases
   const jobs = aliases.jobs;
   aliases.jobs = [];
+
+  // generate each one in its found order
   for (const aliasName of jobs) {
+    // generate a new struct and all fields will be examined
+    // new anonymous objects could be found
+    // they will be stored in aliases.jobs
     generateSingleAlias(aliases, aliasName, aliasCode);
+    // nested C++ structs must be put before the current C++ struct
+    // as they will be used in the current C++ struct
+    // the order will be perfectly and easily ensured by doing this recursively
     generateNestedAliasesInCorrectOrder(aliases, aliasCode, aliasOrder);
+    // all referenced C++ structs are generated
+    // put the current one following them
     aliasOrder.push(aliasName);
   }
 }
@@ -85,6 +96,7 @@ export function generateAliases(aliases: AliasMap): string {
   const aliasOrder: string[] = [];
   generateNestedAliasesInCorrectOrder(aliases, aliasCode, aliasOrder);
 
+  // aliasOrder now has the correct order of C++ struct code
   let traversedAliasedStructs = '';
   for (const aliasName of aliasOrder) {
     traversedAliasedStructs = `${traversedAliasedStructs}${aliasCode[aliasName]}`;

--- a/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
@@ -20,7 +20,7 @@ export function getAliasCppName(typeName: string): string {
 
 export interface AliasMap {
   types: {[name: string]: NativeModuleObjectTypeAnnotation | undefined};
-  jobs?: string[];
+  jobs: string[];
 }
 
 const ExtendedObjectKey = '$RNW-TURBOMODULE-ALIAS';
@@ -35,9 +35,7 @@ function recordAnonymouseAlias(
 ): string {
   extended[ExtendedObjectKey] = baseAliasName;
   aliases.types[baseAliasName] = extended;
-  if (aliases.jobs) {
-    aliases.jobs.push(baseAliasName);
-  }
+  aliases.jobs.push(baseAliasName);
   return baseAliasName;
 }
 

--- a/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
@@ -44,18 +44,26 @@ export function getAnonymousAliasCppName(
   baseAliasName: string,
   objectType: NativeModuleObjectTypeAnnotation,
 ): string {
+  // someone found an anonymous object literal type
+  // if the ExtendedObjectKey flag has been set
+  // then it is a known one
+  // this happens because method signatures are generate twice in spec and error messages
   const extended = <ExtendedObject>objectType;
   const key = extended[ExtendedObjectKey];
   if (key !== undefined) {
     return getAliasCppName(key);
   }
 
+  // if the ExtendedObjectKey flag has not been set
+  // it means it is a unknown one
+  // associate the name with this object literal type and return
   if (aliases.types[baseAliasName] === undefined) {
     return getAliasCppName(
       recordAnonymouseAlias(aliases, baseAliasName, extended),
     );
   }
 
+  // sometimes names could be anonymous
   let index = 2;
   while (aliases.types[`${baseAliasName}${index}`] !== undefined) {
     index++;

--- a/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
@@ -19,7 +19,8 @@ export function getAliasCppName(typeName: string): string {
 }
 
 export interface AliasMap {
-  [name: string]: NativeModuleObjectTypeAnnotation | undefined;
+  types: {[name: string]: NativeModuleObjectTypeAnnotation | undefined};
+  jobs?: string[];
 }
 
 const ExtendedObjectKey = '$RNW-TURBOMODULE-ALIAS';
@@ -33,7 +34,10 @@ function recordAnonymouseAlias(
   extended: ExtendedObject,
 ): string {
   extended[ExtendedObjectKey] = baseAliasName;
-  aliases[baseAliasName] = extended;
+  aliases.types[baseAliasName] = extended;
+  if (aliases.jobs) {
+    aliases.jobs.push(baseAliasName);
+  }
   return baseAliasName;
 }
 
@@ -48,14 +52,14 @@ export function getAnonymousAliasCppName(
     return getAliasCppName(key);
   }
 
-  if (aliases[baseAliasName] === undefined) {
+  if (aliases.types[baseAliasName] === undefined) {
     return getAliasCppName(
       recordAnonymouseAlias(aliases, baseAliasName, extended),
     );
   }
 
   let index = 2;
-  while (aliases[`${baseAliasName}${index}`] !== undefined) {
+  while (aliases.types[`${baseAliasName}${index}`] !== undefined) {
     index++;
   }
 

--- a/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {NativeModuleObjectTypeAnnotation} from 'react-native-tscodegen';
+
+let preferredModuleName: string = '';
+
+export function setPreferredModuleName(moduleName: string): void {
+  preferredModuleName = moduleName;
+}
+
+export function getAliasCppName(typeName: string): string {
+  return `${preferredModuleName}Spec_${typeName}`;
+}
+
+export interface AliasMap {
+  [name: string]: NativeModuleObjectTypeAnnotation | undefined;
+}
+
+const ExtendedObjectKey = '$RNW-TURBOMODULE-ALIAS';
+interface ExtendedObject extends NativeModuleObjectTypeAnnotation {
+  '$RNW-TURBOMODULE-ALIAS'?: string;
+}
+
+function recordAnonymouseAlias(
+  aliases: AliasMap,
+  baseAliasName: string,
+  extended: ExtendedObject,
+): string {
+  extended[ExtendedObjectKey] = baseAliasName;
+  aliases[baseAliasName] = extended;
+  return baseAliasName;
+}
+
+export function getAnonymousAliasCppName(
+  aliases: AliasMap,
+  baseAliasName: string,
+  objectType: NativeModuleObjectTypeAnnotation,
+): string {
+  const extended = <ExtendedObject>objectType;
+  const key = extended[ExtendedObjectKey];
+  if (key !== undefined) {
+    return getAliasCppName(key);
+  }
+
+  if (aliases[baseAliasName] === undefined) {
+    return getAliasCppName(
+      recordAnonymouseAlias(aliases, baseAliasName, extended),
+    );
+  }
+
+  let index = 2;
+  while (aliases[`${baseAliasName}${index}`] !== undefined) {
+    index++;
+  }
+
+  return getAliasCppName(
+    recordAnonymouseAlias(aliases, `${baseAliasName}${index}`, extended),
+  );
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -16,8 +16,8 @@ import {
   AliasMap,
   getAliasCppName,
   setPreferredModuleName,
-  translateObjectBody,
-} from './ObjectTypes';
+} from './AliasManaging';
+import {translateObjectBody} from './ObjectTypes';
 import {translateArgs, translateSpecArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -8,6 +8,7 @@
 
 import {
   NativeModuleFunctionTypeAnnotation,
+  NativeModuleObjectTypeAnnotation,
   NativeModulePropertyShape,
   SchemaType,
 } from 'react-native-tscodegen';
@@ -205,10 +206,12 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         );
 
         // generate code for structs
-        const aliasJobs: string[] = Object.keys(nativeModule.aliases);
+        const aliasJobs: string[] = Object.keys(aliases);
         while (aliasJobs.length > 0) {
           const aliasName = <string>aliasJobs.shift();
-          const aliasType = nativeModule.aliases[aliasName];
+          const aliasType = <NativeModuleObjectTypeAnnotation>(
+            aliases[aliasName]
+          );
           aliasCode[aliasName] = `
 REACT_STRUCT(${getAliasCppName(aliasName)})
 struct ${getAliasCppName(aliasName)} {

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -212,7 +212,7 @@ export function createNM2Generator({namespace}: {namespace: string}) {
           aliasCode[aliasName] = `
 REACT_STRUCT(${getAliasCppName(aliasName)})
 struct ${getAliasCppName(aliasName)} {
-${translateObjectBody(aliasType, aliases, getAliasCppName(aliasName), '    ')}
+${translateObjectBody(aliasType, aliases, aliasName, '    ')}
 };
 `;
           aliasOrder.push(aliasName);

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -12,62 +12,11 @@ import {
   NamedShape,
   Nullable,
 } from 'react-native-tscodegen';
-
-let preferredModuleName: string = '';
-
-export function setPreferredModuleName(moduleName: string): void {
-  preferredModuleName = moduleName;
-}
-
-export function getAliasCppName(typeName: string): string {
-  return `${preferredModuleName}Spec_${typeName}`;
-}
-
-export interface AliasMap {
-  [name: string]: NativeModuleObjectTypeAnnotation | undefined;
-}
-
-const ExtendedObjectKey = '$RNW-TURBOMODULE-ALIAS';
-interface ExtendedObject extends NativeModuleObjectTypeAnnotation {
-  '$RNW-TURBOMODULE-ALIAS'?: string;
-}
-
-function recordAnonymouseAlias(
-  aliases: AliasMap,
-  baseAliasName: string,
-  extended: ExtendedObject,
-): string {
-  extended[ExtendedObjectKey] = baseAliasName;
-  aliases[baseAliasName] = extended;
-  return baseAliasName;
-}
-
-export function getAnonymousAliasCppName(
-  aliases: AliasMap,
-  baseAliasName: string,
-  objectType: NativeModuleObjectTypeAnnotation,
-): string {
-  const extended = <ExtendedObject>objectType;
-  const key = extended[ExtendedObjectKey];
-  if (key !== undefined) {
-    return getAliasCppName(key);
-  }
-
-  if (aliases[baseAliasName] === undefined) {
-    return getAliasCppName(
-      recordAnonymouseAlias(aliases, baseAliasName, extended),
-    );
-  }
-
-  let index = 2;
-  while (aliases[`${baseAliasName}${index}`] !== undefined) {
-    index++;
-  }
-
-  return getAliasCppName(
-    recordAnonymouseAlias(aliases, `${baseAliasName}${index}`, extended),
-  );
-}
+import {
+  AliasMap,
+  getAliasCppName,
+  getAnonymousAliasCppName,
+} from './AliasManaging';
 
 function translateField(
   type: Nullable<NativeModuleBaseTypeAnnotation>,

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -6,19 +6,14 @@
 
 'use strict';
 
-import {
-  NativeModuleBaseTypeAnnotation,
-  NativeModuleObjectTypeAnnotation,
-  NamedShape,
-  Nullable,
-} from 'react-native-tscodegen';
+import {NativeModuleBaseTypeAnnotation, Nullable} from 'react-native-tscodegen';
 import {
   AliasMap,
   getAliasCppName,
   getAnonymousAliasCppName,
 } from './AliasManaging';
 
-function translateField(
+export function translateField(
   type: Nullable<NativeModuleBaseTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
@@ -72,27 +67,4 @@ function translateField(
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }
-}
-
-export function translateObjectBody(
-  type: NativeModuleObjectTypeAnnotation,
-  aliases: AliasMap,
-  baseAliasName: string,
-  prefix: string,
-) {
-  return type.properties
-    .map((prop: NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>) => {
-      let propType = prop.typeAnnotation;
-      if (prop.optional && propType.type !== 'NullableTypeAnnotation') {
-        propType = {type: 'NullableTypeAnnotation', typeAnnotation: propType};
-      }
-      const first = `${prefix}REACT_FIELD(${prop.name})`;
-      const second = `${prefix}${translateField(
-        propType,
-        aliases,
-        `${baseAliasName}_${prop.name}`,
-      )} ${prop.name};`;
-      return `${first}\n${second}`;
-    })
-    .join('\n');
 }

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -15,7 +15,7 @@ import {
   AliasMap,
   getAliasCppName,
   getAnonymousAliasCppName,
-} from './ObjectTypes';
+} from './AliasManaging';
 
 type NativeModuleParamShape = NamedShape<
   Nullable<NativeModuleParamTypeAnnotation>

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -11,7 +11,11 @@ import {
   NativeModuleParamTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
-import {AliasMap, getAliasCppName} from './ObjectTypes';
+import {
+  AliasMap,
+  getAliasCppName,
+  getAnonymousAliasCppName,
+} from './ObjectTypes';
 
 type NativeModuleParamShape = NamedShape<
   Nullable<NativeModuleParamTypeAnnotation>
@@ -103,8 +107,10 @@ function translateParam(
     case 'GenericObjectTypeAnnotation':
       return decorateType('React::JSValue', target);
     case 'ObjectTypeAnnotation':
-      // TODO: we have more information here, and could create a more specific type
-      return decorateType('React::JSValueObject', target);
+      return decorateType(
+        getAnonymousAliasCppName(aliases, baseAliasName, param),
+        target,
+      );
     case 'ReservedTypeAnnotation': {
       // avoid: Property 'name' does not exist on type 'never'
       const name = param.name;

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -10,10 +10,12 @@ import {
   NativeModuleReturnTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
-import {getAliasCppName} from './ObjectTypes';
+import {AliasMap, getAliasCppName} from './ObjectTypes';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
+  aliases: AliasMap,
+  baseAliasName: string,
 ): string {
   // avoid: Property 'type' does not exist on type 'never'
   const returnType = type.type;
@@ -33,7 +35,11 @@ function translateReturnType(
       return 'bool';
     case 'ArrayTypeAnnotation':
       if (type.elementType) {
-        return `std::vector<${translateReturnType(type.elementType)}>`;
+        return `std::vector<${translateReturnType(
+          type.elementType,
+          aliases,
+          `${baseAliasName}_element`,
+        )}>`;
       } else {
         return 'React::JSValueArray';
       }
@@ -56,7 +62,11 @@ function translateReturnType(
     case 'TypeAliasTypeAnnotation':
       return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
-      return `std::optional<${translateReturnType(type.typeAnnotation)}>`;
+      return `std::optional<${translateReturnType(
+        type.typeAnnotation,
+        aliases,
+        baseAliasName,
+      )}>`;
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }
@@ -64,12 +74,16 @@ function translateReturnType(
 
 export function translateSpecReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
+  aliases: AliasMap,
+  baseAliasName: string,
 ) {
-  return translateReturnType(type);
+  return translateReturnType(type, aliases, `${baseAliasName}_returnType`);
 }
 
 export function translateImplReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
+  aliases: AliasMap,
+  baseAliasName: string,
 ) {
-  return translateReturnType(type);
+  return translateReturnType(type, aliases, `${baseAliasName}_returnType`);
 }

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -14,7 +14,7 @@ import {
   AliasMap,
   getAliasCppName,
   getAnonymousAliasCppName,
-} from './ObjectTypes';
+} from './AliasManaging';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -10,7 +10,11 @@ import {
   NativeModuleReturnTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
-import {AliasMap, getAliasCppName} from './ObjectTypes';
+import {
+  AliasMap,
+  getAliasCppName,
+  getAnonymousAliasCppName,
+} from './ObjectTypes';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
@@ -46,8 +50,7 @@ function translateReturnType(
     case 'GenericObjectTypeAnnotation':
       return 'React::JSValue';
     case 'ObjectTypeAnnotation':
-      // TODO: we have more information here, and could create a more specific type
-      return 'React::JSValueObject';
+      return getAnonymousAliasCppName(aliases, baseAliasName, type);
     case 'ReservedTypeAnnotation': {
       // avoid: Property 'name' does not exist on type 'never'
       const name = type.name;

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -47,10 +47,10 @@ void AppState::Initialize(winrt::Microsoft::ReactNative::ReactContext const &rea
 }
 
 void AppState::GetCurrentAppState(
-    std::function<void(React::JSValueObject const &)> const &success,
+    std::function<void(AppStateChangeArgs const &)> const &success,
     std::function<void(React::JSValue const &)> const &error) noexcept {
-  React::JSValueObject args;
-  args["app_state"] = m_active ? "active" : "background";
+  AppStateChangeArgs args;
+  args.app_state = m_active ? "active" : "background";
   success(args);
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
@@ -2,26 +2,23 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeAppStateSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>
 
 namespace Microsoft::ReactNative {
 
-REACT_STRUCT(AppStateChangeArgs)
-struct AppStateChangeArgs {
-  REACT_FIELD(app_state)
-  std::string app_state;
-};
-
 REACT_MODULE(AppState)
 struct AppState : public std::enable_shared_from_this<AppState> {
+  using AppStateChangeArgs = ReactNativeSpecs::AppStateSpec_getCurrentAppState_success_appState;
+
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
   REACT_METHOD(GetCurrentAppState, L"getCurrentAppState")
   void GetCurrentAppState(
-      std::function<void(React::JSValueObject const &)> const &success,
+      std::function<void(AppStateChangeArgs const &)> const &success,
       std::function<void(React::JSValue const &)> const &error) noexcept;
 
   REACT_METHOD(AddListener, L"addListener")

--- a/vnext/codegen/NativeAccessibilityManagerSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityManagerSpec.g.h
@@ -13,6 +13,34 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers)
+struct AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers {
+    REACT_FIELD(extraSmall)
+    std::optional<double> extraSmall;
+    REACT_FIELD(small)
+    std::optional<double> small;
+    REACT_FIELD(medium)
+    std::optional<double> medium;
+    REACT_FIELD(large)
+    std::optional<double> large;
+    REACT_FIELD(extraLarge)
+    std::optional<double> extraLarge;
+    REACT_FIELD(extraExtraLarge)
+    std::optional<double> extraExtraLarge;
+    REACT_FIELD(extraExtraExtraLarge)
+    std::optional<double> extraExtraExtraLarge;
+    REACT_FIELD(accessibilityMedium)
+    std::optional<double> accessibilityMedium;
+    REACT_FIELD(accessibilityLarge)
+    std::optional<double> accessibilityLarge;
+    REACT_FIELD(accessibilityExtraLarge)
+    std::optional<double> accessibilityExtraLarge;
+    REACT_FIELD(accessibilityExtraExtraLarge)
+    std::optional<double> accessibilityExtraExtraLarge;
+    REACT_FIELD(accessibilityExtraExtraExtraLarge)
+    std::optional<double> accessibilityExtraExtraExtraLarge;
+};
+
 struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{0, L"getCurrentBoldTextState"},
@@ -21,7 +49,7 @@ struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
       Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{3, L"getCurrentReduceMotionState"},
       Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{4, L"getCurrentReduceTransparencyState"},
       Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{5, L"getCurrentVoiceOverState"},
-      Method<void(React::JSValueObject) noexcept>{6, L"setAccessibilityContentSizeMultipliers"},
+      Method<void(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers) noexcept>{6, L"setAccessibilityContentSizeMultipliers"},
       Method<void(double) noexcept>{7, L"setAccessibilityFocus"},
       Method<void(std::string) noexcept>{8, L"announceForAccessibility"},
   };
@@ -63,8 +91,8 @@ struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "setAccessibilityContentSizeMultipliers",
-          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) void setAccessibilityContentSizeMultipliers(React::JSValueObject && JSMultipliers) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) static void setAccessibilityContentSizeMultipliers(React::JSValueObject && JSMultipliers) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) static void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "setAccessibilityFocus",

--- a/vnext/codegen/NativeActionSheetManagerSpec.g.h
+++ b/vnext/codegen/NativeActionSheetManagerSpec.g.h
@@ -13,10 +13,62 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(ActionSheetManagerSpec_showActionSheetWithOptions_options)
+struct ActionSheetManagerSpec_showActionSheetWithOptions_options {
+    REACT_FIELD(title)
+    std::optional<std::string> title;
+    REACT_FIELD(message)
+    std::optional<std::string> message;
+    REACT_FIELD(options)
+    std::optional<std::vector<std::string>> options;
+    REACT_FIELD(destructiveButtonIndices)
+    std::optional<std::vector<double>> destructiveButtonIndices;
+    REACT_FIELD(cancelButtonIndex)
+    std::optional<double> cancelButtonIndex;
+    REACT_FIELD(anchor)
+    std::optional<double> anchor;
+    REACT_FIELD(tintColor)
+    std::optional<double> tintColor;
+    REACT_FIELD(userInterfaceStyle)
+    std::optional<std::string> userInterfaceStyle;
+    REACT_FIELD(disabledButtonIndices)
+    std::optional<std::vector<double>> disabledButtonIndices;
+};
+
+REACT_STRUCT(ActionSheetManagerSpec_showShareActionSheetWithOptions_options)
+struct ActionSheetManagerSpec_showShareActionSheetWithOptions_options {
+    REACT_FIELD(message)
+    std::optional<std::string> message;
+    REACT_FIELD(url)
+    std::optional<std::string> url;
+    REACT_FIELD(subject)
+    std::optional<std::string> subject;
+    REACT_FIELD(anchor)
+    std::optional<double> anchor;
+    REACT_FIELD(tintColor)
+    std::optional<double> tintColor;
+    REACT_FIELD(excludedActivityTypes)
+    std::optional<std::vector<std::string>> excludedActivityTypes;
+    REACT_FIELD(userInterfaceStyle)
+    std::optional<std::string> userInterfaceStyle;
+};
+
+REACT_STRUCT(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error)
+struct ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error {
+    REACT_FIELD(domain)
+    std::string domain;
+    REACT_FIELD(code)
+    std::string code;
+    REACT_FIELD(userInfo)
+    std::optional<React::JSValue> userInfo;
+    REACT_FIELD(message)
+    std::string message;
+};
+
 struct ActionSheetManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject, Callback<double>) noexcept>{0, L"showActionSheetWithOptions"},
-      Method<void(React::JSValueObject, Callback<React::JSValueObject>, Callback<bool, std::optional<std::string>>) noexcept>{1, L"showShareActionSheetWithOptions"},
+      Method<void(ActionSheetManagerSpec_showActionSheetWithOptions_options, Callback<double>) noexcept>{0, L"showActionSheetWithOptions"},
+      Method<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_options, Callback<ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error>, Callback<bool, std::optional<std::string>>) noexcept>{1, L"showShareActionSheetWithOptions"},
   };
 
   template <class TModule>
@@ -26,13 +78,13 @@ struct ActionSheetManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showActionSheetWithOptions",
-          "    REACT_METHOD(showActionSheetWithOptions) void showActionSheetWithOptions(React::JSValueObject && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showActionSheetWithOptions) static void showActionSheetWithOptions(React::JSValueObject && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showActionSheetWithOptions) void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showActionSheetWithOptions) static void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "showShareActionSheetWithOptions",
-          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(React::JSValueObject && options, std::function<void(React::JSValueObject const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAppStateSpec.g.h
+++ b/vnext/codegen/NativeAppStateSpec.g.h
@@ -13,9 +13,15 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(AppStateSpec_getCurrentAppState_success_appState)
+struct AppStateSpec_getCurrentAppState_success_appState {
+    REACT_FIELD(app_state)
+    std::string app_state;
+};
+
 struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Callback<React::JSValueObject>, Callback<React::JSValue>) noexcept>{0, L"getCurrentAppState"},
+      Method<void(Callback<AppStateSpec_getCurrentAppState_success_appState>, Callback<React::JSValue>) noexcept>{0, L"getCurrentAppState"},
       Method<void(std::string) noexcept>{1, L"addListener"},
       Method<void(double) noexcept>{2, L"removeListeners"},
   };
@@ -27,8 +33,8 @@ struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getCurrentAppState",
-          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(React::JSValueObject const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(React::JSValueObject const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addListener",

--- a/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
@@ -13,14 +13,62 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(AsyncLocalStorageSpec_multiGet_callback_errors_element)
+struct AsyncLocalStorageSpec_multiGet_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncLocalStorageSpec_multiSet_callback_errors_element)
+struct AsyncLocalStorageSpec_multiSet_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncLocalStorageSpec_multiMerge_callback_errors_element)
+struct AsyncLocalStorageSpec_multiMerge_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncLocalStorageSpec_multiRemove_callback_errors_element)
+struct AsyncLocalStorageSpec_multiRemove_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncLocalStorageSpec_clear_callback_error)
+struct AsyncLocalStorageSpec_clear_callback_error {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncLocalStorageSpec_getAllKeys_callback_error)
+struct AsyncLocalStorageSpec_getAllKeys_callback_error {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
 struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
-      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{1, L"multiSet"},
-      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{2, L"multiMerge"},
-      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{3, L"multiRemove"},
-      Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>>) noexcept>{1, L"multiSet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>>) noexcept>{2, L"multiMerge"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>>) noexcept>{3, L"multiRemove"},
+      Method<void(Callback<AsyncLocalStorageSpec_clear_callback_error>) noexcept>{4, L"clear"},
+      Method<void(Callback<std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,33 +78,33 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
-          "    REACT_METHOD(clear) void clear(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clear) static void clear(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clear) void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
@@ -13,14 +13,62 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element)
+struct AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element)
+struct AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element)
+struct AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element)
+struct AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_clear_callback_error)
+struct AsyncSQLiteDBStorageSpec_clear_callback_error {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
+REACT_STRUCT(AsyncSQLiteDBStorageSpec_getAllKeys_callback_error)
+struct AsyncSQLiteDBStorageSpec_getAllKeys_callback_error {
+    REACT_FIELD(message)
+    std::string message;
+    REACT_FIELD(key)
+    std::optional<std::string> key;
+};
+
 struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
-      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{1, L"multiSet"},
-      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{2, L"multiMerge"},
-      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<React::JSValueObject>>>) noexcept>{3, L"multiRemove"},
-      Method<void(Callback<React::JSValueObject>) noexcept>{4, L"clear"},
-      Method<void(Callback<std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>>) noexcept>{0, L"multiGet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>>) noexcept>{1, L"multiSet"},
+      Method<void(std::vector<std::vector<std::string>>, Callback<std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>>) noexcept>{2, L"multiMerge"},
+      Method<void(std::vector<std::string>, Callback<std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>>) noexcept>{3, L"multiRemove"},
+      Method<void(Callback<AsyncSQLiteDBStorageSpec_clear_callback_error>) noexcept>{4, L"clear"},
+      Method<void(Callback<std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>>) noexcept>{5, L"getAllKeys"},
   };
 
   template <class TModule>
@@ -30,33 +78,33 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<React::JSValueObject>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
-          "    REACT_METHOD(clear) void clear(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clear) static void clear(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clear) void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<React::JSValueObject>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeFrameRateLoggerSpec.g.h
+++ b/vnext/codegen/NativeFrameRateLoggerSpec.g.h
@@ -13,9 +13,17 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(FrameRateLoggerSpec_setGlobalOptions_options)
+struct FrameRateLoggerSpec_setGlobalOptions_options {
+    REACT_FIELD(debug)
+    std::optional<bool> debug;
+    REACT_FIELD(reportStackTraces)
+    std::optional<bool> reportStackTraces;
+};
+
 struct FrameRateLoggerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject) noexcept>{0, L"setGlobalOptions"},
+      Method<void(FrameRateLoggerSpec_setGlobalOptions_options) noexcept>{0, L"setGlobalOptions"},
       Method<void(std::string) noexcept>{1, L"setContext"},
       Method<void() noexcept>{2, L"beginScroll"},
       Method<void() noexcept>{3, L"endScroll"},
@@ -28,8 +36,8 @@ struct FrameRateLoggerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setGlobalOptions",
-          "    REACT_METHOD(setGlobalOptions) void setGlobalOptions(React::JSValueObject && options) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setGlobalOptions) static void setGlobalOptions(React::JSValueObject && options) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setGlobalOptions) void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setGlobalOptions) static void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setContext",

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -13,20 +13,6 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
-REACT_STRUCT(ImageEditorSpec_Options)
-struct ImageEditorSpec_Options {
-    REACT_FIELD(offset)
-    ImageEditorSpec_Options_offset offset;
-    REACT_FIELD(size)
-    ImageEditorSpec_Options_size size;
-    REACT_FIELD(displaySize)
-    std::optional<ImageEditorSpec_Options_displaySize> displaySize;
-    REACT_FIELD(resizeMode)
-    std::optional<std::string> resizeMode;
-    REACT_FIELD(allowExternalStorage)
-    std::optional<bool> allowExternalStorage;
-};
-
 REACT_STRUCT(ImageEditorSpec_Options_offset)
 struct ImageEditorSpec_Options_offset {
     REACT_FIELD(x)
@@ -49,6 +35,20 @@ struct ImageEditorSpec_Options_displaySize {
     double width;
     REACT_FIELD(height)
     double height;
+};
+
+REACT_STRUCT(ImageEditorSpec_Options)
+struct ImageEditorSpec_Options {
+    REACT_FIELD(offset)
+    ImageEditorSpec_Options_offset offset;
+    REACT_FIELD(size)
+    ImageEditorSpec_Options_size size;
+    REACT_FIELD(displaySize)
+    std::optional<ImageEditorSpec_Options_displaySize> displaySize;
+    REACT_FIELD(resizeMode)
+    std::optional<std::string> resizeMode;
+    REACT_FIELD(allowExternalStorage)
+    std::optional<bool> allowExternalStorage;
 };
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -16,15 +16,39 @@ namespace Microsoft::ReactNativeSpecs {
 REACT_STRUCT(ImageEditorSpec_Options)
 struct ImageEditorSpec_Options {
     REACT_FIELD(offset)
-    React::JSValueObject offset;
+    ImageEditorSpec_Options_offset offset;
     REACT_FIELD(size)
-    React::JSValueObject size;
+    ImageEditorSpec_Options_size size;
     REACT_FIELD(displaySize)
-    std::optional<React::JSValueObject> displaySize;
+    std::optional<ImageEditorSpec_Options_displaySize> displaySize;
     REACT_FIELD(resizeMode)
     std::optional<std::string> resizeMode;
     REACT_FIELD(allowExternalStorage)
     std::optional<bool> allowExternalStorage;
+};
+
+REACT_STRUCT(ImageEditorSpec_Options_offset)
+struct ImageEditorSpec_Options_offset {
+    REACT_FIELD(x)
+    double x;
+    REACT_FIELD(y)
+    double y;
+};
+
+REACT_STRUCT(ImageEditorSpec_Options_size)
+struct ImageEditorSpec_Options_size {
+    REACT_FIELD(width)
+    double width;
+    REACT_FIELD(height)
+    double height;
+};
+
+REACT_STRUCT(ImageEditorSpec_Options_displaySize)
+struct ImageEditorSpec_Options_displaySize {
+    REACT_FIELD(width)
+    double width;
+    REACT_FIELD(height)
+    double height;
 };
 
 struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {

--- a/vnext/codegen/NativeImagePickerIOSSpec.g.h
+++ b/vnext/codegen/NativeImagePickerIOSSpec.g.h
@@ -13,12 +13,28 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(ImagePickerIOSSpec_openCameraDialog_config)
+struct ImagePickerIOSSpec_openCameraDialog_config {
+    REACT_FIELD(unmirrorFrontFacingCamera)
+    bool unmirrorFrontFacingCamera;
+    REACT_FIELD(videoMode)
+    bool videoMode;
+};
+
+REACT_STRUCT(ImagePickerIOSSpec_openSelectDialog_config)
+struct ImagePickerIOSSpec_openSelectDialog_config {
+    REACT_FIELD(showImages)
+    bool showImages;
+    REACT_FIELD(showVideos)
+    bool showVideos;
+};
+
 struct ImagePickerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(Callback<bool>) noexcept>{0, L"canRecordVideos"},
       Method<void(Callback<bool>) noexcept>{1, L"canUseCamera"},
-      Method<void(React::JSValueObject, Callback<std::string, double, double>, Callback<>) noexcept>{2, L"openCameraDialog"},
-      Method<void(React::JSValueObject, Callback<std::string, double, double>, Callback<>) noexcept>{3, L"openSelectDialog"},
+      Method<void(ImagePickerIOSSpec_openCameraDialog_config, Callback<std::string, double, double>, Callback<>) noexcept>{2, L"openCameraDialog"},
+      Method<void(ImagePickerIOSSpec_openSelectDialog_config, Callback<std::string, double, double>, Callback<>) noexcept>{3, L"openSelectDialog"},
       Method<void() noexcept>{4, L"clearAllPendingVideos"},
       Method<void(std::string) noexcept>{5, L"removePendingVideo"},
   };
@@ -40,13 +56,13 @@ struct ImagePickerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openCameraDialog",
-          "    REACT_METHOD(openCameraDialog) void openCameraDialog(React::JSValueObject && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openCameraDialog) static void openCameraDialog(React::JSValueObject && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openCameraDialog) void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openCameraDialog) static void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSelectDialog",
-          "    REACT_METHOD(openSelectDialog) void openSelectDialog(React::JSValueObject && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSelectDialog) static void openSelectDialog(React::JSValueObject && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSelectDialog) void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openSelectDialog) static void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clearAllPendingVideos",

--- a/vnext/codegen/NativeImageStoreIOSSpec.g.h
+++ b/vnext/codegen/NativeImageStoreIOSSpec.g.h
@@ -13,12 +13,24 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error)
+struct ImageStoreIOSSpec_getBase64ForTag_errorCallback_error {
+    REACT_FIELD(message)
+    std::string message;
+};
+
+REACT_STRUCT(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error)
+struct ImageStoreIOSSpec_addImageFromBase64_errorCallback_error {
+    REACT_FIELD(message)
+    std::string message;
+};
+
 struct ImageStoreIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Callback<std::string>, Callback<React::JSValueObject>) noexcept>{0, L"getBase64ForTag"},
+      Method<void(std::string, Callback<std::string>, Callback<ImageStoreIOSSpec_getBase64ForTag_errorCallback_error>) noexcept>{0, L"getBase64ForTag"},
       Method<void(std::string, Callback<bool>) noexcept>{1, L"hasImageForTag"},
       Method<void(std::string) noexcept>{2, L"removeImageForTag"},
-      Method<void(std::string, Callback<std::string>, Callback<React::JSValueObject>) noexcept>{3, L"addImageFromBase64"},
+      Method<void(std::string, Callback<std::string>, Callback<ImageStoreIOSSpec_addImageFromBase64_errorCallback_error>) noexcept>{3, L"addImageFromBase64"},
   };
 
   template <class TModule>
@@ -28,8 +40,8 @@ struct ImageStoreIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getBase64ForTag",
-          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(React::JSValueObject const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(React::JSValueObject const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "hasImageForTag",
@@ -43,8 +55,8 @@ struct ImageStoreIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "addImageFromBase64",
-          "    REACT_METHOD(addImageFromBase64) void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(React::JSValueObject const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addImageFromBase64) static void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(React::JSValueObject const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addImageFromBase64) void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(addImageFromBase64) static void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeNetworkingIOSSpec.g.h
+++ b/vnext/codegen/NativeNetworkingIOSSpec.g.h
@@ -13,9 +13,29 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(NetworkingIOSSpec_sendRequest_query)
+struct NetworkingIOSSpec_sendRequest_query {
+    REACT_FIELD(method)
+    std::string method;
+    REACT_FIELD(url)
+    std::string url;
+    REACT_FIELD(data)
+    React::JSValue data;
+    REACT_FIELD(headers)
+    React::JSValue headers;
+    REACT_FIELD(responseType)
+    std::string responseType;
+    REACT_FIELD(incrementalUpdates)
+    bool incrementalUpdates;
+    REACT_FIELD(timeout)
+    double timeout;
+    REACT_FIELD(withCredentials)
+    bool withCredentials;
+};
+
 struct NetworkingIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject, Callback<double>) noexcept>{0, L"sendRequest"},
+      Method<void(NetworkingIOSSpec_sendRequest_query, Callback<double>) noexcept>{0, L"sendRequest"},
       Method<void(double) noexcept>{1, L"abortRequest"},
       Method<void(Callback<bool>) noexcept>{2, L"clearCookies"},
       Method<void(std::string) noexcept>{3, L"addListener"},
@@ -29,8 +49,8 @@ struct NetworkingIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "sendRequest",
-          "    REACT_METHOD(sendRequest) void sendRequest(React::JSValueObject && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendRequest) static void sendRequest(React::JSValueObject && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendRequest) void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendRequest) static void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "abortRequest",

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -45,12 +45,22 @@ struct PushNotificationManagerIOSSpec_Notification {
     std::optional<bool> isSilent;
 };
 
+REACT_STRUCT(PushNotificationManagerIOSSpec_requestPermissions_permission)
+struct PushNotificationManagerIOSSpec_requestPermissions_permission {
+    REACT_FIELD(alert)
+    bool alert;
+    REACT_FIELD(badge)
+    bool badge;
+    REACT_FIELD(sound)
+    bool sound;
+};
+
 struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(std::string, std::string) noexcept>{0, L"onFinishRemoteNotification"},
       Method<void(double) noexcept>{1, L"setApplicationIconBadgeNumber"},
       Method<void(Callback<double>) noexcept>{2, L"getApplicationIconBadgeNumber"},
-      Method<void(React::JSValueObject, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
+      Method<void(PushNotificationManagerIOSSpec_requestPermissions_permission, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
       Method<void() noexcept>{4, L"abandonPermissions"},
       Method<void(Callback<PushNotificationManagerIOSSpec_Permissions>) noexcept>{5, L"checkPermissions"},
       Method<void(PushNotificationManagerIOSSpec_Notification) noexcept>{6, L"presentLocalNotification"},
@@ -89,8 +99,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestPermissions",
-          "    REACT_METHOD(requestPermissions) void requestPermissions(React::JSValueObject && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestPermissions) static void requestPermissions(React::JSValueObject && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestPermissions) void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(requestPermissions) static void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "abandonPermissions",

--- a/vnext/codegen/NativeShareModuleSpec.g.h
+++ b/vnext/codegen/NativeShareModuleSpec.g.h
@@ -13,9 +13,17 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(ShareModuleSpec_share_content)
+struct ShareModuleSpec_share_content {
+    REACT_FIELD(title)
+    std::optional<std::string> title;
+    REACT_FIELD(message)
+    std::optional<std::string> message;
+};
+
 struct ShareModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValueObject, std::string, Promise<React::JSValue>) noexcept>{0, L"share"},
+      Method<void(ShareModuleSpec_share_content, std::string, Promise<React::JSValue>) noexcept>{0, L"share"},
   };
 
   template <class TModule>
@@ -25,8 +33,8 @@ struct ShareModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "share",
-          "    REACT_METHOD(share) void share(React::JSValueObject && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(share) static void share(React::JSValueObject && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(share) void share(ShareModuleSpec_share_content && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(share) static void share(ShareModuleSpec_share_content && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
@@ -13,9 +13,15 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(StatusBarManagerIOSSpec_getHeight_callback_result)
+struct StatusBarManagerIOSSpec_getHeight_callback_result {
+    REACT_FIELD(height)
+    double height;
+};
+
 struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Callback<React::JSValueObject>) noexcept>{0, L"getHeight"},
+      Method<void(Callback<StatusBarManagerIOSSpec_getHeight_callback_result>) noexcept>{0, L"getHeight"},
       Method<void(bool) noexcept>{1, L"setNetworkActivityIndicatorVisible"},
       Method<void(std::string) noexcept>{2, L"addListener"},
       Method<void(double) noexcept>{3, L"removeListeners"},
@@ -30,8 +36,8 @@ struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getHeight",
-          "    REACT_METHOD(getHeight) void getHeight(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getHeight) static void getHeight(std::function<void(React::JSValueObject const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getHeight) void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getHeight) static void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setNetworkActivityIndicatorVisible",

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -13,9 +13,15 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(WebSocketModuleSpec_connect_options)
+struct WebSocketModuleSpec_connect_options {
+    REACT_FIELD(headers)
+    std::optional<React::JSValue> headers;
+};
+
 struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, std::optional<std::vector<std::string>>, React::JSValueObject, double) noexcept>{0, L"connect"},
+      Method<void(std::string, std::optional<std::vector<std::string>>, WebSocketModuleSpec_connect_options, double) noexcept>{0, L"connect"},
       Method<void(std::string, double) noexcept>{1, L"send"},
       Method<void(std::string, double) noexcept>{2, L"sendBinary"},
       Method<void(double) noexcept>{3, L"ping"},
@@ -31,8 +37,8 @@ struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "connect",
-          "    REACT_METHOD(connect) void connect(std::string url, std::optional<std::vector<std::string>> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<std::vector<std::string>> protocols, React::JSValueObject && options, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connect) void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "send",


### PR DESCRIPTION
- Anonymous objects are replaced with `REACT_STRUCT`, `React::JSValueObject` will not be used anymore.
- Anonymous objects could appear in in anonymous objects and aliased objects, the order in the header is important.
- Names for a anonymous object show the location where it is used, e.g.:
  - MODULESPEC_METHOD_ARGUMENT
  - ALIASEDSTRUCT_FIELD
  - etc
- `AppState` is updated to match the updated `NativeAppStateSpec`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8622)