### PR TITLE
feat(deploy): allow overriding build output dir

### DIFF
--- a/change/@react-native-windows-cli-5fdfeaf8-ca16-487f-94cd-ea0612a1f048.json
+++ b/change/@react-native-windows-cli-5fdfeaf8-ca16-487f-94cd-ea0612a1f048.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "feat(deploy): allow overriding build output dir",
+  "packageName": "@react-native-windows/cli",
+  "email": "ali-hk@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@react-native-windows/cli/src/config/projectConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/projectConfig.ts
@@ -38,6 +38,7 @@ opt  - Item is optional. If an override file exists, it MAY provide it. If no ov
     projectName: string, // (auto) Name of the project, determined from projectFile, ex: 'MyApp'
     projectLang: string, // (auto) Language of the project, cpp or cs, determined from projectFile
     projectGuid: string, // (auto) Project identifier, determined from projectFile
+    projectOutputDir: string, // (auto) Project build output directory ex: 'c:\path\to\my-app\build'
   },
   experimentalFeatures: Record<String, string> // (auto) Properties extracted from ExperimentalFeatures.props
 }
@@ -64,6 +65,7 @@ export interface Project {
   projectLang: 'cpp' | 'cs' | null;
   projectGuid: string | null;
   projectTypeGuid?: string;
+  projectOutputDir?: string;
 }
 
 export interface WindowsProjectConfig {
@@ -222,6 +224,7 @@ export function projectConfigWindows(
     );
     result.project.projectLang = configUtils.getProjectLanguage(projectFile);
     result.project.projectGuid = configUtils.getProjectGuid(projectContents);
+    result.project.projectOutputDir = userConfig?.project?.projectOutputDir;
 
     // Since we moved the UseExperimentalNuget property from the project to the
     // ExperimentalFeatures.props file, we should should double-check the project file


### PR DESCRIPTION
some projects override the default build output directory by
specifying `OutDir` in their project files or imported props. as a
result the `AppxManifest.xml` and `AppPackages` directory are not
present under the default `windows` path and aren't found by the
existing glob patterns in `getAppxManifestPath` and
`getAppPackage`. this causes `react-native run-windows` to fail
to deploy the app for these projects.

add an optional `projectOutputDir` field to `WindowsProjectConfig.Project`
to allow users to explicitly provide the path to build output where
the `AppxManifest.xml` and `AppPackages` directory are placed.

ideally the `$(AppxPackageDir)` MSBuild property would be used to
determine the`AppPackages` directory and `$(OutDir)` MSBuild
property would be used to determine the path to `AppxManifest.xml`,
but these can be set in any imported props/targets file and there
is currently no way to get the effective runtime value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8684)