### PR TITLE
Update package.json to include the repository

### DIFF
--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -10,6 +10,11 @@
     "watch": "rnw-scripts watch"
   },
   "main": "lib-commonjs/findRepoRoot.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@react-native-windows/find-repo-root"
+  },
   "dependencies": {
     "find-up": "^4.1.0"
   },

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -10,6 +10,11 @@
     "watch": "rnw-scripts watch"
   },
   "main": "lib-commonjs/packageUtils.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@react-native-windows/package-utils"
+  },
   "dependencies": {
     "@react-native-windows/find-repo-root": "^0.0.0-canary.25",
     "get-monorepo-packages": "^1.2.0",

--- a/packages/@rnw-bots/coordinator/package.json
+++ b/packages/@rnw-bots/coordinator/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.11",
   "license": "MIT",
   "description": "Azure functions application for coordinating react-native-windows bots",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-bots/coordinator"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/babel-node-config/package.json
+++ b/packages/@rnw-scripts/babel-node-config/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.2",
   "license": "MIT",
   "main": "babel.config.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/babel-node-config"
+  },
   "devDependencies": {
     "@babel/core": "^7.14.0",
     "@babel/preset-env": "^7.8.4",

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/create-github-releases",
   "version": "1.1.5",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/create-github-releases"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/doxysaurus/package.json
+++ b/packages/@rnw-scripts/doxysaurus/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/doxysaurus",
   "version": "0.1.9",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/doxysaurus"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/eslint-config/package.json
+++ b/packages/@rnw-scripts/eslint-config/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.8",
   "license": "MIT",
   "main": "eslintrc.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/eslint-config"
+  },
   "dependencies": {
     "@react-native-community/eslint-config": "^2.0.0",
     "eslint-config-prettier": "^6.0.0"

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/format-files",
   "version": "1.0.26",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/format-files"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/integrate-rn",
   "version": "1.0.38",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/integrate-rn"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/jest-debug-config/package.json
+++ b/packages/@rnw-scripts/jest-debug-config/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.4",
   "license": "MIT",
   "main": "jest.debug.config.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/jest-debug-config"
+  },
   "dependencies": {
     "@rnw-scripts/babel-node-config": "2.0.2"
   },

--- a/packages/@rnw-scripts/jest-e2e-config/package.json
+++ b/packages/@rnw-scripts/jest-e2e-config/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.6",
   "license": "MIT",
   "main": "jest.e2e.config.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/jest-e2e-config"
+  },
   "dependencies": {
     "@rnw-scripts/babel-node-config": "2.0.2"
   },

--- a/packages/@rnw-scripts/jest-out-of-snapshot-resolver/package.json
+++ b/packages/@rnw-scripts/jest-out-of-snapshot-resolver/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.2",
   "license": "MIT",
   "main": "jest-snapshot-resolver.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/jest-out-of-snapshot-resolver"
+  },
   "devDependencies": {
     "@rnw-scripts/eslint-config": "1.1.8",
     "eslint": "7.12.0",

--- a/packages/@rnw-scripts/jest-out-of-tree-resolver/package.json
+++ b/packages/@rnw-scripts/jest-out-of-tree-resolver/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.3",
   "license": "MIT",
   "main": "jest-resolver.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/jest-out-of-tree-resolver"
+  },
   "dependencies": {
     "resolve": "^1.14.2"
   },

--- a/packages/@rnw-scripts/jest-unittest-config/package.json
+++ b/packages/@rnw-scripts/jest-unittest-config/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.4",
   "license": "MIT",
   "main": "jest.unittest.config.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/jest-unittest-config"
+  },
   "dependencies": {
     "@rnw-scripts/babel-node-config": "2.0.2"
   },

--- a/packages/@rnw-scripts/just-task/package.json
+++ b/packages/@rnw-scripts/just-task/package.json
@@ -3,6 +3,11 @@
   "version": "2.2.1",
   "license": "MIT",
   "main": "just-task.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/just-task"
+  },
   "bin": {
     "rnw-scripts": "./bin/rnw-scripts.js"
   },

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/promote-release",
   "version": "1.2.27",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/promote-release"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -2,6 +2,11 @@
   "name": "@rnw-scripts/take-screenshot",
   "version": "1.0.17",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/take-screenshot"
+  },
   "scripts": {
     "build": "rnw-scripts build",
     "clean": "rnw-scripts clean",

--- a/packages/@rnw-scripts/ts-config/package.json
+++ b/packages/@rnw-scripts/ts-config/package.json
@@ -3,6 +3,11 @@
   "version": "2.0.1",
   "license": "MIT",
   "main": "tsconfig.json",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/react-native-windows.git",
+    "directory": "packages/@rnw-scripts/ts-config"
+  },
   "engines": {
     "node": ">= 12.0.0"
   }


### PR DESCRIPTION
Hi there!
This change adds the repository property to your package.json file(s). Having this available provides a number of benefits to security tooling. For example, it allows for greater trust by checking for signed commits, contributors to a release and validating history with the project. It also allows for comparison between the source code and the published artifact in order to detect attacks on authors during the publication process.
We validate that we're making a PR against the correct repository by comparing the metadata for the published artifact on [npmjs.com](www.npmjs.com) against the metadata in the package.json file in the repository.
This change is provided by a team at Microsoft -- we're happy to answer any questions you may have. (Members of this team include [@s-tuli](https://github.com/s-tuli), [@iarna](https://github.com/iarna), [@rancyr](https://github.com/v-rr), [@Jaydon Peng](https://github.com/v-jiepeng), [@Zhongpeng Zhou](https://github.com/v-zhzhou) and [@Jingying Gu](https://github.com/v-gjy)). If you would prefer that we not make these sorts of PRs to projects you maintain, please just say. If you'd like to learn more about what we're doing here, we've prepared a document talking about both this project and some of our other activities around supply chain security here: [microsoft/Secure-Supply-Chain](https://github.com/microsoft/Secure-Supply-Chain)
This PR provides repository metadata for the following packages:
* @rnw-scripts/ts-config
* @rnw-scripts/take-screenshot
* @rnw-scripts/promote-release
* @rnw-scripts/just-task
* @rnw-scripts/jest-unittest-config
* @rnw-scripts/jest-out-of-tree-snapshot-resolver
* @rnw-scripts/jest-out-of-tree-resolver
* @rnw-scripts/jest-e2e-config
* @rnw-scripts/jest-debug-config
* @rnw-scripts/integrate-rn
* @rnw-scripts/format-files
* @rnw-scripts/eslint-config
* @rnw-scripts/doxysaurus
* @rnw-scripts/create-github-releases
* @rnw-scripts/babel-node-config
* @rnw-bots/coordinator
* @react-native-windows/package-utils
* @react-native-windows/find-repo-root

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8929)