### PR TITLE
[0.65] Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.

### DIFF
--- a/change/@react-native-windows-cli-904024e0-eb85-4b6b-b76e-32b697944ca5.json
+++ b/change/@react-native-windows-cli-904024e0-eb85-4b6b-b76e-32b697944ca5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Bump the version of xmldom used by @react-native-windows/cli to 0.7.0.",
+  "packageName": "@react-native-windows/cli",
+  "email": "yicyao@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "metro-react-native-babel-transformer": "^0.66.0",
     "metro-resolver": "^0.66.0",
     "metro-runtime": "^0.66.0",
-    "xmldom": "github:xmldom/xmldom#0.7.0",
+    "xmldom": "github:xmldom/xmldom#^0.7.5",
     "**/@react-native/repo-config/ws": "^6.2.2",
     "**/@react-native/tester/ws": "^6.2.2",
     "**/detox/ws": "^5.2.3"

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -33,7 +33,7 @@
     "uuid": "^3.3.2",
     "xml-formatter": "^2.4.0",
     "xml-parser": "^1.2.1",
-    "xmldom": "^0.5.0",
+    "@xmldom/xmldom": "^0.7.5",
     "xpath": "^0.0.27"
   },
   "devDependencies": {

--- a/packages/@react-native-windows/cli/src/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/config/configUtils.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as glob from 'glob';
 
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import * as xpath from 'xpath';
 import {CodedError} from '@react-native-windows/telemetry';
 

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import { projectConfigWindows } from '../config/projectConfig';
 import {AutolinkWindows} from '../runWindows/utils/autolink';
-import {DOMParser} from 'xmldom';
+import {DOMParser} from '@xmldom/xmldom';
 import { ensureWinUI3Project } from './projectConfig.utils';
 
 test('autolink with no windows project', () => {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -31,7 +31,7 @@ import {
 } from '../../config/dependencyConfig';
 import {Project, WindowsProjectConfig} from '../../config/projectConfig';
 import {CodedError} from '@react-native-windows/telemetry';
-import {XMLSerializer} from 'xmldom';
+import {XMLSerializer} from '@xmldom/xmldom';
 import {Ora} from 'ora';
 const formatter = require('xml-formatter');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,11 @@
   dependencies:
     "@wdio/logger" "6.10.10"
 
+"@xmldom/xmldom@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
+  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -11569,7 +11574,7 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.5.0, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
+xmldom@0.1.x, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
   version "0.7.0"
   resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11574,9 +11574,9 @@ xmldoc@^1.1.2:
   dependencies:
     sax "^1.2.1"
 
-xmldom@0.1.x, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
-  version "0.7.0"
-  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
+xmldom@0.1.x, xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#^0.7.5":
+  version "0.7.5"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/03fcf987307a9b1963075007d9fe2e8720fa7e25"
 
 xpath@^0.0.27:
   version "0.0.27"


### PR DESCRIPTION
Back port of 58c1fb5.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8748)