### PR TITLE
Fix Bug in Native Animation Interpolation Clamping

### DIFF
--- a/change/react-native-windows-6e731943-941d-4e37-8582-1a0d32e94184.json
+++ b/change/react-native-windows-6e731943-941d-4e37-8582-1a0d32e94184.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Bug in Animation Clamping",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -138,9 +138,10 @@ winrt::hstring InterpolationAnimatedNode::GetLeftExpression(
     const winrt::hstring &value,
     const winrt::hstring &leftInterpolateExpression) {
   const auto firstInput = s_inputName.data() + std::to_wstring(0);
+  const auto firstOutput = s_outputName.data() + std::to_wstring(0);
   switch (ExtrapolationTypeFromString(m_extrapolateLeft)) {
     case ExtrapolationType::Clamp:
-      return value + L" < " + firstInput + L" ? " + firstInput + L" : ";
+      return value + L" < " + firstInput + L" ? " + firstOutput + L" : ";
     case ExtrapolationType::Identity:
       return value + L" < " + firstInput + L" ? " + value + L" : ";
     case ExtrapolationType::Extend:
@@ -154,9 +155,10 @@ winrt::hstring InterpolationAnimatedNode::GetRightExpression(
     const winrt::hstring &value,
     const winrt::hstring &rightInterpolateExpression) {
   const auto lastInput = s_inputName.data() + std::to_wstring(m_inputRanges.size() - 1);
+  const auto lastOutput = s_outputName.data() + std::to_wstring(m_outputRanges.size() - 1);
   switch (ExtrapolationTypeFromString(m_extrapolateRight)) {
     case ExtrapolationType::Clamp:
-      return value + L" > " + lastInput + L" ? " + lastInput + L" : ";
+      return value + L" > " + lastInput + L" ? " + lastOutput + L" : ";
     case ExtrapolationType::Identity:
       return value + L" > " + lastInput + L" ? " + value + L" : ";
     case ExtrapolationType::Extend:


### PR DESCRIPTION
**_Why_**
When a native animation is rendered which uses interpolation with clamping, the animation has buggy visual behavior. Animation does not perform as expected.

**_What_**
Clamping logic incorrect. Sets clamped value to input range instead of output range for left and right extrapolation. Edited clamping logic to correct behavior. 

Fixes #7214

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8655)