### PR TITLE
[0.66] Fix AppTheme Regressions (#8901)

### DIFF
--- a/change/react-native-windows-e0599a4a-9aac-43f9-a89f-f7189c6752d9.json
+++ b/change/react-native-windows-e0599a4a-9aac-43f9-a89f-f7189c6752d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix AppTheme Regressions",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/AppTheme/AppTheme.ts
+++ b/vnext/src/Libraries/AppTheme/AppTheme.ts
@@ -5,17 +5,36 @@
  */
 'use strict';
 
-import {NativeEventEmitter, NativeModules} from 'react-native';
+import {
+  EmitterSubscription,
+  NativeEventEmitter,
+  NativeModules,
+} from 'react-native';
 import {IHighContrastColors, IHighContrastChangedEvent} from './AppThemeTypes';
 
-const NativeAppTheme = NativeModules.RTCAppTheme;
+// We previously gracefully handled importing AppTheme in the Jest environment.
+// Mock the NM until we have a coherent story for exporting our own Jest mocks,
+// or remove this API.
+const NativeAppTheme = NativeModules.RTCAppTheme || {
+  initialHighContrast: false,
+  initialHighContrastColors: {
+    ButtonFaceColor: '',
+    ButtonTextColor: '',
+    GrayTextColor: '',
+    HighlightColor: '',
+    HighlightTextColor: '',
+    HotlightColor: '',
+    WindowColor: '',
+    WindowTextColor: '',
+  },
+};
 
 class AppThemeModule extends NativeEventEmitter {
   private _isHighContrast: boolean;
   private _highContrastColors: IHighContrastColors;
 
   constructor() {
-    super(NativeAppTheme);
+    super();
 
     this._highContrastColors = NativeAppTheme.initialHighContrastColors;
     this._isHighContrast = NativeAppTheme.initialHighContrast;
@@ -26,6 +45,13 @@ class AppThemeModule extends NativeEventEmitter {
         this._highContrastColors = nativeEvent.highContrastColors;
       },
     );
+  }
+
+  addListener(
+    eventName: 'highContrastChanged',
+    listener: (nativeEvent: IHighContrastChangedEvent) => void,
+  ): EmitterSubscription {
+    return super.addListener(eventName, listener);
   }
 
   get isHighContrast(): boolean {


### PR DESCRIPTION
* Fix AppTheme Regressions

Fixes #8887

Fixes warnings emitted due to upstream NativeEventEmitter refactoring, along with a more specific typing for the API to add a listener.

Fix an uninetional  behavior change when AppTheme is imported in a jest environment.

Not manually validated yet due to some local issues.

* Change files

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8913)