### PR TITLE
[0.63] Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.

### DIFF
--- a/change/@react-native-windows-cli-2021-09-29-12-53-42-0.63-bump-pkg.json
+++ b/change/@react-native-windows-cli-2021-09-29-12-53-42-0.63-bump-pkg.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.",
+  "packageName": "@react-native-windows/cli",
+  "email": "yicyao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2021-09-29T19:53:41.956Z"
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "**/@wdio/utils": "5.12.1",
     "**/webdriver": "git+https://github.com/react-native-windows/webdriver.git",
     "**/webdriverio": "5.12.1",
-    "xmldom": "^0.5.0"
+    "xmldom": "github:xmldom/xmldom#^0.7.5"
   },
   "beachball": {
     "gitTags": false

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -30,7 +30,7 @@
     "shelljs": "^0.8.4",
     "username": "^5.1.0",
     "uuid": "^3.3.2",
-    "xmldom": "^0.5.0",
+    "@xmldom/xmldom": "^0.7.5",
     "xml-parser": "^1.2.1",
     "xpath": "^0.0.27"
   },

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as glob from 'glob';
 
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import * as xpath from 'xpath';
 
 const msbuildSelect = xpath.useNamespaces({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3215,6 +3215,11 @@
     "@wdio/logger" "^5.12.1"
     deepmerge "^4.0.0"
 
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
+  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -14375,10 +14380,9 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
+xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, "xmldom@github:xmldom/xmldom#^0.7.5":
+  version "0.7.5"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/03fcf987307a9b1963075007d9fe2e8720fa7e25"
 
 xpath@0.0.27, xpath@^0.0.27:
   version "0.0.27"


### PR DESCRIPTION
Back port of 58c1fb59eaebbf496915921062540b963aff3685.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8746)