### PR TITLE
Leverage new --verbose flag of beachball in CI/CD

### DIFF
--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -30,7 +30,7 @@ jobs:
       - task: CmdLine@2
         displayName: Check for change files
         inputs:
-          script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "Run `yarn change` from root of repo to generate a change file."
+          script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "Run `yarn change` from root of repo to generate a change file."
 
       - task: CmdLine@2
         displayName: yarn build

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -24,10 +24,10 @@ jobs:
         displayName: Install beachball
     
       - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
-        - script: npx beachball check --branch origin/$(BeachBallBranchName) --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+        - script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
           displayName: Check for change files
 
-      - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
+      - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes --verbose
         displayName: beachball bump
 
       - template: ../templates/set-version-vars.yml

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -71,11 +71,11 @@ jobs:
         displayName: Enable No-Publish
         condition: ${{ parameters.skipGitPush }}
 
-      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***" --no-git-tags
+      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***" --no-git-tags
         displayName: Beachball Publish (Main Branch)
         condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
 
-      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --access public --message "applying package updates ***NO_CI***"
+      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
 
@@ -105,7 +105,7 @@ jobs:
       - template: templates/prepare-js-env.yml
 
       # Bump in case the bot coordinator is dependent on other monorepo packages that were just published
-      - script: npx beachball bump
+      - script: npx beachball bump --verbose
         displayName: beachball bump
 
       # Azure Functions expects a fully packagable folder with dependencies.

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -52,11 +52,11 @@ steps:
 
   - template: compute-beachball-branch-name.yml
 
-  - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --access public --changehint "Run `yarn change` from root of repo to generate a change file."
+  - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --verbose --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
     # Beachball reverts to local state after publish, but we need to know the new version it pushed.
-  - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes
+  - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes --verbose
     displayName: beachball bump
 
   - template: set-version-vars.yml


### PR DESCRIPTION
## Description
Beachball added a new `--verbose` option that improves diagnostics. 
Leverage the flag in rnw's PR/CI/CD scripts


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9060)