### PR TITLE
Fixed CLI options defaults

### DIFF
--- a/change/@react-native-windows-cli-6c46e85a-7b25-4067-971c-737433a62ced.json
+++ b/change/@react-native-windows-cli-6c46e85a-7b25-4067-971c-737433a62ced.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed CLI options defaults",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -1,505 +1,551 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
 import path from 'path';
-import { projectConfigWindows } from '../config/projectConfig';
-import {AutolinkWindows} from '../runWindows/utils/autolink';
+import {projectConfigWindows} from '../config/projectConfig';
+import {AutolinkWindows, autolinkOptions} from '../runWindows/utils/autolink';
 import {DOMParser} from 'xmldom';
-import { ensureWinUI3Project } from './projectConfig.utils';
+import {ensureWinUI3Project} from './projectConfig.utils';
 
 test('autolink with no windows project', () => {
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new AutolinkTest({}, {}, {check: true, logging: false});
-    }).toThrowError();
-  });
-  
-  test('autolink with incomplete windows project', () => {
-    expect(() => {
-      const autolink = new AutolinkTest(
-        {windows: {}},
-        {},
-        {check: true, logging: false},
-      );
-      autolink.validateRequiredAppProperties();
-    }).toThrowError();
-  });
-  
-  class AutolinkTest extends AutolinkWindows {
-    public getWindowsProjectConfig() {
-      return this.windowsAppConfig;
+  expect(() => {
+    // eslint-disable-next-line no-new
+    new AutolinkTest({}, {}, {check: true, logging: false});
+  }).toThrowError();
+});
+
+test('autolink with incomplete windows project', () => {
+  expect(() => {
+    const autolink = new AutolinkTest(
+      {windows: {}},
+      {},
+      {check: true, logging: false},
+    );
+    autolink.validateRequiredAppProperties();
+  }).toThrowError();
+});
+
+class AutolinkTest extends AutolinkWindows {
+  public getWindowsProjectConfig() {
+    return this.windowsAppConfig;
+  }
+  public packagesConfig = '';
+  public experimentalFeaturesProps = '';
+  protected getPackagesConfigXml() {
+    return {
+      path: 'packages.config',
+      content: new DOMParser().parseFromString(
+        this.packagesConfig,
+        'application/xml',
+      ),
+    };
+  }
+  protected getExperimentalFeaturesPropsXml() {
+    return {
+      path: 'ExperimentalFeatures.props',
+      content: new DOMParser().parseFromString(
+        this.experimentalFeaturesProps,
+        'application/xml',
+      ),
+    };
+  }
+  protected async updateFile(filepath: string, content: string) {
+    if (filepath === 'packages.config') {
+      this.packagesConfig = content;
+    } else if (filepath === 'ExperimentalFeatures.props') {
+      this.experimentalFeaturesProps = content;
+    } else {
+      throw new Error(`Unknown path: ${filepath}`);
     }
-    public packagesConfig = '';
-    public experimentalFeaturesProps = '';
-    protected getPackagesConfigXml(){
-        return {path:'packages.config', content: new DOMParser().parseFromString(this.packagesConfig, 'application/xml')};
-    }
-    protected getExperimentalFeaturesPropsXml(){
-        return {path: 'ExperimentalFeatures.props', content: new DOMParser().parseFromString(this.experimentalFeaturesProps, 'application/xml')};
-    }
-    protected async updateFile(filepath: string, content: string) {
-        if (filepath === 'packages.config') {
-            this.packagesConfig = content;
-        } else if (filepath === 'ExperimentalFeatures.props') {
-            this.experimentalFeaturesProps = content;
-        } else {
-            throw new Error(`Unknown path: ${filepath}`);
-        }
-        return true;
-    }
+    return true;
+  }
 }
 
-  
-  test('autolink fixup sln', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.'}},
-      {},
-      {check: true, logging: false, sln: 'foo'},
-    );
-    expect(autolink.getWindowsProjectConfig().solutionFile).toBeUndefined();
-    expect(() => {
-      autolink.validateRequiredAppProperties();
-    }).toThrow();
-    autolink.fixUpForSlnOption();
-    expect(autolink.getWindowsProjectConfig().solutionFile).toEqual('foo');
-    expect(() => {
-      autolink.validateRequiredAppProperties();
-    }).toThrow();
-  });
-  
-  test('autolink fixup proj', async done => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {},
-      {
-        check: true,
-        logging: false,
-        proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
-      },
-    );
-    expect(autolink.getWindowsProjectConfig().solutionFile).toEqual('foo.sln');
-    expect(autolink.getWindowsProjectConfig().project).toBeUndefined();
-  
-    const folder = path.resolve('src/e2etest/projects/', 'WithWinUI3');
-    await ensureWinUI3Project(folder);
-    expect(() => {
-      autolink.validateRequiredProjectProperties();
-    }).toThrow();
-    autolink.fixUpForProjOption();
-  
-    const projectConfig = autolink.getWindowsProjectConfig().project;
-    expect(projectConfig).not.toBeUndefined();
-    expect(projectConfig.projectName).toEqual('WithWinUI3');
+test('autolink fixup sln', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.'}},
+    {},
+    {check: true, logging: false, sln: 'foo'},
+  );
+  expect(autolink.getWindowsProjectConfig().solutionFile).toBeUndefined();
+  expect(() => {
+    autolink.validateRequiredAppProperties();
+  }).toThrow();
+  autolink.fixUpForSlnOption();
+  expect(autolink.getWindowsProjectConfig().solutionFile).toEqual('foo');
+  expect(() => {
+    autolink.validateRequiredAppProperties();
+  }).toThrow();
+});
+
+test('autolink fixup proj', async done => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {},
+    {
+      check: true,
+      logging: false,
+      proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
+    },
+  );
+  expect(autolink.getWindowsProjectConfig().solutionFile).toEqual('foo.sln');
+  expect(autolink.getWindowsProjectConfig().project).toBeUndefined();
+
+  const folder = path.resolve('src/e2etest/projects/', 'WithWinUI3');
+  await ensureWinUI3Project(folder);
+  expect(() => {
     autolink.validateRequiredProjectProperties();
-    done();
-  });
-  
-  test('empty cpp autolink dependencies', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {},
-      {
-        check: true,
-        logging: false,
-        proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
-      },
-    );
-    const replacements = autolink.getCppReplacements();
-    expect(replacements.cppIncludes).toEqual('');
-    expect(replacements.cppPackageProviders).toEqual(
-      '\n    UNREFERENCED_PARAMETER(packageProviders);',
-    );
-  });
-  
-  test('one invalid cpp autolink dependency', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {
-        superModule: {
-          name: 'superModule',
-          root: 'theRoot',
-          platforms: {
-            windows: {},
-          },
-          assets: [],
-          hooks: {},
-          params: [],
+  }).toThrow();
+  autolink.fixUpForProjOption();
+
+  const projectConfig = autolink.getWindowsProjectConfig().project;
+  expect(projectConfig).not.toBeUndefined();
+  expect(projectConfig.projectName).toEqual('WithWinUI3');
+  autolink.validateRequiredProjectProperties();
+  done();
+});
+
+test('empty cpp autolink dependencies', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {},
+    {
+      check: true,
+      logging: false,
+      proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
+    },
+  );
+  const replacements = autolink.getCppReplacements();
+  expect(replacements.cppIncludes).toEqual('');
+  expect(replacements.cppPackageProviders).toEqual(
+    '\n    UNREFERENCED_PARAMETER(packageProviders);',
+  );
+});
+
+test('one invalid cpp autolink dependency', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {
+      superModule: {
+        name: 'superModule',
+        root: 'theRoot',
+        platforms: {
+          windows: {},
         },
+        assets: [],
+        hooks: {},
+        params: [],
       },
-      {
-        check: true,
-        logging: false,
-        proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
-      },
-    );
-    const replacements = autolink.getCppReplacements();
-    expect(replacements.cppIncludes).toEqual('');
-    expect(replacements.cppPackageProviders).toEqual(
-      '\n    UNREFERENCED_PARAMETER(packageProviders);',
-    );
-  });
-  
-  test('one invalid cs autolink dependency', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {
-        superModule: {
-          name: 'superModule',
-          root: 'theRoot',
-          platforms: {
-            windows: {},
-          },
-          assets: [],
-          hooks: {},
-          params: [],
+    },
+    {
+      check: true,
+      logging: false,
+      proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
+    },
+  );
+  const replacements = autolink.getCppReplacements();
+  expect(replacements.cppIncludes).toEqual('');
+  expect(replacements.cppPackageProviders).toEqual(
+    '\n    UNREFERENCED_PARAMETER(packageProviders);',
+  );
+});
+
+test('one invalid cs autolink dependency', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {
+      superModule: {
+        name: 'superModule',
+        root: 'theRoot',
+        platforms: {
+          windows: {},
         },
+        assets: [],
+        hooks: {},
+        params: [],
       },
-      {
-        check: true,
-        logging: false,
-        proj:
-          'projects/SimpleCSharpApp/windows/SimpleCSharpApp/SimpleCSharpApp.csproj',
-      },
-    );
-    const replacements = autolink.getCsReplacements();
-    expect(replacements.csUsingNamespaces).toEqual('');
-    expect(replacements.csReactPackageProviders).toEqual('');
-  });
-  
-  test('one valid cpp autolink dependency', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {
-        superModule: {
-          name: 'superModule',
-          root: 'theRoot',
-          platforms: {
-            windows: {
-              sourceDir: __dirname,
-              projects: [
-                {
-                  directDependency: true,
-                  projectFile: 'superModule.vcxproj',
-                  cppHeaders: ['Garfield.h', 'Snoopy.h'],
-                  cppPackageProviders: ['FamousAnimalCartoons'],
-                },
-              ],
-            },
+    },
+    {
+      check: true,
+      logging: false,
+      proj:
+        'projects/SimpleCSharpApp/windows/SimpleCSharpApp/SimpleCSharpApp.csproj',
+    },
+  );
+  const replacements = autolink.getCsReplacements();
+  expect(replacements.csUsingNamespaces).toEqual('');
+  expect(replacements.csReactPackageProviders).toEqual('');
+});
+
+test('one valid cpp autolink dependency', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {
+      superModule: {
+        name: 'superModule',
+        root: 'theRoot',
+        platforms: {
+          windows: {
+            sourceDir: __dirname,
+            projects: [
+              {
+                directDependency: true,
+                projectFile: 'superModule.vcxproj',
+                cppHeaders: ['Garfield.h', 'Snoopy.h'],
+                cppPackageProviders: ['FamousAnimalCartoons'],
+              },
+            ],
           },
-          assets: [],
-          hooks: {},
-          params: [],
         },
+        assets: [],
+        hooks: {},
+        params: [],
       },
-      {
-        check: true,
-        logging: false,
-        proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
-      },
-    );
-    const replacements = autolink.getCppReplacements();
-    expect(replacements.cppIncludes).toMatch(/#include <Garfield.h>/);
-    expect(replacements.cppIncludes).toMatch(/#include <Snoopy.h>/);
-    expect(replacements.cppPackageProviders).toContain(
-      'packageProviders.Append(winrt::FamousAnimalCartoons())',
-    );
-  });
-  
-  test('one valid cs autolink dependency', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {
-        superModule: {
-          name: 'superModule',
-          root: 'theRoot',
-          platforms: {
-            windows: {
-              sourceDir: __dirname,
-              projects: [
-                {
-                  directDependency: true,
-                  csNamespaces: ['Garfield'],
-                  projectFile: 'superModule.vcxproj',
-                  cppHeaders: ['Garfield.h', 'Snoopy.h'],
-                  csPackageProviders: ['FamousAnimalCartoons'],
-                },
-              ],
-            },
+    },
+    {
+      check: true,
+      logging: false,
+      proj: 'projects/WithWinUI3/windows/WithWinUI3/WithWinUI3.vcxproj',
+    },
+  );
+  const replacements = autolink.getCppReplacements();
+  expect(replacements.cppIncludes).toMatch(/#include <Garfield.h>/);
+  expect(replacements.cppIncludes).toMatch(/#include <Snoopy.h>/);
+  expect(replacements.cppPackageProviders).toContain(
+    'packageProviders.Append(winrt::FamousAnimalCartoons())',
+  );
+});
+
+test('one valid cs autolink dependency', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {
+      superModule: {
+        name: 'superModule',
+        root: 'theRoot',
+        platforms: {
+          windows: {
+            sourceDir: __dirname,
+            projects: [
+              {
+                directDependency: true,
+                csNamespaces: ['Garfield'],
+                projectFile: 'superModule.vcxproj',
+                cppHeaders: ['Garfield.h', 'Snoopy.h'],
+                csPackageProviders: ['FamousAnimalCartoons'],
+              },
+            ],
           },
-          assets: [],
-          hooks: {},
-          params: [],
         },
+        assets: [],
+        hooks: {},
+        params: [],
       },
-      {
-        check: true,
-        logging: false,
-        proj:
-          'projects/SimpleCSharpApp/windows/SimpleCSharpApp/SimpleCSharpApp.csproj',
-      },
-    );
-    const replacements = autolink.getCsReplacements();
-    expect(replacements.csUsingNamespaces).toContain('using Garfield;');
-    expect(replacements.csReactPackageProviders).toContain(
-      'packageProviders.Add(new FamousAnimalCartoons())',
-    );
-  });
-  
-  test('ensureXAMLDialect - useWinUI3=true in react-native.config.js, useWinUI3=false in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
-  
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+    },
+    {
+      check: true,
+      logging: false,
+      proj:
+        'projects/SimpleCSharpApp/windows/SimpleCSharpApp/SimpleCSharpApp.csproj',
+    },
+  );
+  const replacements = autolink.getCsReplacements();
+  expect(replacements.csUsingNamespaces).toContain('using Garfield;');
+  expect(replacements.csReactPackageProviders).toContain(
+    'packageProviders.Add(new FamousAnimalCartoons())',
+  );
+});
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
-    // </packages>
-    //
-    expect(al.packagesConfig).toContain('Microsoft.WinUI');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
-  
-    done();
-  });
+test('ensureXAMLDialect - useWinUI3=true in react-native.config.js, useWinUI3=false in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
 
-  test('ensureXAMLDialect - useWinUI3=false in react-native.config.js, useWinUI3=true in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
-    config.useWinUI3 = false;
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
-    // </packages>
-    //
-    expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
-  
-    done();
-  });
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
 
-  test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=true in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
-    delete config.useWinUI3;
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
-    // </packages>
-    //
-    expect(al.packagesConfig).toContain('Microsoft.WinUI');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
-  
-    done();
-  });
-  
-  test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=false in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
-    delete config.useWinUI3;
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/><package id="Microsoft.WinUI"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
-    // </packages>
-    //
-    expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
-  
-    done();
-  });
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
+  // </packages>
+  //
+  expect(al.packagesConfig).toContain('Microsoft.WinUI');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
 
-  test('ensureXAMLDialect - WinUI2xVersion specified in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
-    delete config.useWinUI3;
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+  done();
+});
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.UI.XAML" version="2.6.0-test" targetFramework="native"/>
-    // </packages>
-    //
-    expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
-    expect(al.packagesConfig).toContain('2.6.0-test');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
-  
-    done();
-  });
+test('ensureXAMLDialect - useWinUI3=false in react-native.config.js, useWinUI3=true in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
 
-  test('ensureXAMLDialect - WinUI3Version specified in ExperimentalFeatures.props', async done => {
-    const folder = path.resolve('src/e2etest/projects/WithWinUI3');
-    const rnc = require(path.join(folder, 'react-native.config.js'));
-  
-    const config = projectConfigWindows(folder, rnc.project.windows)!;
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
+  config.useWinUI3 = false;
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
 
-    const al = new AutolinkTest(
-      {windows: config},
-      {},
-      {
-        check: false,
-        logging: false,
-      },
-    );
-    al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3><WinUI3Version>3.0.0-test</WinUI3Version></PropertyGroup></Project>`;
-    al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
-  
-    const exd = await al.ensureXAMLDialect();
-    expect(exd).toBeTruthy();
-  
-    const expectedExperimentalFeatures = '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3><WinUI3Version>3.0.0-test</WinUI3Version></PropertyGroup></Project>';
-    expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
 
-    // example packages.config: 
-    // <packages>
-    //   <package id="SuperPkg" version="42"/>
-    //   <package id="Microsoft.WinUI" version="3.0.0-test" targetFramework="native"/>
-    // </packages>
-    //
-    
-    expect(al.packagesConfig).toContain('Microsoft.WinUI');
-    expect(al.packagesConfig).toContain('3.0.0-test');
-    expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
-    expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
-  
-    done();
-  });
-  
-  test('Indirect autolink dependency', () => {
-    const autolink = new AutolinkTest(
-      {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
-      {
-        superModule: {
-          name: 'superModule',
-          root: 'theRoot',
-          platforms: {
-            windows: {
-              sourceDir: __dirname,
-              projects: [
-                {
-                  directDependency: true,
-                  projectFile: 'superModule.vcxproj',
-                  cppHeaders: ['Garfield.h', 'Snoopy.h'],
-                  cppPackageProviders: ['FamousAnimalCartoons'],
-                },
-                {
-                  directDependency: false,
-                  projectFile: 'indirect.vcxproj',
-                }
-              ],
-            },
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
+  // </packages>
+  //
+  expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
+
+  done();
+});
+
+test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=true in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
+
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
+  delete config.useWinUI3;
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
+
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
+
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.WinUI" version="3.0.0-preview3.201113.0" targetFramework="native"/>
+  // </packages>
+  //
+  expect(al.packagesConfig).toContain('Microsoft.WinUI');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
+
+  done();
+});
+
+test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=false in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
+
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
+  delete config.useWinUI3;
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/><package id="Microsoft.WinUI"/></packages>`;
+
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
+
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
+  // </packages>
+  //
+  expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
+
+  done();
+});
+
+test('ensureXAMLDialect - WinUI2xVersion specified in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
+
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
+  delete config.useWinUI3;
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
+
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
+
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.UI.XAML" version="2.6.0-test" targetFramework="native"/>
+  // </packages>
+  //
+  expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
+  expect(al.packagesConfig).toContain('2.6.0-test');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
+
+  done();
+});
+
+test('ensureXAMLDialect - WinUI3Version specified in ExperimentalFeatures.props', async done => {
+  const folder = path.resolve('src/e2etest/projects/WithWinUI3');
+  const rnc = require(path.join(folder, 'react-native.config.js'));
+
+  const config = projectConfigWindows(folder, rnc.project.windows)!;
+
+  const al = new AutolinkTest(
+    {windows: config},
+    {},
+    {
+      check: false,
+      logging: false,
+    },
+  );
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3><WinUI3Version>3.0.0-test</WinUI3Version></PropertyGroup></Project>`;
+  al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
+
+  const exd = await al.ensureXAMLDialect();
+  expect(exd).toBeTruthy();
+
+  const expectedExperimentalFeatures =
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>true</UseWinUI3><WinUI3Version>3.0.0-test</WinUI3Version></PropertyGroup></Project>';
+  expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
+
+  // example packages.config:
+  // <packages>
+  //   <package id="SuperPkg" version="42"/>
+  //   <package id="Microsoft.WinUI" version="3.0.0-test" targetFramework="native"/>
+  // </packages>
+  //
+
+  expect(al.packagesConfig).toContain('Microsoft.WinUI');
+  expect(al.packagesConfig).toContain('3.0.0-test');
+  expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
+  expect(al.packagesConfig).not.toContain('Microsoft.UI.Xaml');
+
+  done();
+});
+
+test('Indirect autolink dependency', () => {
+  const autolink = new AutolinkTest(
+    {windows: {folder: __dirname, sourceDir: '.', solutionFile: 'foo.sln'}},
+    {
+      superModule: {
+        name: 'superModule',
+        root: 'theRoot',
+        platforms: {
+          windows: {
+            sourceDir: __dirname,
+            projects: [
+              {
+                directDependency: true,
+                projectFile: 'superModule.vcxproj',
+                cppHeaders: ['Garfield.h', 'Snoopy.h'],
+                cppPackageProviders: ['FamousAnimalCartoons'],
+              },
+              {
+                directDependency: false,
+                projectFile: 'indirect.vcxproj',
+              },
+            ],
           },
-          assets: [],
-          hooks: {},
-          params: [],
         },
+        assets: [],
+        hooks: {},
+        params: [],
       },
-      {
-        check: true,
-        logging: false,
-        proj: 'projects/WithIndirectDependency/windows/WithIndirectDependency/WithIndirectDependency.vcxproj',
-      },
-    );
-    const replacements = autolink.getCppReplacements();
-    expect(replacements.cppIncludes).toMatch(/#include <Garfield.h>/);
-    expect(replacements.cppIncludes).toMatch(/#include <Snoopy.h>/);
-    expect(replacements.cppPackageProviders).toContain(
-      'packageProviders.Append(winrt::FamousAnimalCartoons())',
-    );
-  });
+    },
+    {
+      check: true,
+      logging: false,
+      proj:
+        'projects/WithIndirectDependency/windows/WithIndirectDependency/WithIndirectDependency.vcxproj',
+    },
+  );
+  const replacements = autolink.getCppReplacements();
+  expect(replacements.cppIncludes).toMatch(/#include <Garfield.h>/);
+  expect(replacements.cppIncludes).toMatch(/#include <Snoopy.h>/);
+  expect(replacements.cppPackageProviders).toContain(
+    'packageProviders.Append(winrt::FamousAnimalCartoons())',
+  );
+});
+
+test('autolinkOptions - validate options', () => {
+  for (const commandOption of autolinkOptions) {
+    // Validate names
+    expect(commandOption.name).not.toBeNull();
+    expect(commandOption.name.startsWith('--')).toBe(true);
+    expect(commandOption.name).toBe(commandOption.name.trim());
+
+    // Validate defaults
+    if (
+      !commandOption.name.endsWith(' [string]') &&
+      !commandOption.name.endsWith(' [number]')
+    ) {
+      // Commander ignores defaults for flags, so leave undefined to prevent confusion
+      expect(commandOption.default).toBeUndefined();
+    }
+
+    // Validate description
+    expect(commandOption.description).not.toBeNull();
+    expect(commandOption.description!).toBe(commandOption.description!.trim());
+  }
+});

--- a/packages/@react-native-windows/cli/src/e2etest/runWindows.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/runWindows.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {getAnonymizedProjectName} from '../runWindows/runWindows';
+import {runWindowsOptions} from '../runWindows/runWindowsOptions';
 
 test('getAnonymizedProjectName - Project Exists', async () => {
   const fooName = await getAnonymizedProjectName(
@@ -28,4 +29,26 @@ test('getAnonymizedProjectName - Project Doesnt Exist', async () => {
     `${__dirname}/projects/BlankApp`,
   );
   expect(emptyPackageName).toBeNull();
+});
+
+test('runWindowsOptions - validate options', () => {
+  for (const commandOption of runWindowsOptions) {
+    // Validate names
+    expect(commandOption.name).not.toBeNull();
+    expect(commandOption.name.startsWith('--')).toBe(true);
+    expect(commandOption.name).toBe(commandOption.name.trim());
+
+    // Validate defaults
+    if (
+      !commandOption.name.endsWith(' [string]') &&
+      !commandOption.name.endsWith(' [number]')
+    ) {
+      // Commander ignores defaults for flags, so leave undefined to prevent confusion
+      expect(commandOption.default).toBeUndefined();
+    }
+
+    // Validate description
+    expect(commandOption.description).not.toBeNull();
+    expect(commandOption.description!).toBe(commandOption.description!.trim());
+  }
 });

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -31,9 +31,9 @@ import {totalmem, cpus} from 'os';
 
 function setExitProcessWithError(
   error: Error,
-  loggingWasEnabled: boolean,
+  loggingWasEnabled?: boolean,
 ): void {
-  if (!loggingWasEnabled) {
+  if (loggingWasEnabled !== true) {
     console.log(
       `Re-run the command with ${chalk.bold('--logging')} for more information`,
     );
@@ -220,7 +220,7 @@ async function runWindowsInternal(
   config: Config,
   options: RunWindowsOptions,
 ) {
-  const verbose = options.logging;
+  const verbose = options.logging === true;
 
   if (verbose) {
     newInfo('Verbose: ON');
@@ -346,7 +346,11 @@ async function runWindowsInternal(
 }
 
 function shouldLaunchPackager(options: RunWindowsOptions): boolean {
-  return options.packager && options.launch && options.release !== true;
+  return (
+    options.packager === true &&
+    options.launch === true &&
+    options.release !== true
+  );
 }
 
 /*

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -40,19 +40,19 @@ export interface RunWindowsOptions {
   device?: boolean;
   target?: string;
   remoteDebugging?: string;
-  logging: boolean;
-  packager: boolean;
-  bundle: boolean;
-  launch: boolean;
-  autolink: boolean;
-  build: boolean;
-  deploy: boolean;
+  logging?: boolean;
+  packager?: boolean;
+  bundle?: boolean;
+  launch?: boolean;
+  autolink?: boolean;
+  build?: boolean;
+  deploy?: boolean;
   deployFromLayout?: boolean;
   sln?: string;
   proj?: string;
   msbuildprops?: string;
   buildLogDirectory?: string;
-  info: boolean;
+  info?: boolean;
   directDebugging?: number;
   telemetry?: boolean;
 }
@@ -97,7 +97,6 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--logging',
     description: 'Enables logging',
-    default: false,
   },
   {
     name: '--no-packager',
@@ -107,32 +106,26 @@ export const runWindowsOptions: CommandOption[] = [
     name: '--bundle',
     description:
       'Enable Bundle configuration and it would be ReleaseBundle/DebugBundle other than Release/Debug',
-    default: false,
   },
   {
     name: '--no-launch',
     description: 'Do not launch the app after deployment',
-    default: false,
   },
   {
     name: '--no-autolink',
     description: 'Do not run autolinking',
-    default: false,
   },
   {
     name: '--no-build',
     description: 'Do not build the solution',
-    default: false,
   },
   {
     name: '--no-deploy',
     description: 'Do not deploy the app',
-    default: false,
   },
   {
     name: '--deploy-from-layout',
     description: 'Force deploy from layout, even in release builds',
-    default: false,
   },
   {
     name: '--sln [string]',
@@ -158,7 +151,6 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--info',
     description: 'Dump environment information',
-    default: false,
   },
   {
     name: '--direct-debugging [number]',
@@ -169,7 +161,6 @@ export const runWindowsOptions: CommandOption[] = [
     name: '--no-telemetry',
     description:
       'Disables sending telemetry that allows analysis of usage and failures of the react-native-windows CLI',
-    default: true,
   },
 ];
 

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -21,6 +21,7 @@ import * as configUtils from '../../config/configUtils';
 
 import {
   Command,
+  CommandOption,
   Config,
   Dependency,
   ProjectConfig,
@@ -877,7 +878,7 @@ function resolveTemplateRoot(projectConfig: WindowsProjectConfig) {
  * @param message The message to log.
  * @param verbose Whether or not verbose logging is enabled.
  */
-function verboseMessage(message: any, verbose: boolean) {
+function verboseMessage(message: any, verbose?: boolean) {
   if (verbose) {
     console.log(message);
   }
@@ -951,39 +952,42 @@ async function updateAutoLink(
   }
 }
 
-interface AutoLinkOptions {
-  logging: boolean;
-  check: boolean;
+export interface AutoLinkOptions {
+  logging?: boolean;
+  check?: boolean;
   sln?: string;
   proj?: string;
 }
 
+export const autolinkOptions: CommandOption[] = [
+  {
+    name: '--logging',
+    description: 'Verbose output logging',
+  },
+  {
+    name: '--check',
+    description: 'Only check whether any autolinked files need to change',
+  },
+  {
+    name: '--sln [string]',
+    description:
+      "Override the app solution file determined by 'react-native config', e.g. windows\\myApp.sln",
+    default: undefined,
+  },
+  {
+    name: '--proj [string]',
+    description:
+      "Override the app project file determined by 'react-native config', e.g. windows\\myApp\\myApp.vcxproj",
+    default: undefined,
+  },
+];
+
+/**
+ * Performs auto-linking for RNW native modules and apps.
+ */
 export const autoLinkCommand: Command = {
   name: 'autolink-windows',
   description: 'performs autolinking',
   func: updateAutoLink,
-  options: [
-    {
-      name: '--logging',
-      description: 'Verbose output logging',
-      default: false,
-    },
-    {
-      name: '--check',
-      description: 'Only check whether any autolinked files need to change',
-      default: false,
-    },
-    {
-      name: '--sln [string]',
-      description:
-        "Override the app solution file determined by 'react-native config', e.g. windows\\myApp.sln",
-      default: undefined,
-    },
-    {
-      name: '--proj [string]',
-      description:
-        "Override the app project file determined by 'react-native config', e.g. windows\\myApp\\myApp.vcxproj",
-      default: undefined,
-    },
-  ],
+  options: autolinkOptions,
 };

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -45,7 +45,7 @@ export function getBuildConfiguration(options: RunWindowsOptions): BuildConfig {
 }
 
 function shouldLaunchApp(options: RunWindowsOptions): boolean {
-  return options.launch;
+  return options.launch === true;
 }
 
 function getAppPackage(


### PR DESCRIPTION
Commander (the library used by the RN CLI to define/parse CLI args) does
not support setting defaults for boolean flags. All such options are
resolved to either `true` (if present) or `undefined` (if specified in
the --no-flag format and present).

This PR was extracted from PR #8253, and cleans up the CLI options to
not specify defaults for boolean flags, as they are ignored by Commander
and are therefore potentially misleading. The RunWindowsOptions and
AutoLinkOptions interfaces have been updated to reflect these changes,
and tests were added to make sure we don't set useless defaults in the
future.

This PR also fixes the formatting of autolink.test.ts, which did not
have the proper copyright header and therefore was not being checked by
eslint.

Closes #8630

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8629)