### PR TITLE
Allow arbitrary views to register onMouseEnter/Leave

### DIFF
--- a/change/react-native-windows-a114d733-624e-4270-b49c-6d6f005bc5e8.json
+++ b/change/react-native-windows-a114d733-624e-4270-b49c-6d6f005bc5e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow arbitrary views to register onMouseEnter/Leave",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseExample.windows.js
@@ -82,6 +82,12 @@ const styles = StyleSheet.create({
   overlayChildHovered: {
     backgroundColor: '#666D80',
   },
+  textHovered: {
+    fontWeight: 'bold',
+  },
+  virtualTextHovered: {
+    fontStyle: 'italic',
+  },
 });
 
 export default class ExampleComponent extends React.Component<
@@ -104,6 +110,8 @@ export default class ExampleComponent extends React.Component<
       contentChildHover: false,
       overlayHover: false,
       overlayChildHover: false,
+      textHover: false,
+      virtualTextHover: false,
     };
   }
 
@@ -150,9 +158,24 @@ export default class ExampleComponent extends React.Component<
       onPressIn: this.pressIn,
       onPressOut: this.pressOut,
     };
+    const textProps: any = {
+      style: this.state.textHover ? styles.textHovered : undefined,
+      onMouseEnter: this.mouseEnterText,
+      onMouseLeave: this.mouseLeaveText,
+    };
+    const virtualTextProps: any = {
+      style: this.state.virtualTextHover
+        ? styles.virtualTextHovered
+        : undefined,
+      onMouseEnter: this.mouseEnterVirtualText,
+      onMouseLeave: this.mouseLeaveVirtualText,
+    };
 
     return (
       <View {...containerProps}>
+        <Text {...textProps}>
+          Hoverable <Text {...virtualTextProps}>text</Text>
+        </Text>
         <TouchableHighlight {...childProps}>
           <Text>This is a TouchableHighlight</Text>
         </TouchableHighlight>
@@ -219,6 +242,18 @@ export default class ExampleComponent extends React.Component<
   };
   mouseLeaveOverlayChild = () => {
     this.setState({overlayChildHover: false});
+  };
+  mouseEnterText = () => {
+    this.setState({textHover: true});
+  };
+  mouseLeaveText = () => {
+    this.setState({textHover: false});
+  };
+  mouseEnterVirtualText = () => {
+    this.setState({virtualTextHover: true});
+  };
+  mouseLeaveVirtualText = () => {
+    this.setState({virtualTextHover: false});
   };
 
   click = () => {

--- a/vnext/.flowconfig
+++ b/vnext/.flowconfig
@@ -19,6 +19,7 @@
 <PROJECT_ROOT>/Libraries/Components/Touchable/TouchableHighlight.js
 <PROJECT_ROOT>/Libraries/Components/Touchable/TouchableOpacity.js
 <PROJECT_ROOT>/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+<PROJECT_ROOT>/Libraries/Components/View/ReactNativeViewAttributes.js
 <PROJECT_ROOT>/Libraries/Components/View/ReactNativeViewViewConfig.js
 <PROJECT_ROOT>/Libraries/Components/View/ViewAccessibility.js
 <PROJECT_ROOT>/Libraries/Components/View/ViewPropTypes.js

--- a/vnext/Microsoft.ReactNative/Views/Text/TextHitTestVisitor.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextHitTestVisitor.cpp
@@ -37,7 +37,7 @@ void TextHitTestVisitor::VisitVirtualText(ShadowNodeBase *node) {
 
   // Update pressable count and set pressable ancestor flag
   const auto hadPressableAncestor = m_hasPressableAncestor;
-  if (textNode->isPressable) {
+  if (textNode->isPressable || textNode->IsRegisteredForMouseEvents()) {
     m_pressableCount++;
     m_hasPressableAncestor = true;
   }

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -16,6 +16,7 @@
 #include <Modules/PaperUIManagerModule.h>
 #include <ReactPropertyBag.h>
 #include <TestHook.h>
+#include <Utils/PropertyUtils.h>
 #include <Views/ExpressionAnimationStore.h>
 #include <Views/ShadowNodeBase.h>
 
@@ -97,6 +98,8 @@ void ViewManagerBase::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVal
   React::WriteProperty(writer, L"onLayout", L"function");
   React::WriteProperty(writer, L"keyDownEvents", L"array");
   React::WriteProperty(writer, L"keyUpEvents", L"array");
+  React::WriteProperty(writer, L"onMouseEnter", L"function");
+  React::WriteProperty(writer, L"onMouseLeave", L"function");
 }
 
 void ViewManagerBase::GetConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
@@ -282,6 +285,7 @@ bool ViewManagerBase::UpdateProperty(
         uiElement.ClearValue(xaml::UIElement::IsHitTestVisibleProperty());
       }
     }
+  } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
   } else {
     return false;
   }

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -378,8 +378,6 @@ void ViewViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVal
 
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"pointerEvents", L"string");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"onClick", L"function");
-  winrt::Microsoft::ReactNative::WriteProperty(writer, L"onMouseEnter", L"function");
-  winrt::Microsoft::ReactNative::WriteProperty(writer, L"onMouseLeave", L"function");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"focusable", L"boolean");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"enableFocusRing", L"boolean");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"tabIndex", L"number");

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -96,6 +96,13 @@ bool VirtualTextViewManager::UpdateProperty(
       NotifyAncestorsTextPropertyChanged(node, PropertyChangeType::AddPressable);
     }
   } else {
+    const auto isRegisteringMouseEvent =
+        (propertyName == "onMouseEnter" || propertyName == "onMouseLeave") && propertyValue.AsBoolean();
+    if (isRegisteringMouseEvent) {
+      auto node = static_cast<VirtualTextShadowNode *>(nodeToUpdate);
+      NotifyAncestorsTextPropertyChanged(node, PropertyChangeType::AddPressable);
+    }
+
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }
 

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -19,6 +19,13 @@
     },
     {
       "type": "patch",
+      "file": "src/Libraries/Components/View/ReactNativeViewAttributes.windows.js",
+      "baseFile": "Libraries/Components/View/ReactNativeViewAttributes.js",
+      "baseHash": "9479c8ccfeeadc90721ae2d3327eeaa76818bfaf",
+      "issue": 9053
+    },
+    {
+      "type": "patch",
       "file": "Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp",
       "baseFile": "ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/Color.cpp",
       "baseHash": "82efd0f5b8a1b8500c1f6f75fff5e2e16050d176",

--- a/vnext/src/Libraries/Components/View/ReactNativeViewAttributes.windows.js
+++ b/vnext/src/Libraries/Components/View/ReactNativeViewAttributes.windows.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+import ReactNativeStyleAttributes from './ReactNativeStyleAttributes';
+
+const UIView = {
+  pointerEvents: true,
+  accessible: true,
+  accessibilityActions: true,
+  accessibilityLabel: true,
+  accessibilityLiveRegion: true,
+  accessibilityRole: true,
+  accessibilityState: true,
+  accessibilityValue: true,
+  accessibilityHint: true,
+  importantForAccessibility: true,
+  nativeID: true,
+  testID: true,
+  renderToHardwareTextureAndroid: true,
+  shouldRasterizeIOS: true,
+  onLayout: true,
+  onAccessibilityAction: true,
+  onAccessibilityTap: true,
+  onMagicTap: true,
+  onAccessibilityEscape: true,
+  collapsable: true,
+  needsOffscreenAlphaCompositing: true,
+  style: ReactNativeStyleAttributes,
+  // [Windows
+  onMouseEnter: true,
+  onMouseLeave: true,
+  // Windows]
+};
+
+const RCTView = {
+  ...UIView,
+
+  // This is a special performance property exposed by RCTView and useful for
+  // scrolling content when there are many subviews, most of which are offscreen.
+  // For this property to be effective, it must be applied to a view that contains
+  // many subviews that extend outside its bound. The subviews must also have
+  // overflow: hidden, as should the containing view (or one of its superviews).
+  removeClippedSubviews: true,
+};
+
+const ReactNativeViewAttributes = {
+  UIView: UIView,
+  RCTView: RCTView,
+};
+
+module.exports = ReactNativeViewAttributes;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why

Any view can subscribe to `onTouchStart` / `onTouchEnd` / etc., as well as `pointerEvents`, but not every view can register for `onMouseEnter` / `onMouseLeave`, which feels inconsistent.

Additionally, the `onMouseEnter` / `onMouseLeave` approach on react-native-macos allows arbitrary views to register for these events, so this makes things more consistent across RN Desktop platforms.

Resolves #9054

### What
This change allows arbitrary views (all core views, even virtual text nodes, and third-party view managers) to register to receive `onMouseEnter` and `onMouseLeave` events. This is particularly useful for text and third-party view managers and more consistent with the `onMouseEnter` / `onMouseLeave` implementation on react-native-macos.

## Screenshots

https://user-images.githubusercontent.com/1106239/140236002-2509f08e-ab1f-4c1b-b96c-efae5f15cb7c.mp4

> Note: cursor position is off in the window recording only.

## Testing
Added both a Text and virtual Text hoverable component to the MouseExample in RNTester.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9055)