### PR TITLE
[0.64] Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.

### DIFF
--- a/change/@react-native-windows-cli-e0d819d2-894d-4c90-a47c-ec995d3cb9c5.json
+++ b/change/@react-native-windows-cli-e0d819d2-894d-4c90-a47c-ec995d3cb9c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.",
+  "packageName": "@react-native-windows/cli",
+  "email": "yicyao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node-fetch": "2.6.1",
     "webdriver": "git+https://github.com/react-native-windows/webdriver.git",
     "webdriverio": "5.12.1",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "xmldom": "github:xmldom/xmldom#^0.7.5",
     "xpath": "^0.0.27",
     "yargs-parser": "^18.1.1",
     "**/@react-native/repo-config/ws": "^6.2.2",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -32,7 +32,7 @@
     "username": "^5.1.0",
     "uuid": "^3.3.2",
     "xml-parser": "^1.2.1",
-    "xmldom": "^0.5.0",
+    "@xmldom/xmldom": "^0.7.5",
     "xpath": "^0.0.27"
   },
   "devDependencies": {

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as glob from 'glob';
 
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import * as xpath from 'xpath';
 
 const msbuildSelect = xpath.useNamespaces({

--- a/yarn.lock
+++ b/yarn.lock
@@ -12602,9 +12602,9 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, "xmldom@github:xmldom/xmldom#0.7.0":
-  version "0.7.0"
-  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
+xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, "xmldom@github:xmldom/xmldom#^0.7.5":
+  version "0.7.5"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/03fcf987307a9b1963075007d9fe2e8720fa7e25"
 
 xpath@0.0.27, xpath@^0.0.24, xpath@^0.0.27:
   version "0.0.27"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,6 +2503,11 @@
     "@wdio/logger" "^5.12.1"
     deepmerge "^4.0.0"
 
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
+  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -12597,7 +12602,7 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, xmldom@^0.5.0, "xmldom@github:xmldom/xmldom#0.7.0":
+xmldom@0.1.x, xmldom@^0.1.19, xmldom@^0.1.22, xmldom@^0.1.27, "xmldom@github:xmldom/xmldom#0.7.0":
   version "0.7.0"
   resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 


### PR DESCRIPTION
Back port of 58c1fb5.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8747)