### PR TITLE
Fix Beachball Errors in Init Tests

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -79,10 +79,6 @@ jobs:
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
 
-      # Beachball reverts to local state after publish, but we want the updates it added
-      - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
-        displayName: git pull
-
       - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -55,10 +55,6 @@ steps:
   - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --verbose --access public --changehint "Run `yarn change` from root of repo to generate a change file."
     displayName: Publish packages to verdaccio
 
-    # Beachball reverts to local state after publish, but we need to know the new version it pushed.
-  - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes --verbose
-    displayName: beachball bump
-
   - template: set-version-vars.yml
     parameters:
       buildEnvironment: ${{ parameters.buildEnvironment }}

--- a/change/react-native-windows-d76f4c73-02fd-48c6-84ef-ed292bceefb1.json
+++ b/change/react-native-windows-d76f4c73-02fd-48c6-84ef-ed292bceefb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Force version bump",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION






## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
PR errors seem to imply Beachball publish behavior has changed, to leave updated package.json files and changelogs after the publish command is completed.

We previously had code which added a commit to the beachball temporary branch. I think this may have also commited the bumped files, hiding the change from us. #9062 removed code which injected the commit, which means we now see bumped files in the directory tree after publish. This breaks the bump step, which assumes the project files are unbumped.

### What
This removes the step to bump, since we should now have bumped artifacts already.

## Testing
PR will let us know if fix attempt is successful. Will monitor that RN version reported by env vars if correctly bumped.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9068)