### PR TITLE
[0.67] Fix Init Tests off-by-one RNW version

### DIFF
--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -21,8 +21,8 @@ stages:
 
           - template: templates/yarn-install.yml
 
-          - script: npx --no-install beachball publish --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes -m "applying package updates ***NO_CI***" --bump-deps  --access public --no-git-tags --no-push --no-publish
-            displayName: Beachball Determine versions
+          - script: npx --no-install beachball bump --branch origin/$(Build.SourceBranchName) --yes
+            displayName: beachball bump
 
           - template: templates/set-version-vars.yml
             parameters:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -79,6 +79,10 @@ steps:
   - script: npx --no-install beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
+    # Beachball reverts to local state after publish, but we need to know the new version it pushed.
+  - script: npx --no-install beachball bump --branch origin/$(BeachBallBranchName) --yes
+    displayName: beachball bump
+
   - template: set-version-vars.yml
     parameters:
       buildEnvironment: ${{ parameters.buildEnvironment }}

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -31,10 +31,11 @@ stages:
 
           - template: templates/compute-beachball-branch-name.yml
 
-          - task: CmdLine@2
+          - script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
             displayName: Check for change files
-            inputs:
-              script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+
+          - script: npx --no-install beachball bump --branch origin/$(BeachBallBranchName) --yes
+            displayName: beachball bump
 
           - template: templates/set-version-vars.yml
             parameters:


### PR DESCRIPTION
Beachball changed to revert to previous state after a publish. We fixed this in our publish pipeline, but CLI init tests still assume package.json points to the new version after publish. Bump so that we set the correct new RNW version for later steps.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8919)