### PR TITLE
Fix Alert not rendering in dark theme if XamlRoot or window is dark

### DIFF
--- a/change/react-native-windows-b59fd8be-3390-42f3-b269-8fce04ab15ae.json
+++ b/change/react-native-windows-b59fd8be-3390-42f3-b269-8fce04ab15ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix XAML bug with alerts inside a dark themed parent",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This works around XAML bug https://github.com/microsoft/microsoft-ui-xaml/issues/2331. It happens if a Window or XamlRoot's Content element has RequestedTheme set to Dark and then you open a ContentDialog in that window. To workaround we explicitly set the RequestedTheme on the Popup.

To test I have my OS color set to light, run playground app, set the theme to dark in the app, then open an Alert.

Before playground-win32:
![new-win32-before](https://user-images.githubusercontent.com/359157/135923386-35b4f2ee-0d5b-405e-b394-fa2262addec8.png)

After playground-win32:
![new-win32-after](https://user-images.githubusercontent.com/359157/135923558-4fc74576-e464-42c6-b5ee-e28a96727491.png)

Before playground (UWP):
![new-uwp-before](https://user-images.githubusercontent.com/359157/135923601-973ee214-f3a9-4616-ba3f-0035aba34349.png)

After playground (UWP):
![new-uwp-after](https://user-images.githubusercontent.com/359157/135923620-d006bade-6977-4405-ba2b-1080345c540d.png)
