### PR TITLE
Disable broken x64 debug build of ComponentTest

### DIFF
--- a/change/react-native-windows-8490e8f1-dbb7-4010-8f94-062a27aa2994.json
+++ b/change/react-native-windows-8490e8f1-dbb7-4010-8f94-062a27aa2994.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable broken x64 debug build of ComponentTestt",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.sln
+++ b/vnext/Microsoft.ReactNative.sln
@@ -133,12 +133,12 @@ Global
 		Shared\Shared.vcxitems*{f7d32bd0-2749-483e-9a0d-1635ef7e3136}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Debug|ARM64 = Debug|ARM64
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-		Release|ARM64 = Release|ARM64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F7D32BD0-2749-483E-9A0D-1635EF7E3136}.Debug|ARM64.ActiveCfg = Debug|ARM64
@@ -203,7 +203,6 @@ Global
 		{6C60E295-C8CA-4DC5-B8BE-09888F58B249}.Release|x86.Build.0 = Release|Win32
 		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Debug|ARM64.ActiveCfg = Debug|Win32
 		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Debug|x64.ActiveCfg = Debug|x64
-		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Debug|x64.Build.0 = Debug|x64
 		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Debug|x86.ActiveCfg = Debug|Win32
 		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Release|ARM64.ActiveCfg = Release|Win32
 		{93792779-4948-4A5D-8CA7-86ED5E3BEC27}.Release|x64.ActiveCfg = Release|x64


### PR DESCRIPTION
ComponentTest doesn't build in any flavor, see #8673.

It _was_ building for x64 debug until recent changes caused a new build
break that _only_ gets hit in publish (the only place we build x64
debug).

This PR disables the project all up to unblock publish until we can
decide what to do with the project.

Closes #8671

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8674)