### PR TITLE
Fix Warnings from RoslynCodeTaskFactory in C++ Projects Building ARM64

### DIFF
--- a/change/react-native-windows-3b12d628-e43a-4181-8e8e-a9ab87d07b25.json
+++ b/change/react-native-windows-3b12d628-e43a-4181-8e8e-a9ab87d07b25.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "FIx Warnings from RoslynCodeTaskFactory in C++ Projects Building ARM64",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -807,6 +807,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\FastBuild.targets" />
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\FixupRoslynCscWarnings.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(SolutionDir)packages\boost.1.76.0.0\build\boost.targets" Condition="Exists('$(SolutionDir)\packages\boost.1.76.0.0\build\boost.targets')" />
     <Import Project="$(SolutionDir)packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -42,8 +42,9 @@
   </Target>
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\CppAppConsumeCSharpModule.targets" />
-
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\FixupRoslynCscWarnings.targets" />
+
   <ItemDefinitionGroup>
     <Reference>
         <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>

--- a/vnext/PropertySheets/FixupRoslynCscWarnings.targets
+++ b/vnext/PropertySheets/FixupRoslynCscWarnings.targets
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <!--
+    ARM64 C++ projects will by default add $(DotNetSdk_LibraryPath_arm64) and
+    $(VC_LibraryPath_ATL_ARM64) to the LIB environment variable, even if the
+    paths do not exist. This causes compiler warnings from the csc instance
+    spawned by RoslynCodeTaskFactory in our inline tasks.
+
+    This target alters the build environment to prevent the warning from the
+    RoslynCodeTaskFactory assembly spawned csc process.
+  -->
+  <Target 
+    Name="ReactNativeWindowsFixupRoslynCscWarnings"
+    AfterTargets="SetBuildDefaultEnvironmentVariables"
+    BeforeTargets="PrepareForBuild">
+
+    <PropertyGroup>
+      <_FixedUpLib>$(LIB)</_FixedUpLib>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(DotNetSdk_LibraryPath_arm64)' != '' and $(LIB.Contains('$(DotNetSdk_LibraryPath_arm64)')) and !Exists('$(DotNetSdk_LibraryPath_arm64)')">
+      <_FixedUpLib>$(_FixedUpLib.Replace('$(DotNetSdk_LibraryPath_arm64)', ''))</_FixedUpLib>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(VC_LibraryPath_ATL_ARM64)' != '' and $(LIB.Contains('$(VC_LibraryPath_ATL_ARM64)')) and !Exists('$(VC_LibraryPath_ATL_ARM64)')">
+      <_FixedUpLib>$(_FixedUpLib.Replace('$(VC_LibraryPath_ATL_ARM64)', ''))</_FixedUpLib>
+    </PropertyGroup>
+
+    <SetEnv
+      Condition="'$(LIB)' != '$(_FixedUpLib)'"
+      Name="LIB"
+      Value="$(_FixedUpLib)"
+      Prefix="False" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION





## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We use RoslynCodeTaskFactory to compile inline C# in our MSBuild scripts and execute it with .Net Core. When running under ARM64, `DotNetSdk_LibraryPath_arm64 = C:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\lib\um\arm64` is added to the `csc` library path, but is unused, and not actually present by default. This generates compiler warnings, failing the build with MsBuildWarnAsErrorArgument, despite creating a succesful assembly. This also affects our ARM64 NuGet packages, which run inline C# as part of their targets. We were not testing these in CI though.

Fixes #9063

### What
This change alters the environment to supress the warning, allowing our CI tasks with `/warnaserror` to pass.


## Testing
Validated locally that the warning is no longer present when building the Microsoft.ReactNative project on ARM64.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9064)