### PR TITLE
Automatically Use Large PCH on Machines With >7GB per Thread

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -293,7 +293,6 @@ jobs:
                   platform: ${{ parameters.platform }}
                   configuration: ${{ parameters.configuration }}
                   buildEnvironment: ${{ parameters.buildEnvironment }}
-                  lowResource: ${{ coalesce(matrix.lowResource, false) }}
 
               - template: ../templates/react-native-init.yml
                 parameters:

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -21,9 +21,6 @@ parameters:
     #  - PullRequest
     #  - Continuous  
     #  - Publish
-  - name: lowResource
-    type: boolean
-    default: false
   
 steps:
   # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
@@ -37,10 +34,6 @@ steps:
       platform: ${{ parameters.platform }}
       configuration: ${{ parameters.configuration }}
       buildEnvironment: ${{ parameters.buildEnvironment }}
-
-  - ${{ if and(or(eq(parameters.buildEnvironment, 'PullRequest'), eq(parameters.buildEnvironment, 'Publish')), not(parameters.lowResource)) }}:
-    - powershell:  Write-Host "##vso[task.setvariable variable=RNW_FASTBUILD]true"
-      displayName: Enable RNW_FASTBUILD
 
   - script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd cl
     displayName: Set LocalDumps for cl.exe

--- a/change/react-native-windows-df7a4350-83c2-46df-995f-2de1f60a9e70.json
+++ b/change/react-native-windows-df7a4350-83c2-46df-995f-2de1f60a9e70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Automatically Use Large PCH on Machines With >7GB per Thread",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -134,7 +134,6 @@
         _HAS_AUTO_PTR_ETC;
         %(PreprocessorDefinitions)
       </PreprocessorDefinitions>
-      <PreprocessorDefinitions Condition="'$(RNW_FASTBUILD)' == 'true'">RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -807,6 +806,7 @@
     </Page>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\FastBuild.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.76.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -56,7 +56,7 @@
 
     <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
     <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
-      <ClCompile Include="@(ClCompile)">
+      <ClCompile>
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -54,7 +54,7 @@
     <Message Text="Memory class: $(_MemoryClass)" />
 
     <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
-    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
+    <ItemDefinitionGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
       <ClCompile>
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -11,16 +11,32 @@
     </ParameterGroup>
     
     <Task>
-      <Code Type="Fragnent" Language="cs">
+      <Code Type="Class" Language="cs">
         <![CDATA[
-          var totalMemory = new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory;
-          var totalMemoryGB = ((Double)totalMemory) / 1024 / 1024 / 1024;
-          var memoryGbPerThread = totalMemoryGB / Environment.ProcessorCount;
+          using System;
+          using System.Runtime.InteropServices;
 
-          if (memoryGbPerThread > 7.0) {
-            MemoryClass = "High";
-          } else {
-            MemoryClass = "Low";
+          public class GetMemoryClass : Microsoft.Build.Utilities.Task {
+            [DllImport("kernel32.dll")]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            static extern bool GetPhysicallyInstalledSystemMemory(out long TotalMemoryInKilobytes);
+
+            public virtual string MemoryClass { get; set; }
+            
+            public override bool Execute() {
+              long totalMemoryKB;
+              GetPhysicallyInstalledSystemMemory(out totalMemoryKB);
+              var totalMemoryGB = ((Double)totalMemoryKB) / 1024 / 1024;
+              var memoryGbPerThread = totalMemoryGB / Environment.ProcessorCount;
+
+              if (memoryGbPerThread > 7.0) {
+                MemoryClass = "High";
+              } else {
+                MemoryClass = "Low";
+              }
+
+              return true;
+            }
           }
         ]]>
       </Code>
@@ -38,7 +54,7 @@
 
 
     <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
-    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or  ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass) == 'High')">
+    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or  ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
       <ClCompile Include="@(ClCompile)" >
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -4,7 +4,7 @@
   <UsingTask
     TaskName="GetMemoryClass"
     TaskFactory="RoslynCodeTaskFactory"
-    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
 
     <ParameterGroup>
       <MemoryClass ParameterType="System.String" Output="true" />
@@ -45,8 +45,7 @@
   
   <Target 
     Name="ReactNativeWindowsDetermineFastBuild" 
-    BeforeTargets="PrepareForBuild"
-    >
+    BeforeTargets="ClCompile">
 
     <GetMemoryClass>
       <Output PropertyName="_MemoryClass" TaskParameter="MemoryClass" />

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -54,11 +54,11 @@
     <Message Text="Memory class: $(_MemoryClass)" />
 
     <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
-    <ItemDefinitionGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
+    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
       <ClCompile>
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
-    </ItemDefinitionGroup>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <UsingTask
+    TaskName="GetMemoryClass"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+
+    <ParameterGroup>
+      <MemoryClass ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    
+    <Task>
+      <Code Type="Fragnent" Language="cs">
+        <![CDATA[
+          var totalMemory = new Microsoft.VisualBasic.Devices.ComputerInfo().TotalPhysicalMemory;
+          var totalMemoryGB = ((Double)totalMemory) / 1024 / 1024 / 1024;
+          var memoryGbPerThread = totalMemoryGB / Environment.ProcessorCount;
+
+          if (memoryGbPerThread > 7.0) {
+            MemoryClass = "High";
+          } else {
+            MemoryClass = "Low";
+          }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+  
+  <Target 
+    Name="ReactNativeWindowsDetermineFastBuild" 
+    BeforeTargets="PrepareForBuild"
+    >
+
+    <GetMemoryClass>
+      <Output PropertyName="_MemoryClass" TaskParameter="MemoryClass" />
+    </GetMemoryClass>
+
+
+    <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
+    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or  ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass) == 'High')">
+      <ClCompile Include="@(ClCompile)" >
+         <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -52,10 +52,11 @@
       <Output PropertyName="_MemoryClass" TaskParameter="MemoryClass" />
     </GetMemoryClass>
 
+    <Message Text="Memory class: $(_MemoryClass)" />
 
     <!-- Add RNW_FASTBUILD as preprocessor definition to existing ClCompile items -->
-    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or  ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
-      <ClCompile Include="@(ClCompile)" >
+    <ItemGroup Condition="'$(RNW_FASTBUILD)' == 'true' or ('$(RNW_FASTBUILD)' == '' and '$(_MemoryClass)' == 'High')">
+      <ClCompile Include="@(ClCompile)">
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>

--- a/vnext/PropertySheets/FastBuild.targets
+++ b/vnext/PropertySheets/FastBuild.targets
@@ -58,7 +58,7 @@
       <ClCompile>
          <PreprocessorDefinitions>RNW_FASTBUILD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
-    </ItemGroup>
+    </ItemDefinitionGroup>
   </Target>
 
 </Project>


### PR DESCRIPTION
## Description

### Why
We have an option to use larger PCH's which can dramatically speed up build time on high end machines. It causes build instability on machines with less memory though (e.g. hosted agents, or 8c/16T 32GB systems). The larger PCH is opt-in via environment variable because of this. Not all users with powerful machines will know the variable exists, and may not be using the optimally sized PCH for their build setup. 

### What
This change enables dynamic selection of PCH size based on available system memory. This is done via adding the `RNW_FASTBUILD` preprocessor definition based on a memory-per-thread (how much memory will a cl process get) threshold.

Large PCH saw issues with previous hosted machines, which were 3.5GB per thread. New machines have 8GB per thread, and do not see issues. Enable using large PCH in a known good scenario, so that customers will see the same things we are doing in our CI.

## Testing
Have not yet validated this locally due to some local VS issues.

We have tests now for both PCH scenarios, so we should see coverage so long as we continue to test with lower end agents. Will check that this change builds in CI and does not change runtime numbers.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9048)