### PR TITLE
Make hermes consume icu.dll in Windows for local aware functions

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -75,6 +75,12 @@ jobs:
                 workingDirectory: $(Build.SourcesDirectory)
               condition: false # Must be manually enabled, since it causes a 5x perf reduction that causes test instability
 
+            - task: PowerShell@2
+              displayName: Start tracing
+              inputs:
+                targetType: filePath # filePath | inline
+                filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Start-Tracing.ps1
+
             - template: ../templates/set-experimental-feature.yml
               parameters:
                 package: packages/e2e-test-app
@@ -103,6 +109,21 @@ jobs:
               displayName: Update snapshots
               workingDirectory: packages/e2e-test-app
               condition: and(failed(), eq(variables.StartedTests, 'true'))
+
+            - task: PowerShell@2
+              displayName: Stop tracing
+              inputs:
+                targetType: filePath # filePath | inline
+                filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Stop-Tracing.ps1
+                arguments: -NoAnalysis -outputFolder $(Build.StagingDirectory)/Tracing
+              condition: true
+
+            - task: PublishBuildArtifacts@1
+              displayName: Upload traces
+              inputs:
+                pathtoPublish: '$(Build.StagingDirectory)/Tracing'
+                artifactName: 'Traces - $(Agent.JobName)-$(System.JobAttempt)'
+              condition: true
 
             - task: CopyFiles@2
               displayName: Copy snapshots

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -74,6 +74,12 @@ jobs:
             - script: .ado\scripts\SetupLocalDumps.cmd integrationtest
               displayName: Set LocalDumps
 
+            - task: PowerShell@2
+              displayName: Start tracing
+              inputs:
+                targetType: filePath # filePath | inline
+                filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Start-Tracing.ps1
+
             - template: ../templates/set-experimental-feature.yml
               parameters:
                 package: packages/integration-test-app
@@ -154,6 +160,21 @@ jobs:
                   targetPath: $(Build.StagingDirectory)/Screenshots
                 condition: succeededOrFailed()
 
+              - task: PowerShell@2
+                displayName: Stop tracing
+                inputs:
+                  targetType: filePath # filePath | inline
+                  filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Stop-Tracing.ps1
+                  arguments: -NoAnalysis -outputFolder $(Build.StagingDirectory)/Tracing
+                condition: true
+
+              - task: PublishBuildArtifacts@1
+                displayName: Upload traces
+                inputs:
+                  pathtoPublish: '$(Build.StagingDirectory)/Tracing'
+                  artifactName: 'Traces - $(Agent.JobName)-$(System.JobAttempt)'
+                condition: true
+                
             - task: PublishPipelineArtifact@1
               displayName: Upload targets
               inputs:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -184,6 +184,12 @@ steps:
       script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd msbuild
       workingDirectory: $(Build.SourcesDirectory)
 
+  - task: PowerShell@2
+    displayName: Start tracing
+    inputs:
+      targetType: filePath # filePath | inline
+      filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Start-Tracing.ps1
+
   # Work around issue of parameters not getting expanded in conditions properly
   - powershell: |
       Write-Host "##vso[task.setvariable variable=localConfig]${{ parameters.configuration}}"
@@ -238,3 +244,18 @@ steps:
       targetPath: 'verdaccio.log'
       artifact: '$(Agent.JobName).Verdaccio.log-$(System.JobAttempt)'
     condition: failed()
+
+  - task: PowerShell@2
+    displayName: Stop tracing
+    inputs:
+      targetType: filePath # filePath | inline
+      filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Stop-Tracing.ps1
+      arguments: -NoAnalysis -outputFolder $(Build.StagingDirectory)/Tracing
+    condition: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: Upload traces
+    inputs:
+      pathtoPublish: '$(Build.StagingDirectory)/Tracing'
+      artifactName: 'Traces - $(Agent.JobName)-$(System.JobAttempt)'
+    condition: true

--- a/change/react-native-windows-e156f81a-530f-4f46-8d56-42ecd56d221d.json
+++ b/change/react-native-windows-e156f81a-530f-4f46-8d56-42ecd56d221d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make hermes consume icu.dll in Windows for local aware functions",
+  "packageName": "react-native-windows",
+  "email": "anandrag@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
+++ b/packages/e2e-test-app/windows/ReactUWPTestApp/ReactUWPTestApp.csproj
@@ -135,7 +135,7 @@
       <Version>1.0.9</Version>
     </PackageReference>
     <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.9.0-ms.1</Version>
+      <Version>0.9.0-ms.4</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/packages/integration-test-app/windows/integrationtest/packages.config
+++ b/packages/integration-test-app/windows/integrationtest/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.1" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.6.1-prerelease.210709001" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.1" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.1" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>
 </packages>

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -7,6 +7,6 @@
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
-  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.1" targetFramework="native" />
+  <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native" />
   <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.2" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -9,7 +9,7 @@
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
     <IncludeHermes Condition="'$(IncludeHermes)' == '' And ('$(UseHermes)' == 'true' Or '$(ApplicationType)' == 'Windows Store')">true</IncludeHermes>
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.9.0-ms.1</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.9.0-ms.4</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(SolutionDir)packages\ReactNative.Hermes.Windows.$(HermesVersion)</HermesPackage>
     <!-- TODO: Can we automatically distinguish between uwp and win32 here? -->

--- a/vnext/Scripts/Tracing/Stop-Tracing.ps1
+++ b/vnext/Scripts/Tracing/Stop-Tracing.ps1
@@ -1,11 +1,22 @@
 param(
-    [bool]$NoAnalysis = $False
+    [switch]$NoAnalysis,
+    [string]$outputFolder
 )
 
 $mypath = split-path -parent $MyInvocation.MyCommand.Definition
 $timestamp = [DateTime]::Now.ToString("yyyyMMdd_HHmmss") 
 $fileName = "rnw_" + $timestamp + ".etl"
-$etlPath = Join-Path -Path $mypath -ChildPath $fileName
+
+if (![string]::IsNullOrEmpty($outputFolder)) {
+    If (!(test-path $outputFolder)) {
+        New-Item -ItemType Directory -Force -Path $outputFolder
+    }
+    $etlPath = Join-Path -Path $outputFolder -ChildPath $fileName
+}
+else {
+    $etlPath = Join-Path -Path $mypath -ChildPath $fileName
+}
+
 
 if (!(Get-Command "wpr.exe" -ErrorAction SilentlyContinue)) { 
     throw "
@@ -25,7 +36,7 @@ if (!(Get-Command "wpa.exe" -ErrorAction SilentlyContinue)) {
     Write-Host "Ensure that WPT (Windows Performance Toolkit) is installed and its tools are added to the path "
 }
 
-if ($NoAnalysis) {
+if ($NoAnalysis.IsPresent) {
     Write-Host "To analys this trace, install WPT and run: 'wpa $etlPath'"
 }
 else {


### PR DESCRIPTION
This change has
1. Consume new hermes package which loads icu.dll from Windows for local aware code, instead of the Win-NLS based implemented in which we have discovered bugs last week.
2. Enabling tracing in the CI jobs. This will help us better diagnose CI failures in future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8728)