### PR TITLE
DRAFT: Add config option to ensure Alert is shown on correct window

### DIFF
--- a/change/react-native-windows-3b9d9788-7040-4179-96a2-bc8c81b09c74.json
+++ b/change/react-native-windows-3b9d9788-7040-4179-96a2-bc8c81b09c74.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add config option to ensure Alert is shown on correct window",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -52,7 +52,19 @@ void Alert::ProcessPendingAlertRequests() noexcept {
 
   if (Is19H1OrHigher()) {
     // XamlRoot added in 19H1
-    if (const auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle())) {
+    const auto xamlUIService = React::XamlUIService::FromContext(m_context.Handle());
+    xaml::XamlRoot xamlRoot = nullptr;
+    if (args.rootTag) {
+      if (const auto element = xamlUIService.ElementFromReactTag(args.rootTag.value()).try_as<xaml::UIElement>()) {
+        xamlRoot = element.XamlRoot();
+      }
+    }
+
+    if (!xamlRoot) {
+      xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle());
+    }
+
+    if (xamlRoot) {
       useXamlRootForThemeBugWorkaround = true;
       dialog.XamlRoot(xamlRoot);
       auto rootChangedToken = xamlRoot.Changed([=](auto &&, auto &&) {

--- a/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
@@ -31,6 +31,8 @@ struct DialogManagerWindowsSpec_DialogOptions {
     std::optional<bool> cancelable;
     REACT_FIELD(defaultButton)
     std::optional<int> defaultButton;
+    REACT_FIELD(rootTag)
+    std::optional<int> rootTag;
 };
 
 REACT_STRUCT(DialogManagerWindowsSpec_Constants)

--- a/vnext/src/Libraries/Alert/Alert.windows.js
+++ b/vnext/src/Libraries/Alert/Alert.windows.js
@@ -25,6 +25,7 @@ export type Buttons = Array<{
 type Options = {
   cancelable?: ?boolean,
   onDismiss?: ?() => void,
+  rootTag?: number,
   ...
 };
 
@@ -49,11 +50,17 @@ class Alert {
       title: title || '',
       message: message || '',
       cancelable: false,
+      rootTag: -1,
     };
 
     if (options && options.cancelable) {
       config.cancelable = options.cancelable;
     }
+
+    if (options && options.rootTag) {
+      config.rootTag = options.rootTag;
+    }
+
     // At most three buttons (neutral, negative, positive). Ignore rest.
     // The text 'OK' should be probably localized. iOS Alert does that in native.
     const defaultPositiveText = 'OK';

--- a/vnext/src/Libraries/Alert/NativeDialogManagerWindows.js
+++ b/vnext/src/Libraries/Alert/NativeDialogManagerWindows.js
@@ -29,6 +29,7 @@ export type DialogOptions = {|
   items?: Array<string>,
   cancelable?: boolean,
   defaultButton?: Int32,
+  rootTag?: Int32,
 |};
 
 export interface Spec extends TurboModule {


### PR DESCRIPTION
This change adds an additional config option to specify a root tag that
the alert can be shown on. Apps that wish to ensure the alert is shown
on the correct window can do something like:

```js
const rootTag = useRootTag();
Alert.alert(title, message, [/* buttons */], {rootTag});
```

Fixes #5652

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8874)