### PR TITLE
Make all msbuild in PR and CI multicore builds

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -104,7 +104,7 @@ jobs:
                   platform: ${{ matrix.BuildPlatform}} # Optional
                   configuration: ${{ matrix.BuildConfiguration}} # Optional
                   clean: true # Optional
-                  maximumCpuCount: false # Optional
+                  maximumCpuCount: true
                   restoreNugetPackages: false # Optional
                   msbuildArgs:
                     /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
@@ -125,7 +125,7 @@ jobs:
                   platform: ${{ matrix.BuildPlatform}} # Optional
                   configuration: ${{ matrix.BuildConfiguration}} # Optional
                   clean: true # Optional
-                  maximumCpuCount: false # Optional
+                  maximumCpuCount: true
                   restoreNugetPackages: false # Optional
                   msbuildArgs:
                     /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)

--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -12,7 +12,6 @@ parameters:
   buildPlatform: x64
   buildConfiguration: Debug
   msbuildArguments: ''
-  multicoreBuild: false
   warnAsError: true
 
   # Visual Studio Installer
@@ -59,7 +58,7 @@ steps:
       platform: ${{ parameters.buildPlatform }}
       configuration: ${{ parameters.buildConfiguration }}
       clean: false # Optional
-      maximumCpuCount: ${{ parameters.multicoreBuild }} # Optional
+      maximumCpuCount: true
       restoreNugetPackages: false # Optional
       createLogFile: true
       logFileVerbosity: detailed

--- a/change/react-native-windows-6e463863-71ac-46eb-a69c-d91fc6d7cec5.json
+++ b/change/react-native-windows-6e463863-71ac-46eb-a69c-d91fc6d7cec5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make all msbuild in PR and CI multicore builds",
+  "packageName": "react-native-windows",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
+++ b/vnext/IntegrationTests/React.Windows.IntegrationTests.vcxproj
@@ -65,6 +65,9 @@
     <ProjectReference Include="..\Common\Common.vcxproj">
       <Project>{fca38f3c-7c73-4c47-be4e-32f77fa8538d}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\Folly\Folly.vcxproj">
+      <Project>{A990658C-CE31-4BCC-976F-0FC6B1AF693D}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ControllableMessageQueueThread.cpp" />


### PR DESCRIPTION
## Description
Make all vsbuild tasks multicore builds, we run on 4 or 8 core boxes, silly to still be doing single-threaded builds.

### Why
Improve performance of our PR and CI validations

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/8992)