### PR TITLE
Ensures IsHitTestVisible is set on correct view

### DIFF
--- a/change/react-native-windows-c815a24d-e3b1-4071-8f69-3461f31545ed.json
+++ b/change/react-native-windows-c815a24d-e3b1-4071-8f69-3461f31545ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensures IsHitTestVisible is set on correct view",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
@@ -33,6 +33,9 @@ void TransferFrameworkElementProperties(const xaml::DependencyObject &oldView, c
   // Render Properties
   TransferProperty(oldView, newView, xaml::UIElement::OpacityProperty());
 
+  // Hit Test Properties
+  TransferProperty(oldView, newView, xaml::UIElement::IsHitTestVisibleProperty());
+
   // Layout Properties
   TransferProperty(oldView, newView, xaml::FrameworkElement::WidthProperty());
   TransferProperty(oldView, newView, xaml::FrameworkElement::HeightProperty());

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -409,7 +409,8 @@ bool ViewViewManager::UpdateProperty(
     } else if (propertyName == "pointerEvents") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
         bool hitTestable = propertyValue.AsString() != "none";
-        pPanel.IsHitTestVisible(hitTestable);
+        if (const auto element = nodeToUpdate->GetView().try_as<xaml::UIElement>())
+          element.IsHitTestVisible(hitTestable);
       }
     } else if (propertyName == "focusable") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)


### PR DESCRIPTION
When someone sets `pointerEvents="none"` on a View component, we currently set `IsHitTestVisible` to false on the ViewPanel instance. If the user has done something that forces the ViewPanel to be replaced by a ViewControl, we will not have set `IsHitTestVisible` on the ViewControl and will not also transfer that property if `pointerEvents="none"` is set before the transfer occurs. This change ensures IsHitTestVisible is always set on the correct view.

Fixes #8531

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8634)