### PR TITLE
MakeTurboModuleProvider<TModule> uses TModule::ModuleSpec as the spec

### DIFF
--- a/change/@react-native-windows-codegen-0b9b7adf-601a-4110-a4bf-c1a97b3b611b.json
+++ b/change/@react-native-windows-codegen-0b9b7adf-601a-4110-a4bf-c1a97b3b611b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Codegen prints `::React::JSValue` instead of `React::JSValue`",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-43ee5fe7-40a8-4b6e-8966-b04aea4bffcd.json
+++ b/change/react-native-windows-43ee5fe7-40a8-4b6e-8966-b04aea4bffcd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "MakeTurboModuleProvider<TModule> uses TModule::ModuleSpec as the spec",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -39,10 +39,10 @@ export function translateField(
           `${baseAliasName}_element`,
         )}>`;
       } else {
-        return `React::JSValueArray`;
+        return `::React::JSValueArray`;
       }
     case 'GenericObjectTypeAnnotation':
-      return 'React::JSValue';
+      return '::React::JSValue';
     case 'ObjectTypeAnnotation':
       return getAnonymousAliasCppName(aliases, baseAliasName, type);
     case 'ReservedTypeAnnotation': {

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -102,10 +102,10 @@ function translateParam(
             )}> const &`;
         }
       } else {
-        return decorateType('React::JSValueArray', target);
+        return decorateType('::React::JSValueArray', target);
       }
     case 'GenericObjectTypeAnnotation':
-      return decorateType('React::JSValue', target);
+      return decorateType('::React::JSValue', target);
     case 'ObjectTypeAnnotation':
       return decorateType(
         getAnonymousAliasCppName(aliases, baseAliasName, param),

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -45,10 +45,10 @@ function translateReturnType(
           `${baseAliasName}_element`,
         )}>`;
       } else {
-        return 'React::JSValueArray';
+        return '::React::JSValueArray';
       }
     case 'GenericObjectTypeAnnotation':
-      return 'React::JSValue';
+      return '::React::JSValue';
     case 'ObjectTypeAnnotation':
       return getAnonymousAliasCppName(aliases, baseAliasName, type);
     case 'ReservedTypeAnnotation': {

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -35,7 +35,7 @@ function getPossibleMethodSignatures(
   const args = translateArgs(funcType.params, aliases, baseAliasName);
   if (isMethodReturnPromise(funcType)) {
     // TODO: type of the promise could be provided in the future
-    args.push('React::ReactPromise<React::JSValue> &&result');
+    args.push('::React::ReactPromise<::React::JSValue> &&result');
   }
 
   // TODO: be much more exhastive on the possible method signatures that can be used..
@@ -100,7 +100,7 @@ function renderProperties(
 
       if (isMethodReturnPromise(funcType)) {
         // TODO: type of the promise could be provided in the future
-        traversedArgs.push('Promise<React::JSValue>');
+        traversedArgs.push('Promise<::React::JSValue>');
       }
 
       if (tuple) {

--- a/packages/sample-apps/windows/SampleLibraryCPP/MyModule.h
+++ b/packages/sample-apps/windows/SampleLibraryCPP/MyModule.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "..\..\codegen\NativeMyModuleSpec.g.h"
 #include "DebugHelpers.h"
 
 #define DEBUG_MYMODULE_OUTPUT(...) DebugWriteLine("MyModule", ##__VA_ARGS__);
@@ -11,7 +12,9 @@ namespace SampleLibraryCpp {
 
 REACT_MODULE(MyModule)
 struct MyModule {
-  // The spec file does not currently validate constants
+  using ModuleSpec = ::SampleLibraryCpp::MyModuleSpec;
+
+  // TODO: The spec file needs to be updated to have constant information generated
   REACT_CONSTANT(const1)
   const bool const1 = true;
   REACT_CONSTANT(const2)

--- a/packages/sample-apps/windows/SampleLibraryCPP/ReactPackageProvider.cpp
+++ b/packages/sample-apps/windows/SampleLibraryCPP/ReactPackageProvider.cpp
@@ -11,9 +11,6 @@
 #include "CustomUserControlViewManagerCpp.h"
 #include "SampleModuleCpp.h"
 
-// Generated spec files
-#include "..\..\codegen\NativeMyModuleSpec.g.h"
-
 #include "MyModule.h"
 
 using namespace winrt::Microsoft::ReactNative;
@@ -23,8 +20,7 @@ namespace winrt::SampleLibraryCpp::implementation {
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
   AddAttributedModules(packageBuilder);
 
-  packageBuilder.AddModule(
-      L"MyModule", MakeTurboModuleProvider<::SampleLibraryCpp::MyModule, ::SampleLibraryCpp::MyModuleSpec>());
+  packageBuilder.AddModule(L"MyModule", MakeTurboModuleProvider<::SampleLibraryCpp::MyModule>());
   packageBuilder.AddViewManager(
       L"CustomUserControlViewManagerCpp", []() { return winrt::make<CustomUserControlViewManagerCpp>(); });
   packageBuilder.AddViewManager(L"CircleViewManagerCpp", []() { return winrt::make<CircleViewManagerCpp>(); });

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/TurboModuleTest.cpp
@@ -26,8 +26,622 @@ struct MyTurboModuleConstants2 {
   std::string const82;
 };
 
+// The TurboModule spec is going to be generated from the Flow spec file.
+// It verifies that:
+// - module methods names are unique;
+// - method names are matching to the module spec method names;
+// - method signatures match the spec method signatures.
+struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
+  static constexpr auto constants = std::tuple{
+      TypedConstant<MyTurboModuleConstants1>{0},
+      TypedConstant<MyTurboModuleConstants2>{1},
+  };
+  static constexpr auto methods = std::tuple{
+      Method<void(int, int, Callback<int>) noexcept>{0, L"Add"},
+      Method<void(int, Callback<int>) noexcept>{1, L"Negate"},
+      Method<void(Callback<std::string>) noexcept>{2, L"SayHello"},
+      Method<void(int, int, Callback<int>) noexcept>{3, L"StaticAdd"},
+      Method<void(int, Callback<int>) noexcept>{4, L"StaticNegate"},
+      Method<void(Callback<std::string>) noexcept>{5, L"StaticSayHello"},
+      Method<void() noexcept>{6, L"SayHello0"},
+      Method<void(Point) noexcept>{7, L"PrintPoint"},
+      Method<void(Point, Point) noexcept>{8, L"PrintLine"},
+      Method<void() noexcept>{9, L"StaticSayHello0"},
+      Method<void(Point) noexcept>{10, L"StaticPrintPoint"},
+      Method<void(Point, Point) noexcept>{11, L"StaticPrintLine"},
+      Method<void(int, int, Callback<int>) noexcept>{12, L"AddCallback"},
+      Method<void(int, Callback<int>) noexcept>{13, L"NegateCallback"},
+      Method<void(int, Callback<int>) noexcept>{14, L"NegateAsyncCallback"},
+      Method<void(int, Callback<int>) noexcept>{15, L"NegateDispatchQueueCallback"},
+      Method<void(int, Callback<int>) noexcept>{16, L"NegateFutureCallback"},
+      Method<void(Callback<std::string>) noexcept>{17, L"SayHelloCallback"},
+      Method<void(int, int, Callback<int>) noexcept>{18, L"StaticAddCallback"},
+      Method<void(int, Callback<int>) noexcept>{19, L"StaticNegateCallback"},
+      Method<void(int, Callback<int>) noexcept>{20, L"StaticNegateAsyncCallback"},
+      Method<void(int, Callback<int>) noexcept>{21, L"StaticNegateDispatchQueueCallback"},
+      Method<void(int, Callback<int>) noexcept>{22, L"StaticNegateFutureCallback"},
+      Method<void(Callback<std::string>) noexcept>{23, L"StaticSayHelloCallback"},
+      Method<void(Callback<>) noexcept>{24, L"CallbackZeroArgs"},
+      Method<void(Callback<int, int>) noexcept>{25, L"CallbackTwoArgs"},
+      Method<void(Callback<int, int, std::string>) noexcept>{26, L"CallbackThreeArgs"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{27, L"DivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{28, L"NegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{29, L"NegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{30, L"NegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{31, L"NegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{32, L"ResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{33, L"RejectSayHelloCallbacks"},
+      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{34, L"StaticDivideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{35, L"StaticNegateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{36, L"StaticNegateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{37, L"StaticNegateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{38, L"StaticNegateFutureCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{39, L"StaticResolveSayHelloCallbacks"},
+      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{40, L"StaticRejectSayHelloCallbacks"},
+      Method<void(Callback<>, Callback<>) noexcept>{41, L"TwoCallbacksZeroArgs1"},
+      Method<void(Callback<>, Callback<>) noexcept>{42, L"TwoCallbacksZeroArgs2"},
+      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{43, L"TwoCallbacksTwoArgs1"},
+      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{44, L"TwoCallbacksTwoArgs2"},
+      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
+          45,
+          L"TwoCallbacksThreeArgs1"},
+      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
+          46,
+          L"TwoCallbacksThreeArgs2"},
+      Method<void(int, int, Promise<int>) noexcept>{47, L"DividePromise"},
+      Method<void(int, Promise<int>) noexcept>{48, L"NegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{49, L"NegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{50, L"NegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{51, L"NegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{52, L"voidPromise"},
+      Method<void(Promise<std::string>) noexcept>{53, L"ResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{54, L"RejectSayHelloPromise"},
+      Method<void(int, int, Promise<int>) noexcept>{55, L"StaticDividePromise"},
+      Method<void(int, Promise<int>) noexcept>{56, L"StaticNegatePromise"},
+      Method<void(int, Promise<int>) noexcept>{57, L"StaticNegateAsyncPromise"},
+      Method<void(int, Promise<int>) noexcept>{58, L"StaticNegateDispatchQueuePromise"},
+      Method<void(int, Promise<int>) noexcept>{59, L"StaticNegateFuturePromise"},
+      Method<void(int, Promise<void>) noexcept>{60, L"staticVoidPromise"},
+      Method<void(Promise<std::string>) noexcept>{61, L"StaticResolveSayHelloPromise"},
+      Method<void(Promise<std::string>) noexcept>{62, L"StaticRejectSayHelloPromise"},
+      SyncMethod<int(int, int) noexcept>{63, L"AddSync"},
+      SyncMethod<int(int) noexcept>{64, L"NegateSync"},
+      SyncMethod<std::string() noexcept>{65, L"SayHelloSync"},
+      SyncMethod<int(int, int) noexcept>{66, L"StaticAddSync"},
+      SyncMethod<int(int) noexcept>{67, L"StaticNegateSync"},
+      SyncMethod<std::string() noexcept>{68, L"StaticSayHelloSync"},
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto constantCheckResults = CheckConstants<TModule, MyTurboModuleSpec>();
+    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
+
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+        0,
+        "MyTurboModuleConstants1",
+        "    REACT_GET_CONSTANTS(GetConstants1) MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n"
+        "    REACT_GET_CONSTANTS(GetConstants1) static MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n");
+    REACT_SHOW_CONSTANT_SPEC_ERRORS(
+        1,
+        "MyTurboModuleConstants2",
+        "    REACT_GET_CONSTANTS(GetConstants2) MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n"
+        "    REACT_GET_CONSTANTS(GetConstants2) static MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        0,
+        "Add",
+        "    REACT_METHOD(Add) int Add(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) winrt::fire_and_forget Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static int Add(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Add) static React::Coroutine Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        1,
+        "Negate",
+        "    REACT_METHOD(Negate) int Negate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static int Negate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(Negate) static winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        2,
+        "SayHello",
+        "    REACT_METHOD(SayHello) std::string SayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static std::string SayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello) static winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        3,
+        "StaticAdd",
+        "    REACT_METHOD(StaticAdd) int StaticAdd(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static int StaticAdd(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAdd) static winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        4,
+        "StaticNegate",
+        "    REACT_METHOD(StaticNegate) int StaticNegate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static int StaticNegate(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegate) static winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        5,
+        "StaticSayHello",
+        "    REACT_METHOD(StaticSayHello) std::string StaticSayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static std::string StaticSayHello() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello) static winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        6,
+        "SayHello0",
+        "    REACT_METHOD(SayHello0) void SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) static void SayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHello0) static winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        7,
+        "PrintPoint",
+        "    REACT_METHOD(PrintPoint) void PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static void PrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        8,
+        "PrintLine",
+        "    REACT_METHOD(PrintPoint) void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        9,
+        "StaticSayHello0",
+        "    REACT_METHOD(StaticSayHello0) void StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) static void StaticSayHello0() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHello0) static winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        10,
+        "StaticPrintPoint",
+        "    REACT_METHOD(StaticPrintPoint) void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        11,
+        "StaticPrintLine",
+        "    REACT_METHOD(StaticPrintPoint) void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        12,
+        "AddCallback",
+        "    REACT_METHOD(AddCallback) int AddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static int AddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddCallback) static winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        13,
+        "NegateCallback",
+        "    REACT_METHOD(NegateCallback) int NegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static int NegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallback) static winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        14,
+        "NegateAsyncCallback",
+        "    REACT_METHOD(NegateAsyncCallback) int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallback) static winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        15,
+        "NegateDispatchQueueCallback",
+        "    REACT_METHOD(NegateDispatchQueueCallback) int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallback) static winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        16,
+        "NegateFutureCallback",
+        "    REACT_METHOD(NegateFutureCallback) int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallback) static winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        17,
+        "SayHelloCallback",
+        "    REACT_METHOD(SayHelloCallback) std::string SayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static std::string SayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloCallback) static winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        18,
+        "StaticAddCallback",
+        "    REACT_METHOD(StaticAddCallback) int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddCallback) static winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        19,
+        "StaticNegateCallback",
+        "    REACT_METHOD(StaticNegateCallback) int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallback) static winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        20,
+        "StaticNegateAsyncCallback",
+        "    REACT_METHOD(StaticNegateAsyncCallback) int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallback) static winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        21,
+        "StaticNegateDispatchQueueCallback",
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        22,
+        "StaticNegateFutureCallback",
+        "    REACT_METHOD(StaticNegateFutureCallback) int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallback) static winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        23,
+        "StaticSayHelloCallback",
+        "    REACT_METHOD(StaticSayHelloCallback) std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloCallback) static winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        24,
+        "CallbackZeroArgs",
+        "    REACT_METHOD(CallbackZeroArgs) void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) static void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackZeroArgs) static winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        25,
+        "CallbackTwoArgs",
+        "    REACT_METHOD(CallbackTwoArgs) void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) static void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackTwoArgs) static winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        26,
+        "CallbackThreeArgs",
+        "    REACT_METHOD(CallbackThreeArgs) void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) static void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(CallbackThreeArgs) static winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        27,
+        "DivideCallbacks",
+        "    REACT_METHOD(DivideCallbacks) void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) static void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DivideCallbacks) static winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        28,
+        "NegateCallbacks",
+        "    REACT_METHOD(NegateCallbacks) void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) static void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateCallbacks) static winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        29,
+        "NegateAsyncCallbacks",
+        "    REACT_METHOD(NegateAsyncCallbacks) void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) static void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncCallbacks) static winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        30,
+        "NegateDispatchQueueCallbacks",
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) static void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueueCallbacks) static winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        31,
+        "NegateFutureCallbacks",
+        "    REACT_METHOD(NegateFutureCallbacks) void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) static void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFutureCallbacks) static winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        32,
+        "ResolveSayHelloCallbacks",
+        "    REACT_METHOD(ResolveSayHelloCallbacks) void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) static void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloCallbacks) static winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        33,
+        "RejectSayHelloCallbacks",
+        "    REACT_METHOD(RejectSayHelloCallbacks) void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) static void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloCallbacks) static winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        34,
+        "StaticDivideCallbacks",
+        "    REACT_METHOD(StaticDivideCallbacks) void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) static void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDivideCallbacks) static winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        35,
+        "StaticNegateCallbacks",
+        "    REACT_METHOD(StaticNegateCallbacks) void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) static void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateCallbacks) static winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        36,
+        "StaticNegateAsyncCallbacks",
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) static void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncCallbacks) static winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        37,
+        "StaticNegateDispatchQueueCallbacks",
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        38,
+        "StaticNegateFutureCallbacks",
+        "    REACT_METHOD(StaticNegateFutureCallbacks) void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) static void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFutureCallbacks) static winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        39,
+        "StaticResolveSayHelloCallbacks",
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        40,
+        "StaticRejectSayHelloCallbacks",
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        41,
+        "TwoCallbacksZeroArgs1",
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) static void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs1) static winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        42,
+        "TwoCallbacksZeroArgs2",
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) static void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksZeroArgs2) static winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        43,
+        "TwoCallbacksTwoArgs1",
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) static void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs1) static winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        44,
+        "TwoCallbacksTwoArgs2",
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) static void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksTwoArgs2) static winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        45,
+        "TwoCallbacksThreeArgs1",
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) static void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs1) static winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        46,
+        "TwoCallbacksThreeArgs2",
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) static void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(TwoCallbacksThreeArgs2) static winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        47,
+        "DividePromise",
+        "    REACT_METHOD(DividePromise) void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) static void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(DividePromise) static winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        48,
+        "NegatePromise",
+        "    REACT_METHOD(NegatePromise) void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) static void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegatePromise) static winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        49,
+        "NegateAsyncPromise",
+        "    REACT_METHOD(NegateAsyncPromise) void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) static void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateAsyncPromise) static winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        50,
+        "NegateDispatchQueuePromise",
+        "    REACT_METHOD(NegateDispatchQueuePromise) void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) static void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateDispatchQueuePromise) static winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        51,
+        "NegateFuturePromise",
+        "    REACT_METHOD(NegateFuturePromise) void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) static void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateFuturePromise) static winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        52,
+        "voidPromise",
+        "    REACT_METHOD(voidPromise) void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) static void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(voidPromise) static winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        53,
+        "ResolveSayHelloPromise",
+        "    REACT_METHOD(ResolveSayHelloPromise) void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) static void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(ResolveSayHelloPromise) static winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        54,
+        "RejectSayHelloPromise",
+        "    REACT_METHOD(RejectSayHelloPromise) void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) static void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(RejectSayHelloPromise) static winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        55,
+        "StaticDividePromise",
+        "    REACT_METHOD(StaticDividePromise) void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) static void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticDividePromise) static winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        56,
+        "StaticNegatePromise",
+        "    REACT_METHOD(StaticNegatePromise) void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) static void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegatePromise) static winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        57,
+        "StaticNegateAsyncPromise",
+        "    REACT_METHOD(StaticNegateAsyncPromise) void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) static void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateAsyncPromise) static winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        58,
+        "StaticNegateDispatchQueuePromise",
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        59,
+        "StaticNegateFuturePromise",
+        "    REACT_METHOD(StaticNegateFuturePromise) void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) static void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateFuturePromise) static winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        60,
+        "staticVoidPromise",
+        "    REACT_METHOD(staticVoidPromise) void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) static void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(staticVoidPromise) static winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        61,
+        "StaticResolveSayHelloPromise",
+        "    REACT_METHOD(StaticResolveSayHelloPromise) void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) static void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticResolveSayHelloPromise) static winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_METHOD_SPEC_ERRORS(
+        62,
+        "StaticRejectSayHelloPromise",
+        "    REACT_METHOD(StaticRejectSayHelloPromise) void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) static void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticRejectSayHelloPromise) static winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        63,
+        "AddSync",
+        "    REACT_METHOD(AddSync) int AddSync(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(AddSync) static int AddSync(int, int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        64,
+        "NegateSync",
+        "    REACT_METHOD(NegateSync) int NegateSync(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(NegateSync) static int NegateSync(int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        65,
+        "SayHelloSync",
+        "    REACT_METHOD(SayHelloSync) std::string SayHelloSync() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(SayHelloSync) static std::string SayHelloSync() noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        66,
+        "StaticAddSync",
+        "    REACT_METHOD(StaticAddSync) int StaticAddSync(int, int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticAddSync) static int StaticAddSync(int, int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        67,
+        "StaticNegateSync",
+        "    REACT_METHOD(StaticNegateSync) int StaticNegateSync(int) noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticNegateSync) static int StaticNegateSync(int) noexcept {/*implementation*/}\n");
+    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
+        68,
+        "StaticSayHelloSync",
+        "    REACT_METHOD(StaticSayHelloSync) std::string StaticSayHelloSync() noexcept {/*implementation*/}\n"
+        "    REACT_METHOD(StaticSayHelloSync) static std::string StaticSayHelloSync() noexcept {/*implementation*/}\n");
+  }
+};
+
 REACT_MODULE(MyTurboModule)
 struct MyTurboModule {
+  using ModuleSpec = MyTurboModuleSpec;
+
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &context) noexcept {
     IsInitialized = true;
@@ -675,618 +1289,6 @@ struct MyTurboModule {
 
 /*static*/ std::string MyTurboModule::StaticMessage;
 
-// The TurboModule spec is going to be generated from the Flow spec file.
-// It verifies that:
-// - module methods names are unique;
-// - method names are matching to the module spec method names;
-// - method signatures match the spec method signatures.
-struct MyTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
-  static constexpr auto constants = std::tuple{
-      TypedConstant<MyTurboModuleConstants1>{0},
-      TypedConstant<MyTurboModuleConstants2>{1},
-  };
-  static constexpr auto methods = std::tuple{
-      Method<void(int, int, Callback<int>) noexcept>{0, L"Add"},
-      Method<void(int, Callback<int>) noexcept>{1, L"Negate"},
-      Method<void(Callback<std::string>) noexcept>{2, L"SayHello"},
-      Method<void(int, int, Callback<int>) noexcept>{3, L"StaticAdd"},
-      Method<void(int, Callback<int>) noexcept>{4, L"StaticNegate"},
-      Method<void(Callback<std::string>) noexcept>{5, L"StaticSayHello"},
-      Method<void() noexcept>{6, L"SayHello0"},
-      Method<void(Point) noexcept>{7, L"PrintPoint"},
-      Method<void(Point, Point) noexcept>{8, L"PrintLine"},
-      Method<void() noexcept>{9, L"StaticSayHello0"},
-      Method<void(Point) noexcept>{10, L"StaticPrintPoint"},
-      Method<void(Point, Point) noexcept>{11, L"StaticPrintLine"},
-      Method<void(int, int, Callback<int>) noexcept>{12, L"AddCallback"},
-      Method<void(int, Callback<int>) noexcept>{13, L"NegateCallback"},
-      Method<void(int, Callback<int>) noexcept>{14, L"NegateAsyncCallback"},
-      Method<void(int, Callback<int>) noexcept>{15, L"NegateDispatchQueueCallback"},
-      Method<void(int, Callback<int>) noexcept>{16, L"NegateFutureCallback"},
-      Method<void(Callback<std::string>) noexcept>{17, L"SayHelloCallback"},
-      Method<void(int, int, Callback<int>) noexcept>{18, L"StaticAddCallback"},
-      Method<void(int, Callback<int>) noexcept>{19, L"StaticNegateCallback"},
-      Method<void(int, Callback<int>) noexcept>{20, L"StaticNegateAsyncCallback"},
-      Method<void(int, Callback<int>) noexcept>{21, L"StaticNegateDispatchQueueCallback"},
-      Method<void(int, Callback<int>) noexcept>{22, L"StaticNegateFutureCallback"},
-      Method<void(Callback<std::string>) noexcept>{23, L"StaticSayHelloCallback"},
-      Method<void(Callback<>) noexcept>{24, L"CallbackZeroArgs"},
-      Method<void(Callback<int, int>) noexcept>{25, L"CallbackTwoArgs"},
-      Method<void(Callback<int, int, std::string>) noexcept>{26, L"CallbackThreeArgs"},
-      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{27, L"DivideCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{28, L"NegateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{29, L"NegateAsyncCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{30, L"NegateDispatchQueueCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{31, L"NegateFutureCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{32, L"ResolveSayHelloCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{33, L"RejectSayHelloCallbacks"},
-      Method<void(int, int, Callback<int>, Callback<std::string>) noexcept>{34, L"StaticDivideCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{35, L"StaticNegateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{36, L"StaticNegateAsyncCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{37, L"StaticNegateDispatchQueueCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string>) noexcept>{38, L"StaticNegateFutureCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{39, L"StaticResolveSayHelloCallbacks"},
-      Method<void(Callback<std::string>, Callback<std::string>) noexcept>{40, L"StaticRejectSayHelloCallbacks"},
-      Method<void(Callback<>, Callback<>) noexcept>{41, L"TwoCallbacksZeroArgs1"},
-      Method<void(Callback<>, Callback<>) noexcept>{42, L"TwoCallbacksZeroArgs2"},
-      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{43, L"TwoCallbacksTwoArgs1"},
-      Method<void(Callback<int, int>, Callback<int, int>) noexcept>{44, L"TwoCallbacksTwoArgs2"},
-      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
-          45,
-          L"TwoCallbacksThreeArgs1"},
-      Method<void(Callback<int, int, std::string>, Callback<int, int, std::string>) noexcept>{
-          46,
-          L"TwoCallbacksThreeArgs2"},
-      Method<void(int, int, Promise<int>) noexcept>{47, L"DividePromise"},
-      Method<void(int, Promise<int>) noexcept>{48, L"NegatePromise"},
-      Method<void(int, Promise<int>) noexcept>{49, L"NegateAsyncPromise"},
-      Method<void(int, Promise<int>) noexcept>{50, L"NegateDispatchQueuePromise"},
-      Method<void(int, Promise<int>) noexcept>{51, L"NegateFuturePromise"},
-      Method<void(int, Promise<void>) noexcept>{52, L"voidPromise"},
-      Method<void(Promise<std::string>) noexcept>{53, L"ResolveSayHelloPromise"},
-      Method<void(Promise<std::string>) noexcept>{54, L"RejectSayHelloPromise"},
-      Method<void(int, int, Promise<int>) noexcept>{55, L"StaticDividePromise"},
-      Method<void(int, Promise<int>) noexcept>{56, L"StaticNegatePromise"},
-      Method<void(int, Promise<int>) noexcept>{57, L"StaticNegateAsyncPromise"},
-      Method<void(int, Promise<int>) noexcept>{58, L"StaticNegateDispatchQueuePromise"},
-      Method<void(int, Promise<int>) noexcept>{59, L"StaticNegateFuturePromise"},
-      Method<void(int, Promise<void>) noexcept>{60, L"staticVoidPromise"},
-      Method<void(Promise<std::string>) noexcept>{61, L"StaticResolveSayHelloPromise"},
-      Method<void(Promise<std::string>) noexcept>{62, L"StaticRejectSayHelloPromise"},
-      SyncMethod<int(int, int) noexcept>{63, L"AddSync"},
-      SyncMethod<int(int) noexcept>{64, L"NegateSync"},
-      SyncMethod<std::string() noexcept>{65, L"SayHelloSync"},
-      SyncMethod<int(int, int) noexcept>{66, L"StaticAddSync"},
-      SyncMethod<int(int) noexcept>{67, L"StaticNegateSync"},
-      SyncMethod<std::string() noexcept>{68, L"StaticSayHelloSync"},
-  };
-
-  template <class TModule>
-  static constexpr void ValidateModule() noexcept {
-    constexpr auto constantCheckResults = CheckConstants<TModule, MyTurboModuleSpec>();
-    constexpr auto methodCheckResults = CheckMethods<TModule, MyTurboModuleSpec>();
-
-    REACT_SHOW_CONSTANT_SPEC_ERRORS(
-        0,
-        "MyTurboModuleConstants1",
-        "    REACT_GET_CONSTANTS(GetConstants1) MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n"
-        "    REACT_GET_CONSTANTS(GetConstants1) static MyTurboModuleConstants1 GetConstants1() noexcept {/*implementation*/}\n");
-    REACT_SHOW_CONSTANT_SPEC_ERRORS(
-        1,
-        "MyTurboModuleConstants2",
-        "    REACT_GET_CONSTANTS(GetConstants2) MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n"
-        "    REACT_GET_CONSTANTS(GetConstants2) static MyTurboModuleConstants2 GetConstants2() noexcept {/*implementation*/}\n");
-
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        0,
-        "Add",
-        "    REACT_METHOD(Add) int Add(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Add) void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Add) winrt::fire_and_forget Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Add) static int Add(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Add) static void Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Add) static React::Coroutine Add(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        1,
-        "Negate",
-        "    REACT_METHOD(Negate) int Negate(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Negate) void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Negate) winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Negate) static int Negate(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Negate) static void Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(Negate) static winrt::fire_and_forget Negate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        2,
-        "SayHello",
-        "    REACT_METHOD(SayHello) std::string SayHello() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello) void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello) winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello) static std::string SayHello() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello) static void SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello) static winrt::fire_and_forget SayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        3,
-        "StaticAdd",
-        "    REACT_METHOD(StaticAdd) int StaticAdd(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAdd) void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAdd) winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAdd) static int StaticAdd(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAdd) static void StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAdd) static winrt::fire_and_forget StaticAdd(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        4,
-        "StaticNegate",
-        "    REACT_METHOD(StaticNegate) int StaticNegate(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegate) void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegate) winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegate) static int StaticNegate(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegate) static void StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegate) static winrt::fire_and_forget StaticNegate(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        5,
-        "StaticSayHello",
-        "    REACT_METHOD(StaticSayHello) std::string StaticSayHello() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello) void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello) winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello) static std::string StaticSayHello() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello) static void StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello) static winrt::fire_and_forget StaticSayHello(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        6,
-        "SayHello0",
-        "    REACT_METHOD(SayHello0) void SayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello0) winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello0) static void SayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHello0) static winrt::fire_and_forget SayHello0() noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        7,
-        "PrintPoint",
-        "    REACT_METHOD(PrintPoint) void PrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) static void PrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintPoint(Point) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        8,
-        "PrintLine",
-        "    REACT_METHOD(PrintPoint) void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) static void PrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(PrintPoint) static winrt::fire_and_forget PrintLine(Point, Point) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        9,
-        "StaticSayHello0",
-        "    REACT_METHOD(StaticSayHello0) void StaticSayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello0) winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello0) static void StaticSayHello0() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHello0) static winrt::fire_and_forget StaticSayHello0() noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        10,
-        "StaticPrintPoint",
-        "    REACT_METHOD(StaticPrintPoint) void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintPoint(Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintPoint(Point) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        11,
-        "StaticPrintLine",
-        "    REACT_METHOD(StaticPrintPoint) void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) static void StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticPrintPoint) static winrt::fire_and_forget StaticPrintLine(Point, Point) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        12,
-        "AddCallback",
-        "    REACT_METHOD(AddCallback) int AddCallback(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddCallback) void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddCallback) winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddCallback) static int AddCallback(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddCallback) static void AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddCallback) static winrt::fire_and_forget AddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        13,
-        "NegateCallback",
-        "    REACT_METHOD(NegateCallback) int NegateCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallback) void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallback) winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallback) static int NegateCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallback) static void NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallback) static winrt::fire_and_forget NegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        14,
-        "NegateAsyncCallback",
-        "    REACT_METHOD(NegateAsyncCallback) int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallback) void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallback) winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallback) static int NegateAsyncCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallback) static void NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallback) static winrt::fire_and_forget NegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        15,
-        "NegateDispatchQueueCallback",
-        "    REACT_METHOD(NegateDispatchQueueCallback) int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallback) void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallback) winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallback) static int NegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallback) static void NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallback) static winrt::fire_and_forget NegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        16,
-        "NegateFutureCallback",
-        "    REACT_METHOD(NegateFutureCallback) int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallback) void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallback) winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallback) static int NegateFutureCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallback) static void NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallback) static winrt::fire_and_forget NegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        17,
-        "SayHelloCallback",
-        "    REACT_METHOD(SayHelloCallback) std::string SayHelloCallback() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloCallback) void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloCallback) winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloCallback) static std::string SayHelloCallback() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloCallback) static void SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloCallback) static winrt::fire_and_forget SayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        18,
-        "StaticAddCallback",
-        "    REACT_METHOD(StaticAddCallback) int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddCallback) void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddCallback) winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddCallback) static int StaticAddCallback(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddCallback) static void StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddCallback) static winrt::fire_and_forget StaticAddCallback(int, int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        19,
-        "StaticNegateCallback",
-        "    REACT_METHOD(StaticNegateCallback) int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallback) void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallback) winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallback) static int StaticNegateCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallback) static void StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallback) static winrt::fire_and_forget StaticNegateCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        20,
-        "StaticNegateAsyncCallback",
-        "    REACT_METHOD(StaticNegateAsyncCallback) int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallback) void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallback) winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallback) static int StaticNegateAsyncCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallback) static void StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallback) static winrt::fire_and_forget StaticNegateAsyncCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        21,
-        "StaticNegateDispatchQueueCallback",
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static int StaticNegateDispatchQueueCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static void StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallback) static winrt::fire_and_forget StaticNegateDispatchQueueCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        22,
-        "StaticNegateFutureCallback",
-        "    REACT_METHOD(StaticNegateFutureCallback) int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallback) void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallback) winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallback) static int StaticNegateFutureCallback(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallback) static void StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallback) static winrt::fire_and_forget StaticNegateFutureCallback(int, ReactCallback<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        23,
-        "StaticSayHelloCallback",
-        "    REACT_METHOD(StaticSayHelloCallback) std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloCallback) void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloCallback) winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloCallback) static std::string StaticSayHelloCallback() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloCallback) static void StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloCallback) static winrt::fire_and_forget StaticSayHelloCallback(ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        24,
-        "CallbackZeroArgs",
-        "    REACT_METHOD(CallbackZeroArgs) void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackZeroArgs) winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackZeroArgs) static void CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackZeroArgs) static winrt::fire_and_forget CallbackZeroArgs(ReactCallback<>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        25,
-        "CallbackTwoArgs",
-        "    REACT_METHOD(CallbackTwoArgs) void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackTwoArgs) winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackTwoArgs) static void CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackTwoArgs) static winrt::fire_and_forget CallbackTwoArgs(ReactCallback<int, int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        26,
-        "CallbackThreeArgs",
-        "    REACT_METHOD(CallbackThreeArgs) void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackThreeArgs) winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackThreeArgs) static void CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(CallbackThreeArgs) static winrt::fire_and_forget CallbackThreeArgs(ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        27,
-        "DivideCallbacks",
-        "    REACT_METHOD(DivideCallbacks) void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DivideCallbacks) winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DivideCallbacks) static void DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DivideCallbacks) static winrt::fire_and_forget DivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        28,
-        "NegateCallbacks",
-        "    REACT_METHOD(NegateCallbacks) void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallbacks) winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallbacks) static void NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateCallbacks) static winrt::fire_and_forget NegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        29,
-        "NegateAsyncCallbacks",
-        "    REACT_METHOD(NegateAsyncCallbacks) void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallbacks) winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallbacks) static void NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncCallbacks) static winrt::fire_and_forget NegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        30,
-        "NegateDispatchQueueCallbacks",
-        "    REACT_METHOD(NegateDispatchQueueCallbacks) void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallbacks) winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallbacks) static void NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueueCallbacks) static winrt::fire_and_forget NegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        31,
-        "NegateFutureCallbacks",
-        "    REACT_METHOD(NegateFutureCallbacks) void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallbacks) winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallbacks) static void NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFutureCallbacks) static winrt::fire_and_forget NegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        32,
-        "ResolveSayHelloCallbacks",
-        "    REACT_METHOD(ResolveSayHelloCallbacks) void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloCallbacks) winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloCallbacks) static void ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloCallbacks) static winrt::fire_and_forget ResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        33,
-        "RejectSayHelloCallbacks",
-        "    REACT_METHOD(RejectSayHelloCallbacks) void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloCallbacks) winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloCallbacks) static void RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloCallbacks) static winrt::fire_and_forget RejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        34,
-        "StaticDivideCallbacks",
-        "    REACT_METHOD(StaticDivideCallbacks) void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDivideCallbacks) winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDivideCallbacks) static void StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDivideCallbacks) static winrt::fire_and_forget StaticDivideCallbacks(int, int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        35,
-        "StaticNegateCallbacks",
-        "    REACT_METHOD(StaticNegateCallbacks) void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallbacks) winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallbacks) static void StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateCallbacks) static winrt::fire_and_forget StaticNegateCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        36,
-        "StaticNegateAsyncCallbacks",
-        "    REACT_METHOD(StaticNegateAsyncCallbacks) void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallbacks) winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallbacks) static void StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncCallbacks) static winrt::fire_and_forget StaticNegateAsyncCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        37,
-        "StaticNegateDispatchQueueCallbacks",
-        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static void StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueueCallbacks) static winrt::fire_and_forget StaticNegateDispatchQueueCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        38,
-        "StaticNegateFutureCallbacks",
-        "    REACT_METHOD(StaticNegateFutureCallbacks) void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallbacks) winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallbacks) static void StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFutureCallbacks) static winrt::fire_and_forget StaticNegateFutureCallbacks(int, ReactCallback<int>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        39,
-        "StaticResolveSayHelloCallbacks",
-        "    REACT_METHOD(StaticResolveSayHelloCallbacks) void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloCallbacks) winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static void StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloCallbacks) static winrt::fire_and_forget StaticResolveSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        40,
-        "StaticRejectSayHelloCallbacks",
-        "    REACT_METHOD(StaticRejectSayHelloCallbacks) void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloCallbacks) winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static void StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloCallbacks) static winrt::fire_and_forget StaticRejectSayHelloCallbacks(ReactCallback<std::string>, ReactCallback<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        41,
-        "TwoCallbacksZeroArgs1",
-        "    REACT_METHOD(TwoCallbacksZeroArgs1) void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs1) winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs1) static void TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs1) static winrt::fire_and_forget TwoCallbacksZeroArgs1(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        42,
-        "TwoCallbacksZeroArgs2",
-        "    REACT_METHOD(TwoCallbacksZeroArgs2) void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs2) winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs2) static void TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksZeroArgs2) static winrt::fire_and_forget TwoCallbacksZeroArgs2(ReactCallback<>, ReactCallback<>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        43,
-        "TwoCallbacksTwoArgs1",
-        "    REACT_METHOD(TwoCallbacksTwoArgs1) void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs1) winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs1) static void TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs1) static winrt::fire_and_forget TwoCallbacksTwoArgs1(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        44,
-        "TwoCallbacksTwoArgs2",
-        "    REACT_METHOD(TwoCallbacksTwoArgs2) void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs2) winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs2) static void TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksTwoArgs2) static winrt::fire_and_forget TwoCallbacksTwoArgs2(ReactCallback<int, int>, ReactCallback<int, int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        45,
-        "TwoCallbacksThreeArgs1",
-        "    REACT_METHOD(TwoCallbacksThreeArgs1) void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs1) winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs1) static void TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs1) static winrt::fire_and_forget TwoCallbacksThreeArgs1(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        46,
-        "TwoCallbacksThreeArgs2",
-        "    REACT_METHOD(TwoCallbacksThreeArgs2) void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs2) winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs2) static void TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(TwoCallbacksThreeArgs2) static winrt::fire_and_forget TwoCallbacksThreeArgs2(ReactCallback<int, int, std::string>, ReactCallback<int, int, std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        47,
-        "DividePromise",
-        "    REACT_METHOD(DividePromise) void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DividePromise) winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DividePromise) static void DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(DividePromise) static winrt::fire_and_forget DividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        48,
-        "NegatePromise",
-        "    REACT_METHOD(NegatePromise) void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegatePromise) winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegatePromise) static void NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegatePromise) static winrt::fire_and_forget NegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        49,
-        "NegateAsyncPromise",
-        "    REACT_METHOD(NegateAsyncPromise) void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncPromise) winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncPromise) static void NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateAsyncPromise) static winrt::fire_and_forget NegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        50,
-        "NegateDispatchQueuePromise",
-        "    REACT_METHOD(NegateDispatchQueuePromise) void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueuePromise) winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueuePromise) static void NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateDispatchQueuePromise) static winrt::fire_and_forget NegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        51,
-        "NegateFuturePromise",
-        "    REACT_METHOD(NegateFuturePromise) void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFuturePromise) winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFuturePromise) static void NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateFuturePromise) static winrt::fire_and_forget NegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        52,
-        "voidPromise",
-        "    REACT_METHOD(voidPromise) void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(voidPromise) winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(voidPromise) static void voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(voidPromise) static winrt::fire_and_forget voidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        53,
-        "ResolveSayHelloPromise",
-        "    REACT_METHOD(ResolveSayHelloPromise) void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloPromise) winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloPromise) static void ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(ResolveSayHelloPromise) static winrt::fire_and_forget ResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        54,
-        "RejectSayHelloPromise",
-        "    REACT_METHOD(RejectSayHelloPromise) void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloPromise) winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloPromise) static void RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(RejectSayHelloPromise) static winrt::fire_and_forget RejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        55,
-        "StaticDividePromise",
-        "    REACT_METHOD(StaticDividePromise) void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDividePromise) winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDividePromise) static void StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticDividePromise) static winrt::fire_and_forget StaticDividePromise(int, int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        56,
-        "StaticNegatePromise",
-        "    REACT_METHOD(StaticNegatePromise) void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegatePromise) winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegatePromise) static void StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegatePromise) static winrt::fire_and_forget StaticNegatePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        57,
-        "StaticNegateAsyncPromise",
-        "    REACT_METHOD(StaticNegateAsyncPromise) void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncPromise) winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncPromise) static void StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateAsyncPromise) static winrt::fire_and_forget StaticNegateAsyncPromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        58,
-        "StaticNegateDispatchQueuePromise",
-        "    REACT_METHOD(StaticNegateDispatchQueuePromise) void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueuePromise) winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static void StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateDispatchQueuePromise) static winrt::fire_and_forget StaticNegateDispatchQueuePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        59,
-        "StaticNegateFuturePromise",
-        "    REACT_METHOD(StaticNegateFuturePromise) void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFuturePromise) winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFuturePromise) static void StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateFuturePromise) static winrt::fire_and_forget StaticNegateFuturePromise(int, ReactPromise<int>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        60,
-        "staticVoidPromise",
-        "    REACT_METHOD(staticVoidPromise) void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(staticVoidPromise) winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(staticVoidPromise) static void staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(staticVoidPromise) static winrt::fire_and_forget staticVoidPromise(int, ReactPromise<void>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        61,
-        "StaticResolveSayHelloPromise",
-        "    REACT_METHOD(StaticResolveSayHelloPromise) void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloPromise) winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloPromise) static void StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticResolveSayHelloPromise) static winrt::fire_and_forget StaticResolveSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_METHOD_SPEC_ERRORS(
-        62,
-        "StaticRejectSayHelloPromise",
-        "    REACT_METHOD(StaticRejectSayHelloPromise) void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloPromise) winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloPromise) static void StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticRejectSayHelloPromise) static winrt::fire_and_forget StaticRejectSayHelloPromise(ReactPromise<std::string>) noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        63,
-        "AddSync",
-        "    REACT_METHOD(AddSync) int AddSync(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(AddSync) static int AddSync(int, int) noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        64,
-        "NegateSync",
-        "    REACT_METHOD(NegateSync) int NegateSync(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(NegateSync) static int NegateSync(int) noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        65,
-        "SayHelloSync",
-        "    REACT_METHOD(SayHelloSync) std::string SayHelloSync() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(SayHelloSync) static std::string SayHelloSync() noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        66,
-        "StaticAddSync",
-        "    REACT_METHOD(StaticAddSync) int StaticAddSync(int, int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticAddSync) static int StaticAddSync(int, int) noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        67,
-        "StaticNegateSync",
-        "    REACT_METHOD(StaticNegateSync) int StaticNegateSync(int) noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticNegateSync) static int StaticNegateSync(int) noexcept {/*implementation*/}\n");
-    REACT_SHOW_SYNC_METHOD_SPEC_ERRORS(
-        68,
-        "StaticSayHelloSync",
-        "    REACT_METHOD(StaticSayHelloSync) std::string StaticSayHelloSync() noexcept {/*implementation*/}\n"
-        "    REACT_METHOD(StaticSayHelloSync) static std::string StaticSayHelloSync() noexcept {/*implementation*/}\n");
-  }
-};
-
 TEST_CLASS (TurboModuleTest) {
   winrt::Microsoft::ReactNative::ReactModuleBuilderMock m_builderMock{};
   winrt::Microsoft::ReactNative::IReactModuleBuilder m_moduleBuilder;
@@ -1295,7 +1297,7 @@ TEST_CLASS (TurboModuleTest) {
 
   TurboModuleTest() {
     m_moduleBuilder = winrt::make<winrt::Microsoft::ReactNative::ReactModuleBuilderImpl>(m_builderMock);
-    auto provider = winrt::Microsoft::ReactNative::MakeTurboModuleProvider<MyTurboModule, MyTurboModuleSpec>();
+    auto provider = winrt::Microsoft::ReactNative::MakeTurboModuleProvider<MyTurboModule>();
     m_moduleObject = m_builderMock.CreateModule(provider, m_moduleBuilder);
     m_module = winrt::Microsoft::ReactNative::ReactNonAbiValue<MyTurboModule>::GetPtrUnsafe(m_moduleObject);
   }

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -1314,7 +1314,9 @@ inline ReactModuleProvider MakeModuleProvider() noexcept {
 template <class TModule>
 inline ReactModuleProvider MakeTurboModuleProvider() noexcept {
   using TModuleSpec = typename ReactModuleSpecOrVoid<TModule>::Type;
-  static_assert(!std::is_same_v<void, TModuleSpec>, "TModule::ModuleSpec must exist and it specifies the specification for this module.");
+  static_assert(
+      !std::is_same_v<void, TModuleSpec>,
+      "TModule::ModuleSpec must exist and it specifies the specification for this module.");
   return MakeModuleProvider<TModule>();
 }
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -173,8 +173,7 @@ struct SampleTurboModule {
 struct SampleTurboModulePackageProvider : winrt::implements<SampleTurboModulePackageProvider, IReactPackageProvider> {
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
     auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
-    experimental.AddTurboModule(
-        L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule>());
+    experimental.AddTurboModule(L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule>());
   }
 };
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -15,6 +15,46 @@ namespace ReactNativeIntegrationTests {
 
 namespace {
 
+struct SampleTurboModuleSpec : TurboModuleSpec {
+  static constexpr auto methods = std::tuple{
+      Method<void() noexcept>{0, L"succeeded"},
+      Method<void(std::string) noexcept>{1, L"onError"},
+      Method<void(std::string, int, bool, ReactPromise<React::JSValue>) noexcept>{2, L"promiseFunction"},
+      Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
+      SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
+      Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
+      Method<void(std::string, int, std::string, int, std::string, int) noexcept>{6, L"constants"},
+      Method<void(int, int, const std::function<void(int)> &) noexcept>{7, L"oneCallback"},
+      Method<void(int) noexcept>{8, L"oneCallbackResult"},
+      Method<void(
+          bool,
+          int,
+          std::string,
+          const std::function<void(int)> &,
+          const std::function<void(std::string)> &) noexcept>{9, L"twoCallbacks"},
+      Method<void(int) noexcept>{10, L"twoCallbacksResolved"},
+      Method<void(std::string) noexcept>{11, L"twoCallbacksRejected"},
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(0, "succeeded", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(1, "onError", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(2, "promiseFunction", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(3, "promiseFunctionResult", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(4, "syncFunction", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(5, "syncFunctionResult", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(6, "constants", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(7, "oneCallback", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(8, "oneCallbackResult", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(9, "twoCallbacks", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(10, "twoCallbacksResolved", "I don't care error message");
+    REACT_SHOW_METHOD_SPEC_ERRORS(11, "twoCallbacksRejected", "I don't care error message");
+  }
+};
+
 REACT_STRUCT(SampleTurboModuleConstants)
 struct SampleTurboModuleConstants {
   REACT_FIELD(constantString3)
@@ -25,6 +65,8 @@ struct SampleTurboModuleConstants {
 
 REACT_MODULE(SampleTurboModule)
 struct SampleTurboModule {
+  using ModuleSpec = SampleTurboModuleSpec;
+
   REACT_INIT(Initialize)
   void Initialize(ReactContext const & /*reactContext*/) noexcept {}
 
@@ -128,51 +170,11 @@ struct SampleTurboModule {
   }
 };
 
-struct SampleTurboModuleSpec : TurboModuleSpec {
-  static constexpr auto methods = std::tuple{
-      Method<void() noexcept>{0, L"succeeded"},
-      Method<void(std::string) noexcept>{1, L"onError"},
-      Method<void(std::string, int, bool, ReactPromise<React::JSValue>) noexcept>{2, L"promiseFunction"},
-      Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
-      SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
-      Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
-      Method<void(std::string, int, std::string, int, std::string, int) noexcept>{6, L"constants"},
-      Method<void(int, int, const std::function<void(int)> &) noexcept>{7, L"oneCallback"},
-      Method<void(int) noexcept>{8, L"oneCallbackResult"},
-      Method<void(
-          bool,
-          int,
-          std::string,
-          const std::function<void(int)> &,
-          const std::function<void(std::string)> &) noexcept>{9, L"twoCallbacks"},
-      Method<void(int) noexcept>{10, L"twoCallbacksResolved"},
-      Method<void(std::string) noexcept>{11, L"twoCallbacksRejected"},
-  };
-
-  template <class TModule>
-  static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
-
-    REACT_SHOW_METHOD_SPEC_ERRORS(0, "succeeded", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(1, "onError", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(2, "promiseFunction", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(3, "promiseFunctionResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(4, "syncFunction", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(5, "syncFunctionResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(6, "constants", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(7, "oneCallback", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(8, "oneCallbackResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(9, "twoCallbacks", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(10, "twoCallbacksResolved", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(11, "twoCallbacksRejected", "I don't care error message");
-  }
-};
-
 struct SampleTurboModulePackageProvider : winrt::implements<SampleTurboModulePackageProvider, IReactPackageProvider> {
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
     auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
     experimental.AddTurboModule(
-        L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule, SampleTurboModuleSpec>());
+        L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule>());
   }
 };
 

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeAccessibilityInfoSpec.g.h"
 #include <NativeModules.h>
 
 namespace Microsoft::ReactNative {
 
 REACT_MODULE(AccessibilityInfo)
 struct AccessibilityInfo : public std::enable_shared_from_this<AccessibilityInfo> {
+  using ModuleSpec = ReactNativeSpecs::AccessibilityInfoSpec;
+
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -13,6 +13,7 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(Alert)
 struct Alert : public std::enable_shared_from_this<Alert> {
+  using ModuleSpec = ReactNativeSpecs::DialogManagerWindowsSpec;
   using DialogOptions = ReactNativeSpecs::DialogManagerWindowsSpec_DialogOptions;
   using Constants = ReactNativeSpecs::DialogManagerWindowsSpec_Constants;
 

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
@@ -11,6 +11,7 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(AppState)
 struct AppState : public std::enable_shared_from_this<AppState> {
+  using ModuleSpec = ReactNativeSpecs::AppStateSpec;
   using AppStateChangeArgs = ReactNativeSpecs::AppStateSpec_getCurrentAppState_success_appState;
 
   REACT_INIT(Initialize)

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
@@ -2,12 +2,15 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeClipboardSpec.g.h"
 #include <NativeModules.h>
 
 namespace Microsoft::ReactNative {
 
 REACT_MODULE(Clipboard)
 struct Clipboard {
+  using ModuleSpec = ReactNativeSpecs::ClipboardSpec;
+
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
@@ -5,6 +5,7 @@
 #include <cxxreact/CxxModule.h>
 #include <functional/functor.h>
 
+#include "../../codegen/NativeDevSettingsSpec.g.h"
 #include <NativeModules.h>
 #include <ReactHost/React.h>
 
@@ -12,6 +13,8 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(DevSettings)
 struct DevSettings {
+  using ModuleSpec = ReactNativeSpecs::DevSettingsSpec;
+
   REACT_INIT(Initialize) void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
   REACT_METHOD(reload) void reload() noexcept;

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
@@ -50,6 +50,8 @@ struct DeviceInfoHolder {
 
 REACT_MODULE(DeviceInfo)
 struct DeviceInfo : public std::enable_shared_from_this<DeviceInfo> {
+  using ModuleSpec = ReactNativeSpecs::DeviceInfoSpec;
+
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
@@ -15,6 +15,8 @@ namespace Microsoft::ReactNative {
 // PropertyBag so that the I18nModule can return the constants synchronously.
 REACT_MODULE(I18nManager)
 struct I18nManager {
+  using ModuleSpec = ReactNativeSpecs::I18nManagerSpec;
+
   static void InitI18nInfo(const React::ReactPropertyBag &propertyBag) noexcept;
   static bool IsRTL(const React::ReactPropertyBag &propertyBag) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
@@ -13,6 +13,8 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(ImageLoader)
 struct ImageLoader {
+  using ModuleSpec = ReactNativeSpecs::ImageLoaderIOSSpec;
+
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeLogBoxSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>
@@ -11,6 +12,8 @@ namespace Microsoft::ReactNative {
 
 REACT_MODULE(LogBox)
 struct LogBox : public std::enable_shared_from_this<LogBox> {
+  using ModuleSpec = ReactNativeSpecs::LogBoxSpec;
+
   REACT_INIT(Initialize)
   void Initialize(React::ReactContext const &reactContext) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include "../../codegen/NativeUIManagerSpec.g.h"
 #include <CxxMessageQueue.h>
 #include <INativeUIManager.h>
 #include <NativeModules.h>
@@ -31,6 +32,11 @@ std::weak_ptr<NativeUIManager> GetNativeUIManager(const Mso::React::IReactContex
 
 REACT_MODULE(UIManager)
 struct UIManager final {
+  // TODO:
+  // Spec incorrectly reports commandID as a number, but its actually a number | string..
+  // There is also other issues to catch up, so dont use the spec for now
+  // using ModuleSpec = ReactNativeSpecs::UIManagerSpec;
+
   UIManager();
   ~UIManager();
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -16,17 +16,6 @@
 #include "ReactErrorProvider.h"
 
 #include "Microsoft.ReactNative/IReactNotificationService.h"
-
-#include "../../codegen/NativeAccessibilityInfoSpec.g.h"
-#include "../../codegen/NativeAppStateSpec.g.h"
-#include "../../codegen/NativeClipboardSpec.g.h"
-#include "../../codegen/NativeDevSettingsSpec.g.h"
-#include "../../codegen/NativeDeviceInfoSpec.g.h"
-#include "../../codegen/NativeDialogManagerWindowsSpec.g.h"
-#include "../../codegen/NativeI18nManagerSpec.g.h"
-#include "../../codegen/NativeImageLoaderIOSSpec.g.h"
-#include "../../codegen/NativeLogBoxSpec.g.h"
-#include "../../codegen/NativeUIManagerSpec.g.h"
 #include "NativeModules.h"
 #include "NativeModulesProvider.h"
 #include "Unicode.h"
@@ -280,64 +269,46 @@ void ReactInstanceWin::LoadModules(
 #ifndef CORE_ABI
   registerTurboModule(
       L"UIManager",
-      // Spec incorrectly reports commandID as a number, but its actually a number | string.. so dont use the spec for
-      // now
-      // winrt::Microsoft::ReactNative::MakeTurboModuleProvider < ::Microsoft::ReactNative::UIManager,
-      //::Microsoft::ReactNativeSpecs::UIManagerSpec>());
+      // TODO: Use MakeTurboModuleProvider after it satisfies ReactNativeSpecs::UIManagerSpec
       winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::UIManager>());
 
   registerTurboModule(
       L"AccessibilityInfo",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::AccessibilityInfo,
-          ::Microsoft::ReactNativeSpecs::AccessibilityInfoSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AccessibilityInfo>());
 
   registerTurboModule(
       L"Alert",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::Alert,
-          ::Microsoft::ReactNativeSpecs::DialogManagerWindowsSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Alert>());
 
   registerTurboModule(
       L"AppState",
-      winrt::Microsoft::ReactNative::
-          MakeTurboModuleProvider<::Microsoft::ReactNative::AppState, ::Microsoft::ReactNativeSpecs::AppStateSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AppState>());
 
   registerTurboModule(
       L"LogBox",
-      winrt::Microsoft::ReactNative::
-          MakeTurboModuleProvider<::Microsoft::ReactNative::LogBox, ::Microsoft::ReactNativeSpecs::LogBoxSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::LogBox>());
 
   registerTurboModule(
       L"Clipboard",
-      winrt::Microsoft::ReactNative::
-          MakeTurboModuleProvider<::Microsoft::ReactNative::Clipboard, ::Microsoft::ReactNativeSpecs::ClipboardSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Clipboard>());
 
   registerTurboModule(
       L"DeviceInfo",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::DeviceInfo,
-          ::Microsoft::ReactNativeSpecs::DeviceInfoSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DeviceInfo>());
 
   registerTurboModule(
       L"ImageLoader",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::ImageLoader,
-          ::Microsoft::ReactNativeSpecs::ImageLoaderIOSSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::ImageLoader>());
 #endif
 
   registerTurboModule(
       L"DevSettings",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::DevSettings,
-          ::Microsoft::ReactNativeSpecs::DevSettingsSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DevSettings>());
 
 #ifndef CORE_ABI
   registerTurboModule(
       L"I18nManager",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<
-          ::Microsoft::ReactNative::I18nManager,
-          ::Microsoft::ReactNativeSpecs::I18nManagerSpec>());
+      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::I18nManager>());
 #endif
 }
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -277,38 +277,30 @@ void ReactInstanceWin::LoadModules(
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AccessibilityInfo>());
 
   registerTurboModule(
-      L"Alert",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Alert>());
+      L"Alert", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Alert>());
 
   registerTurboModule(
-      L"AppState",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AppState>());
+      L"AppState", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::AppState>());
 
   registerTurboModule(
-      L"LogBox",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::LogBox>());
+      L"LogBox", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::LogBox>());
 
   registerTurboModule(
-      L"Clipboard",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Clipboard>());
+      L"Clipboard", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Clipboard>());
 
   registerTurboModule(
-      L"DeviceInfo",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DeviceInfo>());
+      L"DeviceInfo", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DeviceInfo>());
 
   registerTurboModule(
-      L"ImageLoader",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::ImageLoader>());
+      L"ImageLoader", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::ImageLoader>());
 #endif
 
   registerTurboModule(
-      L"DevSettings",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DevSettings>());
+      L"DevSettings", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::DevSettings>());
 
 #ifndef CORE_ABI
   registerTurboModule(
-      L"I18nManager",
-      winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::I18nManager>());
+      L"I18nManager", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::I18nManager>());
 #endif
 }
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -260,11 +260,6 @@ ReactInstanceWin::~ReactInstanceWin() noexcept {}
 void ReactInstanceWin::LoadModules(
     const std::shared_ptr<winrt::Microsoft::ReactNative::NativeModulesProvider> &nativeModulesProvider,
     const std::shared_ptr<winrt::Microsoft::ReactNative::TurboModulesProvider> &turboModulesProvider) noexcept {
-  auto registerNativeModule = [&nativeModulesProvider](
-                                  const wchar_t *name, const ReactModuleProvider &provider) noexcept {
-    nativeModulesProvider->AddModuleProvider(name, provider);
-  };
-
   auto registerTurboModule = [this, &nativeModulesProvider, &turboModulesProvider](
                                  const wchar_t *name, const ReactModuleProvider &provider) noexcept {
     if (m_options.UseWebDebugger()) {

--- a/vnext/codegen/NativeAccessibilityManagerSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityManagerSpec.g.h
@@ -43,12 +43,12 @@ struct AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipl
 
 struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{0, L"getCurrentBoldTextState"},
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{1, L"getCurrentGrayscaleState"},
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{2, L"getCurrentInvertColorsState"},
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{3, L"getCurrentReduceMotionState"},
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{4, L"getCurrentReduceTransparencyState"},
-      Method<void(Callback<bool>, Callback<React::JSValue>) noexcept>{5, L"getCurrentVoiceOverState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{0, L"getCurrentBoldTextState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{1, L"getCurrentGrayscaleState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{2, L"getCurrentInvertColorsState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{3, L"getCurrentReduceMotionState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{4, L"getCurrentReduceTransparencyState"},
+      Method<void(Callback<bool>, Callback<::React::JSValue>) noexcept>{5, L"getCurrentVoiceOverState"},
       Method<void(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers) noexcept>{6, L"setAccessibilityContentSizeMultipliers"},
       Method<void(double) noexcept>{7, L"setAccessibilityFocus"},
       Method<void(std::string) noexcept>{8, L"announceForAccessibility"},
@@ -61,33 +61,33 @@ struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getCurrentBoldTextState",
-          "    REACT_METHOD(getCurrentBoldTextState) void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentBoldTextState) static void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentBoldTextState) void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentBoldTextState) static void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getCurrentGrayscaleState",
-          "    REACT_METHOD(getCurrentGrayscaleState) void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentGrayscaleState) static void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentGrayscaleState) void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentGrayscaleState) static void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getCurrentInvertColorsState",
-          "    REACT_METHOD(getCurrentInvertColorsState) void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentInvertColorsState) static void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentInvertColorsState) void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentInvertColorsState) static void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getCurrentReduceMotionState",
-          "    REACT_METHOD(getCurrentReduceMotionState) void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentReduceMotionState) static void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentReduceMotionState) void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentReduceMotionState) static void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getCurrentReduceTransparencyState",
-          "    REACT_METHOD(getCurrentReduceTransparencyState) void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentReduceTransparencyState) static void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentReduceTransparencyState) void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentReduceTransparencyState) static void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getCurrentVoiceOverState",
-          "    REACT_METHOD(getCurrentVoiceOverState) void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentVoiceOverState) static void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentVoiceOverState) void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentVoiceOverState) static void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "setAccessibilityContentSizeMultipliers",

--- a/vnext/codegen/NativeActionSheetManagerSpec.g.h
+++ b/vnext/codegen/NativeActionSheetManagerSpec.g.h
@@ -64,7 +64,7 @@ struct ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_er
     REACT_FIELD(code)
     std::string code;
     REACT_FIELD(userInfo)
-    std::optional<React::JSValue> userInfo;
+    std::optional<::React::JSValue> userInfo;
     REACT_FIELD(message)
     std::string message;
 };

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -20,7 +20,7 @@ struct AlertManagerSpec_Args {
     REACT_FIELD(message)
     std::optional<std::string> message;
     REACT_FIELD(buttons)
-    std::optional<std::vector<React::JSValue>> buttons;
+    std::optional<std::vector<::React::JSValue>> buttons;
     REACT_FIELD(type)
     std::optional<std::string> type;
     REACT_FIELD(defaultValue)

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -31,13 +31,13 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
-      Method<void(double, React::JSValue) noexcept>{2, L"createAnimatedNode"},
+      Method<void(double, ::React::JSValue) noexcept>{2, L"createAnimatedNode"},
       Method<void(double, Callback<double>) noexcept>{3, L"getValue"},
       Method<void(double) noexcept>{4, L"startListeningToAnimatedNodeValue"},
       Method<void(double) noexcept>{5, L"stopListeningToAnimatedNodeValue"},
       Method<void(double, double) noexcept>{6, L"connectAnimatedNodes"},
       Method<void(double, double) noexcept>{7, L"disconnectAnimatedNodes"},
-      Method<void(double, double, React::JSValue, Callback<AnimatedModuleSpec_EndResult>) noexcept>{8, L"startAnimatingNode"},
+      Method<void(double, double, ::React::JSValue, Callback<AnimatedModuleSpec_EndResult>) noexcept>{8, L"startAnimatingNode"},
       Method<void(double) noexcept>{9, L"stopAnimation"},
       Method<void(double, double) noexcept>{10, L"setAnimatedNodeValue"},
       Method<void(double, double) noexcept>{11, L"setAnimatedNodeOffset"},
@@ -70,8 +70,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "createAnimatedNode",
-          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getValue",
@@ -100,8 +100,8 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "startAnimatingNode",
-          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "stopAnimation",

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -31,13 +31,13 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startOperationBatch"},
       Method<void() noexcept>{1, L"finishOperationBatch"},
-      Method<void(double, React::JSValue) noexcept>{2, L"createAnimatedNode"},
+      Method<void(double, ::React::JSValue) noexcept>{2, L"createAnimatedNode"},
       Method<void(double, Callback<double>) noexcept>{3, L"getValue"},
       Method<void(double) noexcept>{4, L"startListeningToAnimatedNodeValue"},
       Method<void(double) noexcept>{5, L"stopListeningToAnimatedNodeValue"},
       Method<void(double, double) noexcept>{6, L"connectAnimatedNodes"},
       Method<void(double, double) noexcept>{7, L"disconnectAnimatedNodes"},
-      Method<void(double, double, React::JSValue, Callback<AnimatedTurboModuleSpec_EndResult>) noexcept>{8, L"startAnimatingNode"},
+      Method<void(double, double, ::React::JSValue, Callback<AnimatedTurboModuleSpec_EndResult>) noexcept>{8, L"startAnimatingNode"},
       Method<void(double) noexcept>{9, L"stopAnimation"},
       Method<void(double, double) noexcept>{10, L"setAnimatedNodeValue"},
       Method<void(double, double) noexcept>{11, L"setAnimatedNodeOffset"},
@@ -70,8 +70,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "createAnimatedNode",
-          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getValue",
@@ -100,8 +100,8 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "startAnimatingNode",
-          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "stopAnimation",

--- a/vnext/codegen/NativeAppStateSpec.g.h
+++ b/vnext/codegen/NativeAppStateSpec.g.h
@@ -30,7 +30,7 @@ struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       TypedConstant<AppStateSpec_Constants>{0},
   };
   static constexpr auto methods = std::tuple{
-      Method<void(Callback<AppStateSpec_getCurrentAppState_success_appState>, Callback<React::JSValue>) noexcept>{0, L"getCurrentAppState"},
+      Method<void(Callback<AppStateSpec_getCurrentAppState_success_appState>, Callback<::React::JSValue>) noexcept>{0, L"getCurrentAppState"},
       Method<void(std::string) noexcept>{1, L"addListener"},
       Method<void(double) noexcept>{2, L"removeListeners"},
   };
@@ -49,8 +49,8 @@ struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getCurrentAppState",
-          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addListener",

--- a/vnext/codegen/NativeBlobModuleSpec.g.h
+++ b/vnext/codegen/NativeBlobModuleSpec.g.h
@@ -29,8 +29,8 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       Method<void() noexcept>{0, L"addNetworkingHandler"},
       Method<void(double) noexcept>{1, L"addWebSocketHandler"},
       Method<void(double) noexcept>{2, L"removeWebSocketHandler"},
-      Method<void(React::JSValue, double) noexcept>{3, L"sendOverSocket"},
-      Method<void(std::vector<React::JSValue>, std::string) noexcept>{4, L"createFromParts"},
+      Method<void(::React::JSValue, double) noexcept>{3, L"sendOverSocket"},
+      Method<void(std::vector<::React::JSValue>, std::string) noexcept>{4, L"createFromParts"},
       Method<void(std::string) noexcept>{5, L"release"},
   };
 
@@ -63,13 +63,13 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "sendOverSocket",
-          "    REACT_METHOD(sendOverSocket) void sendOverSocket(React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendOverSocket) static void sendOverSocket(React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendOverSocket) void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendOverSocket) static void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "createFromParts",
-          "    REACT_METHOD(createFromParts) void createFromParts(std::vector<React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createFromParts) static void createFromParts(std::vector<React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createFromParts) void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createFromParts) static void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "release",

--- a/vnext/codegen/NativeBugReportingSpec.g.h
+++ b/vnext/codegen/NativeBugReportingSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 struct BugReportingSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void() noexcept>{0, L"startReportAProblemFlow"},
-      Method<void(React::JSValue, React::JSValue) noexcept>{1, L"setExtraData"},
+      Method<void(::React::JSValue, ::React::JSValue) noexcept>{1, L"setExtraData"},
       Method<void(std::string) noexcept>{2, L"setCategoryID"},
   };
 
@@ -32,8 +32,8 @@ struct BugReportingSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setExtraData",
-          "    REACT_METHOD(setExtraData) void setExtraData(React::JSValue && extraData, React::JSValue && extraFiles) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setExtraData) static void setExtraData(React::JSValue && extraData, React::JSValue && extraFiles) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "setCategoryID",

--- a/vnext/codegen/NativeClipboardSpec.g.h
+++ b/vnext/codegen/NativeClipboardSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct ClipboardSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Promise<React::JSValue>) noexcept>{0, L"getString"},
+      Method<void(Promise<::React::JSValue>) noexcept>{0, L"getString"},
       Method<void(std::string) noexcept>{1, L"setString"},
   };
 
@@ -26,8 +26,8 @@ struct ClipboardSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getString",
-          "    REACT_METHOD(getString) void getString(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getString) static void getString(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getString) void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getString) static void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setString",

--- a/vnext/codegen/NativeDatePickerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDatePickerAndroidSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct DatePickerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValue, Promise<React::JSValue>) noexcept>{0, L"open"},
+      Method<void(::React::JSValue, Promise<::React::JSValue>) noexcept>{0, L"open"},
   };
 
   template <class TModule>
@@ -25,8 +25,8 @@ struct DatePickerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "open",
-          "    REACT_METHOD(open) void open(React::JSValue && options, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(open) static void open(React::JSValue && options, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(open) void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(open) static void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeDevSplitBundleLoaderSpec.g.h
+++ b/vnext/codegen/NativeDevSplitBundleLoaderSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct DevSplitBundleLoaderSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{0, L"loadBundle"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{0, L"loadBundle"},
   };
 
   template <class TModule>
@@ -25,8 +25,8 @@ struct DevSplitBundleLoaderSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "loadBundle",
-          "    REACT_METHOD(loadBundle) void loadBundle(std::string bundlePath, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(loadBundle) static void loadBundle(std::string bundlePath, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(loadBundle) void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(loadBundle) static void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -44,7 +44,7 @@ struct ExceptionsManagerSpec_ExceptionData {
     REACT_FIELD(isFatal)
     bool isFatal;
     REACT_FIELD(extraData)
-    std::optional<React::JSValue> extraData;
+    std::optional<::React::JSValue> extraData;
 };
 
 struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {

--- a/vnext/codegen/NativeFileReaderModuleSpec.g.h
+++ b/vnext/codegen/NativeFileReaderModuleSpec.g.h
@@ -15,8 +15,8 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct FileReaderModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValue, Promise<React::JSValue>) noexcept>{0, L"readAsDataURL"},
-      Method<void(React::JSValue, std::string, Promise<React::JSValue>) noexcept>{1, L"readAsText"},
+      Method<void(::React::JSValue, Promise<::React::JSValue>) noexcept>{0, L"readAsDataURL"},
+      Method<void(::React::JSValue, std::string, Promise<::React::JSValue>) noexcept>{1, L"readAsText"},
   };
 
   template <class TModule>
@@ -26,13 +26,13 @@ struct FileReaderModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "readAsDataURL",
-          "    REACT_METHOD(readAsDataURL) void readAsDataURL(React::JSValue && data, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(readAsDataURL) static void readAsDataURL(React::JSValue && data, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(readAsDataURL) void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(readAsDataURL) static void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "readAsText",
-          "    REACT_METHOD(readAsText) void readAsText(React::JSValue && data, std::string encoding, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(readAsText) static void readAsText(React::JSValue && data, std::string encoding, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(readAsText) void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(readAsText) static void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
+++ b/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 struct HeadlessJsTaskSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(double) noexcept>{0, L"notifyTaskFinished"},
-      Method<void(double, Promise<React::JSValue>) noexcept>{1, L"notifyTaskRetry"},
+      Method<void(double, Promise<::React::JSValue>) noexcept>{1, L"notifyTaskRetry"},
   };
 
   template <class TModule>
@@ -31,8 +31,8 @@ struct HeadlessJsTaskSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpe
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "notifyTaskRetry",
-          "    REACT_METHOD(notifyTaskRetry) void notifyTaskRetry(double taskId, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(notifyTaskRetry) static void notifyTaskRetry(double taskId, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(notifyTaskRetry) void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(notifyTaskRetry) static void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
@@ -16,10 +16,10 @@ namespace Microsoft::ReactNativeSpecs {
 struct ImageLoaderAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
       Method<void(double) noexcept>{0, L"abortRequest"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"getSize"},
-      Method<void(std::string, React::JSValue, Promise<React::JSValue>) noexcept>{2, L"getSizeWithHeaders"},
-      Method<void(std::string, double, Promise<React::JSValue>) noexcept>{3, L"prefetchImage"},
-      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{1, L"getSize"},
+      Method<void(std::string, ::React::JSValue, Promise<::React::JSValue>) noexcept>{2, L"getSizeWithHeaders"},
+      Method<void(std::string, double, Promise<::React::JSValue>) noexcept>{3, L"prefetchImage"},
+      Method<void(std::vector<std::string>, Promise<::React::JSValue>) noexcept>{4, L"queryCache"},
   };
 
   template <class TModule>
@@ -34,23 +34,23 @@ struct ImageLoaderAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSize",
-          "    REACT_METHOD(getSize) void getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSize) static void getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getSizeWithHeaders",
-          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, React::JSValue && headers, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, React::JSValue && headers, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "prefetchImage",
-          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, double requestId, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, double requestId, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeImageLoaderIOSSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderIOSSpec.g.h
@@ -15,11 +15,11 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct ImageLoaderIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{0, L"getSize"},
-      Method<void(std::string, React::JSValue, Promise<React::JSValue>) noexcept>{1, L"getSizeWithHeaders"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"prefetchImage"},
-      Method<void(std::string, std::string, double, Promise<React::JSValue>) noexcept>{3, L"prefetchImageWithMetadata"},
-      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{4, L"queryCache"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{0, L"getSize"},
+      Method<void(std::string, ::React::JSValue, Promise<::React::JSValue>) noexcept>{1, L"getSizeWithHeaders"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{2, L"prefetchImage"},
+      Method<void(std::string, std::string, double, Promise<::React::JSValue>) noexcept>{3, L"prefetchImageWithMetadata"},
+      Method<void(std::vector<std::string>, Promise<::React::JSValue>) noexcept>{4, L"queryCache"},
   };
 
   template <class TModule>
@@ -29,28 +29,28 @@ struct ImageLoaderIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getSize",
-          "    REACT_METHOD(getSize) void getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSize) static void getSize(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSizeWithHeaders",
-          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, React::JSValue && headers, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, React::JSValue && headers, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "prefetchImage",
-          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "prefetchImageWithMetadata",
-          "    REACT_METHOD(prefetchImageWithMetadata) void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImageWithMetadata) static void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImageWithMetadata) void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(prefetchImageWithMetadata) static void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeIntentAndroidSpec.g.h
+++ b/vnext/codegen/NativeIntentAndroidSpec.g.h
@@ -15,11 +15,11 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct IntentAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Promise<React::JSValue>) noexcept>{0, L"getInitialURL"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"canOpenURL"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"openURL"},
-      Method<void(Promise<React::JSValue>) noexcept>{3, L"openSettings"},
-      Method<void(std::string, std::optional<React::JSValueArray>, Promise<React::JSValue>) noexcept>{4, L"sendIntent"},
+      Method<void(Promise<::React::JSValue>) noexcept>{0, L"getInitialURL"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{1, L"canOpenURL"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{2, L"openURL"},
+      Method<void(Promise<::React::JSValue>) noexcept>{3, L"openSettings"},
+      Method<void(std::string, std::optional<::React::JSValueArray>, Promise<::React::JSValue>) noexcept>{4, L"sendIntent"},
   };
 
   template <class TModule>
@@ -29,28 +29,28 @@ struct IntentAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getInitialURL",
-          "    REACT_METHOD(getInitialURL) void getInitialURL(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialURL) static void getInitialURL(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "canOpenURL",
-          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openURL",
-          "    REACT_METHOD(openURL) void openURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openURL) static void openURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSettings",
-          "    REACT_METHOD(openSettings) void openSettings(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSettings) static void openSettings(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "sendIntent",
-          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, std::optional<React::JSValueArray> extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, std::optional<React::JSValueArray> extras, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeLinkingManagerSpec.g.h
+++ b/vnext/codegen/NativeLinkingManagerSpec.g.h
@@ -15,10 +15,10 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct LinkingManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(Promise<React::JSValue>) noexcept>{0, L"getInitialURL"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"canOpenURL"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"openURL"},
-      Method<void(Promise<React::JSValue>) noexcept>{3, L"openSettings"},
+      Method<void(Promise<::React::JSValue>) noexcept>{0, L"getInitialURL"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{1, L"canOpenURL"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{2, L"openURL"},
+      Method<void(Promise<::React::JSValue>) noexcept>{3, L"openSettings"},
       Method<void(std::string) noexcept>{4, L"addListener"},
       Method<void(double) noexcept>{5, L"removeListeners"},
   };
@@ -30,23 +30,23 @@ struct LinkingManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getInitialURL",
-          "    REACT_METHOD(getInitialURL) void getInitialURL(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialURL) static void getInitialURL(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "canOpenURL",
-          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openURL",
-          "    REACT_METHOD(openURL) void openURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openURL) static void openURL(std::string url, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSettings",
-          "    REACT_METHOD(openSettings) void openSettings(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSettings) static void openSettings(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "addListener",

--- a/vnext/codegen/NativeNetworkingAndroidSpec.g.h
+++ b/vnext/codegen/NativeNetworkingAndroidSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct NetworkingAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, std::string, double, React::JSValueArray, React::JSValue, std::string, bool, double, bool) noexcept>{0, L"sendRequest"},
+      Method<void(std::string, std::string, double, ::React::JSValueArray, ::React::JSValue, std::string, bool, double, bool) noexcept>{0, L"sendRequest"},
       Method<void(double) noexcept>{1, L"abortRequest"},
       Method<void(Callback<bool>) noexcept>{2, L"clearCookies"},
       Method<void(std::string) noexcept>{3, L"addListener"},
@@ -29,8 +29,8 @@ struct NetworkingAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "sendRequest",
-          "    REACT_METHOD(sendRequest) void sendRequest(std::string method, std::string url, double requestId, React::JSValueArray && headers, React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendRequest) static void sendRequest(std::string method, std::string url, double requestId, React::JSValueArray && headers, React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendRequest) void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(sendRequest) static void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "abortRequest",

--- a/vnext/codegen/NativeNetworkingIOSSpec.g.h
+++ b/vnext/codegen/NativeNetworkingIOSSpec.g.h
@@ -20,9 +20,9 @@ struct NetworkingIOSSpec_sendRequest_query {
     REACT_FIELD(url)
     std::string url;
     REACT_FIELD(data)
-    React::JSValue data;
+    ::React::JSValue data;
     REACT_FIELD(headers)
-    React::JSValue headers;
+    ::React::JSValue headers;
     REACT_FIELD(responseType)
     std::string responseType;
     REACT_FIELD(incrementalUpdates)

--- a/vnext/codegen/NativePermissionsAndroidSpec.g.h
+++ b/vnext/codegen/NativePermissionsAndroidSpec.g.h
@@ -15,10 +15,10 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct PermissionsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{0, L"checkPermission"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{1, L"requestPermission"},
-      Method<void(std::string, Promise<React::JSValue>) noexcept>{2, L"shouldShowRequestPermissionRationale"},
-      Method<void(std::vector<std::string>, Promise<React::JSValue>) noexcept>{3, L"requestMultiplePermissions"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{0, L"checkPermission"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{1, L"requestPermission"},
+      Method<void(std::string, Promise<::React::JSValue>) noexcept>{2, L"shouldShowRequestPermissionRationale"},
+      Method<void(std::vector<std::string>, Promise<::React::JSValue>) noexcept>{3, L"requestMultiplePermissions"},
   };
 
   template <class TModule>
@@ -28,23 +28,23 @@ struct PermissionsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "checkPermission",
-          "    REACT_METHOD(checkPermission) void checkPermission(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(checkPermission) static void checkPermission(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(checkPermission) void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(checkPermission) static void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "requestPermission",
-          "    REACT_METHOD(requestPermission) void requestPermission(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestPermission) static void requestPermission(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestPermission) void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(requestPermission) static void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "shouldShowRequestPermissionRationale",
-          "    REACT_METHOD(shouldShowRequestPermissionRationale) void shouldShowRequestPermissionRationale(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(shouldShowRequestPermissionRationale) static void shouldShowRequestPermissionRationale(std::string permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(shouldShowRequestPermissionRationale) void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(shouldShowRequestPermissionRationale) static void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestMultiplePermissions",
-          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(std::vector<std::string> const & permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(std::vector<std::string> const & permissions, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -34,7 +34,7 @@ struct PushNotificationManagerIOSSpec_Notification {
     REACT_FIELD(alertAction)
     std::optional<std::string> alertAction;
     REACT_FIELD(userInfo)
-    std::optional<React::JSValue> userInfo;
+    std::optional<::React::JSValue> userInfo;
     REACT_FIELD(category)
     std::optional<std::string> category;
     REACT_FIELD(repeatInterval)
@@ -60,14 +60,14 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
       Method<void(std::string, std::string) noexcept>{0, L"onFinishRemoteNotification"},
       Method<void(double) noexcept>{1, L"setApplicationIconBadgeNumber"},
       Method<void(Callback<double>) noexcept>{2, L"getApplicationIconBadgeNumber"},
-      Method<void(PushNotificationManagerIOSSpec_requestPermissions_permission, Promise<React::JSValue>) noexcept>{3, L"requestPermissions"},
+      Method<void(PushNotificationManagerIOSSpec_requestPermissions_permission, Promise<::React::JSValue>) noexcept>{3, L"requestPermissions"},
       Method<void() noexcept>{4, L"abandonPermissions"},
       Method<void(Callback<PushNotificationManagerIOSSpec_Permissions>) noexcept>{5, L"checkPermissions"},
       Method<void(PushNotificationManagerIOSSpec_Notification) noexcept>{6, L"presentLocalNotification"},
       Method<void(PushNotificationManagerIOSSpec_Notification) noexcept>{7, L"scheduleLocalNotification"},
       Method<void() noexcept>{8, L"cancelAllLocalNotifications"},
-      Method<void(React::JSValue) noexcept>{9, L"cancelLocalNotifications"},
-      Method<void(Promise<React::JSValue>) noexcept>{10, L"getInitialNotification"},
+      Method<void(::React::JSValue) noexcept>{9, L"cancelLocalNotifications"},
+      Method<void(Promise<::React::JSValue>) noexcept>{10, L"getInitialNotification"},
       Method<void(Callback<PushNotificationManagerIOSSpec_Notification>) noexcept>{11, L"getScheduledLocalNotifications"},
       Method<void() noexcept>{12, L"removeAllDeliveredNotifications"},
       Method<void(std::vector<std::string>) noexcept>{13, L"removeDeliveredNotifications"},
@@ -99,8 +99,8 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestPermissions",
-          "    REACT_METHOD(requestPermissions) void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestPermissions) static void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestPermissions) void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(requestPermissions) static void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "abandonPermissions",
@@ -129,13 +129,13 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "cancelLocalNotifications",
-          "    REACT_METHOD(cancelLocalNotifications) void cancelLocalNotifications(React::JSValue && userInfo) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cancelLocalNotifications) static void cancelLocalNotifications(React::JSValue && userInfo) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cancelLocalNotifications) void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(cancelLocalNotifications) static void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "getInitialNotification",
-          "    REACT_METHOD(getInitialNotification) void getInitialNotification(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialNotification) static void getInitialNotification(React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialNotification) void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getInitialNotification) static void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "getScheduledLocalNotifications",

--- a/vnext/codegen/NativeRedBoxSpec.g.h
+++ b/vnext/codegen/NativeRedBoxSpec.g.h
@@ -15,7 +15,7 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct RedBoxSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValue, std::string) noexcept>{0, L"setExtraData"},
+      Method<void(::React::JSValue, std::string) noexcept>{0, L"setExtraData"},
       Method<void() noexcept>{1, L"dismiss"},
   };
 
@@ -26,8 +26,8 @@ struct RedBoxSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setExtraData",
-          "    REACT_METHOD(setExtraData) void setExtraData(React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setExtraData) static void setExtraData(React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "dismiss",

--- a/vnext/codegen/NativeSampleTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeSampleTurboModuleSpec.g.h
@@ -32,13 +32,13 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       SyncMethod<bool(bool) noexcept>{1, L"getBool"},
       SyncMethod<double(double) noexcept>{2, L"getNumber"},
       SyncMethod<std::string(std::string) noexcept>{3, L"getString"},
-      SyncMethod<React::JSValueArray(React::JSValueArray) noexcept>{4, L"getArray"},
-      SyncMethod<React::JSValue(React::JSValue) noexcept>{5, L"getObject"},
-      SyncMethod<React::JSValue(React::JSValue) noexcept>{6, L"getUnsafeObject"},
+      SyncMethod<::React::JSValueArray(::React::JSValueArray) noexcept>{4, L"getArray"},
+      SyncMethod<::React::JSValue(::React::JSValue) noexcept>{5, L"getObject"},
+      SyncMethod<::React::JSValue(::React::JSValue) noexcept>{6, L"getUnsafeObject"},
       SyncMethod<double(double) noexcept>{7, L"getRootTag"},
-      SyncMethod<React::JSValue(double, std::string, React::JSValue) noexcept>{8, L"getValue"},
+      SyncMethod<::React::JSValue(double, std::string, ::React::JSValue) noexcept>{8, L"getValue"},
       Method<void(Callback<std::string>) noexcept>{9, L"getValueWithCallback"},
-      Method<void(bool, Promise<React::JSValue>) noexcept>{10, L"getValueWithPromise"},
+      Method<void(bool, Promise<::React::JSValue>) noexcept>{10, L"getValueWithPromise"},
   };
 
   template <class TModule>
@@ -75,18 +75,18 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getArray",
-          "    REACT_SYNC_METHOD(getArray) React::JSValueArray getArray(React::JSValueArray && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getArray) static React::JSValueArray getArray(React::JSValueArray && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getArray) ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getArray) static ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getObject",
-          "    REACT_SYNC_METHOD(getObject) React::JSValue getObject(React::JSValue && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getObject) static React::JSValue getObject(React::JSValue && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getObject) ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getObject) static ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "getUnsafeObject",
-          "    REACT_SYNC_METHOD(getUnsafeObject) React::JSValue getUnsafeObject(React::JSValue && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getUnsafeObject) static React::JSValue getUnsafeObject(React::JSValue && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getUnsafeObject) ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getUnsafeObject) static ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "getRootTag",
@@ -95,8 +95,8 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "getValue",
-          "    REACT_SYNC_METHOD(getValue) React::JSValue getValue(double x, std::string y, React::JSValue && z) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getValue) static React::JSValue getValue(double x, std::string y, React::JSValue && z) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getValue) ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getValue) static ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "getValueWithCallback",
@@ -105,8 +105,8 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "getValueWithPromise",
-          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeSegmentFetcherSpec.g.h
+++ b/vnext/codegen/NativeSegmentFetcherSpec.g.h
@@ -15,8 +15,8 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct SegmentFetcherSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(double, React::JSValue, Callback<std::optional<React::JSValue>>) noexcept>{0, L"fetchSegment"},
-      Method<void(double, React::JSValue, Callback<std::optional<React::JSValue>, std::optional<std::string>>) noexcept>{1, L"getSegment"},
+      Method<void(double, ::React::JSValue, Callback<std::optional<::React::JSValue>>) noexcept>{0, L"fetchSegment"},
+      Method<void(double, ::React::JSValue, Callback<std::optional<::React::JSValue>, std::optional<std::string>>) noexcept>{1, L"getSegment"},
   };
 
   template <class TModule>
@@ -26,13 +26,13 @@ struct SegmentFetcherSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "fetchSegment",
-          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSegment",
-          "    REACT_METHOD(getSegment) void getSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, React::JSValue && options, std::function<void(std::optional<React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSegment) void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeSettingsManagerSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 REACT_STRUCT(SettingsManagerSpec_Constants)
 struct SettingsManagerSpec_Constants {
     REACT_FIELD(settings)
-    React::JSValue settings;
+    ::React::JSValue settings;
 };
 
 struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
@@ -24,7 +24,7 @@ struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
       TypedConstant<SettingsManagerSpec_Constants>{0},
   };
   static constexpr auto methods = std::tuple{
-      Method<void(React::JSValue) noexcept>{0, L"setValues"},
+      Method<void(::React::JSValue) noexcept>{0, L"setValues"},
       Method<void(std::vector<std::string>) noexcept>{1, L"deleteValues"},
   };
 
@@ -42,8 +42,8 @@ struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setValues",
-          "    REACT_METHOD(setValues) void setValues(React::JSValue && values) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setValues) static void setValues(React::JSValue && values) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setValues) void setValues(::React::JSValue && values) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(setValues) static void setValues(::React::JSValue && values) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "deleteValues",

--- a/vnext/codegen/NativeShareModuleSpec.g.h
+++ b/vnext/codegen/NativeShareModuleSpec.g.h
@@ -23,7 +23,7 @@ struct ShareModuleSpec_share_content {
 
 struct ShareModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      Method<void(ShareModuleSpec_share_content, std::string, Promise<React::JSValue>) noexcept>{0, L"share"},
+      Method<void(ShareModuleSpec_share_content, std::string, Promise<::React::JSValue>) noexcept>{0, L"share"},
   };
 
   template <class TModule>
@@ -33,8 +33,8 @@ struct ShareModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "share",
-          "    REACT_METHOD(share) void share(ShareModuleSpec_share_content && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(share) static void share(ShareModuleSpec_share_content && content, std::string dialogTitle, React::ReactPromise<React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(share) void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(share) static void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
   }
 };
 

--- a/vnext/codegen/NativeUIManagerSpec.g.h
+++ b/vnext/codegen/NativeUIManagerSpec.g.h
@@ -15,30 +15,30 @@ namespace Microsoft::ReactNativeSpecs {
 
 struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
   static constexpr auto methods = std::tuple{
-      SyncMethod<React::JSValue(std::string) noexcept>{0, L"getConstantsForViewManager"},
+      SyncMethod<::React::JSValue(std::string) noexcept>{0, L"getConstantsForViewManager"},
       SyncMethod<std::vector<std::string>() noexcept>{1, L"getDefaultEventTypes"},
-      SyncMethod<React::JSValue(std::string) noexcept>{2, L"lazilyLoadView"},
-      Method<void(std::optional<double>, std::string, double, React::JSValue) noexcept>{3, L"createView"},
-      Method<void(double, std::string, React::JSValue) noexcept>{4, L"updateView"},
+      SyncMethod<::React::JSValue(std::string) noexcept>{2, L"lazilyLoadView"},
+      Method<void(std::optional<double>, std::string, double, ::React::JSValue) noexcept>{3, L"createView"},
+      Method<void(double, std::string, ::React::JSValue) noexcept>{4, L"updateView"},
       Method<void(std::optional<double>) noexcept>{5, L"focus"},
       Method<void(std::optional<double>) noexcept>{6, L"blur"},
       Method<void(std::optional<double>, std::vector<double>, Callback<double, double, double, double, double>) noexcept>{7, L"findSubviewIn"},
-      Method<void(std::optional<double>, double, std::optional<React::JSValueArray>) noexcept>{8, L"dispatchViewManagerCommand"},
+      Method<void(std::optional<double>, double, std::optional<::React::JSValueArray>) noexcept>{8, L"dispatchViewManagerCommand"},
       Method<void(std::optional<double>, Callback<double, double, double, double, double, double>) noexcept>{9, L"measure"},
       Method<void(std::optional<double>, Callback<double, double, double, double>) noexcept>{10, L"measureInWindow"},
       Method<void(std::optional<double>, std::optional<double>, Callback<std::vector<bool>>) noexcept>{11, L"viewIsDescendantOf"},
-      Method<void(std::optional<double>, std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{12, L"measureLayout"},
-      Method<void(std::optional<double>, Callback<React::JSValue>, Callback<double, double, double, double>) noexcept>{13, L"measureLayoutRelativeToParent"},
+      Method<void(std::optional<double>, std::optional<double>, Callback<::React::JSValue>, Callback<double, double, double, double>) noexcept>{12, L"measureLayout"},
+      Method<void(std::optional<double>, Callback<::React::JSValue>, Callback<double, double, double, double>) noexcept>{13, L"measureLayoutRelativeToParent"},
       Method<void(std::optional<double>, bool) noexcept>{14, L"setJSResponder"},
       Method<void() noexcept>{15, L"clearJSResponder"},
-      Method<void(React::JSValue, Callback<>, Callback<React::JSValue>) noexcept>{16, L"configureNextLayoutAnimation"},
+      Method<void(::React::JSValue, Callback<>, Callback<::React::JSValue>) noexcept>{16, L"configureNextLayoutAnimation"},
       Method<void(double) noexcept>{17, L"removeSubviewsFromContainerWithID"},
       Method<void(std::optional<double>, std::optional<double>) noexcept>{18, L"replaceExistingNonRootView"},
       Method<void(std::optional<double>, std::vector<double>) noexcept>{19, L"setChildren"},
       Method<void(std::optional<double>, std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>, std::vector<double>) noexcept>{20, L"manageChildren"},
       Method<void(bool) noexcept>{21, L"setLayoutAnimationEnabledExperimental"},
       Method<void(std::optional<double>, double) noexcept>{22, L"sendAccessibilityEvent"},
-      Method<void(std::optional<double>, std::vector<std::string>, Callback<React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
+      Method<void(std::optional<double>, std::vector<std::string>, Callback<::React::JSValue>, Callback<std::string, double>) noexcept>{23, L"showPopupMenu"},
       Method<void() noexcept>{24, L"dismissPopupMenu"},
   };
 
@@ -49,8 +49,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getConstantsForViewManager",
-          "    REACT_SYNC_METHOD(getConstantsForViewManager) React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getConstantsForViewManager) static React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getConstantsForViewManager) ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(getConstantsForViewManager) static ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getDefaultEventTypes",
@@ -59,18 +59,18 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "lazilyLoadView",
-          "    REACT_SYNC_METHOD(lazilyLoadView) React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(lazilyLoadView) static React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(lazilyLoadView) ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n"
+          "    REACT_SYNC_METHOD(lazilyLoadView) static ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "createView",
-          "    REACT_METHOD(createView) void createView(std::optional<double> reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createView) static void createView(std::optional<double> reactTag, std::string viewName, double rootTag, React::JSValue && props) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createView) void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(createView) static void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "updateView",
-          "    REACT_METHOD(updateView) void updateView(double reactTag, std::string viewName, React::JSValue && props) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateView) static void updateView(double reactTag, std::string viewName, React::JSValue && props) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateView) void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(updateView) static void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "focus",
@@ -89,8 +89,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "dispatchViewManagerCommand",
-          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "measure",
@@ -109,13 +109,13 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "measureLayout",
-          "    REACT_METHOD(measureLayout) void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayout) static void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayout) void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measureLayout) static void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "measureLayoutRelativeToParent",
-          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "setJSResponder",
@@ -129,8 +129,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           16,
           "configureNextLayoutAnimation",
-          "    REACT_METHOD(configureNextLayoutAnimation) void configureNextLayoutAnimation(React::JSValue && config, std::function<void()> const & callback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(configureNextLayoutAnimation) static void configureNextLayoutAnimation(React::JSValue && config, std::function<void()> const & callback, std::function<void(React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(configureNextLayoutAnimation) void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(configureNextLayoutAnimation) static void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           17,
           "removeSubviewsFromContainerWithID",
@@ -164,8 +164,8 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "showPopupMenu",
-          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
+          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           24,
           "dismissPopupMenu",

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -16,7 +16,7 @@ namespace Microsoft::ReactNativeSpecs {
 REACT_STRUCT(WebSocketModuleSpec_connect_options)
 struct WebSocketModuleSpec_connect_options {
     REACT_FIELD(headers)
-    std::optional<React::JSValue> headers;
+    std::optional<::React::JSValue> headers;
 };
 
 struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {


### PR DESCRIPTION
## Description

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
It is required from other projects where callings to `MakeTurboModule` is automatically generated, so there is no chance to ask people to use `MakeTurboModuleProvider` there.

### What
- `MakeModuleProvider<TModule>` will check the module against its spec if `TModule::ModuleSpec` exists.
- `MakeTurboModuleProvider` requires `TModule::ModuleSpec` exists, instead of specifying the spec type in its template arguments.
- Codegen prints `::React::JSValue` instead of `React::JSValue`
  - Spec types are generated in `namespace Microsoft::ReactNativeSpecs`. But there is also `namespace Microsoft::React` in some other header files. Using `React::JSValue` break builds when `namespace Microsoft::React` is visible to a spec file.

## Testing
Affected test cases are updated.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9049)