### PR TITLE
Revert "Fixes issue with Proofing menu override on XAML Islands"

### DIFF
--- a/change/react-native-windows-161e9493-55e3-48e3-a80c-8a230a247fde.json
+++ b/change/react-native-windows-161e9493-55e3-48e3-a80c-8a230a247fde.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert \"Fixes issue with Proofing menu override on XAML Islands (#8989)\"",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-65b087f3-af52-4025-aa0f-96382c7e6e77.json
+++ b/change/react-native-windows-65b087f3-af52-4025-aa0f-96382c7e6e77.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fixes issue with Proofing menu override on XAML Islands",
-  "packageName": "react-native-windows",
-  "email": "erozell@outlook.com",
-  "dependentChangeType": "patch"
-}

--- a/vnext/Microsoft.ReactNative/Utils/XamlIslandUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/XamlIslandUtils.cpp
@@ -47,7 +47,7 @@ void FixProofingMenuCrashForXamlIsland(xaml::Controls::Primitives::FlyoutBase co
               }
             });
           } else if (appBarButton.Flyout() == textBox.ProofingMenuFlyout()) {
-            if (textBox.IsSpellCheckEnabled()) {
+            if (!appBarButton.try_as<CustomAppBarButton>()) {
               // Replace the AppBarButton for the proofing menu with one that doesn't crash
               const auto customAppBarButton = winrt::make<CustomAppBarButton>();
               customAppBarButton.Label(appBarButton.Label());
@@ -55,7 +55,7 @@ void FixProofingMenuCrashForXamlIsland(xaml::Controls::Primitives::FlyoutBase co
               customAppBarButton.Flyout(appBarButton.Flyout());
               commands.RemoveAt(i);
               commands.InsertAt(i, customAppBarButton);
-            } else {
+            } else if (!textBox.IsSpellCheckEnabled()) {
               // Remove proofing menu option if spell-check is disabled
               commands.RemoveAt(i);
             }


### PR DESCRIPTION
Reverts microsoft/react-native-windows#8989

looks like it was merged before we had a chance to review, reverting until we can take a look
@rozele fyi


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9001)