### PR TITLE
Add REACT_GET_CONSTANTS to turbo module

### DIFF
--- a/change/react-native-windows-e5514276-02c7-4ebb-bece-2744e53be34b.json
+++ b/change/react-native-windows-e5514276-02c7-4ebb-bece-2744e53be34b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add REACT_GET_CONSTANTS to turbo module",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -10,6 +10,22 @@
 
 namespace ReactNativeTests {
 
+REACT_STRUCT(SimpleNativeModuleConstants1)
+struct SimpleNativeModuleConstants1 {
+  REACT_FIELD(const71)
+  Point const71;
+  REACT_FIELD(const72)
+  std::string const72;
+};
+
+REACT_STRUCT(SimpleNativeModuleConstants2)
+struct SimpleNativeModuleConstants2 {
+  REACT_FIELD(const81)
+  Point const81;
+  REACT_FIELD(const82)
+  std::string const82;
+};
+
 REACT_MODULE(SimpleNativeModule)
 struct SimpleNativeModule {
   REACT_INIT(Initialize)
@@ -581,6 +597,24 @@ struct SimpleNativeModule {
   static void Constant6(React::ReactConstantProvider &provider) noexcept {
     provider.Add(L"const61", Point{/*X =*/15, /*Y =*/17});
     provider.Add(L"const62", "MyConstant62");
+  }
+
+  REACT_GET_CONSTANTS(Constant7)
+  SimpleNativeModuleConstants1 Constant7() noexcept {
+    SimpleNativeModuleConstants1 x;
+    x.const71.X = 710;
+    x.const71.Y = 711;
+    x.const72 = "MyConstant72";
+    return x;
+  }
+
+  REACT_GET_CONSTANTS(Constant8)
+  static SimpleNativeModuleConstants2 Constant8() noexcept {
+    SimpleNativeModuleConstants2 x;
+    x.const81.X = 810;
+    x.const81.Y = 811;
+    x.const82 = "MyConstant82";
+    return x;
   }
 
   // Allows to emit native module events
@@ -1471,6 +1505,12 @@ TEST_CLASS (NativeModuleTest) {
     TestCheck(constants["const61"]["X"] == 15);
     TestCheck(constants["const61"]["Y"] == 17);
     TestCheck(constants["const62"] == "MyConstant62");
+    TestCheck(constants["const71"]["X"] == 710);
+    TestCheck(constants["const71"]["Y"] == 711);
+    TestCheck(constants["const72"] == "MyConstant72");
+    TestCheck(constants["const81"]["X"] == 810);
+    TestCheck(constants["const81"]["Y"] == 811);
+    TestCheck(constants["const82"] == "MyConstant82");
   }
 
   TEST_METHOD(TestEvent_IntEventField) {

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -601,20 +601,20 @@ struct SimpleNativeModule {
 
   REACT_GET_CONSTANTS(Constant7)
   SimpleNativeModuleConstants1 Constant7() noexcept {
-    SimpleNativeModuleConstants1 x;
-    x.const71.X = 710;
-    x.const71.Y = 711;
-    x.const72 = "MyConstant72";
-    return x;
+    SimpleNativeModuleConstants1 constants{};
+    constants.const71.X = 710;
+    constants.const71.Y = 711;
+    constants.const72 = "MyConstant72";
+    return constants;
   }
 
   REACT_GET_CONSTANTS(Constant8)
   static SimpleNativeModuleConstants2 Constant8() noexcept {
-    SimpleNativeModuleConstants2 x;
-    x.const81.X = 810;
-    x.const81.Y = 811;
-    x.const82 = "MyConstant82";
-    return x;
+    SimpleNativeModuleConstants2 constants{};
+    constants.const81.X = 810;
+    constants.const81.Y = 811;
+    constants.const82 = "MyConstant82";
+    return constants;
   }
 
   // Allows to emit native module events

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -601,20 +601,20 @@ struct MyTurboModule {
 
   REACT_GET_CONSTANTS(Constant7)
   MyTurboModuleConstants1 Constant7() noexcept {
-    MyTurboModuleConstants1 x;
-    x.const71.X = 710;
-    x.const71.Y = 711;
-    x.const72 = "MyConstant72";
-    return x;
+    MyTurboModuleConstants1 constants{};
+    constants.const71.X = 710;
+    constants.const71.Y = 711;
+    constants.const72 = "MyConstant72";
+    return constants;
   }
 
   REACT_GET_CONSTANTS(Constant8)
   static MyTurboModuleConstants2 Constant8() noexcept {
-    MyTurboModuleConstants2 x;
-    x.const81.X = 810;
-    x.const81.Y = 811;
-    x.const82 = "MyConstant82";
-    return x;
+    MyTurboModuleConstants2 constants{};
+    constants.const81.X = 810;
+    constants.const81.Y = 811;
+    constants.const82 = "MyConstant82";
+    return constants;
   }
 
   // Allows to emit native module events

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -9,6 +9,23 @@
 #include "future/futureWait.h"
 
 namespace ReactNativeTests {
+
+REACT_STRUCT(MyTurboModuleConstants1)
+struct MyTurboModuleConstants1 {
+  REACT_FIELD(const71)
+  Point const71;
+  REACT_FIELD(const72)
+  std::string const72;
+};
+
+REACT_STRUCT(MyTurboModuleConstants2)
+struct MyTurboModuleConstants2 {
+  REACT_FIELD(const81)
+  Point const81;
+  REACT_FIELD(const82)
+  std::string const82;
+};
+
 REACT_MODULE(MyTurboModule)
 struct MyTurboModule {
   REACT_INIT(Initialize)
@@ -580,6 +597,24 @@ struct MyTurboModule {
   static void Constant6(React::ReactConstantProvider &provider) noexcept {
     provider.Add(L"const61", Point{/*X =*/15, /*Y =*/17});
     provider.Add(L"const62", "MyConstant62");
+  }
+
+  REACT_GET_CONSTANTS(Constant7)
+  MyTurboModuleConstants1 Constant7() noexcept {
+    MyTurboModuleConstants1 x;
+    x.const71.X = 710;
+    x.const71.Y = 711;
+    x.const72 = "MyConstant72";
+    return x;
+  }
+
+  REACT_GET_CONSTANTS(Constant8)
+  static MyTurboModuleConstants2 Constant8() noexcept {
+    MyTurboModuleConstants2 x;
+    x.const81.X = 810;
+    x.const81.Y = 811;
+    x.const82 = "MyConstant82";
+    return x;
   }
 
   // Allows to emit native module events
@@ -2066,6 +2101,12 @@ TEST_CLASS (TurboModuleTest) {
     TestCheck(constants["const61"]["X"] == 15);
     TestCheck(constants["const61"]["Y"] == 17);
     TestCheck(constants["const62"] == "MyConstant62");
+    TestCheck(constants["const71"]["X"] == 710);
+    TestCheck(constants["const71"]["Y"] == 711);
+    TestCheck(constants["const72"] == "MyConstant72");
+    TestCheck(constants["const81"]["X"] == 810);
+    TestCheck(constants["const81"]["Y"] == 811);
+    TestCheck(constants["const82"] == "MyConstant82");
   }
 
   TEST_METHOD(TestEvent_IntEventField) {

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -768,7 +768,7 @@ struct ModuleConstantInfo<TStruct (*)() noexcept> {
 
   static ConstantProviderDelegate GetConstantProvider(void * /*module*/, MethodType method) noexcept {
     return [method](IJSValueWriter const &argWriter) mutable noexcept {
-      auto constants = (method *)();
+      auto constants = (*method)();
       WriteProperties(argWriter, constants);
     };
   }

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -75,6 +75,16 @@
 // It can be an instance or static method.
 #define REACT_CONSTANT_PROVIDER(method) INTERNAL_REACT_MEMBER_2_ARGS(ConstantMethod, method)
 
+// REACT_GET_CONSTANTS(method)
+// Arguments:
+// - method (required) - the method name the macro is attached to.
+//
+// REACT_GET_CONSTANTS annotates a method that defines constants.
+// It must have no parameter.
+// It must return a REACT_STRUCT decorated struct, fields become constants.
+// It can be an instance or static method.
+#define REACT_GET_CONSTANTS(method) INTERNAL_REACT_MEMBER_2_ARGS(ConstantStrongTypedMethod, method)
+
 // REACT_CONSTANT(field, [opt] constantName)
 // Arguments:
 // - field (required) - the field name the macro is attached to.
@@ -739,6 +749,31 @@ struct ModuleConstantInfo<void (*)(ReactConstantProvider &) noexcept> {
   }
 };
 
+template <class TModule, class TStruct>
+struct ModuleConstantInfo<TStruct (TModule::*)() noexcept> {
+  using ModuleType = TModule;
+  using MethodType = TStruct (TModule::*)() noexcept;
+
+  static ConstantProviderDelegate GetConstantProvider(void *module, MethodType method) noexcept {
+    return [module = static_cast<ModuleType *>(module), method](IJSValueWriter const &argWriter) mutable noexcept {
+      auto constants = (module->*method)();
+      WriteProperties(argWriter, constants);
+    };
+  }
+};
+
+template <class TStruct>
+struct ModuleConstantInfo<TStruct (*)() noexcept> {
+  using MethodType = TStruct (*)() noexcept;
+
+  static ConstantProviderDelegate GetConstantProvider(void * /*module*/, MethodType method) noexcept {
+    return [method](IJSValueWriter const &argWriter) mutable noexcept {
+      auto constants = (method *)();
+      WriteProperties(argWriter, constants);
+    };
+  }
+};
+
 template <class TField>
 struct ModuleEventFieldInfo;
 
@@ -829,6 +864,7 @@ enum class ReactMemberKind {
   AsyncMethod,
   SyncMethod,
   ConstantMethod,
+  ConstantStrongTypedMethod,
   ConstantField,
   EventField,
   FunctionField,
@@ -847,6 +883,7 @@ using ReactInitMethodAttribute = ReactMemberAttribute<ReactMemberKind::InitMetho
 using ReactAsyncMethodAttribute = ReactMemberAttribute<ReactMemberKind::AsyncMethod>;
 using ReactSyncMethodAttribute = ReactMemberAttribute<ReactMemberKind::SyncMethod>;
 using ReactConstantMethodAttribute = ReactMemberAttribute<ReactMemberKind::ConstantMethod>;
+using ReactConstantStrongTypedMethodAttribute = ReactMemberAttribute<ReactMemberKind::ConstantStrongTypedMethod>;
 using ReactConstantFieldAttribute = ReactMemberAttribute<ReactMemberKind::ConstantField>;
 using ReactEventFieldAttribute = ReactMemberAttribute<ReactMemberKind::EventField>;
 using ReactFunctionFieldAttribute = ReactMemberAttribute<ReactMemberKind::FunctionField>;
@@ -893,6 +930,8 @@ struct ReactModuleBuilder {
       RegisterSyncMethod(member, attributeInfo.JSMemberName);
     } else if constexpr (std::is_same_v<TAttribute, ReactConstantMethodAttribute>) {
       RegisterConstantMethod(member);
+    } else if constexpr (std::is_same_v<TAttribute, ReactConstantStrongTypedMethodAttribute>) {
+      RegisterConstantStrongTypedMethod(member);
     } else if constexpr (std::is_same_v<TAttribute, ReactConstantFieldAttribute>) {
       RegisterConstantField(member, attributeInfo.JSMemberName);
     } else if constexpr (std::is_same_v<TAttribute, ReactEventFieldAttribute>) {
@@ -923,6 +962,12 @@ struct ReactModuleBuilder {
 
   template <class TMethod>
   void RegisterConstantMethod(TMethod method) noexcept {
+    auto constantProvider = ModuleConstantInfo<TMethod>::GetConstantProvider(m_module, method);
+    m_moduleBuilder.AddConstantProvider(constantProvider);
+  }
+
+  template <class TMethod>
+  void RegisterConstantStrongTypedMethod(TMethod method) noexcept {
     auto constantProvider = ModuleConstantInfo<TMethod>::GetConstantProvider(m_module, method);
     m_moduleBuilder.AddConstantProvider(constantProvider);
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -15,6 +15,14 @@ namespace ReactNativeIntegrationTests {
 
 namespace {
 
+REACT_STRUCT(SampleTurboModuleConstants)
+struct SampleTurboModuleConstants {
+  REACT_FIELD(constantString3)
+  std::string constantString3;
+  REACT_FIELD(constantInt3)
+  int constantInt3;
+};
+
 REACT_MODULE(SampleTurboModule)
 struct SampleTurboModule {
   REACT_INIT(Initialize)
@@ -30,6 +38,14 @@ struct SampleTurboModule {
   void GetConstants(React::ReactConstantProvider &provider) noexcept {
     provider.Add(L"constantString2", L"Hello");
     provider.Add(L"constantInt2", 10);
+  }
+
+  REACT_GET_CONSTANTS(GetConstants2)
+  SampleTurboModuleConstants GetConstants2() noexcept {
+    SampleTurboModuleConstants x;
+    x.constantString3 = "strong-typed-constants!";
+    x.constantInt3 = 20;
+    return x;
   }
 
   REACT_METHOD(Succeeded, L"succeeded")
@@ -71,8 +87,9 @@ struct SampleTurboModule {
   }
 
   REACT_METHOD(Constants, L"constants")
-  void Constants(std::string a, int b, std::string c, int d) noexcept {
-    auto resultString = (std::stringstream() << a << ", " << b << ", " << c << ", " << d).str();
+  void Constants(std::string a, int b, std::string c, int d, std::string e, int f) noexcept {
+    auto resultString =
+        (std::stringstream() << a << ", " << b << ", " << c << ", " << d << ", " << e << ", " << f).str();
     TestEventService::LogEvent("constantsSignal", std::move(resultString));
   }
 
@@ -119,7 +136,7 @@ struct SampleTurboModuleSpec : TurboModuleSpec {
       Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
       SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
       Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
-      Method<void(std::string, int, std::string, int) noexcept>{6, L"constants"},
+      Method<void(std::string, int, std::string, int, std::string, int) noexcept>{6, L"constants"},
       Method<void(int, int, const std::function<void(int)> &) noexcept>{7, L"oneCallback"},
       Method<void(int) noexcept>{8, L"oneCallbackResult"},
       Method<void(
@@ -175,7 +192,7 @@ TEST_CLASS (TurboModuleTests) {
         TestEvent{"twoCallbacksResolvedSignal", 123},
         TestEvent{"twoCallbacksResolvedSignal", "Failed"},
         TestEvent{"syncFunctionSignal", "something, 2, false"},
-        TestEvent{"constantsSignal", "constantString, 3, Hello, 10"},
+        TestEvent{"constantsSignal", "constantString, 3, Hello, 10, strong-typed-constants!, 20"},
         TestEvent{"succeededSignal", true},
     });
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -44,7 +44,9 @@ try {
       c.constantString,
       c.constantInt,
       c.constantString2,
-      c.constantInt2
+      c.constantInt2,
+      c.constantString3,
+      c.constantInt3
     );
 
   sampleTurboModule


### PR DESCRIPTION
- Add REACT_GET_CONSTANTS to turbo module
  - It requires a function returning a `REACT_STRUCT` decorated struct, fields become constants
- Update Microsoft.ReactNative.CxxUnitTests
- Update Microsoft.ReactNative.IntegrationTests
- **Type checking not included in this PR**

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8660)