### PR TITLE
Reduce dependabot "open-pull-requests-limit"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
   versioning-strategy: lockfile-only
   commit-message:
     prefix: 📦
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5


### PR DESCRIPTION
## Description

### Why
Dependabot can open up to 10 PRs at once, which can starve CI resources.

### What
This change reduces the number of open PRs to 5.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9030)