### PR TITLE
Use beachball bump hook for version stamping

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -16,21 +16,11 @@ module.exports = {
 
   hooks: {
     // Stamp versions when we publish a new package
-    prepublish: (_packagePath, name, version) => {
+    postbump: (_packagePath, name, version) => {
       if (name === 'react-native-windows') {
         console.log(`Stamping RNW Version ${version}`);
-
-        // prepublish is run before bumping or commiting. Append an additional
-        // commit to check-in stamped versions when we push.
-        
-        execSilent(`yarn stamp-version ${version}`);
-        execSilent('git add --all');
-        execSilent(`git commit --message "Stamp RNW ${version}"`);
+        execSync(`yarn stamp-version ${version}`);
       }
     }
   }
-}
-
-function execSilent(command) {
-  execSync(command, {stdio: 'pipe'});
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "devDependencies": {
-    "beachball": "^2.16.0",
+    "beachball": "^2.20.0",
     "husky": "^4.2.5",
     "unbroken": "1.0.27",
     "lage": "^0.29.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,10 +3186,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^2.16.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.19.0.tgz#00a8305c5ce2a29c81f1ed6fa6024546a87b9334"
-  integrity sha512-o4BfIbsrkUK0tKONjqf+YtGEYBf3m4UDcK08vMHb+1BH3L6uTd6Uq/DhKAuhaUndlwfE4m4TqKYZl/o29ybIBA==
+beachball@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-2.20.0.tgz#7fe55e7d86c9c890de15474c84f6a32653bdb6ca"
+  integrity sha512-vVdF6qDDurO66GZigUtqKuXzQM8ImlG7MgN5iTj9rvZ4RM6vy+nklu0EmqaQtqS5K6hZ4WrHDwgcR/kLa0VHpA==
   dependencies:
     cosmiconfig "^6.0.0"
     execa "^4.0.3"


### PR DESCRIPTION
MSBuild version stamping is triggered by hooking into beachball. Right now we hook into prepublish, then modify Git history. This change uses a newly introduced hook to instead stamp versions during the bump phase.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9062)