### PR TITLE
Update Playground Readme to Include Playground-win32

### DIFF
--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -2,43 +2,11 @@
 
 Playground is a sample standalone application that allows testing of various JS files, including RNTester.
 
-## Launching the app
-
-1. Make sure your development machine has been set up with all the system requirements and dependencies mentioned [here](https://microsoft.github.io/react-native-windows/docs/next/rnw-dependencies). Make sure a browser is launched and running.
-
-1. Install Packages with-in the repo
-
-`yarn`
-
-1. Ensure packages are built
-
-`yarn build`
-
-1. Navigate to the `playground` folder
-
-`cd packages\playground`
-
-1. Run the app
-
-`yarn windows --sln windows\Playground.sln`
-
-This command will build and deploy the application along with launching Metro bundler and the dev tools.
-
-The default configuration is x86. If it fails the build, please open `Playground.sln` in Visual Studio and build x64. If it builds, then run `yarn start` before running this app in Visual Studio.
-
 ## Using the app
 
 You can find several sample .tsx files under the `/playground/samples` folder. You can load any of these files from the drop down at the top of the app, ensure the right App/component name has been picked for the sample on the drop down against "App Name". Click `Load` to load the .tsx file to the bottom pane.
 
-You can edit the .tsx files for fast refresh.
-
 Use the UI at the top of the playground application to modify the instance settings, then hit `Load` to run the instance.
-
-## Editing the app
-
-You can access and edit the .tsx files in the `/playground/samples` folder. Fast Refresh should work as expected while editing the Typescript files.
-
-You can also launch `/playground/windows/playground.sln` solution file in Visual Studio and edit the native C++ code in the Playground Project. You will have to re-launch the app with the above steps if edits are made to the native app code.
 
 ## How to remote debug Playground
 
@@ -58,6 +26,11 @@ You can also launch `/playground/windows/playground.sln` solution file in Visual
 
 Playground-win32 is a sample of an RNW application using XAML Islands that allows testing of various JS files, including RNTester.
 
+## Using the app
+
+You can find several sample .tsx files under the `/playground/samples` folder. You can load any of these files by selecting the "File" menu, then "Open Javascript File", and then clicking on the sample you wish to open.
+
+# Launching and Editing
 ## Launching the app
 
 1. Make sure your development machine has been set up with all the system requirements and dependencies mentioned [here](https://microsoft.github.io/react-native-windows/docs/next/rnw-dependencies). Make sure a browser is launched and running.
@@ -78,7 +51,7 @@ Playground-win32 is a sample of an RNW application using XAML Islands that allow
 
 `yarn start`
 
-1. Open `windows\playground-win32.sln` in Visual Studio
+1. Open the app solution file in Visual Studio either `windows\playground.sln` or `windows\playground-win32.sln` 
 
 1. Set the build configuration to "Debug" and Platform to "x86" or "x64"
 
@@ -86,15 +59,8 @@ Playground-win32 is a sample of an RNW application using XAML Islands that allow
 
 This will build and deploy the application and the dev tools.
 
-## Using the app
-
-You can find several sample .tsx files under the `/playground/samples` folder. You can load any of these files by selecting the "File" menu, then "Open Javascript File", and then clicking on the sample you wish to open.
-
-You can edit the .tsx files for fast refresh.
-
 ## Editing the app
 
 You can access and edit the .tsx files in the `/playground/samples` folder. Fast Refresh should work as expected while editing the Typescript files.
 
-You can also launch `/playground/windows/playground-win32.sln` solution file in Visual Studio and edit the native C++ code in the Playground Project. You will have to re-launch the app with the above steps if edits are made to the native app code.
-
+You can also launch the app solution file in Visual Studio and edit the native C++ code in the Playground Project. You will have to re-launch the app with the above steps if edits are made to the native app code.

--- a/packages/playground/README.md
+++ b/packages/playground/README.md
@@ -53,3 +53,48 @@ You can also launch `/playground/windows/playground.sln` solution file in Visual
 5. F5! This will build your playground app, and deploy to the target machine.
 6. On the target, press `Load`. This will communicate back to the dev machine bundler and launch the web debugger on the dev machine, and serve the pages back to the app running in the target.
    You need an updated version of the bundler in order for remote debugging to work properly: [PR here](https://github.com/react-native-community/cli/pull/829)
+
+# Playground-win32
+
+Playground-win32 is a sample of an RNW application using XAML Islands that allows testing of various JS files, including RNTester.
+
+## Launching the app
+
+1. Make sure your development machine has been set up with all the system requirements and dependencies mentioned [here](https://microsoft.github.io/react-native-windows/docs/next/rnw-dependencies). Make sure a browser is launched and running.
+
+1. Install Packages with-in the repo
+
+`yarn`
+
+1. Ensure packages are built
+
+`yarn build`
+
+1. Navigate to the `playground` folder
+
+`cd packages\playground`
+
+1. Start Metro
+
+`yarn start`
+
+1. Open `windows\playground-win32.sln` in Visual Studio
+
+1. Set the build configuration to "Debug" and Platform to "x86" or "x64"
+
+1. Hit "Local Windows Debugger"
+
+This will build and deploy the application and the dev tools.
+
+## Using the app
+
+You can find several sample .tsx files under the `/playground/samples` folder. You can load any of these files by selecting the "File" menu, then "Open Javascript File", and then clicking on the sample you wish to open.
+
+You can edit the .tsx files for fast refresh.
+
+## Editing the app
+
+You can access and edit the .tsx files in the `/playground/samples` folder. Fast Refresh should work as expected while editing the Typescript files.
+
+You can also launch `/playground/windows/playground-win32.sln` solution file in Visual Studio and edit the native C++ code in the Playground Project. You will have to re-launch the app with the above steps if edits are made to the native app code.
+


### PR DESCRIPTION
**_Why_**
Playground Readme currently does not include mention of Playground-win32 leaving knowledge of RNW with XAML Islands sample to only be known through word of mouth. 

**_What_**
Update Readme in `./packages/playground` directory to include description of Playground-win32 and steps to build/edit the application.

Fixes #8649 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8686)