### PR TITLE
Update CLI Instructions for run-windows

### DIFF
--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -15,7 +15,7 @@ npx react-native run-windows
 Options:
 | option                | description                          | type                                             |
 |-----------------------|--------------------------------------|--------------------------------------------------|
-| `--release`           | Specifies a Release build | [boolean] |
+| `--release`           | Specifies a Release build. Requires a [certificate](https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing) in `windows/<App>` directory. | [boolean] |
 | `--root`              | Override the root directory for the windows build which contains the windows folder. (default: "E:\\test63") | [string] |
 | `--arch`              | The build architecture (ARM64, x86, x64). default: x86 | [string] |
 | `--singleproc`        | Disables multi-proc build | [boolean] |


### PR DESCRIPTION
**_Why_**
Certificates were removed from app init template in #8672. As a result, we need to update our instructions for running RNW apps in Release mode to notify developers that the responsibility will now be on them to generate a certificate.

Additional documentation updates on website in https://github.com/microsoft/react-native-windows-samples/pull/557.

Note we should wait to merge this PR in until the template change is live (i.e. when the next publish of react-native-windows-init occurs).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8761)