### PR TITLE
[0.66] Upgrade V8 to version 9.5

### DIFF
--- a/change/react-native-windows-6a7327b1-a0a5-4a1a-b32d-fac4378feb1f.json
+++ b/change/react-native-windows-6a7327b1-a0a5-4a1a-b32d-fac4378feb1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade ReactNative.V8Jsi.Windows to 0.65.5",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.ChakraCore.vc140" version="1.11.24" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.2" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.5" targetFramework="native" />
   <package id="ReactWindows.ChakraCore.ARM64" version="1.11.20" targetFramework="native" developmentDependency="true" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.2" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.5" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.1" targetFramework="native" />
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.2" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.5" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -19,7 +19,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.65.2</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.65.5</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(SolutionDir)packages\$(V8PackageName).$(V8Version)</V8Package>

--- a/vnext/ReactCommon.UnitTests/packages.config
+++ b/vnext/ReactCommon.UnitTests/packages.config
@@ -4,5 +4,5 @@
   <package id="ChakraCore.Debugger" version="0.0.0.44" targetFramework="native" />
   <package id="Microsoft.ChakraCore.vc140" version="1.11.24" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.2" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.5" targetFramework="native" />
 </packages>


### PR DESCRIPTION
Backport of #8735

- Upgrade ReactNative.V8Jsi.Windows to 0.65.5
- Change files


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8736)