### PR TITLE
[0.66] Fix WACK for apps not packaging hermes.dll (#8823)

### DIFF
--- a/change/react-native-windows-971e0556-efe7-4ea1-90cf-fbd6ab4dc06d.json
+++ b/change/react-native-windows-971e0556-efe7-4ea1-90cf-fbd6ab4dc06d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix WACK for apps not packaging hermes.dll",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -143,6 +143,8 @@
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>Microsoft.ReactNative.def</ModuleDefinitionFile>
+      <!-- #8824: The Hermes NuGet package adds itself to be linked, but we go through Hermes Shim instead. Ignore the unused DLL until the NuGet target is parameterized -->
+      <AdditionalOptions>/IGNORE:4199</AdditionalOptions>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>$(ReactNativeWindowsDir)Microsoft.ReactNative\Views\cppwinrt;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -14,12 +14,14 @@
 #include <hermes/hermes_dbg.h>
 #endif
 #include "HermesRuntimeHolder.h"
+#include "HermesShim.h"
 
 #if defined(HERMES_ENABLE_DEBUGGER)
 #include <hermes/inspector/chrome/Registration.h>
 #endif
 
 using namespace facebook;
+using namespace Microsoft::ReactNative;
 
 namespace facebook {
 namespace react {
@@ -29,7 +31,7 @@ namespace {
 std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeSystraced(
     const ::hermes::vm::RuntimeConfig &runtimeConfig) {
   SystraceSection s("HermesExecutorFactory::makeHermesRuntimeSystraced");
-  return hermes::makeHermesRuntime(runtimeConfig);
+  return HermesShim::makeHermesRuntime(runtimeConfig);
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/vnext/Shared/HermesSamplingProfiler.cpp
+++ b/vnext/Shared/HermesSamplingProfiler.cpp
@@ -15,6 +15,7 @@
 #endif
 
 #include "HermesSamplingProfiler.h"
+#include "HermesShim.h"
 
 namespace Microsoft::ReactNative {
 
@@ -54,7 +55,7 @@ winrt::fire_and_forget HermesSamplingProfiler::Start() noexcept {
   if (!s_isStarted) {
     s_isStarted = true;
     co_await winrt::resume_background();
-    facebook::hermes::HermesRuntime::enableSamplingProfiler();
+    HermesShim::enableSamplingProfiler();
   }
 #endif
   co_return;
@@ -65,9 +66,9 @@ std::future<std::string> HermesSamplingProfiler::Stop() noexcept {
   if (s_isStarted) {
     s_isStarted = false;
     co_await winrt::resume_background();
-    facebook::hermes::HermesRuntime::disableSamplingProfiler();
+    HermesShim::disableSamplingProfiler();
     s_lastTraceFilePath = co_await getTraceFilePath();
-    facebook::hermes::HermesRuntime::dumpSampledTraceToFile(s_lastTraceFilePath);
+    HermesShim::dumpSampledTraceToFile(s_lastTraceFilePath);
   }
 #endif
   co_return s_lastTraceFilePath;

--- a/vnext/Shared/HermesShim.cpp
+++ b/vnext/Shared/HermesShim.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "HermesShim.h"
+
+namespace Microsoft::ReactNative::HermesShim {
+
+static HMODULE s_hermesModule{nullptr};
+static decltype(&facebook::hermes::makeHermesRuntime) s_makeHermesRuntime{nullptr};
+static decltype(&facebook::hermes::HermesRuntime::enableSamplingProfiler) s_enableSamplingProfiler{nullptr};
+static decltype(&facebook::hermes::HermesRuntime::disableSamplingProfiler) s_disableSamplingProfiler{nullptr};
+static decltype(&facebook::hermes::HermesRuntime::dumpSampledTraceToFile) s_dumpSampledTraceToFile{nullptr};
+
+static void EnsureHermesLoaded() noexcept {
+  if (!s_hermesModule) {
+    s_hermesModule = LoadLibrary(L"hermes.dll");
+    VerifyElseCrashSz(s_hermesModule, "Could not load \"hermes.dll\"");
+
+    s_makeHermesRuntime = reinterpret_cast<decltype(s_makeHermesRuntime)>(GetProcAddress(
+        s_hermesModule,
+        "?makeHermesRuntime@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@AEBVRuntimeConfig@vm@1@@Z"));
+    VerifyElseCrash(s_makeHermesRuntime);
+
+    s_enableSamplingProfiler = reinterpret_cast<decltype(s_enableSamplingProfiler)>(
+        GetProcAddress(s_hermesModule, "?enableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ"));
+    VerifyElseCrash(s_enableSamplingProfiler);
+
+    s_disableSamplingProfiler = reinterpret_cast<decltype(s_disableSamplingProfiler)>(
+        GetProcAddress(s_hermesModule, "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ"));
+    VerifyElseCrash(s_disableSamplingProfiler);
+
+    s_dumpSampledTraceToFile = reinterpret_cast<decltype(s_dumpSampledTraceToFile)>(GetProcAddress(
+        s_hermesModule,
+        "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z"));
+    VerifyElseCrash(s_dumpSampledTraceToFile);
+  }
+}
+
+std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes::vm::RuntimeConfig &runtimeConfig) {
+  EnsureHermesLoaded();
+  return s_makeHermesRuntime(runtimeConfig);
+}
+
+void enableSamplingProfiler() {
+  EnsureHermesLoaded();
+  s_enableSamplingProfiler();
+}
+
+void disableSamplingProfiler() {
+  EnsureHermesLoaded();
+  s_disableSamplingProfiler();
+}
+
+void dumpSampledTraceToFile(const std::string &fileName) {
+  EnsureHermesLoaded();
+  s_dumpSampledTraceToFile(fileName);
+}
+
+} // namespace Microsoft::ReactNative::HermesShim

--- a/vnext/Shared/HermesShim.h
+++ b/vnext/Shared/HermesShim.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <hermes/hermes.h>
+
+//! We do not package hermes.dll for projects that do not require it. We cannot
+//! use pure delay-loading to achieve this, since WACK will detect the
+//! non-present DLL. Functions in this namespace shim to the Hermes DLL via
+//! GetProcAddress.
+namespace Microsoft::ReactNative::HermesShim {
+
+std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes::vm::RuntimeConfig &runtimeConfig);
+void enableSamplingProfiler();
+void disableSamplingProfiler();
+void dumpSampledTraceToFile(const std::string &fileName);
+
+} // namespace Microsoft::ReactNative::HermesShim

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -32,6 +32,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)HermesSamplingProfiler.cpp">
       <ExcludedFromBuild Condition="'$(IncludeHermes)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)HermesShim.cpp">
+      <ExcludedFromBuild Condition="'$(IncludeHermes)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.cpp">
       <ExcludedFromBuild Condition="'$(IncludeHermes)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
@@ -79,6 +82,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)AsyncStorage\FollyDynamicConverter.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)AsyncStorage\KeyValueStorage.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)HermesSamplingProfiler.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)HermesShim.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ByteArrayBuffer.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ChakraApi.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ChakraCoreRuntime.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -130,6 +130,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)HermesSamplingProfiler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)HermesShim.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -376,6 +379,9 @@
       <Filter>Header Files\JSI</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)HermesSamplingProfiler.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)HermesShim.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Fixes #8812

We now build a single binary MSRN DLL for both Chakra and Hermes. The current architecture is to delay-load Hermes, which lets us avoid packaging the extra DLL for existing Chakra customers. We missed that calling Hermes functions from the MSRN DLL will break WACK validation for apps that do not include hermes.dll.

This affects 0.66, so there needs to be a relatively confined fix. This change bypasses WACK's detection of imports by using GetProcAddress to link to Hermes functions at runtime. Validation for the scenario is added separately in #8815. This was used to check that this fix works correctly.

This is a little bit skeevy, since the Hermes NuGet package will add hermes.lib to be linked, and local developers can import new Hermes functions without build failures. This will be caught by the above validation at CI-time, but is not ideal, and the unused imports creates warnings. #8824 tracks allowing the NuGet package to not add hermes.lib to be linked. We cannot backport such a change though, since Hermes NuGet package is defined in the user's template.

I expect this to be removed long-term. Either in the case of us always shipping the DLL (Hermes by default), or when we change the interface to be more pluggable.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8843)