### PR TITLE
Update non-solid color brush cache entries on theme change

### DIFF
--- a/change/react-native-windows-0835df02-d3ab-4a99-88f2-96cb8352d82f.json
+++ b/change/react-native-windows-0835df02-d3ab-4a99-88f2-96cb8352d82f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Handle non-SolidColor brushes when updating brush cache on theme change",
+  "packageName": "react-native-windows",
+  "email": "jahiggin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -89,14 +89,15 @@ struct BrushCache {
       dq.TryEnqueue([this]() {
         for (auto &entry : m_map) {
           winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(entry.first))};
+          // If both the incoming new brush and the old brush are BOTH solid color brushes, update the brush color
           if (auto oldSCBrush = entry.second.try_as<xaml::Media::SolidColorBrush>()) {
             if (auto newSCBrush = resource.try_as<xaml::Media::SolidColorBrush>()) {
               oldSCBrush.Color(newSCBrush.Color());
+              return;
             }
           }
-          // Handle other brush types changing by simply updating the value stored at the resource name's
-          // entry in the map
-          else if (auto newBrush = resource.try_as<xaml::Media::Brush>()) {
+          // If the incoming or old brush are not solid color brushes, replace the brush in the cache map
+          if (auto newBrush = resource.try_as<xaml::Media::Brush>()) {
             m_map.insert_or_assign(entry.first, newBrush);
           }
         }

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -94,14 +94,11 @@ struct BrushCache {
               oldSCBrush.Color(newSCBrush.Color());
             }
           }
-          // Similar logic can be applied to copy Acrylic or Reveal brushes
-          /*
-          else if (auto oldAcBrush = entry.second.try_as<xaml::Media::AcrylicBrush>()) {
-            if (auto newAcBrush = resource.try_as<xaml::Media::AcrylicBrush>()) {
-              // ...
-            }
+          // Handle other brush types changing by simply updating the value stored at the resource name's
+          // entry in the map
+          else if (auto newBrush = resource.try_as<xaml::Media::Brush>()) {
+            m_map.insert_or_assign(entry.first, newBrush);
           }
-          */
         }
       });
     });


### PR DESCRIPTION
Fixes #8861 

Currently, when the Windows theme changes, any non SolidColorBrush in the BrushCache is not updated to a new value if one exists for the new theme. This PR changes this to re-fetch the new brush value regardless of type and update it in the cache's `m_map` object.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8863)