### PR TITLE
Restore CI Build

### DIFF
--- a/.ado/templates/setup-certificate.yml
+++ b/.ado/templates/setup-certificate.yml
@@ -21,6 +21,10 @@ steps:
     displayName: Specify Certificate
     condition: and(eq('${{ parameters.buildEnvironment }}', 'Continuous'), eq('${{ parameters.encodedKey}}' , 'playgroundEncodedKey'))
 
+  - powershell: Write-Host "##vso[task.setvariable variable=EncodedKey]$(RNWEncodedKey)"
+    displayName: Specify Certificate
+    condition: and(eq('${{ parameters.buildEnvironment }}', 'Continuous'), eq('${{ parameters.encodedKey}}' , 'RNWEncodedKey'))
+
   - task: PowerShell@2
     displayName: Set Up Certificate
     inputs:


### PR DESCRIPTION
**_Why_**
Restore CI Build. #8672 missing one line change needed to successfully retrieve certificate data to sign CLI tester build. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8697)