### PR TITLE
Update JSIEngineOverride doc_string

### DIFF
--- a/change/react-native-windows-49aea85f-c897-49b0-83d2-ef8204b4c65f.json
+++ b/change/react-native-windows-49aea85f-c897-49b0-83d2-ef8204b4c65f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update JSIEngineOverride documentation to clarify that the setting is ignored while the web debugger is being used, since the browser responsible for debugging must use its own engine to debug correctly.",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -218,7 +218,7 @@ namespace Microsoft.ReactNative
     DOC_STRING(
       "The @JSIEngine override to be used with the React instance.\n"
       "In order for the override to work, Microsoft.ReactNative must be compiled with support of that engine. "
-      "This override will be ignored when @UseWebDebugger is set to true, since the browser must use its own "
+      "This override will be ignored when @.UseWebDebugger is set to true, since the browser must use its own "
       "engine to debug correctly.")
     DOC_DEFAULT("JSIEngine.Chakra")
     JSIEngine JSIEngineOverride { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -217,7 +217,9 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "The @JSIEngine override to be used with the React instance.\n"
-      "In order the override to work the Microsoft.ReactNative must be compiled with support of that engine.")
+      "In order for the override to work, Microsoft.ReactNative must be compiled with support of that engine. "
+      "This override will be ignored when @UseWebDebugger is set to true, since the browser must use its own "
+      "engine to debug correctly.")
     DOC_DEFAULT("JSIEngine.Chakra")
     JSIEngine JSIEngineOverride { get; set; };
 


### PR DESCRIPTION
Fix minor grammar error.
Clarify that JSIEngineOverride will be ignored while the web debugger is being used, since the browser responsible for debugging must use its own engine to debug correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8656)