### PR TITLE
Health check code doesn't handle paths with spaces

### DIFF
--- a/change/@react-native-windows-cli-351665bb-29ec-4fb8-93fa-fa627d7d4d18.json
+++ b/change/@react-native-windows-cli-351665bb-29ec-4fb8-93fa-fa627d7d4d18.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Better handle spaces in project path",
+  "packageName": "@react-native-windows/cli",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/healthChecks.ts
+++ b/packages/@react-native-windows/cli/src/healthChecks.ts
@@ -19,7 +19,7 @@ export function getHealthChecks(): HealthCheckCategory[] | undefined {
         'react-native-windows/package.json',
         {paths: [process.cwd()]})), 'Scripts/rnw-dependencies.ps1');
     
-    const rnwDeps = execSync(`powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -NoPrompt -ListChecks`);
+    const rnwDeps = execSync(`powershell -ExecutionPolicy Unrestricted -NoProfile "${rnwDepScriptPath}" -NoPrompt -ListChecks`);
     const deps = rnwDeps.toString().trim().split('\n');
     return [
       {
@@ -39,7 +39,7 @@ export function getHealthChecks(): HealthCheckCategory[] | undefined {
               getDiagnostics: async () => {
                 let needsToBeFixed = true;
                 try {
-                  await execa(`powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -NoPrompt -Check ${id}`);
+                  await execa(`powershell -ExecutionPolicy Unrestricted -NoProfile "${rnwDepScriptPath}" -NoPrompt -Check ${id}`);
                   needsToBeFixed = false;
                 } catch {
                 }
@@ -48,7 +48,7 @@ export function getHealthChecks(): HealthCheckCategory[] | undefined {
                 }
               },
               runAutomaticFix: async ({ loader, logManualInstallation }) => {
-                const command = `powershell -ExecutionPolicy Unrestricted -NoProfile ${rnwDepScriptPath} -Check ${id}`;
+                const command = `powershell -ExecutionPolicy Unrestricted -NoProfile "${rnwDepScriptPath}" -Check ${id}`;
                 try {
                   const { exitCode } = await execa(command, { stdio: 'inherit' });
                   if (exitCode) {


### PR DESCRIPTION
Health check code doesn't handle paths with spaces.

Fixes #7597

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8625)