### PR TITLE
Permit failure to publish intermediate build artifact

### DIFF
--- a/.ado/templates/publish-build-artifacts.yml
+++ b/.ado/templates/publish-build-artifacts.yml
@@ -20,6 +20,8 @@ steps:
 
   - task: PublishPipelineArtifact@1
     displayName: "Publish Artifact: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
+    # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt
+    continueOnError: true
     inputs:
       artifactName: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}
       targetPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}


### PR DESCRIPTION




## Description

### Why
Azure pipelines allows re-running an already completed job. The pipeline artifacts between attempts are shared. Subsequent build artifacts may collide with each other, causing failure to upload pipeline artifacts.

Attempts run against the same set of source code. Our binaries are not yet fully deterministic from source, but should be similar enough to allow a "pick any" scheme of binaries from different attempts.

### What
This change skips publishing binary artifacts if they were already published by a past attempt. It is not conveniently possible to test for the existence of an artifact, so we instead just allow the intermediate artifact publish to fail, and emit a warning instead of stopping the build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9052)