### PR TITLE
Add accessibilityClassName prop to ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-2224a620-6f6c-45f8-b17e-d15d92938cf8.json
+++ b/change/@office-iss-react-native-win32-2224a620-6f6c-45f8-b17e-d15d92938cf8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add accessibilityClassName property to ViewWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -382,6 +382,7 @@ const ReactNativeViewConfig: ViewConfig = {
     accessibilityDescription: true,
     accessibilityControls: true,
     accessibilityItemType: true,
+    accessibilityClassName: true,
     // Windows]
   },
 };

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -43,7 +43,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
   public render() {
     return (
       <ViewWin32>
-        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" accessibilityItemType="Comment" />
+        <ViewWin32 ref={this._labeledBy} accessibilityLabel="separate label for test" accessibilityItemType="Comment" accessibilityClassName="ViewWin32"/>
       <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
         <TouchableHighlight onPress={this._onPress}>
           <ViewWin32 accessibilityLabeledBy={this._labeledBy} style={styles.blackbox} />

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -182,6 +182,12 @@ export type BasePropsWin32 = {
     * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
     */
    accessibilityItemType?: string;
+
+  /**
+   * Used to specify a class name for an automation element which can be used to identify a group of automation elements
+   * with similar characteristics.
+   */
+   accessibilityClassName?: string;
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &


### PR DESCRIPTION
The accessibilityClassName property allows developers to assign a class name to one or more automation elements with similar characteristics. This property was requested by a partner to help search for automation elements in the accessibility tree that cannot be easily identified by other accessibility properties alone (like accessiblityRole for example).

This property will map to the UIAClassName property - Identifies the ClassName property, which is a string containing the class name for the automation element as assigned by the control developer.
The class name depends on the implementation of the UI Automation provider and therefore is not always in a standard format. However, if the class name is known, it can be used to verify that an application is working with the expected automation element.

This property does not exist in RN core and I could not find an ARIA property that matches it. The closest concept on the web I could find was the HTML "class" attribute which is mainly used for styling and I could not find a RN equivalent for it.