### PR TITLE
Fix "applying package updates ***NO_CI***" in changefiles

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -77,11 +77,11 @@ jobs:
       - script: yarn build
         displayName: yarn build
 
-      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps  --access public --no-git-tags
+      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***" --no-git-tags
         displayName: Beachball Publish (Main Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
 
-      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps  --access public
+      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***"
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
 

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -14,9 +14,6 @@ module.exports = {
   // release for every package.
   gitTags: false,
 
-  // Commit message used when publishing
-  message: 'applying package updates ***NO_CI***',
-
   hooks: {
     // Stamp versions when we publish a new package
     prepublish: (_packagePath, name, version) => {


### PR DESCRIPTION
Beachball's commit message was moved from CLI args to config file. The same message is used when generating changefiles, which we don't want. Remove the message from the config, and add it back to the publish command where we want it to be used as a commit message.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8975)