### PR TITLE
Add timeout to Setup Step

### DIFF
--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -7,6 +7,7 @@ parameters:
 
 jobs:
   - job: Setup
+    timeoutInMinutes: 3
     pool:
       vmImage: ubuntu-latest
     steps:


### PR DESCRIPTION
We are seeing issues again with Beachball hanging with missing changefiles. Fail the job if Beachball hangs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9080)