### PR TITLE
Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.

### DIFF
--- a/change/@react-native-windows-cli-fa19ef9a-896c-4af1-b889-400f32f2bd31.json
+++ b/change/@react-native-windows-cli-fa19ef9a-896c-4af1-b889-400f32f2bd31.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump xmldom to 0.7.0 in @react-native-windows/cli.",
+  "packageName": "@react-native-windows/cli",
+  "email": "yicyao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "glob-parent": "^5.1.2",
     "node-fetch": "2.6.1",
     "node-notifier": "^9.0.0",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "xmldom": "github:xmldom/xmldom#^0.7.5",
     "**/parse-url/normalize-url": "^4.5.1",
     "**/@react-native/repo-config/ws": "^6.2.2",
     "**/@react-native/tester/ws": "^6.2.2",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -34,7 +34,7 @@
     "uuid": "^3.3.2",
     "xml-formatter": "^2.4.0",
     "xml-parser": "^1.2.1",
-    "xmldom": "^0.5.0",
+    "xmldom": "github:xmldom/xmldom#0.7.0",
     "xpath": "^0.0.27"
   },
   "devDependencies": {

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -34,7 +34,7 @@
     "uuid": "^3.3.2",
     "xml-formatter": "^2.4.0",
     "xml-parser": "^1.2.1",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "@xmldom/xmldom": "^0.7.5",
     "xpath": "^0.0.27"
   },
   "devDependencies": {

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -8,7 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import glob from 'glob';
 
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import xpath from 'xpath';
 import {CodedError} from '@react-native-windows/telemetry';
 

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -7,7 +7,7 @@
 import path from 'path';
 import {projectConfigWindows} from '../config/projectConfig';
 import {AutolinkWindows, autolinkOptions} from '../runWindows/utils/autolink';
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import {ensureWinUI3Project} from './projectConfig.utils';
 
 test('autolink with no windows project', () => {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -32,7 +32,7 @@ import {
 } from '../../config/dependencyConfig';
 import {Project, WindowsProjectConfig} from '../../config/projectConfig';
 import {CodedError} from '@react-native-windows/telemetry';
-import {XMLSerializer} from 'xmldom';
+import {XMLSerializer} from '@xmldom/xmldom';
 import {Ora} from 'ora';
 const formatter = require('xml-formatter');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,6 +2554,11 @@
   dependencies:
     "@wdio/logger" "6.10.10"
 
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
+  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -11664,10 +11669,9 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@^0.5.0, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
-  version "0.7.0"
-  uid c568938641cc1f121cef5b4df80fcfda1e489b6e
-  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
+xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#^0.7.5":
+  version "0.7.5"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/03fcf987307a9b1963075007d9fe2e8720fa7e25"
 
 xpath@^0.0.27:
   version "0.0.27"


### PR DESCRIPTION
Since version 0.7.0, xmldom is published to npm as @xmldom/xmldom and no longer as xmldom, because the package owners are no longer able to publish xmldom. See https://github.com/xmldom/xmldom/issues/271 for more information.

We need to upgrade our xmldom dependencies to mitigate CVE-2021-32796. See https://github.com/advisories/GHSA-5fg8-2547-mr8q. This issue was partially mitigated by commit bfc26ac38b14ddeb0c195e69faa22b0826727221, but that commit did not bump the version of xmldom used by @react-native-windows/cli. This PR does do. We would also need to backport this all the way back to 0.63 to mitigate security component governance alerts in internal dependent repos.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8702)