### PR TITLE
Allow Setting Managed Image Independently of Pool

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -252,7 +252,7 @@ jobs:
             pool:
               name: $(AgentPool.Medium)
               demands:
-                - ImageOverride -equals rnw-img-test-fail
+                -  $(AgentImage)
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -250,9 +250,9 @@ jobs:
               - template: ../variables/vs2019.yml
 
             pool:
-              name: $(AgentPool.Medium)
+              name: ${{ variables.AgentPool.Medium) }}
               demands:
-                -  $(AgentImage)
+                -  ${{ variables.AgentImage }}
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -251,8 +251,7 @@ jobs:
 
             pool:
               name: ${{ variables.AgentPool.Medium }}
-              demands:
-                -  ${{ variables.AgentImage }}
+              demands: ${{ variables.AgentImage }}
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -251,7 +251,8 @@ jobs:
 
             pool:
               name: $(AgentPool.Medium)
-              demands: $(AgentImage)
+              demands:
+                - ImageOverride -equals rnw-img-test-fail
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -250,8 +250,8 @@ jobs:
               - template: ../variables/vs2019.yml
 
             pool:
-              name: ${{ variables.AgentPool.Medium }}
-              demands: ${{ variables.AgentImage }}
+              name: ${{ variables['AgentPool.Medium'] }}
+              demands: ${{ variables['AgentImage'] }}
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -250,7 +250,7 @@ jobs:
               - template: ../variables/vs2019.yml
 
             pool:
-              name: ${{ variables.AgentPool.Medium) }}
+              name: ${{ variables.AgentPool.Medium }}
               demands:
                 -  ${{ variables.AgentImage }}
             timeoutInMinutes: 60

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -249,7 +249,9 @@ jobs:
             variables:
               - template: ../variables/vs2019.yml
 
-            pool: $(AgentPool.Medium)
+            pool:
+              name: $(AgentPool.Medium)
+              demands: $(AgentImage)
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -74,9 +74,9 @@ jobs:
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
           pool:
-            name: $(AgentPool.Medium)
+            name: ${{ variables.AgentPool.Medium) }}
             demands:
-              -  $(AgentImage)
+              -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -75,8 +75,7 @@ jobs:
 
           pool:
             name: ${{ variables.AgentPool.Medium }}
-            demands:
-              -  ${{ variables.AgentImage }}
+            demands: ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -74,7 +74,7 @@ jobs:
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
           pool:
-            name: ${{ variables.AgentPool.Medium) }}
+            name: ${{ variables.AgentPool.Medium }}
             demands:
               -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -75,7 +75,8 @@ jobs:
 
           pool:
             name: $(AgentPool.Medium)
-            demands: $(AgentImage)
+            demands:
+              -  $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -73,7 +73,9 @@ jobs:
                 (FullyQualifiedName!~HostObjectProtoTest)&
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
-          pool: $(AgentPool.Medium)
+          pool:
+            name: $(AgentPool.Medium)
+            demands: $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -74,8 +74,8 @@ jobs:
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
           pool:
-            name: ${{ variables.AgentPool.Medium }}
-            demands: ${{ variables.AgentImage }}
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -49,8 +49,7 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: ${{ variables.AgentPool.Medium }}
-            demands:
-              -  ${{ variables.AgentImage }}
+            demands: ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -48,8 +48,8 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium }}
-            demands: ${{ variables.AgentImage }}
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -47,7 +47,9 @@ jobs:
 
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: $(AgentPool.Medium)
+            demands: $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -48,7 +48,7 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium) }}
+            name: ${{ variables.AgentPool.Medium }}
             demands:
               -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -48,9 +48,9 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: $(AgentPool.Medium)
+            name: ${{ variables.AgentPool.Medium) }}
             demands:
-              -  $(AgentImage)
+              -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -49,7 +49,8 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: $(AgentPool.Medium)
-            demands: $(AgentImage)
+            demands:
+              -  $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -57,9 +57,9 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: $(AgentPool.Medium)
+            name: ${{ variables.AgentPool.Medium) }}
             demands:
-              -  $(AgentImage)
+              -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -57,8 +57,8 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium }}
-            demands: ${{ variables.AgentImage }}
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -57,7 +57,7 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium) }}
+            name: ${{ variables.AgentPool.Medium }}
             demands:
               -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -58,8 +58,7 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: ${{ variables.AgentPool.Medium }}
-            demands:
-              -  ${{ variables.AgentImage }}
+            demands: ${{ variables.AgentImage }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -56,7 +56,9 @@ jobs:
           displayName: Integration Test App ${{ matrix.Name }}
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: $(AgentPool.Medium)
+            demands: $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -58,7 +58,8 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: $(AgentPool.Medium)
-            demands: $(AgentImage)
+            demands:
+              -  $(AgentImage)
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -13,8 +13,7 @@ jobs:
     displayName: JavaScript Checks
     pool:
       name: ${{ variables.AgentPool.Medium }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -13,7 +13,8 @@ jobs:
     displayName: JavaScript Checks
     pool:
       name: $(AgentPool.Medium)
-      demands: $(AgentImage)
+      demands:
+        -  $(AgentImage)
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -12,7 +12,8 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: JavaScript Checks
     pool:
-      vmImage: $(VmImage)
+      name: $(AgentPool.Medium)
+      demands: $(AgentImage)
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -12,9 +12,9 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: JavaScript Checks
     pool:
-      name: $(AgentPool.Medium)
+      name: ${{ variables.AgentPool.Medium) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -12,7 +12,7 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: JavaScript Checks
     pool:
-      name: ${{ variables.AgentPool.Medium) }}
+      name: ${{ variables.AgentPool.Medium }}
       demands:
         -  ${{ variables.AgentImage }}
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -12,8 +12,8 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: JavaScript Checks
     pool:
-      name: ${{ variables.AgentPool.Medium }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Medium'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -69,9 +69,9 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: $(AgentPool.Medium)
+            name: ${{ variables.AgentPool.Medium) }}
             demands:
-              -  $(AgentImage)
+              -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -69,7 +69,7 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium) }}
+            name: ${{ variables.AgentPool.Medium }}
             demands:
               -  ${{ variables.AgentImage }}
           timeoutInMinutes: 60

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -70,7 +70,8 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: $(AgentPool.Medium)
-            demands: $(AgentImage)
+            demands:
+              -  $(AgentImage)
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -68,7 +68,9 @@ jobs:
 
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: $(AgentPool.Medium)
+            demands: $(AgentImage)
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -70,8 +70,7 @@ jobs:
             - template: ../variables/vs2019.yml
           pool:
             name: ${{ variables.AgentPool.Medium }}
-            demands:
-              -  ${{ variables.AgentImage }}
+            demands: ${{ variables.AgentImage }}
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -69,8 +69,8 @@ jobs:
           variables:
             - template: ../variables/vs2019.yml
           pool:
-            name: ${{ variables.AgentPool.Medium }}
-            demands: ${{ variables.AgentImage }}
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -23,7 +23,8 @@ jobs:
 
     pool:
       name: $(AgentPool.Medium)
-      demands: $(AgentImage)
+      demands:
+        -  $(AgentImage)
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -21,7 +21,9 @@ jobs:
         #   BuildConfiguration: Debug
         #   BuildPlatform: x86
 
-    pool: $(AgentPool.Medium)
+    pool:
+      name: $(AgentPool.Medium)
+      demands: $(AgentImage)
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -22,8 +22,8 @@ jobs:
         #   BuildPlatform: x86
 
     pool:
-      name: ${{ variables.AgentPool.Medium }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Medium'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -23,8 +23,7 @@ jobs:
 
     pool:
       name: ${{ variables.AgentPool.Medium }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -22,9 +22,9 @@ jobs:
         #   BuildPlatform: x86
 
     pool:
-      name: $(AgentPool.Medium)
+      name: ${{ variables.AgentPool.Medium) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -22,7 +22,7 @@ jobs:
         #   BuildPlatform: x86
 
     pool:
-      name: ${{ variables.AgentPool.Medium) }}
+      name: ${{ variables.AgentPool.Medium }}
       demands:
         -  ${{ variables.AgentImage }}
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -60,8 +60,8 @@ jobs:
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
           pool:
-            name: ${{ variables.AgentPool.Medium }}
-            demands: ${{ variables.AgentImage }}
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
 
           steps:
             - checkout: self
@@ -84,7 +84,7 @@ jobs:
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 deployOption:  ${{ matrix.DeployOption }}
-                buildLogDirectory: ${{ variables.BuildLogDirectory }}
+                buildLogDirectory: ${{ variables['BuildLogDirectory'] }}
                 workingDirectory: packages/sample-apps
 
             - script: yarn bundle-cpp --verbose
@@ -93,4 +93,4 @@ jobs:
 
             - template: ../templates/upload-build-logs.yml
               parameters:
-                buildLogDirectory: ${{ variables.BuildLogDirectory }}
+                buildLogDirectory: ${{ variables['BuildLogDirectory'] }}

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -60,9 +60,9 @@ jobs:
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
           pool:
-            name: $(AgentPool.Medium)
+            name: ${{ variables.AgentPool.Medium) }}
             demands:
-              -  $(AgentImage)
+              -  ${{ variables.AgentImage }}
 
           steps:
             - checkout: self

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -59,7 +59,9 @@ jobs:
           
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
-          pool: $(AgentPool.Medium)
+          pool:
+            name: $(AgentPool.Medium)
+            demands: $(AgentImage)
 
           steps:
             - checkout: self

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -61,8 +61,7 @@ jobs:
           cancelTimeoutInMinutes: 5
           pool:
             name: ${{ variables.AgentPool.Medium }}
-            demands:
-              -  ${{ variables.AgentImage }}
+            demands: ${{ variables.AgentImage }}
 
           steps:
             - checkout: self

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -60,7 +60,7 @@ jobs:
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
           pool:
-            name: ${{ variables.AgentPool.Medium) }}
+            name: ${{ variables.AgentPool.Medium }}
             demands:
               -  ${{ variables.AgentImage }}
 

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -61,7 +61,8 @@ jobs:
           cancelTimeoutInMinutes: 5
           pool:
             name: $(AgentPool.Medium)
-            demands: $(AgentImage)
+            demands:
+              -  $(AgentImage)
 
           steps:
             - checkout: self

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -68,7 +68,8 @@
               displayName: Universal Build ${{ matrix.Name }}
               pool:
                 name: $(AgentPool.Large)
-                demands: $(AgentImage)
+                demands:
+                  -  $(AgentImage)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -138,7 +139,8 @@
 
               pool:
                 name: $(AgentPool.Medium)
-                demands: $(AgentImage)
+                demands:
+                -  $(AgentImage)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -67,9 +67,9 @@
                 - template: ../variables/vs2019.yml
               displayName: Universal Build ${{ matrix.Name }}
               pool:
-                name: $(AgentPool.Large)
+                name: ${{ variables.AgentPool.Large) }}
                 demands:
-                  -  $(AgentImage)
+                  -  ${{ variables.AgentImage }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -138,9 +138,9 @@
                 - UniversalBuild${{ matrix.Name }}
 
               pool:
-                name: $(AgentPool.Medium)
+                name: ${{ variables.AgentPool.Medium) }}
                 demands:
-                -  $(AgentImage)
+                -  ${{ variables.AgentImage }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -66,7 +66,9 @@
               variables:
                 - template: ../variables/vs2019.yml
               displayName: Universal Build ${{ matrix.Name }}
-              pool: $(AgentPool.Large)
+              pool:
+                name: $(AgentPool.Large)
+                demands: $(AgentImage)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -134,7 +136,9 @@
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
 
-              pool: $(AgentPool.Medium)
+              pool:
+                name: $(AgentPool.Medium)
+                demands: $(AgentImage)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -67,7 +67,7 @@
                 - template: ../variables/vs2019.yml
               displayName: Universal Build ${{ matrix.Name }}
               pool:
-                name: ${{ variables.AgentPool.Large) }}
+                name: ${{ variables.AgentPool.Large }}
                 demands:
                   -  ${{ variables.AgentImage }}
               timeoutInMinutes: 60
@@ -138,7 +138,7 @@
                 - UniversalBuild${{ matrix.Name }}
 
               pool:
-                name: ${{ variables.AgentPool.Medium) }}
+                name: ${{ variables.AgentPool.Medium }}
                 demands:
                 -  ${{ variables.AgentImage }}
               timeoutInMinutes: 60

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -68,8 +68,7 @@
               displayName: Universal Build ${{ matrix.Name }}
               pool:
                 name: ${{ variables.AgentPool.Large }}
-                demands:
-                  -  ${{ variables.AgentImage }}
+                demands: ${{ variables.AgentImage }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -139,8 +138,7 @@
 
               pool:
                 name: ${{ variables.AgentPool.Medium }}
-                demands:
-                -  ${{ variables.AgentImage }}
+                demands: ${{ variables.AgentImage }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -67,8 +67,8 @@
                 - template: ../variables/vs2019.yml
               displayName: Universal Build ${{ matrix.Name }}
               pool:
-                name: ${{ variables.AgentPool.Large }}
-                demands: ${{ variables.AgentImage }}
+                name: ${{ variables['AgentPool.Large'] }}
+                demands: ${{ variables['AgentImage'] }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -137,8 +137,8 @@
                 - UniversalBuild${{ matrix.Name }}
 
               pool:
-                name: ${{ variables.AgentPool.Medium }}
-                demands: ${{ variables.AgentImage }}
+                name: ${{ variables['AgentPool.Medium'] }}
+                demands: ${{ variables['AgentImage'] }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -48,8 +48,8 @@ jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -106,8 +106,8 @@ jobs:
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -170,8 +170,8 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: ARM64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -221,8 +221,8 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: arm64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -264,8 +264,8 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -313,8 +313,8 @@ jobs:
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands: ${{ variables.AgentImage }}
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - checkout: none

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -109,7 +109,7 @@ jobs:
     pool:
       name: $(AgentPool.Medium.Microsoft)
       demands:
-                -  $(AgentImage)
+        -  $(AgentImage)
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -174,7 +174,7 @@ jobs:
     pool:
       name: $(AgentPool.Large.Microsoft)
       demands:
-                -  $(AgentImage)
+        -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -226,7 +226,7 @@ jobs:
     pool:
       name: $(AgentPool.Large.Microsoft)
       demands:
-                -  $(AgentImage)
+        -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -270,7 +270,7 @@ jobs:
     pool:
       name: $(AgentPool.Large.Microsoft)
       demands:
-                -  $(AgentImage)
+        -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -320,7 +320,7 @@ jobs:
     pool:
       name: $(AgentPool.Medium.Microsoft)
       demands:
-                -  $(AgentImage)
+        -  $(AgentImage)
 
     steps:
       - checkout: none

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -48,7 +48,7 @@ jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft) }}
+      name: ${{ variables.AgentPool.Medium.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
     timeoutInMinutes: 120
@@ -107,7 +107,7 @@ jobs:
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft) }}
+      name: ${{ variables.AgentPool.Medium.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
     timeoutInMinutes: 30
@@ -172,7 +172,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: ARM64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft) }}
+      name: ${{ variables.AgentPool.Large.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
 
@@ -224,7 +224,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: arm64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft) }}
+      name: ${{ variables.AgentPool.Large.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
 
@@ -268,7 +268,7 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x64
     pool:
-      name: ${{ variables.AgentPool.Large.Microsoft) }}
+      name: ${{ variables.AgentPool.Large.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
 
@@ -318,7 +318,7 @@ jobs:
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
     pool:
-      name: ${{ variables.AgentPool.Medium.Microsoft) }}
+      name: ${{ variables.AgentPool.Medium.Microsoft }}
       demands:
         -  ${{ variables.AgentImage }}
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -48,9 +48,9 @@ jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
-      name: $(AgentPool.Medium.Microsoft)
+      name: ${{ variables.AgentPool.Medium.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -107,9 +107,9 @@ jobs:
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
     pool:
-      name: $(AgentPool.Medium.Microsoft)
+      name: ${{ variables.AgentPool.Medium.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -172,9 +172,9 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: ARM64
     pool:
-      name: $(AgentPool.Large.Microsoft)
+      name: ${{ variables.AgentPool.Large.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -224,9 +224,9 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: arm64
     pool:
-      name: $(AgentPool.Large.Microsoft)
+      name: ${{ variables.AgentPool.Large.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -268,9 +268,9 @@ jobs:
           BuildConfiguration: Release
           BuildPlatform: x64
     pool:
-      name: $(AgentPool.Large.Microsoft)
+      name: ${{ variables.AgentPool.Large.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -318,9 +318,9 @@ jobs:
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
     pool:
-      name: $(AgentPool.Medium.Microsoft)
+      name: ${{ variables.AgentPool.Medium.Microsoft) }}
       demands:
-        -  $(AgentImage)
+        -  ${{ variables.AgentImage }}
 
     steps:
       - checkout: none

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -47,7 +47,9 @@ pr: none
 jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: $(AgentPool.Medium.Microsoft)
+      demands: $(AgentImage)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -103,7 +105,9 @@ jobs:
     displayName: Deploy @rnw-bots/coordinator
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: $(AgentPool.Medium.Microsoft)
+      demands: $(AgentImage)
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -165,7 +169,9 @@ jobs:
         ARM64Release:
           BuildConfiguration: Release
           BuildPlatform: ARM64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: $(AgentPool.Large.Microsoft)
+      demands: $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -214,7 +220,9 @@ jobs:
         Arm64Release:
           BuildConfiguration: Release
           BuildPlatform: arm64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: $(AgentPool.Large.Microsoft)
+      demands: $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -255,7 +263,9 @@ jobs:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: $(AgentPool.Large.Microsoft)
+      demands: $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -302,7 +312,9 @@ jobs:
       - RnwNativeBuildUniversal
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: $(AgentPool.Medium.Microsoft)
+      demands: $(AgentImage)
 
     steps:
       - checkout: none

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -49,7 +49,8 @@ jobs:
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
       name: $(AgentPool.Medium.Microsoft)
-      demands: $(AgentImage)
+      demands:
+        -  $(AgentImage)
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -107,7 +108,8 @@ jobs:
     dependsOn: RnwNpmPublish
     pool:
       name: $(AgentPool.Medium.Microsoft)
-      demands: $(AgentImage)
+      demands:
+                -  $(AgentImage)
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -171,7 +173,8 @@ jobs:
           BuildPlatform: ARM64
     pool:
       name: $(AgentPool.Large.Microsoft)
-      demands: $(AgentImage)
+      demands:
+                -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -222,7 +225,8 @@ jobs:
           BuildPlatform: arm64
     pool:
       name: $(AgentPool.Large.Microsoft)
-      demands: $(AgentImage)
+      demands:
+                -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -265,7 +269,8 @@ jobs:
           BuildPlatform: x64
     pool:
       name: $(AgentPool.Large.Microsoft)
-      demands: $(AgentImage)
+      demands:
+                -  $(AgentImage)
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -314,7 +319,8 @@ jobs:
     displayName: Sign Binaries and Publish NuGet
     pool:
       name: $(AgentPool.Medium.Microsoft)
-      demands: $(AgentImage)
+      demands:
+                -  $(AgentImage)
 
     steps:
       - checkout: none

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -49,8 +49,7 @@ jobs:
     displayName: React-Native-Windows Npm Build Rev Publish
     pool:
       name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -108,8 +107,7 @@ jobs:
     dependsOn: RnwNpmPublish
     pool:
       name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -173,8 +171,7 @@ jobs:
           BuildPlatform: ARM64
     pool:
       name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -225,8 +222,7 @@ jobs:
           BuildPlatform: arm64
     pool:
       name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -269,8 +265,7 @@ jobs:
           BuildPlatform: x64
     pool:
       name: ${{ variables.AgentPool.Large.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -319,8 +314,7 @@ jobs:
     displayName: Sign Binaries and Publish NuGet
     pool:
       name: ${{ variables.AgentPool.Medium.Microsoft }}
-      demands:
-        -  ${{ variables.AgentImage }}
+      demands: ${{ variables.AgentImage }}
 
     steps:
       - checkout: none

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,8 +2,9 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
-  # WARNING: mistyped or not-yet-provisioned images silently fall back to "rnw-img"
-  AgentImage: ImageOverride -equals rnw-img-node16-fail
+  # WARNING: Mistyped or not yet provisioned images may fall back to one whose
+  # name is a prefix. E.g. `rnw-img-new` may fall back to `rnw-img`.
+  AgentImage: ImageOverride -equals rnw-img-fail
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -4,7 +4,7 @@ variables:
   AgentPool.Large: rnw-pool-8
   # WARNING: Mistyped or not yet provisioned images may fall back to one whose
   # name is a prefix. E.g. `rnw-img-new` may fall back to `rnw-img`.
-  AgentImage: ImageOverride -equals rnw-img-fail
+  AgentImage: ImageOverride -equals rnw-img-node16-fail
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -1,7 +1,7 @@
 variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
-  AgentPool.Large: rnw-pool-4
+  AgentPool.Large: rnw-pool-8
   AgentImage: ImageOverride -equals rnw-img
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -3,7 +3,7 @@ variables:
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
   # WARNING: mistyped or not-yet-provisioned images silently fall back to "rnw-img"
-  AgentImage: ImageOverride -equals rnw-img-node16
+  AgentImage: ImageOverride -equals rnw-img-node16-fail
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,7 +2,7 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
-  AgentImage: ImageOverride -equals rnw-img
+  AgentImage: ImageOverride -equals rnw-img-test-fail
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,7 +2,8 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
-  AgentImage: ImageOverride -equals rnw-img-test-node16
+  # WARNING: mistyped or not-yet-provisioned images silently fall back to "rnw-img"
+  AgentImage: ImageOverride -equals rnw-img-node16
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,7 +2,7 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
-  AgentImage: ImageOverride -equals rnw-img-test-fail
+  AgentImage: ImageOverride -equals rnw-img-test-node16
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -3,7 +3,7 @@ variables:
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
   # WARNING: mistyped or not-yet-provisioned images silently fall back to "rnw-img"
-  AgentImage: ImageOverride -equals rnw-img-node16
+  AgentImage: ImageOverride -equals rnw-fail-node16
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -1,7 +1,8 @@
 variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
-  AgentPool.Large: rnw-pool-8
+  AgentPool.Large: rnw-pool-4
+  AgentImage: ImageOverride -equals rnw-img
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,9 +2,7 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
-  # WARNING: Mistyped or not yet provisioned images may fall back to one whose
-  # name is a prefix. E.g. `rnw-img-new` may fall back to `rnw-img`.
-  AgentImage: ImageOverride -equals rnw-img-node16-fail
+  AgentImage: ImageOverride -equals rnw-img-test-node16
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -3,7 +3,7 @@ variables:
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
   # WARNING: mistyped or not-yet-provisioned images silently fall back to "rnw-img"
-  AgentImage: ImageOverride -equals rnw-fail-node16
+  AgentImage: ImageOverride -equals rnw-img-node16
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60


### PR DESCRIPTION
This uses pool demands to allow us to override the image used by a pool supporting multiple images. This should allow us to create an image for each branch without needing a separate pool for each.

Internal folks can see https://eng.ms/docs/cloud-ai-platform/developer-services/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/demands for details.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8983)