### PR TITLE
Allow --useWinUI3 and --experimentalNugetDependency to be used at the same time in react-native-windows-init

### DIFF
--- a/change/react-native-windows-init-0e7a8f00-f244-4c84-a8bd-5b9e2d103171.json
+++ b/change/react-native-windows-init-0e7a8f00-f244-4c84-a8bd-5b9e2d103171.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent --useWinUI3 and --experimentalNugetDependency from being used at the same time in react-native-windows-init",
+  "packageName": "react-native-windows-init",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -377,14 +377,6 @@ function isProjectUsingYarn(cwd: string): boolean {
     const useDevMode = !!argv.useDevMode;
     let version = argv.version;
 
-    if (argv.useWinUI3 && argv.experimentalNuGetDependency) {
-      throw new CodedError(
-        'IncompatibleOptions',
-        "Error: Incompatible options specified. Options '--useWinUI3' and '--experimentalNuGetDependency' are incompatible",
-        {detail: 'useWinUI3 and experimentalNuGetDependency'},
-      );
-    }
-
     if (!useDevMode) {
       if (!version) {
         const rnVersion = getReactNativeVersion();


### PR DESCRIPTION
## Description
Ran into this while testing WinAppSDK NuGet locally. I believe since #8064 added the projection NuGet, this check is no longer needed.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Update react-native-windows-init


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9099)