### PR TITLE
Remove JSI.ForceSystemChakra runtime option

### DIFF
--- a/change/react-native-windows-ca2dbe30-182a-42fa-8afb-2ee4b327e019.json
+++ b/change/react-native-windows-ca2dbe30-182a-42fa-8afb-2ee4b327e019.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Short-circuit ChakraCore to Chakra",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -36,7 +36,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -379,12 +379,6 @@ InstanceImpl::InstanceImpl(
           [[fallthrough]];
 #endif
         }
-        case JSIEngineOverride::Chakra:
-          // Applies only to ChakraCore-linked binaries.
-          Microsoft::React::SetRuntimeOptionBool("JSI.ForceSystemChakra", true);
-          m_devSettings->jsiRuntimeHolder =
-              std::make_shared<Microsoft::JSI::ChakraRuntimeHolder>(m_devSettings, m_jsThread, nullptr, nullptr);
-          break;
         case JSIEngineOverride::V8NodeApi: {
 #if defined(USE_V8)
           std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore;
@@ -412,6 +406,7 @@ InstanceImpl::InstanceImpl(
           [[fallthrough]];
 #endif
         }
+        case JSIEngineOverride::Chakra:
         case JSIEngineOverride::ChakraCore:
         default: // TODO: Add other engines once supported
           m_devSettings->jsiRuntimeHolder =


### PR DESCRIPTION
ChakraCore support has been dropped. Only System Chakra is still used.

- Short-circuit ChakraCore to Chakra
- Delete remaining references to JSI.ForceSystemChakra


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9089)