### PR TITLE
Segregate artifacts in publish

### DIFF
--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -28,7 +28,7 @@ jobs:
 
       - template: ../templates/prep-and-pack-nuget.yml
         parameters:
-          artifacts: [Desktop]
+          artifactName: Desktop
           packDesktop: true
           slices:
             - platform: x64

--- a/.ado/jobs/nuget-desktop.yml
+++ b/.ado/jobs/nuget-desktop.yml
@@ -28,12 +28,8 @@ jobs:
 
       - template: ../templates/prep-and-pack-nuget.yml
         parameters:
-          artifactName: Desktop
+          artifacts: [Desktop]
           packDesktop: true
-          packMicrosoftReactNative: false
-          packMicrosoftReactNativeCxx: false
-          packMicrosoftReactNativeManaged: false
-          packMicrosoftReactNativeManagedCodeGen: false
           slices:
             - platform: x64
               configuration: Release

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -69,12 +69,7 @@ jobs:
 
             - template: ../templates/prep-and-pack-nuget.yml
               parameters:
-                artifactName: ProjectReunion
-                packDesktop: false
-                packMicrosoftReactNative: false
-                packMicrosoftReactNativeCxx: false
-                packMicrosoftReactNativeManaged: false
-                packMicrosoftReactNativeManagedCodeGen: false
+                artifacts: [ProjectReunion]
                 packMicrosoftReactNativeProjectReunion: true
                 slices:
                   - platform: x64

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -69,7 +69,7 @@ jobs:
 
             - template: ../templates/prep-and-pack-nuget.yml
               parameters:
-                artifacts: [ProjectReunion]
+                artifactName: ProjectReunion
                 packMicrosoftReactNativeProjectReunion: true
                 slices:
                   - platform: x64

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -199,15 +199,6 @@ jobs:
     dependsOn: RnwNpmPublish
     strategy:
       matrix:
-        X64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-        Arm64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: ARM64
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
@@ -340,27 +331,59 @@ jobs:
 
       - template: templates/prep-and-pack-nuget.yml
         parameters:
-          artifacts: [Desktop, ReactWindows]
+          artifactName: ReactWindows
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
-          packDesktop: true
+          nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
           packMicrosoftReactNative: true
           packMicrosoftReactNativeCxx: true
           packMicrosoftReactNativeManaged: true
           packMicrosoftReactNativeManagedCodeGen: true
           ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
             signMicrosoft: true
+          slices: 
+            - platform: x64
+              configuration: Release
+            - platform: x86
+              configuration: Release
+            - platform: ARM64
+              configuration: Release  
 
-      # Handle Reunion with a separate nugetroot to avoid conflicting copies of Microsoft.ReactNative
       - template: templates/prep-and-pack-nuget.yml
         parameters:
-          artifacts: [Reunion]
+          artifactName: Desktop
+          publishCommitId: $(publishCommitId)
+          npmVersion: $(npmVersion)
+          nugetroot: $(System.DefaultWorkingDirectory)\Desktop
+          packDesktop: true
+          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+            signMicrosoft: true
+          slices:
+            - platform: x64
+              configuration: Release
+            - platform: x86
+              configuration: Release
+            - platform: ARM64
+              configuration: Release  
+            - platform: x64
+              configuration: Debug
+            - platform: x86
+              configuration: Debug
+            - platform: ARM64
+              configuration: Debug
+
+      - template: templates/prep-and-pack-nuget.yml
+        parameters:
+          artifactName: Reunion
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
           nugetroot: $(System.DefaultWorkingDirectory)\Reunion
           packMicrosoftReactNativeProjectReunion: true
           ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
             signMicrosoft: true
+          slices: 
+            - platform: x64
+              configuration: Release
 
       - task: PublishPipelineArtifact@1
         displayName: "Publish final nuget artifacts"

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -184,7 +184,7 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          artifactName: ReactWindows
+          artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |
@@ -297,10 +297,11 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          artifactName: ReactWindows
+          artifactName: Reunion
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |
+            Microsoft.ReactNative\**
             Microsoft.ReactNative.ProjectReunion\**
 
       - template: templates/component-governance.yml
@@ -339,9 +340,24 @@ jobs:
 
       - template: templates/prep-and-pack-nuget.yml
         parameters:
-          artifactName: ReactWindows
+          artifacts: [Desktop, ReactWindows]
           publishCommitId: $(publishCommitId)
           npmVersion: $(npmVersion)
+          packDesktop: true
+          packMicrosoftReactNative: true
+          packMicrosoftReactNativeCxx: true
+          packMicrosoftReactNativeManaged: true
+          packMicrosoftReactNativeManagedCodeGen: true
+          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+            signMicrosoft: true
+
+      # Handle Reunion with a separate nugetroot to avoid conflicting copies of Microsoft.ReactNative
+      - template: templates/prep-and-pack-nuget.yml
+        parameters:
+          artifacts: [Reunion]
+          publishCommitId: $(publishCommitId)
+          npmVersion: $(npmVersion)
+          nugetroot: $(System.DefaultWorkingDirectory)\Reunion
           packMicrosoftReactNativeProjectReunion: true
           ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
             signMicrosoft: true

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,5 +1,5 @@
 parameters:
-  artifactName: ''
+  artifacts: []
   publishCommitId: '0'
   npmVersion: '0.0.1-pr'
   # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
@@ -7,11 +7,11 @@ parameters:
   desktopId: 'OfficeReact.Win32'
   microsoftRNId: 'Microsoft.ReactNative'
   slices: []
-  packDesktop: true
-  packMicrosoftReactNative: true
-  packMicrosoftReactNativeCxx: true
-  packMicrosoftReactNativeManaged: true
-  packMicrosoftReactNativeManagedCodeGen: true
+  packDesktop: false
+  packMicrosoftReactNative: false
+  packMicrosoftReactNativeCxx: false
+  packMicrosoftReactNativeManaged: false
+  packMicrosoftReactNativeManagedCodeGen: false
   packMicrosoftReactNativeProjectReunion: false
   signMicrosoft: false
 
@@ -49,29 +49,30 @@ steps:
         Write-Host "##vso[task.setvariable variable=baseConfiguration]${{ parameters.slices[0].configuration }}"
       displayName: Set base slice to ${{ parameters.slices[0].platform }}.${{ parameters.slices[0].configuration }}
       
-  - ${{ each slice in parameters.slices }}:
-    - task: DownloadPipelineArtifact@2
-      displayName: 'Download ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }} Artifact'
-      inputs:
-        artifact: ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }}
-        path: $(System.DefaultWorkingDirectory)/ReactWindows/${{ slice.platform }}/${{ slice.configuration }}
+  - ${{ each artifact in parameters.artifacts }}:
+    - ${{ each slice in parameters.slices }}:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download ${{ artifact }}.${{ slice.platform }}.${{ slice.configuration }}'
+        inputs:
+          artifact: ${{ artifact }}.${{ slice.platform }}.${{ slice.configuration }}
+          path: ${{parameters.nugetroot}}/${{ slice.platform }}/${{ slice.configuration }}
 
   - task: PowerShell@2
     displayName: Copy MSRN Resources to NuGet layout
     inputs:
       filePath: vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
-      arguments: -TargetRoot  $(System.DefaultWorkingDirectory)/ReactWindows
+      arguments: -TargetRoot ${{parameters.nugetroot}}
 
   - ${{ if eq(parameters.packDesktop, true) }}:
     - task: PowerShell@2
       displayName: Copy Desktop Resources to NuGet layout
       inputs:
         filePath: vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
-        arguments: -TargetRoot  $(System.DefaultWorkingDirectory)/ReactWindows
+        arguments: -TargetRoot ${{parameters.nugetroot}}
 
   - ${{ if or(eq(parameters.packMicrosoftReactNative, true), eq(parameters.packMicrosoftReactNativeCxx, true), eq(parameters.packMicrosoftReactNativeManaged, true), eq(parameters.packMicrosoftReactNativeManagedCodeGen, true), eq(parameters.packMicrosoftReactNativeProjectReunion, false)) }}:
     - powershell: |
-        (Get-Content -Path $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '${{parameters.npmVersion}}' | Set-Content -Path  $(System.DefaultWorkingDirectory)\ReactWindows\Microsoft.ReactNative.VersionCheck.targets
+        (Get-Content -Path ${{parameters.nugetroot}}\Microsoft.ReactNative.VersionCheck.targets) -replace '\$\$nuGetPackageVersion\$\$', '${{parameters.npmVersion}}' | Set-Content -Path  ${{parameters.nugetroot}}\Microsoft.ReactNative.VersionCheck.targets
       displayName: Patch version check file with version ${{parameters.npmVersion}}
 
   - ${{ if eq(parameters.packDesktop, true) }}:

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,41 +1,41 @@
 parameters:
-  - Name: artifactName
+  - name: artifactName
     type: string
-  - Name: slices
+  - name: slices
     type: object
 
-  - Name: publishCommitId
+  - name: publishCommitId
     type: string
     default: '0'
-  - Name : npmVersion
+  - name : npmVersion
     type: string
     default: '0.0.1-pr'
     
     # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
-  - Name: nugetroot
+  - name: nugetroot
     type: string
     default: $(System.DefaultWorkingDirectory)\ReactWindows
   
-  - Name: packDesktop
+  - name: packDesktop
     type: boolean
     default: false
-  - Name: packMicrosoftReactNative
+  - name: packMicrosoftReactNative
     type: boolean
     default: false
-  - Name: packMicrosoftReactNativeCxx
+  - name: packMicrosoftReactNativeCxx
     type: boolean
     default: false
-  - Name: packMicrosoftReactNativeManaged
+  - name: packMicrosoftReactNativeManaged
     type: boolean
     default: false
-  - Name: packMicrosoftReactNativeManagedCodeGen
+  - name: packMicrosoftReactNativeManagedCodeGen
     type: boolean
     default: false
-  - Name: packMicrosoftReactNativeProjectReunion
+  - name: packMicrosoftReactNativeProjectReunion
     type: boolean
     default: false 
 
-  - Name: signMicrosoft
+  - name: signMicrosoft
     type: boolean
     default: false
 

--- a/.ado/templates/prep-and-pack-nuget.yml
+++ b/.ado/templates/prep-and-pack-nuget.yml
@@ -1,61 +1,56 @@
 parameters:
-  artifacts: []
-  publishCommitId: '0'
-  npmVersion: '0.0.1-pr'
-  # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
-  nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
-  desktopId: 'OfficeReact.Win32'
-  microsoftRNId: 'Microsoft.ReactNative'
-  slices: []
-  packDesktop: false
-  packMicrosoftReactNative: false
-  packMicrosoftReactNativeCxx: false
-  packMicrosoftReactNativeManaged: false
-  packMicrosoftReactNativeManagedCodeGen: false
-  packMicrosoftReactNativeProjectReunion: false
-  signMicrosoft: false
+  - Name: artifactName
+    type: string
+  - Name: slices
+    type: object
 
-  defaultDesktopSlices: 
-    - platform: x64
-      configuration: Debug
-    - platform: x86
-      configuration: Debug
-    - platform: ARM64
-      configuration: Debug
-    - platform: x64
-      configuration: Release
-    - platform: x86
-      configuration: Release
-    - platform: ARM64
-      configuration: Release      
+  - Name: publishCommitId
+    type: string
+    default: '0'
+  - Name : npmVersion
+    type: string
+    default: '0.0.1-pr'
+    
+    # Note: NuGet pack expects platform-specific file separators ('\' on Windows).
+  - Name: nugetroot
+    type: string
+    default: $(System.DefaultWorkingDirectory)\ReactWindows
+  
+  - Name: packDesktop
+    type: boolean
+    default: false
+  - Name: packMicrosoftReactNative
+    type: boolean
+    default: false
+  - Name: packMicrosoftReactNativeCxx
+    type: boolean
+    default: false
+  - Name: packMicrosoftReactNativeManaged
+    type: boolean
+    default: false
+  - Name: packMicrosoftReactNativeManagedCodeGen
+    type: boolean
+    default: false
+  - Name: packMicrosoftReactNativeProjectReunion
+    type: boolean
+    default: false 
 
-  defaultMSRNSlices: 
-    - platform: x64
-      configuration: Release
-    - platform: x86
-      configuration: Release
-    - platform: ARM64
-      configuration: Release      
+  - Name: signMicrosoft
+    type: boolean
+    default: false
 
 steps:
-  - ${{ if eq(length(parameters.slices), 0) }}:
-    - powershell: |
-        Write-Host "##vso[task.setvariable variable=basePlatform]x64"
-        Write-Host "##vso[task.setvariable variable=baseConfiguration]Release"
-      displayName: Set base slice to x64.Release
-  - ${{ else }}:
-    - powershell: |
-        Write-Host "##vso[task.setvariable variable=basePlatform]${{ parameters.slices[0].platform }}"
-        Write-Host "##vso[task.setvariable variable=baseConfiguration]${{ parameters.slices[0].configuration }}"
-      displayName: Set base slice to ${{ parameters.slices[0].platform }}.${{ parameters.slices[0].configuration }}
+  - powershell: |
+      Write-Host "##vso[task.setvariable variable=basePlatform]${{ parameters.slices[0].platform }}"
+      Write-Host "##vso[task.setvariable variable=baseConfiguration]${{ parameters.slices[0].configuration }}"
+    displayName: Set base slice to ${{ parameters.slices[0].platform }}.${{ parameters.slices[0].configuration }}
       
-  - ${{ each artifact in parameters.artifacts }}:
-    - ${{ each slice in parameters.slices }}:
-      - task: DownloadPipelineArtifact@2
-        displayName: 'Download ${{ artifact }}.${{ slice.platform }}.${{ slice.configuration }}'
-        inputs:
-          artifact: ${{ artifact }}.${{ slice.platform }}.${{ slice.configuration }}
-          path: ${{parameters.nugetroot}}/${{ slice.platform }}/${{ slice.configuration }}
+  - ${{ each slice in parameters.slices }}:
+    - task: DownloadPipelineArtifact@2
+      displayName: 'Download ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }}'
+      inputs:
+        artifact: ${{ parameters.artifactName }}.${{ slice.platform }}.${{ slice.configuration }}
+        path: ${{parameters.nugetroot}}/${{ slice.platform }}/${{ slice.configuration }}
 
   - task: PowerShell@2
     displayName: Copy MSRN Resources to NuGet layout
@@ -78,12 +73,9 @@ steps:
   - ${{ if eq(parameters.packDesktop, true) }}:
     - template: prep-and-pack-single.yml
       parameters:
-        packageId: ${{parameters.desktopId}}
+        packageId: OfficeReact.Win32
         packageVersion: ${{parameters.npmVersion}}
-        ${{ if gt(length(parameters.slices), 0) }}:
-          slices: ${{ parameters.slices }}
-        ${{ else }}:
-          slices: ${{ parameters.defaultDesktopSlices }}
+        slices: ${{ parameters.slices }}
         buildProperties: 'CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}}'
 
   - ${{ if eq(parameters.packMicrosoftReactNative, true) }}:
@@ -91,10 +83,7 @@ steps:
       parameters:
         packageId: Microsoft.ReactNative
         packageVersion: ${{parameters.npmVersion}}
-        ${{ if gt(length(parameters.slices), 0) }}:
-          slices: ${{ parameters.slices }}
-        ${{ else }}:
-          slices: ${{ parameters.defaultMSRNSlices }}
+        slices: ${{ parameters.slices }}
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=$(baseConfiguration);baseplatform=$(basePlatform)
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}
@@ -112,10 +101,7 @@ steps:
       parameters:
         packageId: Microsoft.ReactNative.Managed
         packageVersion: ${{parameters.npmVersion}}
-        ${{ if gt(length(parameters.slices), 0) }}:
-          slices: ${{ parameters.slices }}
-        ${{ else }}:
-          slices: ${{ parameters.defaultMSRNSlices }}
+        slices: ${{ parameters.slices }}
         buildProperties: CommitId=${{parameters.publishCommitId}};nugetroot=${{parameters.nugetroot}};baseconfiguration=$(baseConfiguration);baseplatform=$(basePlatform)
         codesignBinaries: ${{ parameters.signMicrosoft }}
         codesignNuget: ${{ parameters.signMicrosoft }}

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -66,7 +66,7 @@ steps:
   - ${{ if eq(parameters.useNuGet, true) }}:
     - template: prep-and-pack-nuget.yml
       parameters:
-        artifacts: [ReactWindows]
+        artifactName: ReactWindows
         npmVersion: $(npmVersion)
         packMicrosoftReactNative: true
         ${{ if eq(parameters.language, 'cpp') }}:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -66,9 +66,14 @@ steps:
   - ${{ if eq(parameters.useNuGet, true) }}:
     - template: prep-and-pack-nuget.yml
       parameters:
-        artifactName: ReactWindows
+        artifacts: [ReactWindows]
         npmVersion: $(npmVersion)
-        packDesktop: false
+        packMicrosoftReactNative: true
+        ${{ if eq(parameters.language, 'cpp') }}:
+          packMicrosoftReactNativeCxx: true
+        ${{ if eq(parameters.language, 'cs') }}:
+          packMicrosoftReactNativeManaged: true
+          packMicrosoftReactNativeManagedCodeGen: true
         slices:
           - platform: ${{ parameters.platform }}
             configuration: ${{ parameters.configuration }}


### PR DESCRIPTION
I switched from publishing build artifacts to publishing pipeline artifacts. This seems to change behavior to no longer allow overlapping artifact names, where the previous allowed them so long as there were not overlapping files within the artifact.

Artifacts are already partitioned in PR, but are still shared in publish. This change makes it so Desktop, MSRN, and Reunion are separate artifacts in publish as well.

This also reminded me that Reunion has a different version of MSRN, which isn't an issue with segregated NuGet creation in PR, but needs special attention in CI. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9043)