### PR TITLE
Allow Setting Managed Image Independently of Pool

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -249,7 +249,9 @@ jobs:
             variables:
               - template: ../variables/vs2019.yml
 
-            pool: $(AgentPool.Medium)
+            pool:
+              name: ${{ variables['AgentPool.Medium'] }}
+              demands: ${{ variables['AgentImage'] }}
             timeoutInMinutes: 60
             cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -73,7 +73,9 @@ jobs:
                 (FullyQualifiedName!~HostObjectProtoTest)&
                 (FullyQualifiedName!~PreparedJavaScriptSourceTest)
 
-          pool: $(AgentPool.Medium)
+          pool:
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -41,7 +41,9 @@ jobs:
 
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -56,7 +56,9 @@ jobs:
           displayName: Integration Test App ${{ matrix.Name }}
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60 # how long to run the job before automatically cancelling
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -12,7 +12,8 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: JavaScript Checks
     pool:
-      vmImage: $(VmImage)
+      name: ${{ variables['AgentPool.Medium'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 30 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
     steps:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -68,7 +68,9 @@ jobs:
 
           variables:
             - template: ../variables/vs2019.yml
-          pool: $(AgentPool.Medium)
+          pool:
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -21,7 +21,9 @@ jobs:
         #   BuildConfiguration: Debug
         #   BuildPlatform: x86
 
-    pool: $(AgentPool.Medium)
+    pool:
+      name: ${{ variables['AgentPool.Medium'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -59,7 +59,9 @@ jobs:
           
           timeoutInMinutes: 60
           cancelTimeoutInMinutes: 5
-          pool: $(AgentPool.Medium)
+          pool:
+            name: ${{ variables['AgentPool.Medium'] }}
+            demands: ${{ variables['AgentImage'] }}
 
           steps:
             - checkout: self
@@ -82,7 +84,7 @@ jobs:
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 deployOption:  ${{ matrix.DeployOption }}
-                buildLogDirectory: ${{ variables.BuildLogDirectory }}
+                buildLogDirectory: ${{ variables['BuildLogDirectory'] }}
                 workingDirectory: packages/sample-apps
 
             - script: yarn bundle-cpp --verbose
@@ -91,4 +93,4 @@ jobs:
 
             - template: ../templates/upload-build-logs.yml
               parameters:
-                buildLogDirectory: ${{ variables.BuildLogDirectory }}
+                buildLogDirectory: ${{ variables['BuildLogDirectory'] }}

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -66,7 +66,9 @@
               variables:
                 - template: ../variables/vs2019.yml
               displayName: Universal Build ${{ matrix.Name }}
-              pool: $(AgentPool.Large)
+              pool:
+                name: ${{ variables['AgentPool.Large'] }}
+                demands: ${{ variables['AgentImage'] }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -134,7 +136,9 @@
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
 
-              pool: $(AgentPool.Medium)
+              pool:
+                name: ${{ variables['AgentPool.Medium'] }}
+                demands: ${{ variables['AgentImage'] }}
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -47,7 +47,9 @@ pr: none
 jobs:
   - job: RnwNpmPublish
     displayName: React-Native-Windows Npm Build Rev Publish
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 120
     cancelTimeoutInMinutes: 5
     steps:
@@ -103,7 +105,9 @@ jobs:
     displayName: Deploy @rnw-bots/coordinator
     condition: eq(variables['Build.SourceBranchName'], 'main')
     dependsOn: RnwNpmPublish
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
     timeoutInMinutes: 30
     steps:
       - template: templates/prepare-env.yml
@@ -165,7 +169,9 @@ jobs:
         ARM64Release:
           BuildConfiguration: Release
           BuildPlatform: ARM64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -214,7 +220,9 @@ jobs:
         Arm64Release:
           BuildConfiguration: Release
           BuildPlatform: arm64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -255,7 +263,9 @@ jobs:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
-    pool: $(AgentPool.Large.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Large.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - template: templates/apply-published-version-vars.yml
@@ -302,7 +312,9 @@ jobs:
       - RnwNativeBuildUniversal
       - RnwNativeBuildReunion
     displayName: Sign Binaries and Publish NuGet
-    pool: $(AgentPool.Medium.Microsoft)
+    pool:
+      name: ${{ variables['AgentPool.Medium.Microsoft'] }}
+      demands: ${{ variables['AgentImage'] }}
 
     steps:
       - checkout: none

--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -2,6 +2,7 @@ variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
   AgentPool.Large: rnw-pool-8
+  AgentImage: ImageOverride -equals rnw-img
   MSBuildVersion: 16.0
   runCodesignValidationInjection: false
   NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS: 60


### PR DESCRIPTION
## Description

### Why
We will be creating multiple versioned images in the future for RNW. We currently associate to an image by picking pool, but would rather not need a pool for every image we have.

### What
This uses pool demands to allow us to override the image used by a pool supporting multiple images. This should allow us to create an image for each branch without needing a separate pool for each.

Internal folks can see https://eng.ms/docs/cloud-ai-platform/developer-services/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/demands for details.

## Testing
Validated that changing the value exhibits behavior of different images I created.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9008)