### PR TITLE
Use MSBuild Builtin Restore

### DIFF
--- a/.ado/templates/build-rnw.yml
+++ b/.ado/templates/build-rnw.yml
@@ -30,18 +30,6 @@ steps:
     condition: not(eq('${{parameters.warnAsError}}', 'true'))
     displayName: Disable WarnAsError
 
-
-  # NuGetCommand@2 workaround: https://developercommunity.visualstudio.com/content/problem/288534/vsts-yaml-build-failure-the-task-name-nugetcommand.html
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
-    displayName: NuGet restore
-    inputs:
-      command: restore
-      restoreSolution: ${{parameters.project }}
-      feedsToUse: config
-      nugetConfigPath: $(Build.SourcesDirectory)/vnext/NuGet.config
-      restoreDirectory: packages/
-      verbosityRestore: Detailed # Options: quiet, normal, detailed
-
   - task: VSBuild@1
     displayName: VSBuild ${{parameters.project}}
     inputs:
@@ -64,6 +52,8 @@ steps:
         /flp1:errorsonly;logfile=$(BuildLogDirectory)\MsBuild.err
         /flp2:warningsonly;logfile=$(BuildLogDirectory)\MsBuild.wrn
         /flp3:verbosity=diagnostic;logfile=$(BuildLogDirectory)\MsBuild.log
+        /restore
+        /p:RestorePackagesConfig=true
         $(MsBuildWarnAsErrorArgument)
         ${{parameters.msbuildArguments}}
 


### PR DESCRIPTION
This matches CLI logic of restoring NuGet packages using built-in MSBuild support. Does not seem to be a major time difference, but should help ensure we are using an up-to-date/synchronized version without relying on a separate NuGet client.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9018)