### PR TITLE
Enable codesigning in main, enable symbol packages for everyone

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -13,10 +13,6 @@ parameters:
   displayName: Skip Deploying Bots to Azure Functions
   type: boolean
   default: false
-- name: skipStableCodesign
-  displayName: Skip Codesigning for Stable Branch
-  type: boolean
-  default: false
 - name: stopOnNoCI
   displayName: Stop if latest commit is ***NO_CI***
   type: boolean
@@ -327,9 +323,8 @@ jobs:
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
           packMicrosoftReactNativeProjectReunion: true
-          ${{ if or(eq(variables['EnableCodesign'], 'true'), and(endsWith(variables['Build.SourceBranchName'], '-stable'), not(parameters.skipStableCodesign))) }}: # Sign on stable release builds
+          ${{ if or(eq(variables['EnableCodesign'], 'true'), eq(variables['Build.SourceBranchName'], 'main'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign, or on main, *-stable release builds
             signMicrosoft: true
-          ${{ if eq(variables['Build.SourceBranchName'], 'main') }}: # Enable symbol packages on main builds
             createSymbolPackages: true
 
       - task: PublishPipelineArtifact@1


### PR DESCRIPTION
This PR changes the publish pipeline to start codesigning daily main
release builds, so they can start to be published to Nuget.org. This
PR also enables symbol packages for all release builds.

This is a continuation of the work started in PR #8626 for issue #6011.

This also sets the groundwork to be able to resolve issue #8529.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8658)