### PR TITLE
Add CheckConstants<TModule, TModuleSpec> for REACT_GET_CONSTANTS

### DIFF
--- a/change/react-native-windows-00365c35-3f39-4262-9631-ae26ee94631b.json
+++ b/change/react-native-windows-00365c35-3f39-4262-9631-ae26ee94631b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add CheckConstants<TModule, TModuleSpec> for REACT_GET_CONSTANTS",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -756,10 +756,24 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       SyncMethod<int(int) noexcept>{67, L"StaticNegateSync"},
       SyncMethod<std::string() noexcept>{68, L"StaticSayHelloSync"},
   };
+  static constexpr auto constants = std::tuple{
+      TypedConstant<MyTurboModuleConstants1>{},
+      TypedConstant<MyTurboModuleConstants2>{},
+  };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
     constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
+    constexpr auto constantCheckResults = CheckConstants<TModule, MyTurboModuleSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+        0,
+        "    REACT_GET_CONSTANTS(GetConstants1) MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n"
+        "    REACT_GET_CONSTANTS(GetConstants1) static MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n");
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+        1,
+        "    REACT_GET_CONSTANTS(GetConstants2) MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n"
+        "    REACT_GET_CONSTANTS(GetConstants2) static MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
         0,

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -768,10 +768,12 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
     REACT_SHOW_CONSTANT_SPEC_ERRORS(
         0,
+        "MyTurboModuleConstants1",
         "    REACT_GET_CONSTANTS(GetConstants1) MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n"
         "    REACT_GET_CONSTANTS(GetConstants1) static MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n");
     REACT_SHOW_CONSTANT_SPEC_ERRORS(
         1,
+        "MyTurboModuleConstants2",
         "    REACT_GET_CONSTANTS(GetConstants2) MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n"
         "    REACT_GET_CONSTANTS(GetConstants2) static MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n");
 

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -681,6 +681,10 @@ struct MyTurboModule {
 // - method names are matching to the module spec method names;
 // - method signatures match the spec method signatures.
 struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<MyTurboModuleConstants1>{0},
+      TypedConstant<MyTurboModuleConstants2>{1},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(int, int, Callback<int>) noexcept>{0, L"Add"},
       Method<void(int, Callback<int>) noexcept>{1, L"Negate"},
@@ -756,15 +760,11 @@ struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       SyncMethod<int(int) noexcept>{67, L"StaticNegateSync"},
       SyncMethod<std::string() noexcept>{68, L"StaticSayHelloSync"},
   };
-  static constexpr auto constants = std::tuple{
-      TypedConstant<MyTurboModuleConstants1>{},
-      TypedConstant<MyTurboModuleConstants2>{},
-  };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
     constexpr auto constantCheckResults = CheckConstants<TModule, MyTurboModuleSpec>();
+    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
 
     REACT_SHOW_CONSTANT_SPEC_ERRORS(
         0,

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -121,6 +121,11 @@
 #define REACT_FUNCTION(/* field, [opt] functionName, [opt] moduleName */...) \
   INTERNAL_REACT_MEMBER(__VA_ARGS__)(FunctionField, __VA_ARGS__)
 
+#define REACT_SHOW_CONSTANT_SIGNATURES(signatures)  \
+  " (see details below in output).\n"               \
+  "  It must be one of the following:\n" signatures \
+  "  The C++ method name could be different, just keep the method name identical to the argument in REACT_GET_CONSTANTS\n"
+
 #define REACT_SHOW_METHOD_SIGNATURES(methodName, signatures)                      \
   " (see details below in output).\n"                                             \
   "  It must be one of the following:\n" signatures                               \
@@ -134,6 +139,15 @@
   "  The C++ method name could be different. In that case add the L\"" methodName \
   "\" to the attribute:\n"                                                        \
   "    REACT_SYNC_METHOD(method, L\"" methodName "\")\n...\n"
+
+#define REACT_SHOW_CONSTANT_SPEC_ERRORS(index, typeName, signatures)                                                  \
+  static_assert(constantCheckResults[index].IsUniqueName, "Constant type '" typeName "' used for multiple methods");  \
+  static_assert(                                                                                                      \
+      constantCheckResults[index].IsMethodFound,                                                                      \
+      "Method for constant type '" typeName "' is not defined" REACT_SHOW_METHOD_SIGNATURES(methodName, signatures)); \
+  static_assert(                                                                                                      \
+      !constantCheckResults[index].IsMethodOverloaded,                                                                \
+      "Method for constant type '" typeName "' is overloaded"
 
 #define REACT_SHOW_METHOD_SPEC_ERRORS(index, methodName, signatures)                                        \
   static_assert(methodCheckResults[index].IsUniqueName, "Name '" methodName "' used for multiple methods"); \

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -1142,7 +1142,7 @@ struct TurboModuleSpec {
     GetReactModuleInfo(static_cast<TModule *>(nullptr), verifier);
     ConstantCheckResult result;
     result.IsMethodFound = verifier.m_matchedCount > 0;
-    result.IsMethodFound = verifier.m_matchedCount < 2;
+    result.IsMethodUnique = verifier.m_matchedCount < 2;
     return result;
   }
 


### PR DESCRIPTION
When constants are required in a module, the following code could be added to the spec to enforce type checking:
```c++
struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
  static constexpr auto constants = std::tuple{
      TypedConstant<MyTurboModuleConstants1>{0},
      TypedConstant<MyTurboModuleConstants2>{1},
  };

  template <class TModule>
  static constexpr void ValidateModule() noexcept {
    constexpr auto constantCheckResults = CheckConstants<TModule, MyTurboModuleSpec>();

    REACT_SHOW_CONSTANT_SPEC_ERRORS(
        0,
        "MyTurboModuleConstants1",
        "    REACT_GET_CONSTANTS(GetConstants1) MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n"
        "    REACT_GET_CONSTANTS(GetConstants1) static MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n");
    REACT_SHOW_CONSTANT_SPEC_ERRORS(
        1,
        "MyTurboModuleConstants2",
        "    REACT_GET_CONSTANTS(GetConstants2) MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n"
        "    REACT_GET_CONSTANTS(GetConstants2) static MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n");
  }
};
```

For each `TypedConstant<T>`, it requires that, there must be one and only one `REACT_GET_CONSTANTS` method for such `T`, and it should be either `T()noexcept` or its static version.

I have manually tested to ensured that error messages will be emitted as expected when the module doesn't match the module spec in all ways.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8696)