### PR TITLE
[0.63] Fix ARM64 layout issues in Office

### DIFF
--- a/change/react-native-windows-2021-09-21-14-02-03-fix-arm64-layout.json
+++ b/change/react-native-windows-2021-09-21-14-02-03-fix-arm64-layout.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Change the definitino of YGUndefined from NAN (contra the comment in YGValue, MSVC does define NAN) to __builtin_nanf(\"0\"), which generates a quiet NaN. The problem with NAN is that corecrt_math.h defines it as:",
+  "packageName": "react-native-windows",
+  "email": "hpratt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-21T21:02:03.830Z"
+}

--- a/vnext/DeforkingPatches/ReactCommon/yoga/yoga/YGValue.h
+++ b/vnext/DeforkingPatches/ReactCommon/yoga/yoga/YGValue.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <math.h>
+#include "YGEnums.h"
+#include "YGMacros.h"
+
+#if defined(_MSC_VER) && defined(__clang__)
+#define COMPILING_WITH_CLANG_ON_WINDOWS
+#endif
+#if defined(COMPILING_WITH_CLANG_ON_WINDOWS)
+#include <limits>
+constexpr float YGUndefined = std::numeric_limits<float>::quiet_NaN();
+#else
+YG_EXTERN_C_BEGIN
+
+#if defined(_MSC_VER)
+#define YGUndefined __builtin_nanf("0")
+#else
+#define YGUndefined NAN
+#endif
+
+#endif
+
+typedef struct YGValue {
+  float value;
+  YGUnit unit;
+} YGValue;
+
+YOGA_EXPORT extern const YGValue YGValueAuto;
+YOGA_EXPORT extern const YGValue YGValueUndefined;
+YOGA_EXPORT extern const YGValue YGValueZero;
+
+#if !defined(COMPILING_WITH_CLANG_ON_WINDOWS)
+YG_EXTERN_C_END
+#endif
+#undef COMPILING_WITH_CLANG_ON_WINDOWS
+
+#ifdef __cplusplus
+
+inline bool operator==(const YGValue& lhs, const YGValue& rhs) {
+  if (lhs.unit != rhs.unit) {
+    return false;
+  }
+
+  switch (lhs.unit) {
+    case YGUnitUndefined:
+    case YGUnitAuto:
+      return true;
+    case YGUnitPoint:
+    case YGUnitPercent:
+      return lhs.value == rhs.value;
+  }
+
+  return false;
+}
+
+inline bool operator!=(const YGValue& lhs, const YGValue& rhs) {
+  return !(lhs == rhs);
+}
+
+inline YGValue operator-(const YGValue& value) {
+  return {-value.value, value.unit};
+}
+
+namespace facebook {
+namespace yoga {
+namespace literals {
+
+inline YGValue operator"" _pt(long double value) {
+  return YGValue{static_cast<float>(value), YGUnitPoint};
+}
+inline YGValue operator"" _pt(unsigned long long value) {
+  return operator"" _pt(static_cast<long double>(value));
+}
+
+inline YGValue operator"" _percent(long double value) {
+  return YGValue{static_cast<float>(value), YGUnitPercent};
+}
+inline YGValue operator"" _percent(unsigned long long value) {
+  return operator"" _percent(static_cast<long double>(value));
+}
+
+} // namespace literals
+} // namespace yoga
+} // namespace facebook
+
+#endif

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -38,6 +38,14 @@
     },
     {
       "type": "patch",
+      "file": "DeforkingPatches/ReactCommon/yoga/yoga/YGValue.h",
+      "baseFile": "ReactCommon/yoga/yoga/YGValue.h",
+      "baseVersion": "0.63.2",
+      "baseHash": "1beec1c755f33ebbd4ab9ec5e138cd1a3cfba3ee",
+      "issue": 8683
+    },
+    {
+      "type": "patch",
       "file": "DeforkingPatches/ReactCommon/yoga/yoga/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",
       "baseVersion": "0.63.2",


### PR DESCRIPTION
The commit message pretty much says it all - Yoga is using NAN, which happens to be defined in such a way that, if you:

1. Compile with /fp:strict (which do due to #4122; this should be fixed. I'll be making a new issue for that later today).
2. Set the rounding mode to round down

Then NAN is not a not-a-number value, but instead a plain old 0! Since YGUndefined is used for the unconstrained dimension in a flexbox layout, this goes... _very_ wrong.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8676)