### PR TITLE
[0.67] Upgrade WinUI/MUX to 2.7 (#8726)

### DIFF
--- a/change/@react-native-windows-cli-b48b1ee3-e8c5-48b7-a915-d4f16f794dc5.json
+++ b/change/@react-native-windows-cli-b48b1ee3-e8c5-48b7-a915-d4f16f794dc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade WinUI/MUX to 2.7",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-aa33d71f-b112-4de6-b245-cf3818756c8b.json
+++ b/change/react-native-windows-aa33d71f-b112-4de6-b245-cf3818756c8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade WinUI/MUX to 2.7",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -421,24 +421,24 @@ test('ensureXAMLDialect - WinUI2xVersion specified in ExperimentalFeatures.props
       logging: false,
     },
   );
-  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>`;
+  al.experimentalFeaturesProps = `<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.7.0-test</WinUI2xVersion></PropertyGroup></Project>`;
   al.packagesConfig = `<packages><package id="SuperPkg" version="42"/></packages>`;
 
   const exd = await al.ensureXAMLDialect();
   expect(exd).toBeTruthy();
 
   const expectedExperimentalFeatures =
-    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.6.0-test</WinUI2xVersion></PropertyGroup></Project>';
+    '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"><PropertyGroup><UseWinUI3>false</UseWinUI3><WinUI2xVersion>2.7.0-test</WinUI2xVersion></PropertyGroup></Project>';
   expect(al.experimentalFeaturesProps).toEqual(expectedExperimentalFeatures);
 
   // example packages.config:
   // <packages>
   //   <package id="SuperPkg" version="42"/>
-  //   <package id="Microsoft.UI.XAML" version="2.6.0-test" targetFramework="native"/>
+  //   <package id="Microsoft.UI.XAML" version="2.7.0-test" targetFramework="native"/>
   // </packages>
   //
   expect(al.packagesConfig).toContain('Microsoft.UI.Xaml');
-  expect(al.packagesConfig).toContain('2.6.0-test');
+  expect(al.packagesConfig).toContain('2.7.0-test');
   expect(al.packagesConfig).toContain('<package id="SuperPkg" version="42"/>');
   expect(al.packagesConfig).not.toContain('Microsoft.WinUI');
 

--- a/packages/integration-test-app/windows/integrationtest/packages.config
+++ b/packages/integration-test-app/windows/integrationtest/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
+  <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Unpackaged playground-win32" Condition="'$(SolutionName)'=='playground-win32'">
-    <WinUI2xVersion>2.6.1-prerelease.210709001</WinUI2xVersion>
+    <WinUI2xVersion>2.7.0-prerelease.210913003</WinUI2xVersion>
   </PropertyGroup>
 
 </Project>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -6,7 +6,7 @@
       Playground-Win32 is an unpackaged win32 app, and needs to use Microsoft.UI.Xaml from a prerelease, to be able to carry WinUI in-app instead of using the Framework Package 
     /WARNING
   -->
-  <package id="Microsoft.UI.Xaml" version="2.6.1-prerelease.210709001" targetFramework="native"/>
+  <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
+  <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native"/>
 </packages>

--- a/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
+++ b/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
@@ -187,14 +187,14 @@
     <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets'))" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.UI.Xaml.2.6.0\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.6.0\build\native\Microsoft.UI.Xaml.targets')" />
+    <Import Project="..\packages\Microsoft.UI.Xaml.2.7.0\build\native\Microsoft.UI.Xaml.targets" Condition="Exists('..\packages\Microsoft.UI.Xaml.2.7.0\build\native\Microsoft.UI.Xaml.targets')" />
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.6.0\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.6.0\build\native\Microsoft.UI.Xaml.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.UI.Xaml.2.7.0\build\native\Microsoft.UI.Xaml.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.UI.Xaml.2.7.0\build\native\Microsoft.UI.Xaml.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>

--- a/packages/sample-apps/windows/SampleAppCPP/packages.config
+++ b/packages/sample-apps/windows/SampleAppCPP/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native" />

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -7,7 +7,7 @@
 
   <PropertyGroup Label="WinUI2x versioning">
 		<!--This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.6.0</WinUI2xVersion>
+    <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.7.0</WinUI2xVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(UseWinUI3)'=='true'">

--- a/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
+++ b/vnext/Scripts/Microsoft.ReactNative.Managed.nuspec
@@ -15,7 +15,7 @@
     <tags>react react-native react-native-windows native-module microsoft c# csharp</tags>
     <dependencies>
       <group targetFramework="UAP10.0">
-        <dependency id="Microsoft.UI.Xaml" version="2.6.0" />
+        <dependency id="Microsoft.UI.Xaml" version="2.7.0" />
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.9" />
         <dependency id="Microsoft.ReactNative" version="$version$" />
         <dependency id="Microsoft.ReactNative.Managed.CodeGen" version="$version$" />


### PR DESCRIPTION
This PR upgrades our MUX dependency from 2.6 to 2.7.

Closes #8724

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8938)