### PR TITLE
fix(config): respect project config overrides

### DIFF
--- a/change/@react-native-windows-cli-b86f41c2-24ad-4327-8623-a12fc8499066.json
+++ b/change/@react-native-windows-cli-b86f41c2-24ad-4327-8623-a12fc8499066.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(config): respect project config overrides",
+  "packageName": "@react-native-windows/cli",
+  "email": "ali-hk@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -216,12 +216,15 @@ export function projectConfigWindows(
     result.project.projectFile = path.relative(sourceDir, projectFile);
 
     // Add missing (auto) items
-    result.project.projectName = configUtils.getProjectName(
-      projectFile,
-      projectContents,
-    );
-    result.project.projectLang = configUtils.getProjectLanguage(projectFile);
-    result.project.projectGuid = configUtils.getProjectGuid(projectContents);
+    result.project.projectName =
+      userConfig?.project?.projectName ??
+      configUtils.getProjectName(projectFile, projectContents);
+    result.project.projectLang =
+      userConfig?.project?.projectLang ??
+      configUtils.getProjectLanguage(projectFile);
+    result.project.projectGuid =
+      userConfig?.project?.projectGuid ??
+      configUtils.getProjectGuid(projectContents);
 
     // Since we moved the UseExperimentalNuget property from the project to the
     // ExperimentalFeatures.props file, we should should double-check the project file


### PR DESCRIPTION
values for `projectName`, `projectLang` and `projectGuid` that are
specified in the `windows` config block in `react-native.config.js`
are currently ignored.

if users have specified these values, respect the overrides and
always use them instead of determining them from the project file.
