### PR TITLE
[0.65] Change AgentPool.Large to rnw-pool-8

### DIFF
--- a/.ado/variables/vs2019.yml
+++ b/.ado/variables/vs2019.yml
@@ -1,7 +1,7 @@
 variables:
   VmImage: windows-2019
   AgentPool.Medium: rnw-pool-4
-  AgentPool.Large: windevbuildagents
+  AgentPool.Large: rnw-pool-8
   MSBuildVersion: 16.0
   GoogleTestAdapterPathExpression: '(Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\Common7\IDE\Extensions\" -Directory | Where-Object -FilterScript { Test-Path $_\GoogleTestAdapter.Core.dll}).FullName'
   BaseIntDir: $(Agent.HomeDirectory)\BaseIntDir # redirect to C:


### PR DESCRIPTION
The `windevbuildagents` pool is being retired soon and we shouldn't be running anything on it.

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9105)