### PR TITLE
Revert creation of symbol packages, main codesign

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -323,9 +323,8 @@ jobs:
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
           packMicrosoftReactNativeProjectReunion: true
-          ${{ if or(eq(variables['EnableCodesign'], 'true'), eq(variables['Build.SourceBranchName'], 'main'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign, or on main, *-stable release builds
+          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
             signMicrosoft: true
-            createSymbolPackages: true
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish final nuget artifacts"

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -13,7 +13,6 @@ parameters:
   packMicrosoftReactNativeManagedCodeGen: true
   packMicrosoftReactNativeProjectReunion: false
   signMicrosoft: false
-  createSymbolPackages: false
 
 steps:
   - task: DownloadPipelineArtifact@2
@@ -44,7 +43,6 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
-        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeCxx, true) }}:
     - template: prep-and-pack-single.yml
@@ -74,7 +72,6 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
-        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeManagedCodeGen, true) }}:
     - template: prep-and-pack-single.yml
@@ -85,7 +82,6 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
-        createSymbolPackages: ${{ parameters.createSymbolPackages }}
 
   - ${{ if eq(parameters.packMicrosoftReactNativeProjectReunion, true) }}:
     - template: prep-and-pack-single.yml
@@ -96,4 +92,3 @@ steps:
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=Release;baseplatform=x64
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
-        createSymbolPackages: ${{ parameters.createSymbolPackages }}

--- a/.ado/templates/prep-and-pack-single.yml
+++ b/.ado/templates/prep-and-pack-single.yml
@@ -5,7 +5,6 @@ parameters:
   buildProperties: ''
   codesignBinaries: false
   codesignNuget: false
-  createSymbolPackages: false
 
 steps:
 
@@ -63,7 +62,6 @@ steps:
       verbosityPack: 'Detailed'
       packagesToPack: $(System.DefaultWorkingDirectory)/ReactWindows/${{ parameters.packageId }}.nuspec
       packDestination: $(System.DefaultWorkingDirectory)/NugetRootFinal
-      includeSymbols: ${{ parameters.createSymbolPackages }}
       buildProperties: version=${{ parameters.packageVersion }};id=${{ parameters.packageId }};${{ parameters.buildProperties }}
 
   - ${{ if eq(parameters.codesignNuget, true) }}:
@@ -74,7 +72,6 @@ steps:
         FolderPath: $(System.DefaultWorkingDirectory)/NugetRootFinal
         Pattern: |
           **/${{ parameters.packageId }}.${{ parameters.packageVersion }}.nupkg
-          **/${{ parameters.packageId }}.${{ parameters.packageVersion }}.symbols.nupkg
         UseMinimatch: true
         signConfigType: inlineSignParams
         inlineOperation: |

--- a/change/react-native-windows-9b7711a1-087c-4e91-aa59-f72cf6689f5d.json
+++ b/change/react-native-windows-9b7711a1-087c-4e91-aa59-f72cf6689f5d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert creation of symbol packages, main codesign",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/PublishNugetPackagesLocally.cmd
+++ b/vnext/Scripts/PublishNugetPackagesLocally.cmd
@@ -94,6 +94,6 @@ exit /b 0
         copy %scriptFolder%%nuspecFile% %targetNuspec% /y
     )
     echo nuget pack %targetNuspec% -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%
-    nuget pack %targetNuspec% -OutputDirectory %targetDir%\pkgs -symbols -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%;NoWarn=NU5100
+    nuget pack %targetNuspec% -OutputDirectory %targetDir%\pkgs -properties CommitId=TestCommit;version=%version%;id=%packageId%;nugetroot=%nugetRoot%;baseconfiguration=%baseConfiguration%;baseplatform=%basePlatform%;NoWarn=NU5100
     nuget add %targetNupkg% -Source %targetDir%\feed
     goto :EOF


### PR DESCRIPTION
This PR stops the creation of symbol packages, as implemented by PRs #8626 and #8658.

Unfortunately the E2E of publishing and consuming such packages was not
viable.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8690)