### PR TITLE
[0.63] Upgrade V8-JSI to 0.63.16

### DIFF
--- a/change/react-native-windows-2021-09-27-19-45-59-v8jsi-0.63.16.json
+++ b/change/react-native-windows-2021-09-27-19-45-59-v8jsi-0.63.16.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Upgrade to V8-JSI 0.63.16",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-28T02:45:59.359Z"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.ChakraCore.vc140" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.63.14" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.63.16" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->

--- a/vnext/Microsoft.ReactNative.ComponentTests/packages.config
+++ b/vnext/Microsoft.ReactNative.ComponentTests/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
   <package id="boost" version="1.72.0.0" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.14" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.16" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -160,7 +160,7 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.14\build\native\ReactNative.V8Jsi.Windows.UWP.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.14\build\native\ReactNative.V8Jsi.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" />
+    <Import Project="$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.16\build\native\ReactNative.V8Jsi.Windows.UWP.targets" Condition="Exists('$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.16\build\native\ReactNative.V8Jsi.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -169,6 +169,6 @@
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.200615.7\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.14\build\native\ReactNative.V8Jsi.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.14\build\native\ReactNative.V8Jsi.Windows.UWP.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.16\build\native\ReactNative.V8Jsi.Windows.UWP.targets') AND '$(USE_V8)' == 'true'" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.0.63.16\build\native\ReactNative.V8Jsi.Windows.UWP.targets'))" />
   </Target>
 </Project>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.14" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.16" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200615.7" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview2.200713.0" targetFramework="native"/>
   <!-- package id="ReactNative.Hermes.Windows" version="0.5.0-f56606a8" targetFramework="native" / -->
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.10" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.63.16" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -33,7 +33,7 @@
     <HERMES_ARCH Condition="'$(HERMES_ARCH)' == ''">uwp</HERMES_ARCH>
 
     <USE_V8 Condition="('$(USE_V8)' == '') OR ('$(Platform)' == 'ARM')">false</USE_V8>
-    <V8_Version Condition="'$(V8_Version)' == ''">0.63.14</V8_Version>
+    <V8_Version Condition="'$(V8_Version)' == ''">0.63.16</V8_Version>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' == 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.$(V8_Version)</V8_Package>
     <V8_Package Condition="'$(V8_Package)' == '' AND '$(V8AppPlatform)' != 'win32'">$(SolutionDir)packages\ReactNative.V8Jsi.Windows.UWP.$(V8_Version)</V8_Package>
 


### PR DESCRIPTION
**NOT a backport**

- Upgrade to V8-JSI 0.63.16

The V8-JSI verison deployed in Office differs from the one in this branch.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8713)