### PR TITLE
Share setup job between PR and CI

### DIFF
--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -10,24 +10,9 @@ variables:
 stages:
   - stage: Setup
     jobs:
-      - job: Setup
-        variables:
-          - template: variables/windows.yml
-        pool:
-          vmImage: windows-2019
-        steps:
-          - template: templates/configure-git.yml
-
-          - template: templates/yarn-install.yml
-
-          - script: npx beachball bump --branch origin/$(Build.SourceBranchName) --yes
-            displayName: beachball bump
-
-          - template: templates/set-version-vars.yml
-            parameters:
-              buildEnvironment: Continuous
-
-          - template: templates/publish-version-vars.yml
+      - template: jobs/setup.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
 
   - template: stages.yml
     parameters:

--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -8,12 +8,6 @@ variables:
   - group: platform-override-zero-permission-token
 
 stages:
-  - stage: Setup
-    jobs:
-      - template: jobs/setup.yml
-        parameters:
-          buildEnvironment: ${{ parameters.buildEnvironment }}
-
   - template: stages.yml
     parameters:
       buildEnvironment: Continuous

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -18,7 +18,7 @@ jobs:
             targetType: filePath
             filePath: .ado/scripts/shouldSkipPRBuild.ps1
 
-      - template: templates/compute-beachball-branch-name.yml
+      - template: ../templates/compute-beachball-branch-name.yml
 
       - script: npm install -g beachball@2.18.0
         displayName: Install beachball
@@ -30,8 +30,8 @@ jobs:
       - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
         displayName: beachball bump
 
-      - template: templates/set-version-vars.yml
+      - template: ../templates/set-version-vars.yml
         parameters:
           buildEnvironment: ${{ parameters.buildEnvironment }}
 
-      - template: templates/publish-version-vars.yml
+      - template: ../templates/publish-version-vars.yml

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -1,0 +1,36 @@
+parameters:
+  - name: buildEnvironment
+    type: string
+    values:
+      - PullRequest
+      - Continuous 
+
+- job: Setup
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+    - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+      - task: powershell@2
+        name: checkPayload
+        displayName: "Check if build is required for this PR"
+        inputs:
+          targetType: filePath
+          filePath: .ado/scripts/shouldSkipPRBuild.ps1
+
+    - template: templates/compute-beachball-branch-name.yml
+
+    - script: npm install -g beachball@2.18.0
+      displayName: Install beachball
+  
+    - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+      - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+        displayName: Check for change files
+
+    - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
+      displayName: beachball bump
+
+    - template: templates/set-version-vars.yml
+      parameters:
+        buildEnvironment: ${{ parameters.buildEnvironment }}
+
+    - template: templates/publish-version-vars.yml

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -34,3 +34,4 @@ parameters:
         buildEnvironment: ${{ parameters.buildEnvironment }}
 
     - template: templates/publish-version-vars.yml
+    

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -5,33 +5,33 @@ parameters:
       - PullRequest
       - Continuous 
 
-- job: Setup
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-    - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
-      - task: powershell@2
-        name: checkPayload
-        displayName: "Check if build is required for this PR"
-        inputs:
-          targetType: filePath
-          filePath: .ado/scripts/shouldSkipPRBuild.ps1
+jobs:
+  - job: Setup
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+        - task: powershell@2
+          name: checkPayload
+          displayName: "Check if build is required for this PR"
+          inputs:
+            targetType: filePath
+            filePath: .ado/scripts/shouldSkipPRBuild.ps1
 
-    - template: templates/compute-beachball-branch-name.yml
+      - template: templates/compute-beachball-branch-name.yml
 
-    - script: npm install -g beachball@2.18.0
-      displayName: Install beachball
-  
-    - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
-      - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
-        displayName: Check for change files
-
-    - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
-      displayName: beachball bump
-
-    - template: templates/set-version-vars.yml
-      parameters:
-        buildEnvironment: ${{ parameters.buildEnvironment }}
-
-    - template: templates/publish-version-vars.yml
+      - script: npm install -g beachball@2.18.0
+        displayName: Install beachball
     
+      - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+        - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+          displayName: Check for change files
+
+      - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
+        displayName: beachball bump
+
+      - template: templates/set-version-vars.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+
+      - template: templates/publish-version-vars.yml

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -7,6 +7,12 @@ parameters:
       - Continuous
 
 stages:
+  - stage: Setup
+    jobs:
+      - template: jobs/setup.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+
   - stage: Build
     displayName: Build 🔨
     dependsOn: Setup

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -10,13 +10,7 @@ pr:
 variables:
   - group: platform-override-zero-permission-token
 
-stages:
-  - stage: Setup
-    jobs:
-      - template: jobs/setup.yml
-        parameters:
-          buildEnvironment: ${{ parameters.buildEnvironment }}
-     
+stages:     
   - template: stages.yml
     parameters:
       buildEnvironment: PullRequest

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -13,34 +13,10 @@ variables:
 stages:
   - stage: Setup
     jobs:
-      - job: Setup
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - task: powershell@2
-            name: checkPayload
-            displayName: "Check if build is required for this PR"
-            inputs:
-              targetType: filePath
-              filePath: .ado/scripts/shouldSkipPRBuild.ps1
-
-          - template: templates/compute-beachball-branch-name.yml
-
-          - script: npm install -g beachball@2.18.0
-            displayName: Install beachball
-
-          - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
-            displayName: Check for change files
-
-          - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
-            displayName: beachball bump
-
-          - template: templates/set-version-vars.yml
-            parameters:
-              buildEnvironment: Continuous
-
-          - template: templates/publish-version-vars.yml
-
+      - template: jobs/setup.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+     
   - template: stages.yml
     parameters:
       buildEnvironment: PullRequest


### PR DESCRIPTION
## Description

### Why
CI is failing after my recent changes due to differences between setup phases.

### What
This change consolidates the setup job into a single sequence, to ensure changes happen in unison, and to allow us to get further in CI.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9040)