### PR TITLE
Upgrade NugetToolInstaller Instances to v1

### DIFF
--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -19,7 +19,7 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
-      - task: NuGetToolInstaller@0
+      - task: NuGetToolInstaller@1
         inputs:
           versionSpec: ">=5.8.0"
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -63,7 +63,7 @@ jobs:
           pathToPublish: $(Build.StagingDirectory)
           parallel: true
 
-      - task: NuGetToolInstaller@0
+      - task: NuGetToolInstaller@1
         inputs:
           versionSpec: ">=5.8.0"
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -314,7 +314,7 @@ jobs:
       - template: templates/apply-published-version-vars.yml
 
       # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
-      - task: NuGetToolInstaller@0
+      - task: NuGetToolInstaller@1
         inputs:
           versionSpec: ">=5.8.0"
 

--- a/.ado/templates/prepare-env.yml
+++ b/.ado/templates/prepare-env.yml
@@ -24,7 +24,7 @@ steps:
         Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\UWPNuGetPackages\Microsoft.Net.UWPCoreRuntimeSdk" | Select-Object FullName
 
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     inputs:
       versionSpec: ">=5.8.0"
 

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -78,7 +78,7 @@ steps:
       buildEnvironment: ${{ parameters.buildEnvironment }}
 
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     inputs:
       versionSpec: ">=5.8.0"
 


### PR DESCRIPTION
**_Why_**
NugetToolInstaller step of pipeline has been failing on and off for the last week.

**_What_**
Moved to NugetToolInstaller v1 from v0 in pipeline following suggestion in thread [here](https://developercommunity.visualstudio.com/t/DotNetTool-task-fails-randomly-with-ERR/1541538?space=21&q=nuget+download+tool&sort=newest). Since this buggy behavior is not consistent. Unclear if this change has resolved the issue, but will monitor over the coming weeks and see if behavior improves.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8741)