### PR TITLE
Fixes default background for mouse events with border

### DIFF
--- a/change/react-native-windows-f0084024-b791-4e76-a6ba-cdef4c805415.json
+++ b/change/react-native-windows-f0084024-b791-4e76-a6ba-cdef4c805415.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes default background for mouse events with border",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseExample.windows.js
@@ -42,6 +42,14 @@ const styles = StyleSheet.create({
     height: 400,
     backgroundColor: '#CCCCCC',
   },
+  borderContainer: {
+    padding: 10,
+    borderColor: 'black',
+    borderWidth: 2,
+  },
+  borderContainerHovered: {
+    borderColor: 'green',
+  },
   contentContainer: {
     flex: 1,
     backgroundColor: '#F2E2C4',
@@ -100,6 +108,7 @@ export default class ExampleComponent extends React.Component<
     this.state = {
       clicked: 0,
       pageHover: false,
+      borderHover: false,
       contentHover: false,
       contentChildHover: false,
       overlayHover: false,
@@ -117,11 +126,21 @@ export default class ExampleComponent extends React.Component<
       onMouseEnter: this.mouseEnterPage,
       onMouseLeave: this.mouseLeavePage,
     };
+    const borderProps: any = {
+      style: [
+        styles.borderContainer,
+        this.state.borderHover ? styles.borderContainerHovered : undefined,
+      ],
+      onMouseEnter: this.mouseEnterBorder,
+      onMouseLeave: this.mouseLeaveBorder,
+    };
     return (
       <View {...pageProps}>
-        <View style={styles.mainContainer}>
-          {this.renderContent()}
-          {this.renderOverlay()}
+        <View {...borderProps}>
+          <View style={styles.mainContainer}>
+            {this.renderContent()}
+            {this.renderOverlay()}
+          </View>
         </View>
         <View>
           <Text>{this.state.pageHover ? 'Mouse over page' : ''}</Text>
@@ -192,6 +211,14 @@ export default class ExampleComponent extends React.Component<
   };
   mouseLeavePage = () => {
     this.setState({pageHover: false});
+  };
+
+  mouseEnterBorder = () => {
+    this.setState({borderHover: true});
+  };
+
+  mouseLeaveBorder = () => {
+    this.setState({borderHover: false});
   };
 
   mouseEnterContentContainer = () => {

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -433,12 +433,12 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto *viewShadowNode = static_cast<ViewShadowNode *>(node);
   auto panel = viewShadowNode->GetViewPanel();
 
-  if (panel.Background() == nullptr) {
+  if (panel.ReadLocalValue(ViewPanel::ViewBackgroundProperty()) == xaml::DependencyProperty::UnsetValue()) {
     // In XAML, a null background means no hit-test will happen.
     // We actually want hit-testing to happen if the app has registered
     // for mouse events, so detect that case and add a transparent background.
     if (viewShadowNode->IsHitTestBrushRequired()) {
-      panel.Background(EnsureTransparentBrush());
+      panel.ViewBackground(EnsureTransparentBrush());
     }
     // Note:  Technically we could detect when the transparent brush is
     // no longer needed, but this adds complexity and it can't hurt to


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When `onMouseEnter` or `onMouseLeave` is set, react-native-windows sets a transparent background by default on a View if it has no other background. Since we were setting the `Panel::Background` property directly instead of using the `ViewPanel::ViewBackground` property, the transparent background could be cleared out after being set. This change ensures that the transparent background is set even if a border is applied.

Resolves #9034

### What

Switched from using `Panel::Background` to `ViewPanel::Background` for default Transparent SolidColorBrush when mouse events registered.

## Screenshots
Before:

https://user-images.githubusercontent.com/1106239/139733354-ab0f7bcc-d400-494d-a78e-921c2ce47afd.mp4

After:

https://user-images.githubusercontent.com/1106239/139733116-c5611b7a-4fc5-4a0e-990c-8641c10657cc.mp4

## Testing

Adds to "Mouse Events" example in RNTester to test the case where a border is set with undefined `backgroundColor`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9035)