### PR TITLE
Do minimal yarn install during setup

### DIFF
--- a/.ado/package.json
+++ b/.ado/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-native-windows-ado",
+  "description": "Minimal dependencies to run ADO scripts (sharing the main lockfile)",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "beachball": "^2.16.0",
+    "semver": "^7.3.2"
+  }
+}

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -27,7 +27,8 @@ stages:
               targetType: filePath
               filePath: .ado/scripts/shouldSkipPRBuild.ps1
 
-          - template: templates/yarn-install.yml
+          - script: npx midgard-yarn-strict@1.2.4 --scope react-native-windows-ado --frozen-lockfile --network-concurrency 40 --cache-folder \.yarnCache
+            displayName: Minimal yarn install
 
           - template: templates/compute-beachball-branch-name.yml
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "workspaces": {
     "packages": [
+      ".ado",
       "packages/*",
       "packages/@office-iss/*",
       "packages/@react-native-windows/*",


### PR DESCRIPTION
midgard-yarn-strict has functionality to scope installation to a single monorepo package. Testing to see if doing this can reduce PR critical-path time by installing less in the setup phase.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8954)