### PR TITLE
Add tabIndex to Flow for Pressable

### DIFF
--- a/change/react-native-windows-98df690e-f622-4e75-b8d6-63fe47b7d80f.json
+++ b/change/react-native-windows-98df690e-f622-4e75-b8d6-63fe47b7d80f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "xyz",
+  "packageName": "react-native-windows",
+  "email": "igklemen@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -34,6 +34,7 @@ import type {
 import type {HandledKeyboardEvent} from '../../Components/View/ViewPropTypes';
 import View from '../View/View';
 import TextInputState from '../TextInput/TextInputState';
+import {number} from 'prop-types';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 
@@ -188,6 +189,8 @@ type Props = $ReadOnly<{|
    * Duration to wait after press down before calling `onPressIn`.
    */
   unstable_pressDelay?: ?number,
+
+  tabIndex?: ?number, // [Windows]
 |}>;
 
 /**


### PR DESCRIPTION
Closes #8643 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8677)