### PR TITLE
Default `run-windows` to building system architecture

### DIFF
--- a/change/@react-native-windows-cli-da13474f-cd34-41ae-94d0-2fa8c9bf4d78.json
+++ b/change/@react-native-windows-cli-da13474f-cd34-41ae-94d0-2fa8c9bf4d78.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Default `run-windows` to building system architecture",
+  "packageName": "@react-native-windows/cli",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/README.md
+++ b/packages/@react-native-windows/cli/README.md
@@ -17,7 +17,7 @@ Options:
 |-----------------------|--------------------------------------|--------------------------------------------------|
 | `--release`           | Specifies a Release build | [boolean] |
 | `--root`              | Override the root directory for the windows build which contains the windows folder. (default: "E:\\test63") | [string] |
-| `--arch`              | The build architecture (ARM64, x86, x64). default: x86 | [string] |
+| `--arch`              | The build architecture (ARM64, x86, x64). defaults to system architecture | [string] |
 | `--singleproc`        | Disables multi-proc build | [boolean] |
 | `--emulator`          | Deploys the app to an emulator | [boolean] |
 | `--device`            | Deploys the app to a connected device | [boolean] |

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -4,6 +4,7 @@
  * @format
  */
 
+import os from 'os';
 import {CommandOption} from '@react-native-community/cli-types';
 
 export type BuildArch = 'x86' | 'x64' | 'ARM64';
@@ -71,7 +72,7 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--arch [string]',
     description: 'The build architecture (ARM64, x86, x64)',
-    default: 'x86',
+    default: os.arch(),
     parse: parseBuildArch,
   },
   {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
x64 is likely more important than x86 for most, and @dannyv discovered the x86 build will also build x64 due to AppX targets (looking at that separately).

### What
This causes the CLI to build x64 by default on x64 machines, and ARM64 by default on ARM64 machines. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9003)