### PR TITLE
Replace use of FrameworkElement.Tag with a custom attached property

### DIFF
--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -930,12 +930,21 @@ winrt::Windows::Foundation::Rect GetRectOfElementInParentCoords(xaml::UIElement 
 
   winrt::GeneralTransform transform = element.TransformToVisual(parent);
   winrt::Point anchorTopLeftConverted = transform.TransformPoint(anchorTopLeft);
-  auto size = element.ActualSize();
 
   anchorRect.X = anchorTopLeftConverted.X;
   anchorRect.Y = anchorTopLeftConverted.Y;
-  anchorRect.Width = size.x;
-  anchorRect.Height = size.y;
+
+  if (auto uiElem = element.try_as<xaml::IUIElement10>()) {
+    auto size = uiElem.ActualSize();
+    anchorRect.Width = size.x;
+    anchorRect.Height = size.y;
+  } else if (auto fe = element.try_as<xaml::FrameworkElement>()) {
+    anchorRect.Width = static_cast<float>(fe.ActualWidth());
+    anchorRect.Height = static_cast<float>(fe.ActualHeight());
+  } else {
+    anchorRect.Width = 0;
+    anchorRect.Height = 0;
+  }
 
   return anchorRect;
 }

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -93,10 +93,6 @@ class NativeUIManager final : public INativeUIManager {
   // specific root tag.
   xaml::XamlRoot tryGetXamlRoot(int64_t rootTag);
 
-  // Searches itself and its parent to get a valid XamlView.
-  // Like Mouse/Keyboard, the event source may not have matched XamlView.
-  XamlView reactPeerOrContainerFrom(xaml::FrameworkElement fe);
-
   int64_t AddMeasuredRootView(facebook::react::IReactRootView *rootView);
 
  private:

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -13,89 +13,89 @@
 #include <processthreadsapi.h>
 
 namespace winrt {
-  using namespace xaml::Controls::Primitives;
-  using namespace xaml::Media;
-  using namespace Windows::Foundation::Metadata;
+using namespace xaml::Controls::Primitives;
+using namespace xaml::Media;
+using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 
 namespace Microsoft::ReactNative {
 
-  std::int32_t CountOpenPopups() {
-    // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
-    // RS6
-    winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
+std::int32_t CountOpenPopups() {
+  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
+  // RS6
+  winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
       xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
-    return (int32_t)popups.Size();
-  }
+  return (int32_t)popups.Size();
+}
 
-  template <uint16_t APIVersion>
-  bool IsAPIContractVxAvailable() {
-    static bool isAPIContractVxAvailableInitialized = false;
-    static bool isAPIContractVxAvailable = false;
-    if (!isAPIContractVxAvailableInitialized) {
-      isAPIContractVxAvailableInitialized = true;
-      isAPIContractVxAvailable =
+template <uint16_t APIVersion>
+bool IsAPIContractVxAvailable() {
+  static bool isAPIContractVxAvailableInitialized = false;
+  static bool isAPIContractVxAvailable = false;
+  if (!isAPIContractVxAvailableInitialized) {
+    isAPIContractVxAvailableInitialized = true;
+    isAPIContractVxAvailable =
         winrt::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
-    }
-
-    return isAPIContractVxAvailable;
   }
 
-  bool IsAPIContractV5Available() {
-    return IsAPIContractVxAvailable<5>();
-  }
+  return isAPIContractVxAvailable;
+}
 
-  bool IsAPIContractV6Available() {
-    return IsAPIContractVxAvailable<6>();
-  }
+bool IsAPIContractV5Available() {
+  return IsAPIContractVxAvailable<5>();
+}
 
-  bool IsAPIContractV7Available() {
-    return IsAPIContractVxAvailable<7>();
-  }
+bool IsAPIContractV6Available() {
+  return IsAPIContractVxAvailable<6>();
+}
 
-  bool IsAPIContractV8Available() {
-    return IsAPIContractVxAvailable<8>();
-  }
+bool IsAPIContractV7Available() {
+  return IsAPIContractVxAvailable<7>();
+}
 
-  bool IsAPIContractV12Available() {
-    return IsAPIContractVxAvailable<12>();
-  }
+bool IsAPIContractV8Available() {
+  return IsAPIContractVxAvailable<8>();
+}
 
-  bool IsRS3OrHigher() {
-    return IsAPIContractV5Available();
-  }
+bool IsAPIContractV12Available() {
+  return IsAPIContractVxAvailable<12>();
+}
 
-  bool IsRS4OrHigher() {
-    return IsAPIContractV6Available();
-  }
+bool IsRS3OrHigher() {
+  return IsAPIContractV5Available();
+}
 
-  bool IsRS5OrHigher() {
-    return IsAPIContractV7Available();
-  }
+bool IsRS4OrHigher() {
+  return IsAPIContractV6Available();
+}
 
-  bool Is19H1OrHigher() {
-    return IsAPIContractV8Available();
-  }
+bool IsRS5OrHigher() {
+  return IsAPIContractV7Available();
+}
 
-  bool Is21H1OrHigher() {
-    return IsAPIContractV12Available();
-  }
+bool Is19H1OrHigher() {
+  return IsAPIContractV8Available();
+}
 
-  bool IsXamlIsland() {
-    AppPolicyWindowingModel e;
-    if (FAILED(AppPolicyGetWindowingModel(GetCurrentThreadEffectiveToken(), &e)) ||
+bool Is21H1OrHigher() {
+  return IsAPIContractV12Available();
+}
+
+bool IsXamlIsland() {
+  AppPolicyWindowingModel e;
+  if (FAILED(AppPolicyGetWindowingModel(GetCurrentThreadEffectiveToken(), &e)) ||
       e == AppPolicyWindowingModel_ClassicDesktop) {
-      return true;
-    }
-    return false;
+    return true;
   }
+  return false;
+}
 
-  bool IsWinUI3Island() {
+bool IsWinUI3Island() {
 #ifndef USE_WINUI3
-    return false;
+  return false;
 #else
-    return IsXamlIsland();
+  return IsXamlIsland();
 #endif
-  }
+}
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -13,110 +13,89 @@
 #include <processthreadsapi.h>
 
 namespace winrt {
-using namespace xaml::Controls::Primitives;
-using namespace xaml::Media;
-using namespace Windows::Foundation::Metadata;
+  using namespace xaml::Controls::Primitives;
+  using namespace xaml::Media;
+  using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 
 namespace Microsoft::ReactNative {
 
-// Not only react-native, native modules could set tag too for controls.
-// For example, to identify an clicked item, customer may add tag in
-// NavigationView since content for the two NavigationViewItem are empty.
-//
-// <NavigationView>
-//  <NavigationViewItem Icon="Accept" Tag="1" />
-//  <NavigationViewItem Icon="Accept" Tag="2" />
-// </NavigationView>
-// Instead of deduce view id directly from FrameworkElement.Tag, this do
-// additional check by uimanager.
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe) {
-  ReactId reactId;
-  if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(context).lock()) {
-    if (auto peer = uiManager->reactPeerOrContainerFrom(fe)) {
-      reactId.isValid = true;
-      reactId.tag = Microsoft::ReactNative::GetTag(peer);
-    }
-  }
-  return reactId;
-};
-
-std::int32_t CountOpenPopups() {
-  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
-  // RS6
-  winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
+  std::int32_t CountOpenPopups() {
+    // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
+    // RS6
+    winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
       xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
-  return (int32_t)popups.Size();
-}
+    return (int32_t)popups.Size();
+  }
 
-template <uint16_t APIVersion>
-bool IsAPIContractVxAvailable() {
-  static bool isAPIContractVxAvailableInitialized = false;
-  static bool isAPIContractVxAvailable = false;
-  if (!isAPIContractVxAvailableInitialized) {
-    isAPIContractVxAvailableInitialized = true;
-    isAPIContractVxAvailable =
+  template <uint16_t APIVersion>
+  bool IsAPIContractVxAvailable() {
+    static bool isAPIContractVxAvailableInitialized = false;
+    static bool isAPIContractVxAvailable = false;
+    if (!isAPIContractVxAvailableInitialized) {
+      isAPIContractVxAvailableInitialized = true;
+      isAPIContractVxAvailable =
         winrt::ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", APIVersion);
+    }
+
+    return isAPIContractVxAvailable;
   }
 
-  return isAPIContractVxAvailable;
-}
+  bool IsAPIContractV5Available() {
+    return IsAPIContractVxAvailable<5>();
+  }
 
-bool IsAPIContractV5Available() {
-  return IsAPIContractVxAvailable<5>();
-}
+  bool IsAPIContractV6Available() {
+    return IsAPIContractVxAvailable<6>();
+  }
 
-bool IsAPIContractV6Available() {
-  return IsAPIContractVxAvailable<6>();
-}
+  bool IsAPIContractV7Available() {
+    return IsAPIContractVxAvailable<7>();
+  }
 
-bool IsAPIContractV7Available() {
-  return IsAPIContractVxAvailable<7>();
-}
+  bool IsAPIContractV8Available() {
+    return IsAPIContractVxAvailable<8>();
+  }
 
-bool IsAPIContractV8Available() {
-  return IsAPIContractVxAvailable<8>();
-}
+  bool IsAPIContractV12Available() {
+    return IsAPIContractVxAvailable<12>();
+  }
 
-bool IsAPIContractV12Available() {
-  return IsAPIContractVxAvailable<12>();
-}
+  bool IsRS3OrHigher() {
+    return IsAPIContractV5Available();
+  }
 
-bool IsRS3OrHigher() {
-  return IsAPIContractV5Available();
-}
+  bool IsRS4OrHigher() {
+    return IsAPIContractV6Available();
+  }
 
-bool IsRS4OrHigher() {
-  return IsAPIContractV6Available();
-}
+  bool IsRS5OrHigher() {
+    return IsAPIContractV7Available();
+  }
 
-bool IsRS5OrHigher() {
-  return IsAPIContractV7Available();
-}
+  bool Is19H1OrHigher() {
+    return IsAPIContractV8Available();
+  }
 
-bool Is19H1OrHigher() {
-  return IsAPIContractV8Available();
-}
+  bool Is21H1OrHigher() {
+    return IsAPIContractV12Available();
+  }
 
-bool Is21H1OrHigher() {
-  return IsAPIContractV12Available();
-}
-
-bool IsXamlIsland() {
-  AppPolicyWindowingModel e;
-  if (FAILED(AppPolicyGetWindowingModel(GetCurrentThreadEffectiveToken(), &e)) ||
+  bool IsXamlIsland() {
+    AppPolicyWindowingModel e;
+    if (FAILED(AppPolicyGetWindowingModel(GetCurrentThreadEffectiveToken(), &e)) ||
       e == AppPolicyWindowingModel_ClassicDesktop) {
-    return true;
+      return true;
+    }
+    return false;
   }
-  return false;
-}
 
-bool IsWinUI3Island() {
+  bool IsWinUI3Island() {
 #ifndef USE_WINUI3
-  return false;
+    return false;
 #else
-  return IsXamlIsland();
+    return IsXamlIsland();
 #endif
-}
+  }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -12,17 +12,11 @@ namespace Microsoft::ReactNative {
 
 using namespace std;
 
-struct ReactId {
-  int64_t tag{0};
-  bool isValid{false};
-};
-
 template <typename T>
 inline typename T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());
 }
 
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe);
 std::int32_t CountOpenPopups();
 
 bool IsRS3OrHigher();

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -157,7 +157,7 @@ bool ImageViewManager::UpdateProperty(
 }
 
 void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, ReactImageSource &source) {
-  int64_t tag = grid.Tag().as<winrt::IPropertyValue>().GetInt64();
+  int64_t tag = GetTag(grid);
   folly::dynamic imageSource =
       folly::dynamic::object()("uri", source.uri)("width", source.width)("height", source.height);
 

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -61,7 +61,7 @@ std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::React
 
 static folly::dynamic ToEventData(ReactKeyboardEvent event, double timestamp) {
   return folly::dynamic::object(TARGET, event.target)(ALT_KEY, event.altKey)(CTRL_KEY, event.ctrlKey)(KEY, event.key)(
-      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, timestamp);
+    META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, timestamp);
 }
 
 KeyboardEventBaseHandler::KeyboardEventBaseHandler(KeyboardEventCallback &&keyDown, KeyboardEventCallback &&keyUp)
@@ -217,10 +217,10 @@ void PreviewKeyboardEventHandlerOnRoot::DispatchEventToJs(
   const auto timestamp =
       std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count();
   if (auto source = args.OriginalSource().try_as<xaml::FrameworkElement>()) {
-    auto reactId = getViewId(*m_context, source);
-    if (reactId.isValid) {
+    int64_t tag;
+    if (TryGetClosestTag(source, tag)) {
       ReactKeyboardEvent event;
-      event.target = reactId.tag;
+      event.target = tag;
       UpdateModifiedKeyStatusTo(event);
       event.key = KeyboardHelper::FromVirtualKey(args.Key(), event.shiftKey, event.capLocked);
       event.code = KeyboardHelper::CodeFromVirtualKey(args.OriginalKey());

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -61,7 +61,7 @@ std::vector<HandledKeyboardEvent> KeyboardHelper::FromJS(winrt::Microsoft::React
 
 static folly::dynamic ToEventData(ReactKeyboardEvent event, double timestamp) {
   return folly::dynamic::object(TARGET, event.target)(ALT_KEY, event.altKey)(CTRL_KEY, event.ctrlKey)(KEY, event.key)(
-    META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, timestamp);
+      META_KEY, event.metaKey)(SHIFT_KEY, event.shiftKey)(CODE, event.code)(TIMESTAMP, timestamp);
 }
 
 KeyboardEventBaseHandler::KeyboardEventBaseHandler(KeyboardEventCallback &&keyDown, KeyboardEventCallback &&keyUp)

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -392,12 +392,9 @@ facebook::react::SharedEventEmitter EventEmitterForElement(
 
   auto element = view->Element();
   while (auto parent = element.Parent()) {
-    if (element = parent.try_as<xaml::FrameworkElement>()) {
-      auto boxedTag = element.Tag();
-      if (boxedTag) {
-        if (tag = winrt::unbox_value<facebook::react::Tag>(element.Tag()))
-          return EventEmitterForElement(uimanager, tag);
-      }
+    int64_t elementTag;
+    if (TryGetTag(element, elementTag)) {
+      return EventEmitterForElement(uimanager, static_cast<facebook::react::Tag>(elementTag));
     }
   }
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -150,7 +150,7 @@ void TouchEventHandler::OnPointerExited(
     return;
 
   std::vector<int64_t> tagsForBranch;
-  UpdatePointersInViews(args, INVALID_TAG, nullptr);
+  UpdatePointersInViews(args, nullptr, std::move(tagsForBranch));
 }
 
 void TouchEventHandler::OnPointerMoved(
@@ -656,7 +656,8 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactSourceBranch(
         // Nested React <Text> elements get translated into nested XAML <Span> elements,
         // while the content of the <Text> becomes a list of XAML <Run> elements.
         // However, we should report the Text element as the target, not the contexts of the text.
-        if (auto tag = GetTagAsPropertyValue(args.Target().as<XamlView>())) {
+        int64_t tag;
+        if (TryGetTag(args.Target().as<XamlView>(), tag)) {
           if (const auto textBlock = sourceElement.try_as<xaml::Controls::TextBlock>()) {
             const auto pointerPos = args.Args().GetCurrentPoint(textBlock).RawPosition();
             const auto inlines = textBlock.Inlines().GetView();
@@ -664,7 +665,7 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactSourceBranch(
             const auto finerTag = TestHit(inlines, pointerPos, isHit);
             if (finerTag) {
               // Insert nested text tags in reverse order
-              const auto tagsToCurrentTarget = GetTagsForBranch(uiManager->getHost(), GetTag(finerTag), GetTag(tag));
+              const auto tagsToCurrentTarget = GetTagsForBranch(uiManager->getHost(), finerTag, tag);
               auto iter = tagsToCurrentTarget.rbegin();
               while (iter != tagsToCurrentTarget.rend()) {
                 tagsForBranch.insert(tagsForBranch.begin(), *iter);

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -108,7 +108,7 @@ class TouchEventHandler {
       const winrt::Microsoft::ReactNative::ReactPointerEventArgs &args,
       std::vector<int64_t> *pTagsForBranch,
       xaml::UIElement *pSourceElement);
-  winrt::IPropertyValue TestHit(
+  int64_t TestHit(
       const winrt::Collections::IVectorView<xaml::Documents::Inline> &inlines,
       const winrt::Point &pointerPos,
       bool &isHit);

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -6,11 +6,18 @@
 #include "XamlUIService.g.cpp"
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
 #include "DynamicWriter.h"
 #include "ShadowNodeBase.h"
 #include "Views/ShadowNodeBase.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
+
+xaml::DependencyProperty XamlUIService::m_ReactTagProperty = xaml::DependencyProperty::RegisterAttached(
+    L"ReactTag",
+    winrt::xaml_typename<int64_t>(),
+    winrt::xaml_typename<winrt::Microsoft::ReactNative::XamlUIService>(),
+    xaml::PropertyMetadata{winrt::box_value(-1)});
 
 XamlUIService::XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context(context) {}
 
@@ -32,12 +39,12 @@ xaml::DependencyObject XamlUIService::ElementFromReactTag(int64_t reactTag) noex
 }
 
 void XamlUIService::DispatchEvent(
-    xaml::FrameworkElement const &view,
+    xaml::DependencyObject const &view,
     hstring const &eventName,
     JSValueArgWriter const &eventDataArgWriter) noexcept {
   auto paramsWriter = winrt::make_self<DynamicWriter>();
   paramsWriter->WriteArrayBegin();
-  paramsWriter->WriteInt64(unbox_value<int64_t>(view.Tag()));
+  paramsWriter->WriteInt64(GetReactTag(view));
   paramsWriter->WriteString(eventName);
   if (eventDataArgWriter) {
     eventDataArgWriter(*paramsWriter);

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -17,15 +17,21 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
   xaml::DependencyObject ElementFromReactTag(int64_t reactTag) noexcept;
 
   void DispatchEvent(
-    xaml::DependencyObject const &view,
-    hstring const &eventName,
-    JSValueArgWriter const &eventDataArgWriter) noexcept;
+      xaml::DependencyObject const &view,
+      hstring const &eventName,
+      JSValueArgWriter const &eventDataArgWriter) noexcept;
 
   static ReactPropertyId<XamlUIService> XamlUIServiceProperty() noexcept;
 
-  static xaml::DependencyProperty ReactTagProperty() noexcept { return m_ReactTagProperty; }
-  static int64_t GetReactTag(xaml::DependencyObject const& target) { return winrt::unbox_value<int64_t>(target.GetValue(m_ReactTagProperty)); }
-  static void SetReactTag(xaml::DependencyObject const& target, int64_t value) { target.SetValue(m_ReactTagProperty, winrt::box_value(value)); }
+  static xaml::DependencyProperty ReactTagProperty() noexcept {
+    return m_ReactTagProperty;
+  }
+  static int64_t GetReactTag(xaml::DependencyObject const &target) {
+    return winrt::unbox_value<int64_t>(target.GetValue(m_ReactTagProperty));
+  }
+  static void SetReactTag(xaml::DependencyObject const &target, int64_t value) {
+    target.SetValue(m_ReactTagProperty, winrt::box_value(value));
+  }
 
   static winrt::Microsoft::ReactNative::XamlUIService FromContext(IReactContext context);
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -27,7 +27,7 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
     return m_ReactTagProperty;
   }
   static int64_t GetReactTag(xaml::DependencyObject const &target) {
-    return winrt::unbox_value<int64_t>(target.GetValue(m_ReactTagProperty));
+    return winrt::unbox_value_or<int64_t>(target.GetValue(m_ReactTagProperty), -1);
   }
   static void SetReactTag(xaml::DependencyObject const &target, int64_t value) {
     target.SetValue(m_ReactTagProperty, winrt::box_value(value));

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -13,15 +13,21 @@ namespace winrt::Microsoft::ReactNative::implementation {
 struct XamlUIService : XamlUIServiceT<XamlUIService> {
  public:
   XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
-  static ReactPropertyId<XamlUIService> XamlUIServiceProperty() noexcept;
 
   xaml::DependencyObject ElementFromReactTag(int64_t reactTag) noexcept;
-  static winrt::Microsoft::ReactNative::XamlUIService FromContext(IReactContext context);
-  void DispatchEvent(
-      xaml::FrameworkElement const &view,
-      hstring const &eventName,
-      JSValueArgWriter const &eventDataArgWriter) noexcept;
 
+  void DispatchEvent(
+    xaml::DependencyObject const &view,
+    hstring const &eventName,
+    JSValueArgWriter const &eventDataArgWriter) noexcept;
+
+  static ReactPropertyId<XamlUIService> XamlUIServiceProperty() noexcept;
+
+  static xaml::DependencyProperty ReactTagProperty() noexcept { return m_ReactTagProperty; }
+  static int64_t GetReactTag(xaml::DependencyObject const& target) { return winrt::unbox_value<int64_t>(target.GetValue(m_ReactTagProperty)); }
+  static void SetReactTag(xaml::DependencyObject const& target, int64_t value) { target.SetValue(m_ReactTagProperty, winrt::box_value(value)); }
+
+  static winrt::Microsoft::ReactNative::XamlUIService FromContext(IReactContext context);
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static void SetAccessibleRoot(
       IReactPropertyBag const &properties,
@@ -33,6 +39,8 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
   static uint64_t GetIslandWindowHandle(IReactPropertyBag const &properties) noexcept;
 
  private:
+  static Windows::UI::Xaml::DependencyProperty m_ReactTagProperty;
+
   std::weak_ptr<::Microsoft::ReactNative::INativeUIManagerHost> m_wkUIManager;
   Mso::CntPtr<Mso::React::IReactContext> m_context;
 };

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -18,6 +18,10 @@ namespace Microsoft.ReactNative
     DOC_STRING("Use this method to get access to the @XamlUIService associated with the @IReactContext.")
     static XamlUIService FromContext(IReactContext context);
 
+    static XAML_NAMESPACE.DependencyProperty ReactTagProperty { get; };
+    static Int64 GetReactTag(XAML_NAMESPACE.DependencyObject target);
+    static void SetReactTag(XAML_NAMESPACE.DependencyObject target, Int64 value);
+
     DOC_STRING("Gets the backing XAML element from a react tag.")
     XAML_NAMESPACE.DependencyObject ElementFromReactTag(Int64 reactTag);
 

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -11,6 +11,18 @@
 
 namespace Microsoft::ReactNative {
 
+bool TryGetClosestTag(XamlView view, int64_t &value) {
+  while (view) {
+    if (TryGetTag(view, value)) {
+      return true;
+    }
+    else {
+      view = xaml::Media::VisualTreeHelper::GetParent(view);
+    }
+  }
+  return false;
+}
+
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view) {
   xaml::XamlRoot root{nullptr};
   if (auto uielement = view.try_as<xaml::UIElement>()) {

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -15,8 +15,7 @@ bool TryGetClosestTag(XamlView view, int64_t &value) {
   while (view) {
     if (TryGetTag(view, value)) {
       return true;
-    }
-    else {
+    } else {
       view = xaml::Media::VisualTreeHelper::GetParent(view);
     }
   }

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -4,42 +4,39 @@
 #pragma once
 
 #include "CppWinRTIncludes.h"
+#include <winrt/Microsoft.ReactNative.h>
 
 namespace Microsoft::ReactNative {
 
 using XamlView = xaml::DependencyObject;
 
+const int64_t INVALID_TAG = -1;
+
 inline int64_t GetTag(XamlView view) {
-  auto tagValue = view.ReadLocalValue(xaml::FrameworkElement::TagProperty());
-  if (tagValue != xaml::DependencyProperty::UnsetValue()) {
-    return tagValue.as<winrt::IPropertyValue>().GetInt64();
-  } else {
-    return -1;
-  }
+  return winrt::Microsoft::ReactNative::XamlUIService::GetReactTag(view);
 }
 
 inline void SetTag(XamlView view, int64_t tag) {
-  view.SetValue(xaml::FrameworkElement::TagProperty(), winrt::PropertyValue::CreateInt64(tag));
+  winrt::Microsoft::ReactNative::XamlUIService::SetReactTag(view, tag);
 }
 
-inline void SetTag(XamlView view, winrt::IInspectable tag) {
-  SetTag(view, tag.as<winrt::IPropertyValue>().GetInt64());
+inline bool IsValidTag(int64_t value) {
+  return value != INVALID_TAG;
 }
 
-inline bool IsValidTag(winrt::IPropertyValue value) {
-  assert(value);
-  return (value.Type() == winrt::PropertyType::Int64);
+inline bool TryGetTag(XamlView view, int64_t &value) {
+  int64_t tag = GetTag(view);
+  if (IsValidTag(tag)) {
+    value = tag;
+    return true;
+  }
+  return false;
 }
 
-inline int64_t GetTag(winrt::IPropertyValue value) {
-  assert(value);
-  return value.GetInt64();
-}
+// Walk up the XAML element tree to find the closest React element
+// Searches itself and its parent to get a valid XamlView.
+bool TryGetClosestTag(XamlView view, int64_t &value);
 
-inline winrt::IPropertyValue GetTagAsPropertyValue(XamlView view) {
-  assert(view);
-  return view.GetValue(xaml::FrameworkElement::TagProperty()).try_as<winrt::IPropertyValue>();
-}
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);
 comp::Compositor GetCompositor(const XamlView &view);

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "CppWinRTIncludes.h"
 #include <winrt/Microsoft.ReactNative.h>
+#include "CppWinRTIncludes.h"
 
 namespace Microsoft::ReactNative {
 
@@ -36,7 +36,6 @@ inline bool TryGetTag(XamlView view, int64_t &value) {
 // Walk up the XAML element tree to find the closest React element
 // Searches itself and its parent to get a valid XamlView.
 bool TryGetClosestTag(XamlView view, int64_t &value);
-
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);
 comp::Compositor GetCompositor(const XamlView &view);


### PR DESCRIPTION
This change adds a `ReactTag` attached dependency property and uses it to store the RN Tag value for React elements.

This allows assigning tags to any DependencyObject-derived object instead of only FrameworkElement-derived objects, which is a pre-requisite to supporting a wider array of native component types. It also prevents potential collision with any application-defined usage of FrameworkElement.Tag.

I'm open to suggestions if there's a better public interface to expose this property instead of through XamlUIService.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8951)