### PR TITLE
CLI: Default to deploy by layout

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -54,14 +54,14 @@ jobs:
             platform: x64
             projectType: app
             additionalInitArguments:
-            additionalRunArguments: --deploy-from-layout
+            additionalRunArguments:
           X64ReleaseCs:
             language: cs
             configuration: Release
             platform: x64
             projectType: app
             additionalInitArguments:
-            additionalRunArguments: --deploy-from-layout
+            additionalRunArguments:
           X86DebugCpp:
             language: cpp
             configuration: Debug
@@ -84,14 +84,14 @@ jobs:
               platform: x86
               projectType: app
               additionalInitArguments:
-              additionalRunArguments: --deploy-from-layout
+              additionalRunArguments:
             X86ReleaseCs:
               language: cs
               configuration: Release
               platform: x86
               projectType: app
               additionalInitArguments:
-              additionalRunArguments: --deploy-from-layout
+              additionalRunArguments:
             X64DebugCpp:
               language: cpp
               configuration: Debug
@@ -150,7 +150,7 @@ jobs:
             platform: x64
             projectType: app
             additionalInitArguments: --useHermes
-            additionalRunArguments: --deploy-from-layout
+            additionalRunArguments:
           # ARM64ReleaseCsHermes:
           #   language: cs
           #   configuration: Release
@@ -164,7 +164,7 @@ jobs:
             platform: x64
             projectType: app
             additionalInitArguments: --useHermes
-            additionalRunArguments: --deploy-from-layout
+            additionalRunArguments:
 
       pool: $(AgentPool.Medium)
       timeoutInMinutes: 60

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -193,14 +193,14 @@ jobs:
         matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
           X64DebugCppNuget:
             language: cpp
-            config: Debug
+            localConfig: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
             additionalRunArguments:
           X64DebugCsNuget:
             language: cs
-            config: Debug
+            localConfig: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
@@ -213,7 +213,7 @@ jobs:
         - template: ../templates/react-native-init.yml
           parameters:
             language: $(language)
-            configuration: $(config)
+            configuration: $(localConfig)
             platform: $(platform)
             projectType: $(projectType)
             additionalInitArguments: $(additionalInitArguments)

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -193,14 +193,14 @@ jobs:
         matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
           X64DebugCppNuget:
             language: cpp
-            localConfig: Debug
+            configuration: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
             additionalRunArguments:
           X64DebugCsNuget:
             language: cs
-            localConfig: Debug
+            configuration: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
@@ -213,7 +213,7 @@ jobs:
         - template: ../templates/react-native-init.yml
           parameters:
             language: $(language)
-            configuration: $(localConfig)
+            configuration: $(configuration)
             platform: $(platform)
             projectType: $(projectType)
             additionalInitArguments: $(additionalInitArguments)

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -193,14 +193,14 @@ jobs:
         matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
           X64DebugCppNuget:
             language: cpp
-            configuration: Debug
+            config: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
             additionalRunArguments:
           X64DebugCsNuget:
             language: cs
-            configuration: Debug
+            config: Debug
             platform: x86
             projectType: app
             additionalInitArguments:
@@ -213,7 +213,7 @@ jobs:
         - template: ../templates/react-native-init.yml
           parameters:
             language: $(language)
-            configuration: $(configuration)
+            configuration: $(config)
             platform: $(platform)
             projectType: $(projectType)
             additionalInitArguments: $(additionalInitArguments)

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -33,7 +33,7 @@ jobs:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
-          DeployOption: --deploy-from-layout
+          DeployOption:
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -68,8 +68,7 @@ jobs:
         parameters:
           buildEnvironment: ${{ parameters.BuildEnvironment }}
           encodedKey: sampleAppCPPEncodedKey
-          ${{ if eq(variables.BuildConfiguration, 'Release') }}:
-            buildConfiguration: Release
+          buildConfiguration: $(BuildConfiguration)
           buildPlatform: $(BuildPlatform)
           deployOption: $(DeployOption)
           buildLogDirectory: $(BuildLogDirectory)

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -6,10 +6,6 @@ parameters:
     type: string
   - name: configuration
     type: string
-    default: Debug
-    values:
-      - Debug
-      - Release
   - name: projectType
     type: string
   - name: additionalRunArguments

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -6,6 +6,10 @@ parameters:
     type: string
   - name: configuration
     type: string
+    default: Debug
+    values:
+      - Debug
+      - Release
   - name: projectType
     type: string
   - name: additionalRunArguments
@@ -192,7 +196,6 @@ steps:
 
   # Work around issue of parameters not getting expanded in conditions properly
   - powershell: |
-      Write-Host "##vso[task.setvariable variable=localConfig]${{ parameters.configuration}}"
       Write-Host "##vso[task.setvariable variable=MSBUILDDEBUGPATH]$(Build.StagingDirectory)\CrashDumps"
 
   # Useful info to have in the log, but also a necessary workaround to make sure the cli is cached by npx

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -213,8 +213,7 @@ steps:
     parameters:
       buildEnvironment: ${{ parameters.BuildEnvironment }}
       encodedKey: RNWEncodedKey
-      ${{ if eq(variables.localConfig, 'Release') }}:
-        buildConfiguration: Release
+      buildConfiguration: ${{ parameters.configuration }}
       buildPlatform: ${{ parameters.platform }}
       deployOption: ${{ parameters.additionalRunArguments }}
       buildLogDirectory: $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -92,6 +92,7 @@ steps:
   # Work around issue of parameters not getting expanded in conditions properly
   - powershell: |
       Write-Host "##vso[task.setvariable variable=localProjectType]${{ parameters.projectType}}"
+      Write-Host "##vso[task.setvariable variable=localConfiguration]${{ parameters.configuration}}"
 
   # We force the usage of npm instead of yarn because yarn has fragility issues when redirected to a different server (such as verdaccio)
   # We use --no-install and symlink the node_modules from the source tree to avoid having npx download react-native and all it dependencies

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -9,7 +9,7 @@ parameters:
     type: string
   - name: buildConfiguration
     type: string
-    default: 'Debug'
+    default: Debug
     values:
       - Debug
       - Release

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -9,7 +9,6 @@ parameters:
     type: string
   - name: buildConfiguration
     type: string
-    default: Debug
   - name: buildPlatform
     type: string
   - name: deployOption
@@ -25,26 +24,30 @@ steps:
       buildEnvironment: ${{ parameters.BuildEnvironment }}
       encodedKey: ${{ parameters.encodedKey }}
 
+  # Work around issue of parameters not getting expanded in conditions properly
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=localConfig]${{ parameters.buildConfiguration }}"
+
   - task: CmdLine@2
     displayName: run-windows (Debug)
     inputs:
       script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --msbuildprops AppxPackageSigningEnabled=False
       workingDirectory: ${{ parameters.workingDirectory }}
-    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Debug'))
+    condition: and(succeeded(), eq(variables.localConfig, 'Debug'))
 
   - task: CmdLine@2
     displayName: run-windows (Release) - PR
     inputs:
       script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops AppxPackageSigningEnabled=False
       workingDirectory: ${{ parameters.workingDirectory }}
-    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'PullRequest'))
+    condition: and(succeeded(), eq(variables.localConfig, 'Release'), eq('${{ parameters.buildEnvironment }}', 'PullRequest'))
 
   - task: CmdLine@2
     displayName: run-windows (Release) - CI
     inputs:
       script: yarn windows --no-packager --no-launch ${{ parameters.deployOption }} --arch ${{ parameters.buildPlatform }} --logging --buildLogDirectory ${{ parameters.buildLogDirectory }} --release --msbuildprops PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
       workingDirectory: ${{ parameters.workingDirectory }}
-    condition: and(succeeded(), eq('${{ parameters.buildConfiguration }}', 'Release'), eq('${{ parameters.buildEnvironment }}', 'Continuous'))
+    condition: and(succeeded(), eq(variables.localConfig, 'Release'), eq('${{ parameters.buildEnvironment }}', 'Continuous'))
 
   - template: ../templates/cleanup-certificate.yml
     parameters:

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -10,9 +10,6 @@ parameters:
   - name: buildConfiguration
     type: string
     default: Debug
-    values:
-      - Debug
-      - Release
   - name: buildPlatform
     type: string
   - name: deployOption

--- a/change/@react-native-windows-cli-5cfe030a-4c31-41aa-9c38-1f9c624e5e4a.json
+++ b/change/@react-native-windows-cli-5cfe030a-4c31-41aa-9c38-1f9c624e5e4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CLI: Default to deploy by layout",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -125,7 +125,7 @@ export const runWindowsOptions: CommandOption[] = [
   },
   {
     name: '--deploy-from-layout',
-    description: 'Force deploy from layout, even in release builds',
+    description: 'Force deploy from layout',
   },
   {
     name: '--sln [string]',

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -24,6 +24,7 @@ import * as build from './build';
 import {BuildConfig, RunWindowsOptions} from '../runWindowsOptions';
 import MSBuildTools from './msbuildtools';
 import {Config} from '@react-native-community/cli-types';
+import * as configUtils from '../../config/configUtils';
 import {WindowsProjectConfig} from '../../config/projectConfig';
 import {CodedError} from '@react-native-windows/telemetry';
 import Version from './version';
@@ -42,6 +43,69 @@ export function getBuildConfiguration(options: RunWindowsOptions): BuildConfig {
     : options.bundle
     ? 'DebugBundle'
     : 'Debug';
+}
+
+function shouldDeployByPackage(
+  options: RunWindowsOptions,
+  config: Config,
+): boolean {
+  if (options.deployFromLayout) {
+    // Force deploy by layout
+    return false;
+  }
+
+  let hasAppxSigningEnabled: boolean | null = null;
+  let hasPackageCertificateKeyFile: boolean | null = null;
+
+  // TODO: These two properties should really be determined by
+  // getting the actual values msbuild used during the build,
+  // but for now we'll try to get them manually
+
+  // Check passed in msbuild property overrides
+  if (options.msbuildprops) {
+    const msbuildprops = build.parseMsBuildProps(options);
+    if ('AppxSigningEnabled' in msbuildprops) {
+      hasAppxSigningEnabled =
+        msbuildprops.AppxSigningEnabled.toLowerCase() === 'true';
+    }
+    if ('PackageCertificateKeyFile' in msbuildprops) {
+      hasPackageCertificateKeyFile = true;
+    }
+  }
+
+  // If at least one override wasn't set, we need to parse the project file
+  if (hasAppxSigningEnabled === null || hasPackageCertificateKeyFile === null) {
+    const projectFile = build.getAppProjectFile(options, config);
+    if (projectFile) {
+      const projectContents = configUtils.readProjectFile(projectFile);
+
+      // Find AppxSigningEnabled
+      if (hasAppxSigningEnabled === null) {
+        const appxSigningEnabled = configUtils.tryFindPropertyValue(
+          projectContents,
+          'AppxSigningEnabled',
+        );
+        if (appxSigningEnabled !== null) {
+          hasAppxSigningEnabled = appxSigningEnabled.toLowerCase() === 'true';
+        }
+      }
+
+      // Find PackageCertificateKeyFile
+      if (hasPackageCertificateKeyFile === null) {
+        const packageCertificateKeyFile = configUtils.tryFindPropertyValue(
+          projectContents,
+          'PackageCertificateKeyFile',
+        );
+        if (packageCertificateKeyFile !== null) {
+          hasPackageCertificateKeyFile = true;
+        }
+      }
+    }
+  }
+
+  return (
+    hasAppxSigningEnabled === true && hasPackageCertificateKeyFile === true
+  );
 }
 
 function shouldLaunchApp(options: RunWindowsOptions): boolean {
@@ -290,7 +354,8 @@ export async function deployToDesktop(
 
   const appPackageFolder = getAppPackage(options, projectName);
 
-  if (options.release && !options.deployFromLayout) {
+  if (shouldDeployByPackage(options, config)) {
+    // Deploy by package
     await runPowerShellScriptFunction(
       'Removing old version of the app',
       windowsStoreAppUtils,
@@ -311,6 +376,7 @@ export async function deployToDesktop(
       'InstallAppFailure',
     );
   } else {
+    // Deploy from layout
     // If we have DeployAppRecipe.exe, use it (start in 16.8.4, earlier 16.8 versions have bugs)
     const appxRecipe = path.join(
       path.dirname(appxManifestPath),


### PR DESCRIPTION
This PR changes the CLI to always deploy from layout if:
- passed `--deploy-from-layout` (to force it) OR
- the build had `AppxSigningEnabled` missing or set to false OR
- the build had `PackageCertificateFile` not set

Alternatively, you can say we only try to deploy via package if BOTH
`AppxSigningEnabled` is set to true AND `PackageCertificateFile` is set.

Closes #8773

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8776)