### PR TITLE
Fix playground PR

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -67,7 +67,6 @@ jobs:
           displayName: Playground ${{ matrix.Name }}
 
           variables:
-            - template: ../variables/msbuild.yml
             - template: ../variables/vs2019.yml
           pool:
             name: ${{ variables['AgentPool.Medium'] }}
@@ -117,7 +116,7 @@ jobs:
                 configuration: ${{ matrix.BuildConfiguration}} # Optional
                 clean: true # Optional
                 maximumCpuCount: false # Optional
-                restoreNugetPackages: true
+                restoreNugetPackages: false
                 ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
                     /p:PreferredToolArchitecture=$(MSBuildPreferredToolArchitecture)

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -67,6 +67,7 @@ jobs:
           displayName: Playground ${{ matrix.Name }}
 
           variables:
+            - template: ../variables/msbuild.yml
             - template: ../variables/vs2019.yml
           pool:
             name: ${{ variables['AgentPool.Medium'] }}


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/pull/9004 accidentally changed `restoreNugetPackages: false` to `restoreNugetPackages: true`. Revert that change, to unblock validation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9013)