### PR TITLE
fix(deploy): broken projectName override for deployToDevice

### DIFF
--- a/change/@react-native-windows-cli-cd23fb1b-e116-44b4-a453-217abeecdedd.json
+++ b/change/@react-native-windows-cli-cd23fb1b-e116-44b4-a453-217abeecdedd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix(deploy): broken projectName override for deployToDevice",
+  "packageName": "@react-native-windows/cli",
+  "email": "ali-hk@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -332,7 +332,7 @@ async function runWindowsInternal(
     try {
       runWindowsPhase = 'Deploy';
       if (options.device || options.emulator || options.target) {
-        await deploy.deployToDevice(options, verbose);
+        await deploy.deployToDevice(options, verbose, config);
       } else {
         await deploy.deployToDesktop(options, verbose, config, buildTools);
       }

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -165,8 +165,11 @@ function parseAppxManifest(appxManifestPath: string): parse.Document {
   return parse(fs.readFileSync(appxManifestPath, 'utf8'));
 }
 
-function getAppxManifest(options: RunWindowsOptions): parse.Document {
-  return parseAppxManifest(getAppxManifestPath(options, undefined));
+function getAppxManifest(
+  options: RunWindowsOptions,
+  projectName?: string,
+): parse.Document {
+  return parseAppxManifest(getAppxManifestPath(options, projectName));
 }
 
 function handleResponseError(e: Error): never {
@@ -187,7 +190,14 @@ function handleResponseError(e: Error): never {
 export async function deployToDevice(
   options: RunWindowsOptions,
   verbose: boolean,
+  config: Config,
 ) {
+  const windowsConfig: Partial<WindowsProjectConfig> | undefined =
+    config.project.windows;
+  const projectName =
+    windowsConfig && windowsConfig.project && windowsConfig.project.projectName
+      ? windowsConfig.project.projectName
+      : path.parse(options.proj!).name;
   const appPackageFolder = getAppPackage(options);
 
   const deployTarget = options.target
@@ -196,7 +206,7 @@ export async function deployToDevice(
     ? 'emulator'
     : 'device';
   const deployTool = new WinAppDeployTool();
-  const appxManifest = getAppxManifest(options);
+  const appxManifest = getAppxManifest(options, projectName);
   const shouldLaunch = shouldLaunchApp(options);
   const identity = appxManifest.root.children.filter(x => {
     return x.name === 'mp:PhoneIdentity';


### PR DESCRIPTION
when `projectName` is specified in the `windows` config block and
more than one `AppxManifest.xml` is found, `projectName` should be
used to disambiguate as intended. this works when called from
`deployToDesktop`, but `deployToDevice` does not currently pass the
overridden `projectName` to `getAppxManifestPath`.

add a `projectName` parameter to `getAppxManifest` and modify
`getAppxManifest` to pass the argument along to
`getAppxManifestPath` instead of `undefined`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8638)