### PR TITLE
Restore Fast Refresh Functionality

### DIFF
--- a/change/react-native-windows-9991abee-8b19-4ff1-a209-7478d569bfe2.json
+++ b/change/react-native-windows-9991abee-8b19-4ff1-a209-7478d569bfe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Break in Fast Refresh Behavior",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -500,7 +500,8 @@ void ReactInstanceWin::Initialize() noexcept {
                   DebugBundlePath(),
                   SourceBundleHost(),
                   SourceBundlePort(),
-                  m_isFastReloadEnabled);
+                  m_isFastReloadEnabled,
+                  "ws");
               m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
             }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,9 +2179,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@^14.14.22":
-  version "14.17.15"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
-  integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
+  version "14.17.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.16.tgz#2b9252bd4fdf0393696190cd9550901dd967c777"
+  integrity sha512-WiFf2izl01P1CpeY8WqFAeKWwByMueBEkND38EcN8N68qb0aDG3oIS1P5MhAX5kUdr469qRyqsY/MjanLjsFbQ==
 
 "@types/node@10.17.13":
   version "10.17.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,9 +2179,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@^14.14.22":
-  version "14.17.16"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.16.tgz#2b9252bd4fdf0393696190cd9550901dd967c777"
-  integrity sha512-WiFf2izl01P1CpeY8WqFAeKWwByMueBEkND38EcN8N68qb0aDG3oIS1P5MhAX5kUdr469qRyqsY/MjanLjsFbQ==
+  version "14.17.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.15.tgz#d5ebfb62a69074ebb85cbe0529ad917bb8f2bae8"
+  integrity sha512-D1sdW0EcSCmNdLKBGMYb38YsHUS6JcM7yQ6sLQ9KuZ35ck7LYCKE7kYFHOO59ayFOY3zobWVZxf4KXhYHcHYFA==
 
 "@types/node@10.17.13":
   version "10.17.13"


### PR DESCRIPTION
**_Why_**
Integration from core #8535 broke Fast Refresh functionality on Windows.

**_What_**
Break came from change in HMRClient.js in https://github.com/facebook/react-native/commit/f085e09be5a148065d286ba3950324dc9e44b7f6. Default value used for Metro scheme was changed to 'http' from 'ws'. Updated Windows HMRClient instance which relied on default 'ws' scheme value. Fast Refresh functionality restored. 

Fixes #8608 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8635)