### PR TITLE
Check constants in generated turbo module specs

### DIFF
--- a/change/@react-native-windows-codegen-6c4bbd11-6b44-4efd-a05f-f9c8dd4cee28.json
+++ b/change/@react-native-windows-codegen-6c4bbd11-6b44-4efd-a05f-f9c8dd4cee28.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check constants in generated turbo module specs",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-b42a7122-6b6e-4976-8994-ea45fecb435c.json
+++ b/change/react-native-windows-b42a7122-6b6e-4976-8994-ea45fecb435c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check constants in generated turbo module specs",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -6,15 +6,10 @@
 
 'use strict';
 
-import {
-  NativeModuleFunctionTypeAnnotation,
-  NativeModulePropertyShape,
-  SchemaType,
-} from 'react-native-tscodegen';
+import {SchemaType} from 'react-native-tscodegen';
 import {AliasMap, setPreferredModuleName} from './AliasManaging';
 import {createAliasMap, generateAliases} from './AliasGen';
-import {translateArgs, translateSpecArgs} from './ParamTypes';
-import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
+import {generateValidateMethods} from './ValidateMethods';
 
 type FilesOutput = Map<string, string>;
 
@@ -34,129 +29,12 @@ const moduleTemplate = `
 namespace ::_NAMESPACE_:: {
 ::_MODULE_ALIASED_STRUCTS_::
 struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  static constexpr auto methods = std::tuple{
-::_MODULE_PROPERTIES_TUPLE_::
-  };
-
-  template <class TModule>
-  static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();
-
-::_MODULE_PROPERTIES_SPEC_ERRORS_::
+::_MODULE_MEMBERS_VALIDATION_::
   }
 };
 
 } // namespace ::_NAMESPACE_::
 `;
-
-function isMethodSync(funcType: NativeModuleFunctionTypeAnnotation) {
-  return (
-    funcType.returnTypeAnnotation.type !== 'VoidTypeAnnotation' &&
-    funcType.returnTypeAnnotation.type !== 'PromiseTypeAnnotation'
-  );
-}
-
-function isMethodReturnPromise(funcType: NativeModuleFunctionTypeAnnotation) {
-  return funcType.returnTypeAnnotation.type === 'PromiseTypeAnnotation';
-}
-
-function getPossibleMethodSignatures(
-  prop: NativeModulePropertyShape,
-  funcType: NativeModuleFunctionTypeAnnotation,
-  aliases: AliasMap,
-  baseAliasName: string,
-): string[] {
-  const args = translateArgs(funcType.params, aliases, baseAliasName);
-  if (isMethodReturnPromise(funcType)) {
-    // TODO: type of the promise could be provided in the future
-    args.push('React::ReactPromise<React::JSValue> &&result');
-  }
-
-  // TODO: be much more exhastive on the possible method signatures that can be used..
-  const sig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
-    prop.name
-  }) ${translateImplReturnType(
-    funcType.returnTypeAnnotation,
-    aliases,
-    baseAliasName,
-  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
-
-  const staticsig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
-    prop.name
-  }) static ${translateImplReturnType(
-    funcType.returnTypeAnnotation,
-    aliases,
-    baseAliasName,
-  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
-
-  return [sig, staticsig];
-}
-
-function translatePossibleMethodSignatures(
-  prop: NativeModulePropertyShape,
-  funcType: NativeModuleFunctionTypeAnnotation,
-  aliases: AliasMap,
-  baseAliasName: string,
-): string {
-  return getPossibleMethodSignatures(prop, funcType, aliases, baseAliasName)
-    .map(sig => `"    ${sig}\\n"`)
-    .join('\n          ');
-}
-
-function renderProperties(
-  properties: ReadonlyArray<NativeModulePropertyShape>,
-  aliases: AliasMap,
-  tuple: boolean,
-): string {
-  // TODO: generate code for constants
-  return properties
-    .filter(prop => prop.name !== 'getConstants')
-    .map((prop, index) => {
-      // TODO: prop.optional === true
-      // TODO: prop.typeAnnotation.type === 'NullableTypeAnnotation'
-      const propAliasName = prop.name;
-      const funcType =
-        prop.typeAnnotation.type === 'NullableTypeAnnotation'
-          ? prop.typeAnnotation.typeAnnotation
-          : prop.typeAnnotation;
-
-      const traversedArgs = translateSpecArgs(
-        funcType.params,
-        aliases,
-        propAliasName,
-      );
-
-      const translatedReturnParam = translateSpecReturnType(
-        funcType.returnTypeAnnotation,
-        aliases,
-        propAliasName,
-      );
-
-      if (isMethodReturnPromise(funcType)) {
-        // TODO: type of the promise could be provided in the future
-        traversedArgs.push('Promise<React::JSValue>');
-      }
-
-      if (tuple) {
-        return `      ${
-          isMethodSync(funcType) ? 'Sync' : ''
-        }Method<${translatedReturnParam}(${traversedArgs.join(
-          ', ',
-        )}) noexcept>{${index}, L"${prop.name}"},`;
-      } else {
-        return `    REACT_SHOW_METHOD_SPEC_ERRORS(
-          ${index},
-          "${prop.name}",
-          ${translatePossibleMethodSignatures(
-            prop,
-            funcType,
-            aliases,
-            propAliasName,
-          )});`;
-      }
-    })
-    .join('\n');
-}
 
 export function createNM2Generator({namespace}: {namespace: string}) {
   return (
@@ -182,18 +60,8 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         // copy all explicit to a map
         const aliases: AliasMap = createAliasMap(nativeModule.aliases);
 
-        // prepare members for turbo modules
-        const properties = nativeModule.spec.properties;
-        const traversedProperties = renderProperties(
-          properties,
-          aliases,
-          false,
-        );
-        const traversedPropertyTuples = renderProperties(
-          properties,
-          aliases,
-          true,
-        );
+        // prepare methods
+        const methods = generateValidateMethods(nativeModule, aliases);
 
         // generate code for structs
         const traversedAliasedStructs = generateAliases(aliases);
@@ -202,11 +70,7 @@ export function createNM2Generator({namespace}: {namespace: string}) {
           `Native${preferredModuleName}Spec.g.h`,
           moduleTemplate
             .replace(/::_MODULE_ALIASED_STRUCTS_::/g, traversedAliasedStructs)
-            .replace(/::_MODULE_PROPERTIES_TUPLE_::/g, traversedPropertyTuples)
-            .replace(
-              /::_MODULE_PROPERTIES_SPEC_ERRORS_::/g,
-              traversedProperties,
-            )
+            .replace(/::_MODULE_MEMBERS_VALIDATION_::/g, methods)
             .replace(/::_MODULE_NAME_::/g, preferredModuleName)
             .replace(/::_NAMESPACE_::/g, namespace),
         );

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -33,7 +33,7 @@ struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();
+::_MODULE_MEMBERS_CHECKS_::
 
 ::_MODULE_MEMBERS_ERRORS_::
   }
@@ -72,12 +72,13 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         // generate code for structs
         const traversedAliasedStructs = generateAliases(aliases);
 
-        // prepare spec
+        // prepare method spec
         const tuples = `
   static constexpr auto methods = std::tuple{
 ${methods[0]}
   };`;
-
+        const checks = `
+    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();`;
         const errors = methods[1];
 
         files.set(
@@ -85,6 +86,7 @@ ${methods[0]}
           moduleTemplate
             .replace(/::_MODULE_ALIASED_STRUCTS_::/g, traversedAliasedStructs)
             .replace(/::_MODULE_MEMBERS_TUPLES_::/g, tuples.substr(1))
+            .replace(/::_MODULE_MEMBERS_CHECKS_::/g, checks.substr(1))
             .replace(/::_MODULE_MEMBERS_ERRORS_::/g, errors)
             .replace(/::_MODULE_NAME_::/g, preferredModuleName)
             .replace(/::_NAMESPACE_::/g, namespace),

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -85,7 +85,7 @@ ${methods[0]}
 ${constants[0]}
   };${tuples}`;
           checks = `
-    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();${checks}`;
+    constexpr auto constantCheckResults = CheckConstants<TModule, ::_MODULE_NAME_::Spec>();${checks}`;
           errors = `${constants[1]}
 
 ${errors}`;

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -29,7 +29,13 @@ const moduleTemplate = `
 namespace ::_NAMESPACE_:: {
 ::_MODULE_ALIASED_STRUCTS_::
 struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-::_MODULE_MEMBERS_VALIDATION_::
+::_MODULE_MEMBERS_TUPLES_::
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();
+
+::_MODULE_MEMBERS_ERRORS_::
   }
 };
 
@@ -66,11 +72,20 @@ export function createNM2Generator({namespace}: {namespace: string}) {
         // generate code for structs
         const traversedAliasedStructs = generateAliases(aliases);
 
+        // prepare spec
+        const tuples = `
+  static constexpr auto methods = std::tuple{
+${methods[0]}
+  };`;
+
+        const errors = methods[1];
+
         files.set(
           `Native${preferredModuleName}Spec.g.h`,
           moduleTemplate
             .replace(/::_MODULE_ALIASED_STRUCTS_::/g, traversedAliasedStructs)
-            .replace(/::_MODULE_MEMBERS_VALIDATION_::/g, methods)
+            .replace(/::_MODULE_MEMBERS_TUPLES_::/g, tuples.substr(1))
+            .replace(/::_MODULE_MEMBERS_ERRORS_::/g, errors)
             .replace(/::_MODULE_NAME_::/g, preferredModuleName)
             .replace(/::_NAMESPACE_::/g, namespace),
         );

--- a/packages/@react-native-windows/codegen/src/generators/ValidateConstants.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateConstants.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {NativeModuleSchema} from 'react-native-tscodegen';
+import {AliasMap, getAnonymousAliasCppName} from './AliasManaging';
+
+export function generateValidateConstants(
+  nativeModule: NativeModuleSchema,
+  aliases: AliasMap,
+): [string, string] | undefined {
+  const candidates = nativeModule.spec.properties.filter(
+    prop => prop.name === 'getConstants',
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const getConstant = candidates[0];
+  const funcType =
+    getConstant.typeAnnotation.type === 'NullableTypeAnnotation'
+      ? getConstant.typeAnnotation.typeAnnotation
+      : getConstant.typeAnnotation;
+  if (
+    funcType.params.length > 0 ||
+    funcType.returnTypeAnnotation.type !== 'ObjectTypeAnnotation'
+  ) {
+    return undefined;
+  }
+
+  const constantType = funcType.returnTypeAnnotation;
+  if (constantType.properties.length === 0) {
+    return undefined;
+  }
+
+  const cppName = getAnonymousAliasCppName(aliases, 'Constants', constantType);
+
+  return [
+    `      TypedConstant<${cppName}>{0},`,
+    `    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "${cppName}",
+          "    REACT_GET_CONSTANTS(GetConstants) ${cppName} GetConstants() noexcept {/*implementation*/}\\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static ${cppName} GetConstants() noexcept {/*implementation*/}\\n");`,
+  ];
+}

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -15,17 +15,6 @@ import {AliasMap} from './AliasManaging';
 import {translateArgs, translateSpecArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
-const validateMethodTemplate = `
-  static constexpr auto methods = std::tuple{
-::_MODULE_PROPERTIES_TUPLE_::
-  };
-
-  template <class TModule>
-  static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();
-
-::_MODULE_PROPERTIES_SPEC_ERRORS_::`;
-
 function isMethodSync(funcType: NativeModuleFunctionTypeAnnotation) {
   return (
     funcType.returnTypeAnnotation.type !== 'VoidTypeAnnotation' &&
@@ -138,13 +127,9 @@ function renderProperties(
 export function generateValidateMethods(
   nativeModule: NativeModuleSchema,
   aliases: AliasMap,
-): string {
+): [string, string] {
   const properties = nativeModule.spec.properties;
   const traversedProperties = renderProperties(properties, aliases, false);
   const traversedPropertyTuples = renderProperties(properties, aliases, true);
-
-  return validateMethodTemplate
-    .replace(/::_MODULE_PROPERTIES_TUPLE_::/g, traversedPropertyTuples)
-    .replace(/::_MODULE_PROPERTIES_SPEC_ERRORS_::/g, traversedProperties)
-    .substr(1);
+  return [traversedPropertyTuples, traversedProperties];
 }

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {
+  NativeModuleFunctionTypeAnnotation,
+  NativeModulePropertyShape,
+  NativeModuleSchema,
+} from 'react-native-tscodegen';
+import {AliasMap} from './AliasManaging';
+import {translateArgs, translateSpecArgs} from './ParamTypes';
+import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
+
+const validateMethodTemplate = `
+  static constexpr auto methods = std::tuple{
+::_MODULE_PROPERTIES_TUPLE_::
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto methodCheckResults = CheckMethods<TModule, ::_MODULE_NAME_::Spec>();
+
+::_MODULE_PROPERTIES_SPEC_ERRORS_::`;
+
+function isMethodSync(funcType: NativeModuleFunctionTypeAnnotation) {
+  return (
+    funcType.returnTypeAnnotation.type !== 'VoidTypeAnnotation' &&
+    funcType.returnTypeAnnotation.type !== 'PromiseTypeAnnotation'
+  );
+}
+
+function isMethodReturnPromise(funcType: NativeModuleFunctionTypeAnnotation) {
+  return funcType.returnTypeAnnotation.type === 'PromiseTypeAnnotation';
+}
+
+function getPossibleMethodSignatures(
+  prop: NativeModulePropertyShape,
+  funcType: NativeModuleFunctionTypeAnnotation,
+  aliases: AliasMap,
+  baseAliasName: string,
+): string[] {
+  const args = translateArgs(funcType.params, aliases, baseAliasName);
+  if (isMethodReturnPromise(funcType)) {
+    // TODO: type of the promise could be provided in the future
+    args.push('React::ReactPromise<React::JSValue> &&result');
+  }
+
+  // TODO: be much more exhastive on the possible method signatures that can be used..
+  const sig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
+    prop.name
+  }) ${translateImplReturnType(
+    funcType.returnTypeAnnotation,
+    aliases,
+    baseAliasName,
+  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
+
+  const staticsig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
+    prop.name
+  }) static ${translateImplReturnType(
+    funcType.returnTypeAnnotation,
+    aliases,
+    baseAliasName,
+  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
+
+  return [sig, staticsig];
+}
+
+function translatePossibleMethodSignatures(
+  prop: NativeModulePropertyShape,
+  funcType: NativeModuleFunctionTypeAnnotation,
+  aliases: AliasMap,
+  baseAliasName: string,
+): string {
+  return getPossibleMethodSignatures(prop, funcType, aliases, baseAliasName)
+    .map(sig => `"    ${sig}\\n"`)
+    .join('\n          ');
+}
+
+function renderProperties(
+  properties: ReadonlyArray<NativeModulePropertyShape>,
+  aliases: AliasMap,
+  tuple: boolean,
+): string {
+  // TODO: generate code for constants
+  return properties
+    .filter(prop => prop.name !== 'getConstants')
+    .map((prop, index) => {
+      // TODO: prop.optional === true
+      // TODO: prop.typeAnnotation.type === 'NullableTypeAnnotation'
+      const propAliasName = prop.name;
+      const funcType =
+        prop.typeAnnotation.type === 'NullableTypeAnnotation'
+          ? prop.typeAnnotation.typeAnnotation
+          : prop.typeAnnotation;
+
+      const traversedArgs = translateSpecArgs(
+        funcType.params,
+        aliases,
+        propAliasName,
+      );
+
+      const translatedReturnParam = translateSpecReturnType(
+        funcType.returnTypeAnnotation,
+        aliases,
+        propAliasName,
+      );
+
+      if (isMethodReturnPromise(funcType)) {
+        // TODO: type of the promise could be provided in the future
+        traversedArgs.push('Promise<React::JSValue>');
+      }
+
+      if (tuple) {
+        return `      ${
+          isMethodSync(funcType) ? 'Sync' : ''
+        }Method<${translatedReturnParam}(${traversedArgs.join(
+          ', ',
+        )}) noexcept>{${index}, L"${prop.name}"},`;
+      } else {
+        return `    REACT_SHOW_METHOD_SPEC_ERRORS(
+          ${index},
+          "${prop.name}",
+          ${translatePossibleMethodSignatures(
+            prop,
+            funcType,
+            aliases,
+            propAliasName,
+          )});`;
+      }
+    })
+    .join('\n');
+}
+
+export function generateValidateMethods(
+  nativeModule: NativeModuleSchema,
+  aliases: AliasMap,
+): string {
+  const properties = nativeModule.spec.properties;
+  const traversedProperties = renderProperties(properties, aliases, false);
+  const traversedPropertyTuples = renderProperties(properties, aliases, true);
+
+  return validateMethodTemplate
+    .replace(/::_MODULE_PROPERTIES_TUPLE_::/g, traversedPropertyTuples)
+    .replace(/::_MODULE_PROPERTIES_SPEC_ERRORS_::/g, traversedProperties)
+    .substr(1);
+}

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -63,7 +63,7 @@ void AppState::RemoveListeners(double /*count*/) noexcept {
 }
 
 ReactNativeSpecs::AppStateSpec_Constants AppState::GetConstants() noexcept {
-  return {"native"};
+  return {m_active ? "active" : "background"};
 }
 
 void AppState::SetActive(bool active) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.cpp
@@ -62,6 +62,10 @@ void AppState::RemoveListeners(double /*count*/) noexcept {
   // noop
 }
 
+ReactNativeSpecs::AppStateSpec_Constants AppState::GetConstants() noexcept {
+  return {"native"};
+}
+
 void AppState::SetActive(bool active) noexcept {
   m_active = active;
   m_context.JSDispatcher().Post([this]() { AppStateDidChange({m_active ? "active" : "background"}); });

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
@@ -27,8 +27,8 @@ struct AppState : public std::enable_shared_from_this<AppState> {
   REACT_METHOD(RemoveListeners, L"removeListeners")
   void RemoveListeners(double count) noexcept;
 
-  REACT_CONSTANT(initialAppState)
-  const std::string initialAppState{"active"};
+  REACT_GET_CONSTANTS(GetConstants)
+  ReactNativeSpecs::AppStateSpec_Constants GetConstants() noexcept;
 
   REACT_EVENT(AppStateDidChange, L"appStateDidChange")
   std::function<void(AppStateChangeArgs const &)> AppStateDidChange;

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -89,33 +89,43 @@ void DeviceInfoHolder::InitDeviceInfoHolder(const Mso::React::IReactContext &con
 
 void DeviceInfoHolder::notifyChanged() noexcept {
   if (m_notifyCallback) {
-    m_notifyCallback(getDimensions());
+    auto writer = MakeJSValueTreeWriter();
+    WriteValue(writer, getDimensions());
+    m_notifyCallback(TakeJSValue(writer).MoveObject());
   }
 }
 
-React::JSValueObject DeviceInfoHolder::GetDimensions(const React::ReactPropertyBag &propertyBag) noexcept {
+ReactNativeSpecs::DeviceInfoSpec_DimensionsPayload DeviceInfoHolder::GetDimensions(
+    const React::ReactPropertyBag &propertyBag) noexcept {
   auto holder = propertyBag.Get(DeviceInfoHolderPropertyId());
-
   return (*holder)->getDimensions();
 }
 
-React::JSValueObject DeviceInfoHolder::getDimensions() noexcept {
-  return React::JSValueObject{
-      {"windowPhysicalPixels",
-       React::JSValueObject{
-           {"width", m_windowWidth * m_scale},
-           {"height", m_windowHeight * m_scale},
-           {"scale", m_scale},
-           {"fontScale", m_textScaleFactor},
-           {"densityDpi", m_dpi}}},
-      {"screenPhysicalPixels",
-       React::JSValueObject{
-           {"width", m_screenWidth},
-           {"height", m_screenHeight},
-           {"scale", m_scale},
-           {"fontScale", m_textScaleFactor},
-           {"densityDpi", m_dpi}}},
-  };
+ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid DeviceInfoHolder::getWindow() noexcept {
+  ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid metrics;
+  metrics.width = m_windowWidth * m_scale;
+  metrics.height = m_windowHeight * m_scale;
+  metrics.scale = m_scale;
+  metrics.fontScale = m_textScaleFactor;
+  metrics.densityDpi = m_dpi;
+  return metrics;
+}
+
+ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid DeviceInfoHolder::getScreen() noexcept {
+  ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid metrics;
+  metrics.width = m_screenWidth;
+  metrics.height = m_screenHeight;
+  metrics.scale = m_scale;
+  metrics.fontScale = m_textScaleFactor;
+  metrics.densityDpi = m_dpi;
+  return metrics;
+}
+
+ReactNativeSpecs::DeviceInfoSpec_DimensionsPayload DeviceInfoHolder::getDimensions() noexcept {
+  ReactNativeSpecs::DeviceInfoSpec_DimensionsPayload payload;
+  payload.windowPhysicalPixels = getWindow();
+  payload.screenPhysicalPixels = getScreen();
+  return payload;
 }
 
 void DeviceInfoHolder::SetCallback(
@@ -163,8 +173,10 @@ void DeviceInfoHolder::updateDeviceInfo() noexcept {
   }
 }
 
-void DeviceInfo::GetConstants(React::ReactConstantProvider &provider) noexcept {
-  provider.Add(L"Dimensions", DeviceInfoHolder::GetDimensions(m_context.Properties()));
+ReactNativeSpecs::DeviceInfoSpec_Constants DeviceInfo::GetConstants() noexcept {
+  ReactNativeSpecs::DeviceInfoSpec_Constants constants;
+  constants.Dimensions = DeviceInfoHolder::GetDimensions(m_context.Properties());
+  return constants;
 }
 
 void DeviceInfo::Initialize(React::ReactContext const &reactContext) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeDeviceInfoSpec.g.h"
 #include <NativeModules.h>
 #include <React.h>
 #include <ReactNotificationService.h>
@@ -22,10 +23,13 @@ struct DeviceInfoHolder {
       const React::ReactPropertyBag &propertyBag,
       Mso::Functor<void(React::JSValueObject &&)> &&callback) noexcept;
   static void InitDeviceInfoHolder(const Mso::React::IReactContext &context) noexcept;
-  static React::JSValueObject GetDimensions(const React::ReactPropertyBag &propertyBag) noexcept;
+  static ReactNativeSpecs::DeviceInfoSpec_DimensionsPayload GetDimensions(
+      const React::ReactPropertyBag &propertyBag) noexcept;
 
  private:
-  React::JSValueObject getDimensions() noexcept;
+  ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid getWindow() noexcept;
+  ReactNativeSpecs::DeviceInfoSpec_DisplayMetricsAndroid getScreen() noexcept;
+  ReactNativeSpecs::DeviceInfoSpec_DimensionsPayload getDimensions() noexcept;
   void updateDeviceInfo() noexcept;
   void notifyChanged() noexcept;
 
@@ -49,8 +53,8 @@ struct DeviceInfo : public std::enable_shared_from_this<DeviceInfo> {
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 
-  REACT_CONSTANT_PROVIDER(GetConstants)
-  void GetConstants(React::ReactConstantProvider &provider) noexcept;
+  REACT_GET_CONSTANTS(GetConstants)
+  ReactNativeSpecs::DeviceInfoSpec_Constants GetConstants() noexcept;
 
  private:
   winrt::Microsoft::ReactNative::ReactContext m_context;

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.cpp
@@ -61,7 +61,7 @@ void I18nManager::SwapLeftAndRightInRTL(bool /*flipStyles*/) noexcept {
   // TODO - https://github.com/microsoft/react-native-windows/issues/4662
 }
 
-void I18nManager::GetConstants(React::ReactConstantProvider &provider) noexcept {
+ReactNativeSpecs::I18nManagerSpec_Constants I18nManager::GetConstants() noexcept {
   std::string locale = "en-us";
 
   auto langs = winrt::Windows::Globalization::ApplicationLanguages::Languages();
@@ -69,9 +69,11 @@ void I18nManager::GetConstants(React::ReactConstantProvider &provider) noexcept 
     locale = Microsoft::Common::Unicode::Utf16ToUtf8(langs.GetAt(0));
   }
 
-  provider.Add(L"localeIdentifier", locale);
-  provider.Add(L"doLeftAndRightSwapInRTL", false);
-  provider.Add(L"isRTL", IsRTL(m_context.Properties()));
+  ReactNativeSpecs::I18nManagerSpec_Constants constants;
+  constants.localeIdentifier = locale;
+  constants.doLeftAndRightSwapInRTL = false;
+  constants.isRTL = IsRTL(m_context.Properties());
+  return constants;
 }
 
 void I18nManager::Initialize(React::ReactContext const &reactContext) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeI18nManagerSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>
@@ -20,8 +21,8 @@ struct I18nManager {
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 
-  REACT_CONSTANT_PROVIDER(GetConstants)
-  void GetConstants(React::ReactConstantProvider &provider) noexcept;
+  REACT_GET_CONSTANTS(GetConstants)
+  ReactNativeSpecs::I18nManagerSpec_Constants GetConstants() noexcept;
 
   REACT_METHOD(AllowRTL, L"allowRTL")
   void AllowRTL(bool allowRTL) noexcept;

--- a/vnext/codegen/NativeAppStateSpec.g.h
+++ b/vnext/codegen/NativeAppStateSpec.g.h
@@ -19,7 +19,16 @@ struct AppStateSpec_getCurrentAppState_success_appState {
     std::string app_state;
 };
 
+REACT_STRUCT(AppStateSpec_Constants)
+struct AppStateSpec_Constants {
+    REACT_FIELD(initialAppState)
+    std::string initialAppState;
+};
+
 struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<AppStateSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(Callback<AppStateSpec_getCurrentAppState_success_appState>, Callback<React::JSValue>) noexcept>{0, L"getCurrentAppState"},
       Method<void(std::string) noexcept>{1, L"addListener"},
@@ -28,7 +37,14 @@ struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, AppStateSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, AppStateSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "AppStateSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) AppStateSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static AppStateSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeBlobModuleSpec.g.h
+++ b/vnext/codegen/NativeBlobModuleSpec.g.h
@@ -13,7 +13,18 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(BlobModuleSpec_Constants)
+struct BlobModuleSpec_Constants {
+    REACT_FIELD(BLOB_URI_SCHEME)
+    std::optional<std::string> BLOB_URI_SCHEME;
+    REACT_FIELD(BLOB_URI_HOST)
+    std::optional<std::string> BLOB_URI_HOST;
+};
+
 struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<BlobModuleSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"addNetworkingHandler"},
       Method<void(double) noexcept>{1, L"addWebSocketHandler"},
@@ -25,7 +36,14 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, BlobModuleSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, BlobModuleSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "BlobModuleSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) BlobModuleSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static BlobModuleSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeDeviceInfoSpec.g.h
+++ b/vnext/codegen/NativeDeviceInfoSpec.g.h
@@ -51,14 +51,32 @@ struct DeviceInfoSpec_DimensionsPayload {
     std::optional<DeviceInfoSpec_DisplayMetricsAndroid> screenPhysicalPixels;
 };
 
+REACT_STRUCT(DeviceInfoSpec_Constants)
+struct DeviceInfoSpec_Constants {
+    REACT_FIELD(Dimensions)
+    DeviceInfoSpec_DimensionsPayload Dimensions;
+    REACT_FIELD(isIPhoneX_deprecated)
+    std::optional<bool> isIPhoneX_deprecated;
+};
+
 struct DeviceInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<DeviceInfoSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
 
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, DeviceInfoSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, DeviceInfoSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "DeviceInfoSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) DeviceInfoSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static DeviceInfoSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
 
   }

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -31,14 +31,38 @@ struct DialogManagerAndroidSpec_DialogOptions {
     std::optional<bool> cancelable;
 };
 
+REACT_STRUCT(DialogManagerAndroidSpec_Constants)
+struct DialogManagerAndroidSpec_Constants {
+    REACT_FIELD(buttonClicked)
+    std::string buttonClicked;
+    REACT_FIELD(dismissed)
+    std::string dismissed;
+    REACT_FIELD(buttonPositive)
+    double buttonPositive;
+    REACT_FIELD(buttonNegative)
+    double buttonNegative;
+    REACT_FIELD(buttonNeutral)
+    double buttonNeutral;
+};
+
 struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<DialogManagerAndroidSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(DialogManagerAndroidSpec_DialogOptions, Callback<std::string>, Callback<std::string, double>) noexcept>{0, L"showAlert"},
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, DialogManagerAndroidSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, DialogManagerAndroidSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "DialogManagerAndroidSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) DialogManagerAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static DialogManagerAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeI18nManagerSpec.g.h
+++ b/vnext/codegen/NativeI18nManagerSpec.g.h
@@ -13,7 +13,20 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(I18nManagerSpec_Constants)
+struct I18nManagerSpec_Constants {
+    REACT_FIELD(isRTL)
+    bool isRTL;
+    REACT_FIELD(doLeftAndRightSwapInRTL)
+    bool doLeftAndRightSwapInRTL;
+    REACT_FIELD(localeIdentifier)
+    std::optional<std::string> localeIdentifier;
+};
+
 struct I18nManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<I18nManagerSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(bool) noexcept>{0, L"allowRTL"},
       Method<void(bool) noexcept>{1, L"forceRTL"},
@@ -22,7 +35,14 @@ struct I18nManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, I18nManagerSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, I18nManagerSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "I18nManagerSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) I18nManagerSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static I18nManagerSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeJSDevSupportSpec.g.h
+++ b/vnext/codegen/NativeJSDevSupportSpec.g.h
@@ -13,7 +13,18 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(JSDevSupportSpec_Constants)
+struct JSDevSupportSpec_Constants {
+    REACT_FIELD(ERROR_CODE_EXCEPTION)
+    double ERROR_CODE_EXCEPTION;
+    REACT_FIELD(ERROR_CODE_VIEW_NOT_FOUND)
+    double ERROR_CODE_VIEW_NOT_FOUND;
+};
+
 struct JSDevSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<JSDevSupportSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(std::string) noexcept>{0, L"onSuccess"},
       Method<void(double, std::string) noexcept>{1, L"onFailure"},
@@ -21,7 +32,14 @@ struct JSDevSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, JSDevSupportSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, JSDevSupportSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "JSDevSupportSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) JSDevSupportSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static JSDevSupportSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
@@ -13,14 +13,62 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(PlatformConstantsAndroidSpec_Constants_reactNativeVersion)
+struct PlatformConstantsAndroidSpec_Constants_reactNativeVersion {
+    REACT_FIELD(major)
+    double major;
+    REACT_FIELD(minor)
+    double minor;
+    REACT_FIELD(patch)
+    double patch;
+    REACT_FIELD(prerelease)
+    std::optional<double> prerelease;
+};
+
+REACT_STRUCT(PlatformConstantsAndroidSpec_Constants)
+struct PlatformConstantsAndroidSpec_Constants {
+    REACT_FIELD(isTesting)
+    bool isTesting;
+    REACT_FIELD(reactNativeVersion)
+    PlatformConstantsAndroidSpec_Constants_reactNativeVersion reactNativeVersion;
+    REACT_FIELD(Version)
+    double Version;
+    REACT_FIELD(Release)
+    std::string Release;
+    REACT_FIELD(Serial)
+    std::string Serial;
+    REACT_FIELD(Fingerprint)
+    std::string Fingerprint;
+    REACT_FIELD(Model)
+    std::string Model;
+    REACT_FIELD(ServerHost)
+    std::optional<std::string> ServerHost;
+    REACT_FIELD(uiMode)
+    std::string uiMode;
+    REACT_FIELD(Brand)
+    std::string Brand;
+    REACT_FIELD(Manufacturer)
+    std::string Manufacturer;
+};
+
 struct PlatformConstantsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<PlatformConstantsAndroidSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       SyncMethod<std::string() noexcept>{0, L"getAndroidID"},
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, PlatformConstantsAndroidSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, PlatformConstantsAndroidSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "PlatformConstantsAndroidSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) PlatformConstantsAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static PlatformConstantsAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativePlatformConstantsIOSSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsIOSSpec.g.h
@@ -13,14 +13,52 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(PlatformConstantsIOSSpec_Constants_reactNativeVersion)
+struct PlatformConstantsIOSSpec_Constants_reactNativeVersion {
+    REACT_FIELD(major)
+    double major;
+    REACT_FIELD(minor)
+    double minor;
+    REACT_FIELD(patch)
+    double patch;
+    REACT_FIELD(prerelease)
+    std::optional<double> prerelease;
+};
+
+REACT_STRUCT(PlatformConstantsIOSSpec_Constants)
+struct PlatformConstantsIOSSpec_Constants {
+    REACT_FIELD(isTesting)
+    bool isTesting;
+    REACT_FIELD(reactNativeVersion)
+    PlatformConstantsIOSSpec_Constants_reactNativeVersion reactNativeVersion;
+    REACT_FIELD(forceTouchAvailable)
+    bool forceTouchAvailable;
+    REACT_FIELD(osVersion)
+    std::string osVersion;
+    REACT_FIELD(systemName)
+    std::string systemName;
+    REACT_FIELD(interfaceIdiom)
+    std::string interfaceIdiom;
+};
+
 struct PlatformConstantsIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<PlatformConstantsIOSSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
 
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, PlatformConstantsIOSSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, PlatformConstantsIOSSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "PlatformConstantsIOSSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) PlatformConstantsIOSSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static PlatformConstantsIOSSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
 
   }

--- a/vnext/codegen/NativePlatformConstantsWinSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsWinSpec.g.h
@@ -13,14 +13,46 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(PlatformConstantsWinSpec_Constants_reactNativeVersion)
+struct PlatformConstantsWinSpec_Constants_reactNativeVersion {
+    REACT_FIELD(major)
+    double major;
+    REACT_FIELD(minor)
+    double minor;
+    REACT_FIELD(patch)
+    double patch;
+    REACT_FIELD(prerelease)
+    std::optional<double> prerelease;
+};
+
+REACT_STRUCT(PlatformConstantsWinSpec_Constants)
+struct PlatformConstantsWinSpec_Constants {
+    REACT_FIELD(isTesting)
+    bool isTesting;
+    REACT_FIELD(reactNativeVersion)
+    PlatformConstantsWinSpec_Constants_reactNativeVersion reactNativeVersion;
+    REACT_FIELD(osVersion)
+    double osVersion;
+};
+
 struct PlatformConstantsWinSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<PlatformConstantsWinSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
 
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, PlatformConstantsWinSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, PlatformConstantsWinSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "PlatformConstantsWinSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) PlatformConstantsWinSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static PlatformConstantsWinSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
 
   }

--- a/vnext/codegen/NativeSampleTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeSampleTurboModuleSpec.g.h
@@ -13,7 +13,20 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(SampleTurboModuleSpec_Constants)
+struct SampleTurboModuleSpec_Constants {
+    REACT_FIELD(const1)
+    bool const1;
+    REACT_FIELD(const2)
+    double const2;
+    REACT_FIELD(const3)
+    std::string const3;
+};
+
 struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<SampleTurboModuleSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"voidFunc"},
       SyncMethod<bool(bool) noexcept>{1, L"getBool"},
@@ -30,7 +43,14 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, SampleTurboModuleSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "SampleTurboModuleSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) SampleTurboModuleSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static SampleTurboModuleSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeSettingsManagerSpec.g.h
@@ -13,7 +13,16 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(SettingsManagerSpec_Constants)
+struct SettingsManagerSpec_Constants {
+    REACT_FIELD(settings)
+    React::JSValue settings;
+};
+
 struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<SettingsManagerSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(React::JSValue) noexcept>{0, L"setValues"},
       Method<void(std::vector<std::string>) noexcept>{1, L"deleteValues"},
@@ -21,7 +30,14 @@ struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, SettingsManagerSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, SettingsManagerSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "SettingsManagerSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) SettingsManagerSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static SettingsManagerSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeSourceCodeSpec.g.h
+++ b/vnext/codegen/NativeSourceCodeSpec.g.h
@@ -13,14 +13,30 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(SourceCodeSpec_Constants)
+struct SourceCodeSpec_Constants {
+    REACT_FIELD(scriptURL)
+    std::string scriptURL;
+};
+
 struct SourceCodeSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<SourceCodeSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
 
   };
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, SourceCodeSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, SourceCodeSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "SourceCodeSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) SourceCodeSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static SourceCodeSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
 
   }

--- a/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
@@ -13,7 +13,18 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(StatusBarManagerAndroidSpec_Constants)
+struct StatusBarManagerAndroidSpec_Constants {
+    REACT_FIELD(HEIGHT)
+    double HEIGHT;
+    REACT_FIELD(DEFAULT_BACKGROUND_COLOR)
+    double DEFAULT_BACKGROUND_COLOR;
+};
+
 struct StatusBarManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<StatusBarManagerAndroidSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(double, bool) noexcept>{0, L"setColor"},
       Method<void(bool) noexcept>{1, L"setTranslucent"},
@@ -23,7 +34,14 @@ struct StatusBarManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleS
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, StatusBarManagerAndroidSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, StatusBarManagerAndroidSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "StatusBarManagerAndroidSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static StatusBarManagerAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
@@ -19,7 +19,18 @@ struct StatusBarManagerIOSSpec_getHeight_callback_result {
     double height;
 };
 
+REACT_STRUCT(StatusBarManagerIOSSpec_Constants)
+struct StatusBarManagerIOSSpec_Constants {
+    REACT_FIELD(HEIGHT)
+    double HEIGHT;
+    REACT_FIELD(DEFAULT_BACKGROUND_COLOR)
+    std::optional<double> DEFAULT_BACKGROUND_COLOR;
+};
+
 struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<StatusBarManagerIOSSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(Callback<StatusBarManagerIOSSpec_getHeight_callback_result>) noexcept>{0, L"getHeight"},
       Method<void(bool) noexcept>{1, L"setNetworkActivityIndicatorVisible"},
@@ -31,7 +42,14 @@ struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, StatusBarManagerIOSSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, StatusBarManagerIOSSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "StatusBarManagerIOSSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) StatusBarManagerIOSSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static StatusBarManagerIOSSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,

--- a/vnext/codegen/NativeToastAndroidSpec.g.h
+++ b/vnext/codegen/NativeToastAndroidSpec.g.h
@@ -13,7 +13,24 @@
 
 namespace Microsoft::ReactNativeSpecs {
 
+REACT_STRUCT(ToastAndroidSpec_Constants)
+struct ToastAndroidSpec_Constants {
+    REACT_FIELD(SHORT)
+    double SHORT;
+    REACT_FIELD(LONG)
+    double LONG;
+    REACT_FIELD(TOP)
+    double TOP;
+    REACT_FIELD(BOTTOM)
+    double BOTTOM;
+    REACT_FIELD(CENTER)
+    double CENTER;
+};
+
 struct ToastAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<ToastAndroidSpec_Constants>{0},
+  };
   static constexpr auto methods = std::tuple{
       Method<void(std::string, double) noexcept>{0, L"show"},
       Method<void(std::string, double, double) noexcept>{1, L"showWithGravity"},
@@ -22,7 +39,14 @@ struct ToastAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 
   template <class TModule>
   static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, ToastAndroidSpec>();
     constexpr auto methodCheckResults = CheckMethods<TModule, ToastAndroidSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+          0,
+          "ToastAndroidSpec_Constants",
+          "    REACT_GET_CONSTANTS(GetConstants) ToastAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n"
+          "    REACT_GET_CONSTANTS(GetConstants) static ToastAndroidSpec_Constants GetConstants() noexcept {/*implementation*/}\n");
 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,


### PR DESCRIPTION
- Update `GenerateNM2.ts` to create constant spec for turbo modules
- Move `REACT_CONSTANT` and `REACT_CONSTANT_PROVIDER` to `REACT_GET_CONSTANTS`
  - AppStateModule
  - I18nManagerModule
  - DeviceInfoModule

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8730)