### PR TITLE
[0.66] Restore Fast Refresh Functionality

### DIFF
--- a/change/react-native-windows-83a35785-ab50-466c-80bd-5e9937041fe5.json
+++ b/change/react-native-windows-83a35785-ab50-466c-80bd-5e9937041fe5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Restore Fast Refresh",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -491,7 +491,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
         if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
           folly::dynamic params = folly::dynamic::array(
-              STRING(RN_PLATFORM), DebugBundlePath(), SourceBundleHost(), SourceBundlePort(), m_isFastReloadEnabled);
+              STRING(RN_PLATFORM), DebugBundlePath(), SourceBundleHost(), SourceBundlePort(), m_isFastReloadEnabled, "ws");
           m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
         }
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -491,7 +491,12 @@ void ReactInstanceWin::Initialize() noexcept {
 
         if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
           folly::dynamic params = folly::dynamic::array(
-              STRING(RN_PLATFORM), DebugBundlePath(), SourceBundleHost(), SourceBundlePort(), m_isFastReloadEnabled, "ws");
+              STRING(RN_PLATFORM),
+              DebugBundlePath(),
+              SourceBundleHost(),
+              SourceBundlePort(),
+              m_isFastReloadEnabled,
+              "ws");
           m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
         }
 


### PR DESCRIPTION
**_Why_**
Integration from core #8535 broke Fast Refresh functionality on Windows.

**_What_**
Break came from change in HMRClient.js in facebook/react-native@f085e09. Default value used for Metro scheme was changed to 'http' from 'ws'. Updated Windows HMRClient instance which relied on default 'ws' scheme value. Fast Refresh functionality restored.

Backport #8635 to 0.66

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8636)