### PR TITLE
Only build x86 of Playground.sln in CI because in PR it takes 2x 

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -93,44 +93,33 @@ jobs:
                 restoreSolution: packages/playground/windows/${{ matrix.SolutionFile }}
                 verbosityRestore: Detailed # Options: quiet, normal, detailed
 
-
-            - ${{if eq(config.BuildEnvironment, 'PullRequest')}}:
-              - task: VSBuild@1
-                displayName: VSBuild - Playground PR
-                inputs:
-                  solution: packages/playground/windows/${{ matrix.SolutionFile }}
-                  vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-                  msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
-                  platform: ${{ matrix.BuildPlatform}} # Optional
-                  configuration: ${{ matrix.BuildConfiguration}} # Optional
-                  clean: true # Optional
-                  maximumCpuCount: false # Optional
-                  restoreNugetPackages: false # Optional
-                  msbuildArgs:
-                    /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
-                    /p:PlatformToolset=$(MSBuildPlatformToolset)
-                    
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml
                 parameters:
                   certificateName: playgroundEncodedKey
 
-              - task: VSBuild@1
-                displayName: VSBuild - Playground CI
-                inputs:
-                  solution: packages/playground/windows/${{ matrix.SolutionFile }}
-                  vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
-                  msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
-                  platform: ${{ matrix.BuildPlatform}} # Optional
-                  configuration: ${{ matrix.BuildConfiguration}} # Optional
-                  clean: true # Optional
-                  maximumCpuCount: false # Optional
-                  restoreNugetPackages: false # Optional
+            - task: VSBuild@1
+              displayName: VSBuild - Playground
+              inputs:
+                solution: packages/playground/windows/${{ matrix.SolutionFile }}
+                vsVersion: $(MSBuildVersion) # Optional. Options: latest, 16.0, 15.0, 14.0, 12.0, 4.0
+                msbuildArchitecture: $(MSBuildArchitecture) # Optional. Options: x86, x64
+                platform: ${{ matrix.BuildPlatform}} # Optional
+                configuration: ${{ matrix.BuildConfiguration}} # Optional
+                clean: true # Optional
+                maximumCpuCount: false # Optional
+                restoreNugetPackages: false # Optional
+                ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
                     /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
                     /p:PlatformToolset=$(MSBuildPlatformToolset)
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+                ${{ else }}:
+                  msbuildArgs:
+                    /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)
+                    /p:PlatformToolset=$(MSBuildPlatformToolset)
 
+            - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/cleanup-certificate.yml
 
             - ${{ if eq(matrix.UploadAppx, true) }}:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -10,10 +10,6 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
-          - Name: X86DebugUniversal
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground.sln
           - Name: X64ReleaseUniversal
             BuildConfiguration: Release
             BuildPlatform: x64
@@ -26,9 +22,9 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Win32.sln
-          - Name: X86DebugWinUI3
+          - Name: X64DebugWinUI3
             BuildConfiguration: Debug
-            BuildPlatform: x86
+            BuildPlatform: x64
             SolutionFile: Playground.sln
             BuildWinUI3: true
       - BuildEnvironment: Continuous
@@ -58,6 +54,11 @@ parameters:
             SolutionFile: Playground.sln
             BuildWinUI3: true
             UploadAppx: true
+          - Name: X64DebugWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            BuildWinUI3: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:


### PR DESCRIPTION
## Description
Only build x86 of Playground.sln in CI because in PR it takes 2x
as long as x64 because it builds both x86 and x64, whereas x64 Only builds the x64 version.
We'll still have the full coverage in the nightly builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9005)