### PR TITLE
CG: Bump ansi-regex 5.0.0 to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "set-value": "^4.0.1",
     "strip-ansi": "^6.0.1",
     "**/parse-url/normalize-url": "^4.5.1",
+    "**/@react-native/repo-config/jest-junit": "^13.0.0",
     "**/@react-native/repo-config/ws": "^6.2.2",
     "**/@react-native/tester/ws": "^6.2.2",
     "**/detox/ws": "^5.2.3"

--- a/packages/@react-native/repo-config/package.json
+++ b/packages/@react-native/repo-config/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-relay": "1.8.1",
     "flow-bin": "^0.161.0",
     "jest": "^26.6.3",
-    "jest-junit": "^13.0.0",
+    "jest-junit": "^10.0.0",
     "jscodeshift": "^0.11.0",
     "metro-babel-register": "0.66.2",
     "metro-transform-plugins": "^0.66.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6760,7 +6760,7 @@ jest-jasmine2@^26.6.3:
     pretty-format "^26.6.2"
     throat "^5.0.0"
 
-jest-junit@^13.0.0:
+jest-junit@^10.0.0, jest-junit@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-13.0.0.tgz#479be347457aad98ae8a5983a23d7c3ec526c9a3"
   integrity sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==


### PR DESCRIPTION
Fix to pass CG.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8859)