### PR TITLE
Fix Publish pipeline

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -171,6 +171,8 @@ jobs:
       demands: ${{ variables['AgentImage'] }}
 
     steps:
+      - template: templates/prepare-js-env.yml
+
       - template: templates/prepare-build-env.yml
         parameters:
           platform: $(BuildPlatform)
@@ -228,6 +230,8 @@ jobs:
       demands: ${{ variables['AgentImage'] }}
 
     steps:
+      - template: templates/prepare-js-env.yml
+
       - template: templates/prepare-build-env.yml
         parameters:
           platform: $(BuildPlatform)
@@ -277,6 +281,8 @@ jobs:
       demands: ${{ variables['AgentImage'] }}
 
     steps:
+      - template: templates/prepare-js-env.yml
+
       - template: templates/prepare-build-env.yml
         parameters:
           platform: $(BuildPlatform)


### PR DESCRIPTION
## Description
A recent change nicely split up our prepare scripts.
But to build rnw, we need to run at least 'yarn install' so that we can find the folly version to download from github in the publish pipeline...

At the moment this does more than it needs to as it also runs `yarn build` which technically isn't needed in the publish phase. But this is just to unblock the publish pipeline for the canary builds.
 
## Testing
None, will check if the publish pipline succeeds after merging...



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9036)