### PR TITLE
[RNTester] Fix tabIndex Example

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
@@ -22,7 +22,11 @@ class TabStopExample extends React.Component {
     return (
       <View>
         <Text>No tab index, this item will be tabbed to last</Text>
-        <TouchableHighlight style={itemStyle}>
+        <TouchableHighlight
+          style={itemStyle}
+          onPress={() => {
+            //onPress, even if empty, is required for TouchableWithoutFeedback to be focusable
+          }}>
           <Text>tabIndex default</Text>
         </TouchableHighlight>
 
@@ -35,13 +39,28 @@ class TabStopExample extends React.Component {
             flexDirection: 'row',
             justifyContent: 'space-between',
           }}>
-          <TouchableHighlight style={itemStyle} {...{tabIndex: 1}}>
+          <TouchableHighlight
+            style={itemStyle}
+            {...{tabIndex: 1}}
+            onPress={() => {
+              //onPress, even if empty, is required for Touchable components to be focusable
+            }}>
             <Text>tabIndex 1</Text>
           </TouchableHighlight>
-          <TouchableHighlight style={itemStyle} {...{tabIndex: 3}}>
+          <TouchableHighlight
+            style={itemStyle}
+            {...{tabIndex: 3}}
+            onPress={() => {
+              //onPress, even if empty, is required for Touchable components to be focusable
+            }}>
             <Text>tabIndex 3</Text>
           </TouchableHighlight>
-          <TouchableHighlight style={itemStyle} {...{tabIndex: 2}}>
+          <TouchableHighlight
+            style={itemStyle}
+            {...{tabIndex: 2}}
+            onPress={() => {
+              //onPress, even if empty, is required for Touchable components to be focusable
+            }}>
             <Text>tabIndex 2</Text>
           </TouchableHighlight>
         </View>

--- a/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Keyboard/KeyboardExample.tsx
@@ -24,6 +24,9 @@ class TabStopExample extends React.Component {
         <Text>No tab index, this item will be tabbed to last</Text>
         <TouchableHighlight
           style={itemStyle}
+          {...{
+            focusable: true,
+          }}
           onPress={() => {
             //onPress, even if empty, is required for TouchableWithoutFeedback to be focusable
           }}>
@@ -41,25 +44,34 @@ class TabStopExample extends React.Component {
           }}>
           <TouchableHighlight
             style={itemStyle}
-            {...{tabIndex: 1}}
             onPress={() => {
               //onPress, even if empty, is required for Touchable components to be focusable
+            }}
+            {...{
+              focusable: true,
+              tabIndex: 1,
             }}>
             <Text>tabIndex 1</Text>
           </TouchableHighlight>
           <TouchableHighlight
             style={itemStyle}
-            {...{tabIndex: 3}}
             onPress={() => {
               //onPress, even if empty, is required for Touchable components to be focusable
+            }}
+            {...{
+              focusable: true,
+              tabIndex: 3,
             }}>
             <Text>tabIndex 3</Text>
           </TouchableHighlight>
           <TouchableHighlight
             style={itemStyle}
-            {...{tabIndex: 2}}
             onPress={() => {
               //onPress, even if empty, is required for Touchable components to be focusable
+            }}
+            {...{
+              focusable: true,
+              tabIndex: 2,
             }}>
             <Text>tabIndex 2</Text>
           </TouchableHighlight>


### PR DESCRIPTION
In order to test `tabIndex`, a component must be focusable. In the keyboarding example page we use TouchableHighlight in the tabIndex example, this adds an onPress() function to those components to make them focusable and make the example functional. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8644)