### PR TITLE
Type information for react-native-windows should contain complete RN types

### DIFF
--- a/change/@office-iss-react-native-win32-62afd43b-9b7c-4f0e-89ca-c2f14a224175.json
+++ b/change/@office-iss-react-native-win32-62afd43b-9b7c-4f0e-89ca-c2f14a224175.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export complete type information",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-7cc6df89-33fb-4172-8029-b61318a0c9d4.json
+++ b/change/react-native-windows-7cc6df89-33fb-4172-8029-b61318a0c9d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Export complete type information",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/.gitignore
+++ b/packages/@office-iss/react-native-win32/.gitignore
@@ -11,4 +11,6 @@
 /RNTester.*
 /temp
 /typings-index.*
+/rntypes
+/src/rntypes
 /rn-get-polyfills.js

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/Text/TextWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/Text/TextWin32.Props.ts
@@ -17,7 +17,7 @@ export type SharedTextPropsAndroidandWin32 = {
 /**
  * Role-based text style names.
  */
-export type TextStyle =
+export type TextWin32TextStyle =
   | 'None'
   | 'SmallStandard'
   | 'SmallSecondary'
@@ -88,7 +88,7 @@ export interface ITextWin32Props extends Omit<RN.TextProps, TextWin32OmitTypes>,
    *
    * @deprecated Use `style` instead.
    */
-  textStyle?: TextStyle;
+  textStyle?: TextWin32TextStyle;
 
   /** Tooltip displayed on mouse hover of this element */
   tooltip?: string;

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -127,12 +127,6 @@ export type AccessibilityActionInfo = Readonly<{
   label?: string;
 }>;
 
-export type AccessibilityActionEvent = RN.NativeSyntheticEvent<
-  Readonly<{
-    actionName: string;
-  }>
-  >;
-
 export type AccessibilityState = RN.AccessibilityState & { multiselectable?: boolean, required?: boolean };
 
 export type SharedAccessibilityPropsIOSandWin32 = {

--- a/packages/@office-iss/react-native-win32/src/typings-index.ts
+++ b/packages/@office-iss/react-native-win32/src/typings-index.ts
@@ -1,20 +1,27 @@
 /**
  * @packagedocumentation
  *
- * This package provides Win32 specific components and provides JS implementations for some react-native primitives
+ * This package provides Win32 specific components in addition to providing the core react-native primities.
  * Cross platform React-native primitives should be imported from 'react-native'
  * Win32 specific components need to be imported from '\@office-iss/react-native-win32'
  *
  */
 
 /*
-   This file is used to provide the typings for this package.  The typings should only include the Win32 specific types, even though
-   the package actually exports the whole of the win32 implementation of react-native.
-
+   This file is used to provide the typings for this package.
    NOTE: Concrete classes, objects etc that actually need to be exported from the package,
          need to also be added to index.win32.js
 */
 
+// Importing from a copy of react-native types instead of from react-native
+// to allow custom typescript resolvers to redirect react-native to react-native-win32
+// when building bundles for the win32 platform
+export * from './rntypes/index';
+export type { 
+      AccessibilityActionInfo,
+      AccessibilityActionName,
+      AccessibilityState
+} from './Libraries/Components/View/ViewWin32.Props';
 export * from './Libraries/Components/View/ViewWin32.Props';
 export * from './Libraries/Components/View/ViewWin32';
 export * from './Libraries/Components/Text/TextWin32.Props';

--- a/vnext/.gitignore
+++ b/vnext/.gitignore
@@ -50,6 +50,8 @@ node_modules
 /RNTester.*
 /index.*
 /interface.*
+/src/rntypes
+/rntypes
 /typings-index.*
 /rn-get-polyfills.js
 

--- a/vnext/Scripts/copyRNLibraries.js
+++ b/vnext/Scripts/copyRNLibraries.js
@@ -14,9 +14,14 @@ const rnCopiesDir = path.join(
   path.dirname(require.resolve('react-native-windows/package.json')),
   'ReactCopies',
 );
+const rnTypesDir = path.dirname(
+  require.resolve('@types/react-native/package.json'),
+);
 
 exports.copyTask = baseDir => {
   const reactNative = (...files) => files.map(f => path.join(rnDir, f));
+  const reactNativeTypes = (...files) =>
+    files.map(f => path.join(rnTypesDir, f));
   const reactCopies = (...files) => files.map(f => path.join(rnCopiesDir, f));
   const src = (...files) => files.map(f => path.join(baseDir, 'src', f));
   const base = file => path.join(baseDir, file);
@@ -24,6 +29,10 @@ exports.copyTask = baseDir => {
   return series(
     exports.cleanTask(baseDir),
 
+    copyTask({
+      paths: reactNativeTypes('*.d.ts'),
+      dest: base('src/rntypes'),
+    }),
     copyTask({
       paths: reactNative('flow/**'),
       dest: base('flow'),
@@ -73,6 +82,7 @@ exports.cleanTask = baseDir => {
       base('index.js'),
       base('interface.js'),
       base('rn-get-polyfills.js'),
+      base('src/rntypes'),
 
       // Remove TS compiled gunk in our root
       ...glob.sync(

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -115,6 +115,7 @@
     "/Shared",
     "/stubs",
     "/template",
+    "/rntypes",
     "/.flowconfig",
     "/Directory.Build.props",
     "/Directory.Build.targets",

--- a/vnext/src/typings-index.ts
+++ b/vnext/src/typings-index.ts
@@ -1,20 +1,22 @@
 /**
  * @packagedocumentation
  *
- * This package provides Windows specific components and provides JS implementations for some react-native primitives
+ * This package provides Windows specific components in addition to providing the core react-native primities.
  * Cross platform React-native primitives should be imported from 'react-native'
  * Windows specific components need to be imported from 'react-native-windows'
  *
  */
 
 /*
-   This file is used to provide the typings for this package.  The typings should only include the Windows specific types, even though
-   the package actually exports the whole of the Windows implementation of react-native.
-
+   This file is used to provide the typings for this package.
    NOTE: Concrete classes, objects etc that actually need to be exported from the package,
          need to also be added to index.windows.js
 */
 
+// Importing from a copy of react-native types instead of from react-native
+// to allow custom typescript resolvers to redirect react-native to react-native-windows
+// when building bundles for the windows platform
+export * from './rntypes/index';
 export * from './Libraries/Components/Flyout/FlyoutProps';
 export * from './Libraries/Components/Flyout/Flyout';
 export * from './Libraries/Components/Glyph/Glyph';


### PR DESCRIPTION
Currently TS only type checks using RNWs type information when importing directly from `react-native-windows`.

There is some work being done to provide the ability of TS to type check each platform with its platform overrides more correctly.  With that modification any import from `react-native` would be type checked against `react-native-windows`'s types when building a windows bundle.  -- But that would only work if we provide more complete type infomation.

Fixes #8627

