### PR TITLE
Use Node 16

### DIFF
--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -4,7 +4,6 @@ trigger: none # will disable CI builds entirely
 pr: none
 
 variables:
-  - template: variables/msbuild.yml
   - group: RNW Secrets
   - group: platform-override-zero-permission-token
 
@@ -13,7 +12,7 @@ stages:
     jobs:
       - job: Setup
         variables:
-          - template: variables/vs2019.yml
+          - template: variables/windows.yml
         pool:
           vmImage: windows-2019
         steps:
@@ -21,7 +20,7 @@ stages:
 
           - template: templates/yarn-install.yml
 
-          - script: npx --no-install beachball bump --branch origin/$(Build.SourceBranchName) --yes
+          - script: npx beachball bump --branch origin/$(Build.SourceBranchName) --yes
             displayName: beachball bump
 
           - template: templates/set-version-vars.yml

--- a/.ado/integrate-rn.yaml
+++ b/.ado/integrate-rn.yaml
@@ -14,7 +14,7 @@ variables:
   - group: RNW Secrets
 
 pool:
-  vmImage: $(VmImage)
+  vmImage: windows-2019
 
 jobs:
   - job: IntegrateRN

--- a/.ado/integrate-rn.yaml
+++ b/.ado/integrate-rn.yaml
@@ -10,7 +10,7 @@ parameters:
   type: string
 
 variables:
-  - template: variables/vs2019.yml
+  - template: variables/windows.yml
   - group: RNW Secrets
 
 pool:

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -247,7 +247,7 @@ jobs:
                 - UniversalBuild
 
             variables:
-              - template: ../variables/vs2019.yml
+              - template: ../variables/windows.yml
 
             pool:
               name: ${{ variables['AgentPool.Medium'] }}

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -48,7 +48,7 @@ jobs:
           displayName: Desktop ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
 
             # Enable if any issues RNTesterIntegrationTests::* become unstable.
             - name: Desktop.IntegrationTests.SkipRNTester
@@ -100,9 +100,9 @@ jobs:
                   Write-Host "##vso[task.setvariable variable=Desktop.IntegrationTests.Filter]$newValue"
                 displayName: Update Desktop.IntegrationTests.Filter to exclude RNTester integration tests
 
-            - template: ../templates/build-rnw.yml
+            - template: ../templates/msbuild-sln.yml
               parameters:
-                project: vnext/ReactWindows-Desktop.sln
+                solution: vnext/ReactWindows-Desktop.sln
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -40,7 +40,7 @@ jobs:
           displayName: E2E Test App ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
           pool:
             name: ${{ variables['AgentPool.Medium'] }}
             demands: ${{ variables['AgentImage'] }}

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -55,7 +55,7 @@ jobs:
         - job: IntegrationTest${{ matrix.Name }}
           displayName: Integration Test App ${{ matrix.Name }}
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
           pool:
             name: ${{ variables['AgentPool.Medium'] }}
             demands: ${{ variables['AgentImage'] }}
@@ -101,7 +101,7 @@ jobs:
                 displayName: yarn windows --no-launch
                 workingDirectory: packages/integration-test-app
 
-              - powershell: Start-Process npm -ArgumentList "run","start"
+              - powershell: Start-Process npm.cmd -ArgumentList "run","start"
                 displayName: Start packager
                 workingDirectory: packages/integration-test-app
 

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -9,7 +9,7 @@ parameters:
 jobs:
   - job: JSChecks
     variables:
-      - template: ../variables/vs2019.yml
+      - template: ../variables/windows.yml
     displayName: JavaScript Checks
     pool:
       name: ${{ variables['AgentPool.Medium'] }}
@@ -30,7 +30,7 @@ jobs:
       - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+          script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn build
@@ -62,12 +62,12 @@ jobs:
       - task: CmdLine@2
         displayName: check local links in .md files
         inputs:
-          script: npx --no-install unbroken -q --local-only --allow-local-line-sections
+          script: npx unbroken -q --local-only --allow-local-line-sections
 
       # This runs will check for web-links. If broken links are found, since external changes could affect this.
       # It will report a warning if this step fails so we'll pay attention to fix quickly.
       - task: CmdLine@2
         displayName: check web links in .md files
         inputs:
-          script: npx --no-install unbroken -q --allow-local-line-sections
+          script: npx unbroken -q --allow-local-line-sections
         continueOnError: true

--- a/.ado/jobs/macos-tests.yml
+++ b/.ado/jobs/macos-tests.yml
@@ -17,6 +17,14 @@ jobs:
         clean: true
         submodules: false
 
+      - task: NodeTool@0
+        displayName: Set Node Version
+        inputs:
+          versionSpec: '16.x'
+
+      - script: npm install -g midgard-yarn@1.23.33
+        displayName: Install midgard-yarn
+
       - template: ../templates/prepare-js-env.yml
 
       - script: yarn test

--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -9,7 +9,7 @@ jobs:
       - DesktopX86Debug
       - UniversalBuild # Needed to have artifacts uploaded from LayoutHeaders
     pool:
-      vmImage: $(VmImage)
+      vmImage: windows-2019
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -2,7 +2,7 @@
 jobs:
   - job: PackDesktop
     variables:
-      - template: ../variables/vs2019.yml
+      - template: ../variables/windows.yml
     displayName: Pack Desktop NuGet Package
     dependsOn:
       - DesktopX64Release

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -67,7 +67,7 @@ jobs:
           displayName: Playground ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
           pool:
             name: ${{ variables['AgentPool.Medium'] }}
             demands: ${{ variables['AgentImage'] }}
@@ -94,38 +94,20 @@ jobs:
                   feature: UseWinUI3
                   value: true
 
-            - task: NuGetCommand@2
-              displayName: NuGet restore - Playground
-              inputs:
-                command: restore
-                restoreSolution: packages/playground/windows/${{ matrix.SolutionFile }}
-                verbosityRestore: Detailed # Options: quiet, normal, detailed
-
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml
                 parameters:
                   certificateName: playgroundEncodedKey
 
-            - task: VSBuild@1
-              displayName: VSBuild - Playground
-              inputs:
+            - template: ../templates/msbuild-sln.yml
+              parameters:
                 solution: packages/playground/windows/${{ matrix.SolutionFile }}
-                vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-                msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
-                platform: ${{ matrix.BuildPlatform}} # Optional
-                configuration: ${{ matrix.BuildConfiguration}} # Optional
-                clean: true # Optional
-                maximumCpuCount: false # Optional
-                restoreNugetPackages: true
+                buildPlatform: ${{ matrix.BuildPlatform}}
+                buildConfiguration: ${{ matrix.BuildConfiguration}}
+                warnAsError: false
                 ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
-                    /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
-                    /p:PlatformToolset=$(MSBuildPlatformToolset)
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
-                ${{ else }}:
-                  msbuildArgs:
-                    /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
-                    /p:PlatformToolset=$(MSBuildPlatformToolset)
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/cleanup-certificate.yml

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -27,7 +27,7 @@ jobs:
           displayName: Project Reunion ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
 
           pool:
             name: ${{ variables['AgentPool.Medium'] }}
@@ -50,9 +50,9 @@ jobs:
 
             - template: ../templates/apply-published-version-vars.yml
 
-            - template: ../templates/build-rnw.yml
+            - template: ../templates/msbuild-sln.yml
               parameters:
-                project: vnext/Microsoft.ReactNative.ProjectReunion.sln
+                solution: vnext/Microsoft.ReactNative.ProjectReunion.sln
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration}}
                 msbuildArguments: /p:UseWinUI3=true

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -53,7 +53,7 @@ jobs:
           displayName: Sample Apps ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/vs2019.yml
+            - template: ../variables/windows.yml
             - name: BuildLogDirectory
               value: $(Build.BinariesDirectory)\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\BuildLogs
           

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -256,7 +256,7 @@
             - ${{ each matrix in config.Matrix }}:
               - UniversalBuild${{ matrix.Name }}
       pool:
-        vmImage: $(VmImage)
+        vmImage: ubuntu-latest
       timeoutInMinutes: 60
       cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -64,7 +64,7 @@
         - ${{ each matrix in config.Matrix }}:
             - job: UniversalBuild${{ matrix.Name }}
               variables:
-                - template: ../variables/vs2019.yml
+                - template: ../variables/windows.yml
               displayName: Universal Build ${{ matrix.Name }}
               pool:
                 name: ${{ variables['AgentPool.Large'] }}
@@ -87,12 +87,11 @@
 
                 - template: ../templates/apply-published-version-vars.yml
 
-                - template: ../templates/build-rnw.yml
+                - template: ../templates/msbuild-sln.yml
                   parameters:
-                    project: vnext/Microsoft.ReactNative.sln
+                    solution: vnext/Microsoft.ReactNative.sln
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
-                    multicoreBuild: true
                     msbuildArguments: /p:RNW_FASTBUILD=${{ matrix.FastBuild }}
 
                 - ${{ if eq(matrix.CreateApiDocs, true) }}: 
@@ -129,7 +128,7 @@
 
             - job: UniversalTest${{ matrix.Name }}
               variables:
-                - template: ../variables/vs2019.yml
+                - template: ../variables/windows.yml
               displayName: Universal Test ${{ matrix.Name }}
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
@@ -250,7 +249,7 @@
     - job: UniversalBuild
       displayName: Universal Build 🏗
       variables:
-        - template: ../variables/vs2019.yml
+        - template: ../variables/windows.yml
       dependsOn:
         - ${{ each config in parameters.buildMatrix }}:
           - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -19,8 +19,7 @@ parameters:
   default: true
 
 variables:
-  - template: variables/msbuild.yml
-  - template: variables/vs2019.yml
+  - template: variables/windows.yml
   - group: RNW Secrets
   - name: SkipNpmPublishArgs
     value: ''
@@ -36,10 +35,6 @@ variables:
     value: microsoft
   - name: ArtifactServices.Symbol.PAT
     value: $(pat-symbols-publish-microsoft)
-  - name: AgentPool.Medium.Microsoft 
-    value: rnw-pool-4-microsoft
-  - name: AgentPool.Large.Microsoft
-    value: rnw-pool-8-microsoft
 
 trigger: none
 pr: none
@@ -48,7 +43,7 @@ jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
-      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      name: ${{ variables['AgentPool.Medium.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
@@ -76,11 +71,11 @@ jobs:
         displayName: Enable No-Publish
         condition: ${{ parameters.skipGitPush }}
 
-      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***" --no-git-tags
+      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***" --no-git-tags
         displayName: Beachball Publish (Main Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
 
-      - script: npx --no-install beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***"
+      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***"
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
 
@@ -88,7 +83,7 @@ jobs:
       - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
         displayName: git pull
 
-      - script: npx --ignore-existing @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
+      - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )
 
@@ -103,14 +98,14 @@ jobs:
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
     pool:
-      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      name: ${{ variables['AgentPool.Medium.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-js-env.yml
 
       # Bump in case the bot coordinator is dependent on other monorepo packages that were just published
-      - script: npx --no-install beachball bump
+      - script: npx beachball bump
         displayName: beachball bump
 
       # Azure Functions expects a fully packagable folder with dependencies.
@@ -167,7 +162,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: ARM64
     pool:
-      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      name: ${{ variables['AgentPool.Large.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
 
     steps:
@@ -179,7 +174,7 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - template: templates/build-rnw.yml
+      - template: templates/msbuild-sln.yml
         parameters:
           project: vnext/ReactWindows-Desktop.sln
           buildPlatform: $(BuildPlatform)
@@ -224,7 +219,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: arm64
     pool:
-      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      name: ${{ variables['AgentPool.Large.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
 
     steps:
@@ -236,9 +231,9 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - template: templates/build-rnw.yml
+      - template: templates/msbuild-sln.yml
         parameters:
-          project: vnext/Microsoft.ReactNative.sln
+          solution: vnext/Microsoft.ReactNative.sln
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           msbuildArguments:
@@ -273,7 +268,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x64
     pool:
-      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      name: ${{ variables['AgentPool.Large.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
 
     steps:
@@ -285,9 +280,9 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - template: templates/build-rnw.yml
+      - template: templates/msbuild-sln.yml
         parameters:
-          project: vnext/Microsoft.ReactNative.ProjectReunion.sln
+          solution: vnext/Microsoft.ReactNative.ProjectReunion.sln
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           msbuildArguments:
@@ -328,7 +323,7 @@ jobs:
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
     pool:
-      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      name: ${{ variables['AgentPool.Medium.Publish'] }}
       demands: ${{ variables['AgentImage'] }}
 
     steps:

--- a/.ado/templates/apply-published-version-vars.yml
+++ b/.ado/templates/apply-published-version-vars.yml
@@ -1,11 +1,6 @@
 # Downloads previously published variables for versioning and applies them
 
 steps:
-  - task: NodeTool@0
-    displayName: Installing Node
-    inputs:
-      versionSpec: '14.x'
-
   - task: DownloadPipelineArtifact@2
     displayName: Download version variables
     inputs:

--- a/.ado/templates/msbuild-sln.yml
+++ b/.ado/templates/msbuild-sln.yml
@@ -4,11 +4,11 @@ parameters:
   debug: false
 
   # NuGet & MSBuild
-  project:
-  msbuildVersion: $(MSBuildVersion)
-  msBuildArchitecture: $(MSBuildArchitecture)
-  preferredToolArchitecture: $(MSBuildPreferredToolArchitecture)
-  platformToolset: $(MSBuildPlatformToolset)
+  solution:
+  msbuildVersion: 16.0
+  msBuildArchitecture: x64
+  preferredToolArchitecture: x64
+  platformToolset: v142
   buildPlatform: x64
   buildConfiguration: Debug
   msbuildArguments: ''
@@ -36,16 +36,16 @@ steps:
     displayName: NuGet restore
     inputs:
       command: restore
-      restoreSolution: ${{parameters.project }}
+      restoreSolution: ${{parameters.solution }}
       feedsToUse: config
       nugetConfigPath: $(Build.SourcesDirectory)/vnext/NuGet.config
       restoreDirectory: packages/
       verbosityRestore: Detailed # Options: quiet, normal, detailed
 
   - task: VSBuild@1
-    displayName: VSBuild ${{parameters.project}}
+    displayName: VSBuild ${{parameters.solution}}
     inputs:
-      solution: ${{parameters.project}}
+      solution: ${{parameters.solution}}
       vsVersion: ${{parameters.msbuildVersion}}
       msbuildArchitecture: ${{parameters.msBuildArchitecture}}
       platform: ${{ parameters.buildPlatform }}

--- a/.ado/templates/prepare-js-env.yml
+++ b/.ado/templates/prepare-js-env.yml
@@ -1,11 +1,6 @@
 # Steps to setup an environment that can run JavaScript executables
 
 steps:
-  - task: NodeTool@0
-    displayName: Set Node Version
-    inputs:
-      versionSpec: '14.x'
-
   - template: yarn-install.yml
 
   - script: yarn build

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -70,7 +70,7 @@ steps:
   - script: yarn build
     displayName: yarn build
 
-  - powershell: start-process npx -ArgumentList @('verdaccio', '--config', './.ado/verdaccio/config.yaml')
+  - powershell: start-process verdaccio.cmd -ArgumentList @('--config', './.ado/verdaccio/config.yaml')
     displayName: Launch test npm server (verdaccio)
 
   - script: node .ado/scripts/waitForVerdaccio.js
@@ -81,11 +81,11 @@ steps:
 
   - template: compute-beachball-branch-name.yml
 
-  - script: npx --no-install beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
+  - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
     # Beachball reverts to local state after publish, but we need to know the new version it pushed.
-  - script: npx --no-install beachball bump --branch origin/$(BeachBallBranchName) --yes
+  - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
     displayName: beachball bump
 
   - template: set-version-vars.yml
@@ -99,20 +99,15 @@ steps:
         packDesktop: false
         slices: '("${{ parameters.platform }}.${{ parameters.configuration }}")'
 
-  # We force the usage of npm instead of yarn because yarn has fragility issues when redirected to a different server (such as verdaccio)
-  # We use --no-install and symlink the node_modules from the source tree to avoid having npx download react-native and all it dependencies
-  # which takes over a minute on the CI machines.
   - ${{ if eq(parameters.projectType, 'app') }}:
     - script: |
-        mklink /D node_modules $(System.DefaultWorkingDirectory)\node_modules
-        npx --no-install react-native init testcli --npm --template react-native@$(reactNativeDevDependency)
+        npx --yes react-native@$(reactNativeDevDependency) init testcli --template react-native@$(reactNativeDevDependency)
       displayName: Init new app project
       workingDirectory: $(Agent.BuildDirectory)
 
   - ${{ if eq(parameters.projectType, 'lib') }}:
     - script: |
-        mklink /D node_modules $(System.DefaultWorkingDirectory)\node_modules
-        npx create-react-native-module --package-name "testcli" testcli
+        npx --yes create-react-native-module@0.20.2 --package-name "testcli" testcli
       displayName: Init new lib project
       workingDirectory: $(Agent.BuildDirectory)
 
@@ -123,19 +118,18 @@ steps:
       displayName: Update lib project react and react-native dev versions
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - script: npm set registry http://localhost:4873
-    displayName: Modify default npm config to point to local verdaccio server
-
-  - script: npm set fetch-retries 10
-    displayName: Allow additional npm fetch retries
+  - script: yarn config set registry http://localhost:4873
+    displayName: Modify yarn config to point to local verdaccio server
 
   - ${{ if eq(parameters.useNuget, true) }}:
-    - script: npx react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+    - script: |
+        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
       displayName: Apply windows template (with nuget)      
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - ${{ if eq(parameters.useNuget, false) }}:
-    - script: npx react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
+    - script: |
+        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
       displayName: Apply windows template (without nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
@@ -200,7 +194,7 @@ steps:
 
   # Only test bundling in debug since we already bundle as part of release builds
   - ${{ if and(eq(parameters.projectType, 'app'), eq(parameters.configuration, 'Debug')) }}:
-    - script: npx --no-install react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
+    - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli
 

--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -5,15 +5,12 @@ parameters:
 - name: frozenLockfile
   type: boolean
   default: true
-- name: extraArgs
-  type: string
-  default: --network-concurrency 40 --cache-folder \.yarnCache
 
 steps:
   - ${{ if eq(parameters.frozenLockfile, true) }}:
-    - script: npx midgard-yarn@1.23.33 --frozen-lockfile --cwd ${{ parameters.workingDirectory }} ${{ parameters.extraArgs }}
+    - script: midgard-yarn --frozen-lockfile --cwd ${{ parameters.workingDirectory }}
       displayName: midgard-yarn (faster yarn install)
 
   - ${{ if eq(parameters.frozenLockfile, false) }}:
-    - script: npx midgard-yarn@1.23.33 --cwd ${{ parameters.workingDirectory }} ${{ parameters.extraArgs }}
+    - script: midgard-yarn --cwd ${{ parameters.workingDirectory }}
       displayName: midgard-yarn (faster yarn install)

--- a/.ado/variables/macos.yml
+++ b/.ado/variables/macos.yml
@@ -1,2 +1,5 @@
 variables:
-  VmImage: macOS-10.15
+  - template: shared.yml
+
+  - name: VmImage
+    value: macOS-10.15

--- a/.ado/variables/msbuild.yml
+++ b/.ado/variables/msbuild.yml
@@ -1,6 +1,0 @@
-variables:
-  MSBuildArchitecture: x64
-  MSBuildPreferredToolArchitecture: x64
-  MSBuildPlatformToolset: v142
-  TargetPlatformVersion: 10.0.19041.0
-  Win10Version: 19041

--- a/.ado/variables/pools.yml
+++ b/.ado/variables/pools.yml
@@ -1,0 +1,6 @@
+variables:
+  AgentPool.Medium: rnw-pool-4
+  AgentPool.Large: rnw-pool-8
+  AgentPool.Medium.Publish: rnw-pool-4-microsoft
+  AgentPool.Large.Publish: rnw-pool-8-microsoft
+  AgentImage: ImageOverride -equals rnw-img-node16

--- a/.ado/variables/shared.yml
+++ b/.ado/variables/shared.yml
@@ -1,0 +1,8 @@
+variables:
+  runCodesignValidationInjection: false
+  NPM_CONFIG_YES: false
+  NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
+  NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60
+  YARN_CACHE_FOLDER: $(Agent.TempDirectory)/.yarnCache
+  YARN_NETWORK_CONCURRENCY: 40
+  

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -1,9 +1,0 @@
-variables:
-  VmImage: windows-2019
-  AgentPool.Medium: rnw-pool-4
-  AgentPool.Large: rnw-pool-8
-  AgentImage: ImageOverride -equals rnw-img
-  MSBuildVersion: 16.0
-  runCodesignValidationInjection: false
-  NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60
-  NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/windows.yml
+++ b/.ado/variables/windows.yml
@@ -1,0 +1,3 @@
+variables:
+  - template: pools.yml
+  - template: shared.yml

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -8,7 +8,6 @@ pr:
   - "*-stable"
 
 variables:
-  - template: variables/msbuild.yml
   - group: platform-override-zero-permission-token
 
 stages:
@@ -30,10 +29,10 @@ stages:
           - script: npm install -g beachball@2.18.0
             displayName: Install beachball
 
-          - script: npx --no-install beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+          - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
             displayName: Check for change files
 
-          - script: npx --no-install beachball bump --branch origin/$(BeachBallBranchName) --yes
+          - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
             displayName: beachball bump
 
           - template: templates/set-version-vars.yml

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,7 +15,7 @@
   <!-- 
     This target checks if Yarn install needs to run or not. 
     This is a common cause of failed builds for developers not used to running it after syncing...
-    This check does not run during design time build and in our CI validation runs (detected via PublishToolDuringBuild because we know yarn install runs there.
+    This check does not run during design time build and in our CI validation runs (detected via AGENT_NAME).
   -->
   <Target
     Name="EnsureJavaScriptCodeUpToDate"
@@ -23,13 +23,13 @@
     DependsOnTargets="EnsureJavaScriptCodeUpToDateInputAndOutputs"
     Inputs="@(_EnsureJavaScriptCodeUpToDateInputFiles)"
     Outputs="@(_EnsureJavaScriptCodeUpToDateOutputFiles)"
-    Condition="'$(DesignTimeBuild)'=='' AND '$(PublishToolDuringBuild)' == ''"
+    Condition="'$(DesignTimeBuild)'=='' AND '$(AGENT_NAME)' == ''"
     >
 
     <Message Text="Checking if yarn is 'up to date' by running a 'dry-run' version of `yarn install` and checking the exit code" />
     <Exec 
       ContinueOnError="True"
-      Command="npx yarn install --offline --cache-folder $(RootIntDir)\JsUpToDateCheck\Cache"
+      Command="yarn install --offline --cache-folder $(RootIntDir)\JsUpToDateCheck\Cache"
       WorkingDirectory="$(MSBuildThisFileDirectory)"
       >
       <Output TaskParameter="ExitCode" ItemName="_YarnExitCode"/>

--- a/change/@react-native-windows-cli-051bedb1-8993-4f0d-a342-c89a1d14184a.json
+++ b/change/@react-native-windows-cli-051bedb1-8993-4f0d-a342-c89a1d14184a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use NPM 8",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-b4896c33-d518-427a-bee2-135a57377c2d.json
+++ b/change/react-native-windows-b4896c33-d518-427a-bee2-135a57377c2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use NPM 8",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -488,5 +488,5 @@ function launchServer(options: RunWindowsOptions, verbose: boolean) {
     stdio: verbose ? 'inherit' : 'ignore',
   };
 
-  spawn('cmd.exe', ['/C', 'start npx --no-install react-native start'], opts);
+  spawn('cmd.exe', ['/C', 'start npx react-native start'], opts);
 }

--- a/vnext/PropertySheets/Bundle.props
+++ b/vnext/PropertySheets/Bundle.props
@@ -39,7 +39,7 @@
     <BundlerExtraArgs Condition="'$(BundlerExtraArgs)' == '' AND '$(UseHermes)' == 'true'">--minify false</BundlerExtraArgs>
 
     <!-- Command to use to create a bundle -->
-    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx --no-install react-native bundle</BundleCliCommand>
+    <BundleCliCommand Condition="'$(BundleCliCommand)' == ''">npx react-native bundle</BundleCliCommand>
 
     <!-- This should be the app package root, this is where the bundle command will be run from -->
     <BundleCommandWorkingDir Condition="'$(BundleCommandWorkingDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(ProjectDir), 'package.json'))</BundleCommandWorkingDir>

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -123,7 +123,7 @@ function InstallVS {
 function CheckNode {
     try {
         $v = (Get-Command node -ErrorAction Stop).Version.Major
-        return $v -eq 12 -or $v -eq 13 -or $v -eq 14
+        return ($v -ge 12) -and (($v % 2) -eq 0);
     } catch {
         return $false;
     }
@@ -254,7 +254,7 @@ $requirements = @(
     },
     @{
         Id=[CheckId]::Node;
-        Name = 'NodeJS lts installed';
+        Name = 'NodeJS LTS';
         Tags = @('appDev');
         Valid = { CheckNode; }
         Install = { choco install -y nodejs-lts };


### PR DESCRIPTION
All of the changes here are due to new behavior of npm/npx.

NPM 7 will prompt before fetching network packages unless `--yes` is passed. I set the env var `NPM_CONFIG_YES=false` to automatically fail these instead of hanging in our CI runs. I've removed/replaced all instances of `--ignore-existing`, which was removed, along with `--no-install` which was deprecated.

A previous trick of symlinking yarn's node_modules to npm's for the init test no longer works. I've modified init tests to use yarn, but to share the same yarn cache as the one used to install the repo, which should include most if not all dependencies.

I've also added midgard-yarn (and soon verdaccio) to the VM image, to save a couple of downloads during PRs.

This change causes the `rnw-deps` script to fail. I updated its logic to allow any Node LTS >= 12.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8982)