### PR TITLE
Throw an exception when trying to call into JSI when using web debugging, as it won't work

### DIFF
--- a/change/react-native-windows-85bbdd26-3c79-4835-9339-aeee48996f59.json
+++ b/change/react-native-windows-85bbdd26-3c79-4835-9339-aeee48996f59.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Throw an exception when trying to call into JSI when using web debugging, as it won't work",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
@@ -20,6 +20,9 @@ facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) n
 // The code is executed synchronously if it is already in JSDispatcher, or asynchronously otherwise.
 template <class TCodeWithRuntime>
 void ExecuteJsi(ReactContext const &context, TCodeWithRuntime const &code) {
+  if (context.Handle().SettingsSnapshot().UseWebDebugger()) {
+    throw std::invalid_argument("Attempted to use JSI while web debugging is enabled.");
+  }
   ReactDispatcher jsDispatcher = context.JSDispatcher();
   if (jsDispatcher.HasThreadAccess()) {
     // Execute immediately if we are in JS thread.


### PR DESCRIPTION
This will help with devs chasing "why doesn't my app work" kinds of bugs : )

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8986)