### PR TITLE
Add failOnStderr to `react-native init`

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -79,6 +79,7 @@ steps:
         npx --yes react-native@$(reactNativeDevDependency) init testcli --template react-native@$(reactNativeDevDependency)
       displayName: Init new app project
       workingDirectory: $(Agent.BuildDirectory)
+      failOnStderr: true # react-native init may fail but return zero exit code
 
   - ${{ if eq(parameters.projectType, 'lib') }}:
     - script: |


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9073)