### PR TITLE
Switch ImageLoader to be a codegen'd turbomodule

### DIFF
--- a/change/react-native-windows-90f786a3-38e1-415b-bfd8-2473d3bab6ec.json
+++ b/change/react-native-windows-90f786a3-38e1-415b-bfd8-2473d3bab6ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Switch ImageLoader to be a codegen'd turbomodule",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -11,7 +11,6 @@
 #include <Modules/AppearanceModule.h>
 #include <Modules/AsyncStorageModuleWin32.h>
 #include <Modules/ClipboardModule.h>
-#include <Modules/ImageViewManagerModule.h>
 #include <Modules/LinkingManagerModule.h>
 #include <Modules/NativeUIManager.h>
 #include <Modules/NetworkingModule.h>
@@ -62,11 +61,6 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
 
   modules.emplace_back(
       LinkingManagerModule::name, []() { return std::make_unique<LinkingManagerModule>(); }, batchingUIMessageQueue);
-
-  modules.emplace_back(
-      ImageViewManagerModule::name,
-      []() { return std::make_unique<ImageViewManagerModule>(); },
-      batchingUIMessageQueue);
 
   modules.emplace_back(
       AppThemeModule::Name,

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
@@ -23,39 +23,20 @@ using namespace xaml::Media::Imaging;
 } // namespace winrt
 
 namespace Microsoft::ReactNative {
-//
-// ImageViewManagerModule::ImageViewManagerModuleImpl
-//
-class ImageViewManagerModule::ImageViewManagerModuleImpl {
- public:
-  ImageViewManagerModuleImpl(ImageViewManagerModule *parent) : m_parent(parent) {}
-
-  void Disconnect() {
-    m_parent = nullptr;
-  }
-
-  void getSize(std::string uri, Callback successCallback, Callback errorCallback);
-  void getSizeWithHeaders(std::string uri, folly::dynamic &headers, Callback successCallback, Callback errorCallback);
-  void prefetchImage(std::string uri, Callback successCallback, Callback errorCallback);
-  void queryCache(const folly::dynamic &requests, Callback successCallback, Callback errorCallback);
-
- private:
-  ImageViewManagerModule *m_parent;
-};
 
 winrt::fire_and_forget GetImageSizeAsync(
     std::string uriString,
-    folly::dynamic &headers,
-    facebook::xplat::module::CxxModule::Callback successCallback,
-    facebook::xplat::module::CxxModule::Callback errorCallback) {
+    winrt::Microsoft::ReactNative::JSValue &&headers,
+    Mso::Functor<void(int32_t width, int32_t height)> successCallback,
+    Mso::Functor<void()> errorCallback) {
   bool succeeded{false};
 
   try {
     ReactImageSource source;
     source.uri = uriString;
-    if (!headers.isNull()) {
-      for (auto &header : headers.items()) {
-        source.headers.push_back(std::make_pair(header.first.asString(), header.second.asString()));
+    if (!headers.IsNull()) {
+      for (auto &header : headers.AsObject()) {
+        source.headers.push_back(std::make_pair(header.first, header.second.AsString()));
       }
     }
 
@@ -77,96 +58,67 @@ winrt::fire_and_forget GetImageSizeAsync(
     }
 
     if (bitmap) {
-      successCallback({folly::dynamic::array(bitmap.PixelWidth(), bitmap.PixelHeight())});
+      successCallback(bitmap.PixelWidth(), bitmap.PixelHeight());
       succeeded = true;
     }
   } catch (winrt::hresult_error const &) {
   }
 
   if (!succeeded)
-    errorCallback({});
+    errorCallback();
 
   co_return;
 }
 
-void ImageViewManagerModule::ImageViewManagerModuleImpl::getSize(
+void ImageLoader::Initialize(React::ReactContext const &reactContext) noexcept {
+  m_context = reactContext;
+}
+
+void ImageLoader::getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept {
+  getSizeWithHeaders(std::move(uri), {}, std::move(result));
+}
+
+void ImageLoader::getSizeWithHeaders(
     std::string uri,
-    Callback successCallback,
-    Callback errorCallback) {
-  folly::dynamic headers{};
-  GetImageSizeAsync(uri, headers, successCallback, errorCallback);
+    React::JSValue &&headers,
+    React::ReactPromise<React::JSValue> &&result) noexcept {
+  m_context.UIDispatcher().Post([context = m_context,
+                                 uri = std::move(uri),
+                                 headers = std::move(headers),
+                                 result = std::move(result)]() mutable noexcept {
+    GetImageSizeAsync(
+        std::move(uri),
+        std::move(headers),
+        [result, context](int32_t width, int32_t height) noexcept {
+          context.JSDispatcher().Post([result = std::move(result), width, height]() noexcept {
+            result.Resolve(React::JSValueArray{width, height});
+          });
+        },
+        [result, context]() noexcept {
+          context.JSDispatcher().Post([result = std::move(result)]() noexcept { result.Reject("Failed"); });
+        });
+  });
 }
 
-void ImageViewManagerModule::ImageViewManagerModuleImpl::getSizeWithHeaders(
+void ImageLoader::prefetchImage(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept {
+  // NYI
+  result.Resolve(true);
+}
+
+void ImageLoader::prefetchImageWithMetadata(
     std::string uri,
-    folly::dynamic &headers,
-    Callback successCallback,
-    Callback errorCallback) {
-  GetImageSizeAsync(uri, headers, successCallback, errorCallback);
+    std::string queryRootName,
+    double rootTag,
+    React::ReactPromise<React::JSValue> &&result) noexcept {
+  // NYI
+  result.Resolve(true);
 }
 
-void ImageViewManagerModule::ImageViewManagerModuleImpl::prefetchImage(
-    std::string /*uri*/,
-    Callback successCallback,
-    Callback /*errorCallback*/) {
-  // NotYetImplemented
-  successCallback({});
-}
-
-void ImageViewManagerModule::ImageViewManagerModuleImpl::queryCache(
-    const folly::dynamic & /*requests*/,
-    Callback successCallback,
-    Callback /*errorCallback*/) {
-  // NotYetImplemented
-  successCallback({folly::dynamic::object()});
-}
-
-//
-// ImageViewManagerModule
-//
-const char *ImageViewManagerModule::name = "ImageLoader";
-
-ImageViewManagerModule::ImageViewManagerModule()
-    : m_imageViewManagerModule(std::make_shared<ImageViewManagerModuleImpl>(this)) {}
-
-ImageViewManagerModule::~ImageViewManagerModule() {}
-
-std::string ImageViewManagerModule::getName() {
-  return name;
-}
-
-std::map<std::string, folly::dynamic> ImageViewManagerModule::getConstants() {
-  return {{}};
-}
-
-auto ImageViewManagerModule::getMethods() -> std::vector<Method> {
-  std::shared_ptr<ImageViewManagerModuleImpl> imageViewManager(m_imageViewManagerModule);
-  return {
-      Method(
-          "getSize",
-          [imageViewManager](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            imageViewManager->getSize(facebook::xplat::jsArgAsString(args, 0), successCallback, errorCallback);
-          }),
-      Method(
-          "getSizeWithHeaders",
-          [imageViewManager](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            imageViewManager->getSizeWithHeaders(
-                facebook::xplat::jsArgAsString(args, 0),
-                facebook::xplat::jsArgAsObject(args, 1),
-                successCallback,
-                errorCallback);
-          }),
-      Method(
-          "prefetchImage",
-          [imageViewManager](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            imageViewManager->prefetchImage(facebook::xplat::jsArgAsString(args, 0), successCallback, errorCallback);
-          }),
-      Method(
-          "queryCache",
-          [imageViewManager](folly::dynamic args, Callback successCallback, Callback errorCallback) {
-            imageViewManager->queryCache(args[0], successCallback, errorCallback);
-          }),
-  };
+void ImageLoader::queryCache(
+    std::vector<std::string> const &uris,
+    React::ReactPromise<React::JSValue> &&result) noexcept {
+  // NYI
+  result.Resolve(React::JSValueObject{});
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
@@ -2,31 +2,42 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <cxxreact/CxxModule.h>
 
-namespace facebook {
-namespace react {
-class MessageQueueThread;
-}
-} // namespace facebook
+#include "../../codegen/NativeImageLoaderIOSSpec.g.h"
+#include <NativeModules.h>
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Graphics.Display.h>
 
 namespace Microsoft::ReactNative {
 
-class ImageViewManagerModule : public facebook::xplat::module::CxxModule {
- public:
-  ImageViewManagerModule();
-  virtual ~ImageViewManagerModule();
+REACT_MODULE(ImageLoader)
+struct ImageLoader {
+  REACT_INIT(Initialize)
+  void Initialize(React::ReactContext const &reactContext) noexcept;
 
-  // CxxModule
-  std::string getName() override;
-  std::map<std::string, folly::dynamic> getConstants() override;
-  auto getMethods() -> std::vector<Method> override;
+  REACT_METHOD(getSize)
+  void getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept;
 
-  static const char *name;
+  REACT_METHOD(getSizeWithHeaders)
+  void
+  getSizeWithHeaders(std::string uri, React::JSValue &&headers, React::ReactPromise<React::JSValue> &&result) noexcept;
+
+  REACT_METHOD(prefetchImage)
+  void prefetchImage(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept;
+
+  REACT_METHOD(prefetchImageWithMetadata)
+  void prefetchImageWithMetadata(
+      std::string uri,
+      std::string queryRootName,
+      double rootTag,
+      React::ReactPromise<React::JSValue> &&result) noexcept;
+
+  REACT_METHOD(queryCache)
+  void queryCache(std::vector<std::string> const &uris, React::ReactPromise<React::JSValue> &&result) noexcept;
 
  private:
-  class ImageViewManagerModuleImpl;
-  std::shared_ptr<ImageViewManagerModuleImpl> m_imageViewManagerModule;
+  React::ReactContext m_context;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -24,6 +24,7 @@
 #include "../../codegen/NativeDeviceInfoSpec.g.h"
 #include "../../codegen/NativeDialogManagerWindowsSpec.g.h"
 #include "../../codegen/NativeI18nManagerSpec.g.h"
+#include "../../codegen/NativeImageLoaderIOSSpec.g.h"
 #include "../../codegen/NativeLogBoxSpec.g.h"
 #include "../../codegen/NativeUIManagerSpec.g.h"
 #include "NativeModules.h"
@@ -55,6 +56,7 @@
 #endif
 #include "Modules/DevSettingsModule.h"
 #ifndef CORE_ABI
+#include <Modules/ImageViewManagerModule.h>
 #include "Modules/DeviceInfoModule.h"
 #include "Modules/I18nManagerModule.h"
 #include "Modules/LogBoxModule.h"
@@ -323,6 +325,12 @@ void ReactInstanceWin::LoadModules(
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
           ::Microsoft::ReactNative::DeviceInfo,
           ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
+
+  registerTurboModule(
+      L"ImageLoader",
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
+          ::Microsoft::ReactNative::ImageLoader,
+          ::Microsoft::ReactNativeSpecs::ImageLoaderIOSSpec>());
 #endif
 
   registerTurboModule(


### PR DESCRIPTION
ImageLoader is currently implemented using a cxxmodule.  This replaces that implementation with a TurboModule that is type checked against the native spec.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8754)