### PR TITLE
Enable publishing NuGet symbol packages

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -329,6 +329,8 @@ jobs:
           packMicrosoftReactNativeProjectReunion: true
           ${{ if or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(parameters.skipStableCodesign))) }}: # Sign on stable release builds
             signMicrosoft: true
+          ${{ if eq(variables['Build.SourceBranchName'], 'main') }}: # Enable symbol packages on main builds
+            createSymbolPackages: true
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish final nuget artifacts"

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -13,6 +13,7 @@ parameters:
   packMicrosoftReactNativeManagedCodeGen: true
   packMicrosoftReactNativeProjectReunion: false
   signMicrosoft: false
+  createSymbolPackages: false
 
 steps:
   - task: DownloadPipelineArtifact@2
@@ -43,6 +44,7 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
+        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeCxx, true) }}:
     - template: prep-and-pack-single.yml
@@ -72,6 +74,7 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
+        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeManagedCodeGen, true) }}:
     - template: prep-and-pack-single.yml
@@ -82,6 +85,7 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
+        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeProjectReunion, true) }}:
     - template: prep-and-pack-single.yml
@@ -92,3 +96,4 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
+        createSymbolPackages: ${{ parameters.createSymbolPackages }}

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -5,6 +5,7 @@ parameters:
   buildProperties: ''
   codesignBinaries: false
   codesignNuget: false
+  createSymbolPackages: false
 
 steps:
 
@@ -62,6 +63,7 @@ steps:
       verbosityPack: 'Detailed'
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/${{ parameters.packageId }}.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
+      includeSymbols: ${{ parameters.createSymbolPackages }}
       buildProperties: version=${{ parameters.packageVersion }};id=${{ parameters.packageId }};${{ parameters.buildProperties }}
 
   - ${{ if eq(parameters.codesignNuget, true) }}:
@@ -72,6 +74,7 @@ steps:
         FolderPath: $(System.DefaultWorkingDirectory)/NugetRootFinal
         Pattern: |
           **/${{ parameters.packageId }}.${{ parameters.packageVersion }}.nupkg
+          **/${{ parameters.packageId }}.${{ parameters.packageVersion }}.symbols.nupkg
         UseMinimatch: true
         signConfigType: inlineSignParams
         inlineOperation: |

--- a/change/react-native-windows-4ba0a096-3ae5-48d9-92c2-9ef0966f6f61.json
+++ b/change/react-native-windows-4ba0a096-3ae5-48d9-92c2-9ef0966f6f61.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable publishing NuGet symbol packages",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/PublishNugetPackagesLocally.cmd
+++ b/vnext/Scripts/PublishNugetPackagesLocally.cmd
@@ -94,6 +94,6 @@ exit /b 0
         copy %scriptFolder%%nuspecFile% %targetNuspec% /y
     )
     echo nuget pack %targetNuspec% -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%
-    nuget pack %targetNuspec% -OutputDirectory %targetDir%\pkgs -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%;NoWarn=NU5100
+    nuget pack %targetNuspec% -OutputDirectory %targetDir%\pkgs -symbols -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%;NoWarn=NU5100
     nuget add %targetNupkg% -Source %targetDir%\feed
     goto :EOF


### PR DESCRIPTION
This PR start us generating symbol packages for our nugets, in order to reduce the bandwidth and disk space costs of developers who don't debug our code.

For the moment this will only affect the daily main/canary nugets, so we can work out any publishing kinks (and dev dev setup instructions) before enabling in other branches.

Closes #6011

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8626)