### PR TITLE
Add accessibilityInfo example to RNTester 

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
@@ -92,7 +92,7 @@ function TouchableExample(props): React.Node {
       <TouchableWithoutFeedback
         ref={myElement}
         onPress={() => {
-          //onPress, even if empty, is required for TouchableWithoutFocus to be focusable
+          //onPress, even if empty, is required for TouchableWithoutFeedback to be focusable
         }}
         accessibilityLabel="focus received"
         {...{

--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
@@ -70,7 +70,6 @@ function AccessibilityInfoExample(props): React.Node {
 }
 
 function TouchableExample(props): React.Node {
-
   let myElement = React.createRef();
 
   return (
@@ -82,12 +81,12 @@ function TouchableExample(props): React.Node {
             AccessibilityInfo.setAccessibilityFocus(reactTag);
           }
         }}
-        accessibilityLabel="TEST Set Accessibility Focus"
+        accessibilityLabel="Test Setting Accessibility Focus"
         {...{
           focusable: true,
         }}>
         <View>
-          <Text>TEST setAccessibilityFocus</Text>
+          <Text>Test setAccessibilityFocus</Text>
         </View>
       </TouchableWithoutFeedback>
       <TouchableWithoutFeedback
@@ -101,7 +100,7 @@ function TouchableExample(props): React.Node {
         }}>
         <View>
           {/* When using Text, must wrap it within a View to receive keyboard focus*/}
-          <Text>TEST touchablewithoutfeedback focusability</Text>
+          <Text>Testing touchablewithoutfeedback focusability</Text>
         </View>
       </TouchableWithoutFeedback>
     </View>

--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
@@ -11,6 +11,7 @@ const {
   AccessibilityInfo,
   Button,
   Text,
+  TouchableWithoutFeedback,
   View,
   TextInput,
   findNodeHandle,
@@ -68,6 +69,45 @@ function AccessibilityInfoExample(props): React.Node {
   );
 }
 
+function TouchableExample(props): React.Node {
+
+  let myElement = React.createRef();
+
+  return (
+    <View>
+      <TouchableWithoutFeedback
+        onPress={() => {
+          const reactTag = findNodeHandle(myElement.current);
+          if (reactTag) {
+            AccessibilityInfo.setAccessibilityFocus(reactTag);
+          }
+        }}
+        accessibilityLabel="TEST Set Accessibility Focus"
+        {...{
+          focusable: true,
+        }}>
+        <View>
+          <Text>TEST setAccessibilityFocus</Text>
+        </View>
+      </TouchableWithoutFeedback>
+      <TouchableWithoutFeedback
+        ref={myElement}
+        onPress={() => {
+          //onPress, even if empty, is required for TouchableWithoutFocus to be focusable
+        }}
+        accessibilityLabel="focus received"
+        {...{
+          focusable: true,
+        }}>
+        <View>
+          {/* When using Text, must wrap it within a View to receive keyboard focus*/}
+          <Text>TEST touchablewithoutfeedback focusability</Text>
+        </View>
+      </TouchableWithoutFeedback>
+    </View>
+  );
+}
+
 exports.title = 'AccessibilityInfo';
 exports.category = 'Basic';
 exports.description = 'Examples of using AccessibilityInfo APIs.';
@@ -76,6 +116,12 @@ exports.examples = [
     title: 'Basic AccessibilityInfo',
     render(): React.Element<typeof AccessibilityInfoExample> {
       return <AccessibilityInfoExample />;
+    },
+  },
+  {
+    title: 'setAccessibilityFocus on TouchableWithoutFeedback',
+    render(): React.Element<typeof TouchableExample> {
+      return <TouchableExample />;
     },
   },
 ];


### PR DESCRIPTION
Adding an example of using `accessibilityInfo.setAccessibilifyFocus` with TouchableWithoutFeedback components as it's a bit of a trickier use case. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8633)