### PR TITLE
Bring back Questions list item via config.yml link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+    - name: Question
+      url: https://github.com/microsoft/react-native-windows/discussions
+      about: I have a question


### PR DESCRIPTION
This was removed in the previous change to [move to issue forms](https://github.com/microsoft/react-native-windows/pull/8639), but I found out how to add just a simple link to the list so that we can direct people to Discussions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8688)