### PR TITLE
Download less artifacts in NuGet Init Test

### DIFF
--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -13,25 +13,51 @@ parameters:
   packMicrosoftReactNativeManagedCodeGen: true
   packMicrosoftReactNativeProjectReunion: false
   signMicrosoft: false
-  downloadPatterns:
-    - "**"
-    - ${{ if not(contains(parameters.slices, 'x86')) }}:
-      - "!**/x86/**"
-    - ${{ if not(contains(parameters.slices, 'x64')) }}:
-      - "!**/x64/**"
-    - ${{ if not(contains(parameters.slices, 'ARM64')) }}:
-      - "!**/ARM64/**"
-    - ${{ if not(parameters.packDesktop) }}:
-      - "!**/React.Windows.Desktop*/**"
 
 steps:
   - task: DownloadPipelineArtifact@2
-    displayName: 'Download ReactWindows Artifact'
+    displayName: Download Shared Artifacts
     inputs:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
-      patterns: ${{ join( '\n', parameters.downloadPatterns) }}
+      patterns: |
+        **
+        !**/x86/**
+        !**/x64/**
+        !**/ARM64/**
+        !**/React.Windows.Desktop*/**
 
+  - ${{ if contains(parameters.slices, 'x86') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download x86 Artifacts
+      inputs:
+        artifact: ReactWindows
+        path: $(System.DefaultWorkingDirectory)/ReactWindows
+        patterns: "**/x86/**"
+
+  - ${{ if contains(parameters.slices, 'x64') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download x64 Artifacts
+      inputs:
+        artifact: ReactWindows
+        path: $(System.DefaultWorkingDirectory)/ReactWindows
+        patterns: "**/x64/**"
+
+  - ${{ if contains(parameters.slices, 'ARM64') }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download ARM64 Artifacts
+      inputs:
+        artifact: ReactWindows
+        path: $(System.DefaultWorkingDirectory)/ReactWindows
+        patterns: "**/ARM64/**"
+
+  - ${{ if parameters.packDesktop }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Desktop Artifacts
+      inputs:
+        artifact: ReactWindows
+        path: $(System.DefaultWorkingDirectory)/ReactWindows
+        patterns: "**/React.Windows.Desktop*/**"
 
   - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true), eq(parameters.packMicrosoftReactNativeProjectReunion, false)) }}:
     - powershell: |

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -13,6 +13,16 @@ parameters:
   packMicrosoftReactNativeManagedCodeGen: true
   packMicrosoftReactNativeProjectReunion: false
   signMicrosoft: false
+  downloadPatterns:
+    - "**"
+    - ${{ if not(contains(parameters.slices, 'x86')) }}:
+      - "!**/x86/**"
+    - ${{ if not(contains(parameters.slices, 'x64')) }}:
+      - "!**/x64/**"
+    - ${{ if not(contains(parameters.slices, 'ARM64')) }}:
+      - "!**/ARM64/**"
+    - ${{ if not(parameters.packDesktop) }}:
+      - "!**/React.Windows.Desktop*/**"
 
 steps:
   - task: DownloadPipelineArtifact@2
@@ -20,16 +30,7 @@ steps:
     inputs:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
-      patterns:
-        - "**"
-        - ${{ if not(contains(parameters.slices, 'x86')) }}:
-          - "!**/x86/**"
-        - ${{ if not(contains(parameters.slices, 'x64')) }}:
-          - "!**/x64/**"
-        - ${{ if not(contains(parameters.slices, 'ARM64')) }}:
-          - "!**/ARM64/**"
-        - ${{ if not(parameters.packDesktop) }}:
-          - "!**/React.Windows.Desktop*/**"
+      patterns: ${{ join( '\n', parameters.downloadPatterns) }}
 
 
   - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true), eq(parameters.packMicrosoftReactNativeProjectReunion, false)) }}:

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -20,6 +20,17 @@ steps:
     inputs:
       artifact: ReactWindows
       path: $(System.DefaultWorkingDirectory)/ReactWindows
+      patterns:
+        - "**"
+        - ${{ if not(contains(parameters.slices, 'x86')) }}:
+          - "!**/x86/**"
+        - ${{ if not(contains(parameters.slices, 'x64')) }}:
+          - "!**/x64/**"
+        - ${{ if not(contains(parameters.slices, 'ARM64')) }}:
+          - "!**/ARM64/**"
+        - ${{ if not(parameters.packDesktop) }}:
+          - "!**/React.Windows.Desktop*/**"
+
 
   - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true), eq(parameters.packMicrosoftReactNativeProjectReunion, false)) }}:
     - powershell: |


### PR DESCRIPTION



## Description

### Why
One of the tests that tends to finish last is the init test using NuGet package. This test relies on the build in a first stage, then in its own, it locally creates the NuGet package for testing. Downloading artifacts currently takes over a minute.

### What
This PR aims to decrease total PR time by not downloading build artifacts for slices that are not needed.

## Testing
Seeing that PR still passes


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9009)