### PR TITLE
Fix TextViewManager from a PR conflict

### DIFF
--- a/change/react-native-windows-671c670f-d58d-436a-877e-0a6e3107b87e.json
+++ b/change/react-native-windows-671c670f-d58d-436a-877e-0a6e3107b87e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "\"add missing include due to pr conflict\"",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -11,6 +11,8 @@
 #include <Views/Text/TextVisitors.h>
 #include <Views/VirtualTextViewManager.h>
 
+#include <UI.Xaml.Automation.Peers.h>
+#include <UI.Xaml.Automation.h>
 #include <UI.Xaml.Controls.h>
 #include <UI.Xaml.Documents.h>
 #include <Utils/PropertyUtils.h>


### PR DESCRIPTION
Fixing a break in TextViewManager from a PR conflict:
-  PR checks for https://github.com/microsoft/react-native-windows/pull/8454 were run before https://github.com/microsoft/react-native-windows/pull/8516 was merged in & both made changed to the same file. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8647)