### PR TITLE
ReactNativeHost ReloadInstance and UnloadInstance actions do not alwa…

### DIFF
--- a/change/react-native-windows-cfcd8b42-ad9b-49b8-9bb5-28f8a60c27d3.json
+++ b/change/react-native-windows-cfcd8b42-ad9b-49b8-9bb5-28f8a60c27d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ReactNativeHost ReloadInstance and UnloadInstance actions do not always fire completed events",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
@@ -116,6 +116,7 @@ TEST_CLASS (ExecuteJsiTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"ExecuteJsiTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<TestPackageProvider>());
+      return true;
     });
 
     TestEventService::ObserveEvents({

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.cpp
@@ -96,6 +96,7 @@ TEST_CLASS (JsiSimpleTurboModuleTests) {
                 TestEventService::LogEvent("Instance destroyed event", nullptr);
                 TestCheck(ReactContext(args.Context()).JSDispatcher().HasThreadAccess());
               });
+          return true;
         });
 
     TestEventService::ObserveEvents({

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.cpp
@@ -288,6 +288,7 @@ TEST_CLASS (JsiTurboModuleTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"JsiTurboModuleTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<MySimpleTurboModulePackageProvider>());
+      return true;
     });
 
     TestEventService::ObserveEvents(

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -95,7 +95,7 @@ TEST_CLASS (ReactNativeHostTests) {
     TestEventService::Initialize();
 
     auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
-      host.ReloadInstance().Completed([](auto const &task, winrt::Windows::Foundation::AsyncStatus status) mutable {
+      host.ReloadInstance().Completed([](auto const &, winrt::Windows::Foundation::AsyncStatus status) mutable {
         if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
           TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
         } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -95,16 +95,15 @@ TEST_CLASS (ReactNativeHostTests) {
     TestEventService::Initialize();
 
     auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
-      auto loadAction =
-          host.ReloadInstance().Completed([](auto const &task, winrt::Windows::Foundation::AsyncStatus status) mutable {
-            if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
-              TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
-            } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {
-              TestEventService::LogEvent("InstanceLoaded::Canceled", nullptr);
-            } else {
-              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
-            }
-          });
+      host.ReloadInstance().Completed([](auto const &task, winrt::Windows::Foundation::AsyncStatus status) mutable {
+        if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
+          TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
+        } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {
+          TestEventService::LogEvent("InstanceLoaded::Canceled", nullptr);
+        } else {
+          TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+        }
+      });
       return false; // Already called ReloadInstance, so we dont need the holder to load the instance
     });
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -19,7 +19,7 @@ REACT_MODULE(TestHostModule)
 struct TestHostModule {
   REACT_INIT(Initialize)
   void Initialize(ReactContext const & /*reactContext*/) noexcept {
-    TestEventService::LogEvent("initialize", nullptr);
+    TestEventService::LogEvent("TestHostModule::Initialize", nullptr);
   }
 
   REACT_FUNCTION(addValues, L"addValues", L"TestHostModuleFunctions")
@@ -27,7 +27,7 @@ struct TestHostModule {
 
   REACT_METHOD(StartTests, L"startTests")
   void StartTests() noexcept {
-    TestEventService::LogEvent("start tests", nullptr);
+    TestEventService::LogEvent("TestHostModule::startTests", nullptr);
 
     TestEventService::LogEvent("call addValues", JSValueArray{4, 7});
     addValues(4, 7);
@@ -35,7 +35,7 @@ struct TestHostModule {
 
   REACT_METHOD(ReturnResult, L"returnResult")
   void ReturnResult(JSValue value) noexcept {
-    TestEventService::LogEvent("return result", std::move(value));
+    TestEventService::LogEvent("TestHostModule::ReturnResult", std::move(value));
   }
 };
 
@@ -81,13 +81,34 @@ TEST_CLASS (ReactNativeHostTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<TestPackageProvider>());
+      return true;
     });
 
     TestEventService::ObserveEvents(
-        {TestEvent{"initialize", nullptr},
-         TestEvent{"start tests", nullptr},
+        {TestEvent{"TestHostModule::Initialize", nullptr},
+         TestEvent{"TestHostModule::startTests", nullptr},
          TestEvent{"call addValues", JSValueArray{4, 7}},
-         TestEvent{"return result", 11}});
+         TestEvent{"TestHostModule::ReturnResult", 11}});
+  }
+
+  TEST_METHOD(HostReloadedAsyncActionCompletedEvent) {
+    TestEventService::Initialize();
+
+    auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
+      auto loadAction =
+          host.ReloadInstance().Completed([](auto const &task, winrt::Windows::Foundation::AsyncStatus status) mutable {
+            if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
+              TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
+            } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {
+              TestEventService::LogEvent("InstanceLoaded::Canceled", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            }
+          });
+      return false; // Already called ReloadInstance, so we dont need the holder to load the instance
+    });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Completed", nullptr}});
   }
 };
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
@@ -314,6 +314,7 @@ TEST_CLASS (ReactNotificationServiceTests) {
                 // Unsubscribe after the first notification.
                 args.Subscription().Unsubscribe();
               });
+          return true;
         });
 
     TestEventService::ObserveEvents({

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
@@ -38,10 +38,16 @@ using namespace std::literals::chrono_literals;
       // Check the event name and value
       auto const &expectedEvent = expectedEvents[observeEventIndex];
       TestCheckEqual(expectedEvent.EventName, loggedEvent.EventName);
+      if (expectedEvent.EventName != loggedEvent.EventName) {
+        break; // Dont hang waiting for more data
+      }
       if (auto d1 = expectedEvent.Value.TryGetDouble(), d2 = loggedEvent.Value.TryGetDouble(); d1 && d2) {
         // Comparison of doubles has special logic because NaN != NaN.
         if (!isnan(*d1) && !isnan(*d2)) {
           TestCheckEqual(*d1, *d2);
+          if (*d1 != *d2) {
+            break; // Dont hang waiting for more data
+          }
         }
       } else if (expectedEvent.Value != loggedEvent.Value) { // Use JSValue strict compare
         std::stringstream os;
@@ -49,6 +55,7 @@ using namespace std::literals::chrono_literals;
            << "Expected: " << expectedEvent.Value.ToString() << '\n'
            << "Actual: " << loggedEvent.Value.ToString();
         TestCheckFail("%s", os.str().c_str());
+        break; // Dont hang waiting for more data
       }
 
       ++observeEventIndex;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
@@ -12,7 +12,7 @@ using namespace Windows::System;
 
 TestReactNativeHostHolder::TestReactNativeHostHolder(
     std::wstring_view jsBundle,
-    Mso::Functor<void(ReactNativeHost const &)> &&hostInitializer) noexcept {
+    Mso::Functor<bool(ReactNativeHost const &)> &&hostInitializer) noexcept {
   m_host = ReactNativeHost{};
   m_queueController = DispatcherQueueController::CreateOnDedicatedThread();
   m_queueController.DispatcherQueue().TryEnqueue(
@@ -30,9 +30,9 @@ TestReactNativeHostHolder::TestReactNativeHostHolder(
         m_host.InstanceSettings().UseLiveReload(false);
         m_host.InstanceSettings().EnableDeveloperMenu(false);
 
-        hostInitializer(m_host);
-
-        m_host.LoadInstance();
+        if (hostInitializer(m_host)) {
+          m_host.LoadInstance();
+        }
       });
 }
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
@@ -13,7 +13,7 @@ namespace ReactNativeIntegrationTests {
 struct TestReactNativeHostHolder {
   TestReactNativeHostHolder(
       std::wstring_view jsBundle,
-      Mso::Functor<void(winrt::Microsoft::ReactNative::ReactNativeHost const &)> &&hostInitializer) noexcept;
+      Mso::Functor<bool(winrt::Microsoft::ReactNative::ReactNativeHost const &)> &&hostInitializer) noexcept;
   ~TestReactNativeHostHolder() noexcept;
 
   winrt::Microsoft::ReactNative::ReactNativeHost const &Host() const noexcept;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -184,6 +184,7 @@ TEST_CLASS (TurboModuleTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"TurboModuleTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<SampleTurboModulePackageProvider>());
+      return true;
     });
 
     TestEventService::ObserveEvents({

--- a/vnext/Mso/future/futureWinRT.h
+++ b/vnext/Mso/future/futureWinRT.h
@@ -57,7 +57,9 @@ struct AsyncActionFutureAdapter : winrt::implements<
       m_completedAssigned = true;
 
       if (m_status == AsyncStatus::Started) {
-        m_completed = winrt::impl::make_agile_delegate(handler);
+        m_completed = winrt::impl::make_agile_delegate(
+            [keepAlive = get_strong(), handler = std::move(handler)](
+                auto const &task, winrt::Windows::Foundation::AsyncStatus status) { handler(task, status); });
         return;
       }
 


### PR DESCRIPTION
ReactNativeHost ReloadInstance and UnloadInstance actions do not always fire completed events.

Currently you have to keep a ref to the async action for the completed handler to get fired:

Ex: 
```
host.ReloadInstance().Completed([](...));
```
will never fire.  Instead currently you have to do:

```
m_action = host.ReloadInstance();
m_action.Completed([](...));
```
or 
```
auto action = host.ReloadInstance();
action.Completed([action]() mutable { action = nullptr; ... });
```


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8709)