### PR TITLE
Remove RuntimeTypeInfo even when fabric enabled

### DIFF
--- a/change/react-native-windows-11886957-e076-4c09-997e-77e67772c69c.json
+++ b/change/react-native-windows-11886957-e076-4c09-997e-77e67772c69c.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Remove rtti even when fabric enabled",
+  "comment": "Remove rtti even when fabric enabled (in release)",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -89,6 +89,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
+      <RuntimeTypeInfo Condition="'$(UseFabric)' == 'true' AND '$(Configuration)'=='Debug'">true</RuntimeTypeInfo>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>


### PR DESCRIPTION
Fixes #7981

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8834)