### PR TITLE
Remove schedule from continuous.yml

### DIFF
--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -1,14 +1,5 @@
 name: RNW CI $(Date:yyyyMMdd).$(Rev:r)
 
-schedules:
-- cron: "0 11 * * *" # 11AM Daily UTC (3AM Daily PST)
-  displayName: Nightly CI verification build
-  branches:
-    include:
-      - main
-      - master
-      - 0.65-stable
-
 trigger: none # will disable CI builds entirely
 pr: none
 


### PR DESCRIPTION
The schedule is now being managed in ADO, removing this to prevent confusion.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8828)