### PR TITLE
Add `enableFocusRing` to RNWin32 

### DIFF
--- a/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
+++ b/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add enableFocusRing prop for View and test",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -381,6 +381,7 @@ const ReactNativeViewConfig: ViewConfig = {
     accessibilityDescription: true,
     accessibilityControls: true,
     accessibilityItemType: true,
+    enableFocusRing: true,
     // Windows]
   },
 };

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -246,20 +246,61 @@ const CursorExample: React.FunctionComponent = () => {
     </ViewWin32>
   );
 }
+class EnableFocusRingExample extends React.Component<{}, IFocusableComponentState> {
+  public constructor(props) {
+    super(props);
+    this.state = {
+      hasFocus: false,
+    };
+  }
+  
+  public render() {
+    return (
+      <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
+        <ViewWin32
+          style={{
+            backgroundColor: 'pink',
+            height: 100,
+            width: 100,
+          }}
+          enableFocusRing={true}
+          focusable
+        >
+          <Text>enableFocusRing set to true</Text>
+        </ViewWin32>
+        <ViewWin32
+          style={{
+            backgroundColor: 'pink',
+            height: 100,
+            width: 100,
+          }}
+          enableFocusRing={true}
+          focusable
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+        >
+          <>
+            <Text>enableFocusRing set to false</Text>
+            <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
+          </>
+        </ViewWin32>
+      </ViewWin32>
+    );
+  }
 
-const EnableFocusRingExample: React.FunctionComponent<{}> = () => {
-  return (
-    <ViewWin32
-      style={{
-        backgroundColor: 'red',
-        height: 100,
-        width: 100,
-      }}
-      enableFocusRing={true}
-      focusable
-    />
-  );
+  private readonly _onFocus = () => {
+    this.setState({
+      hasFocus: true,
+    });
+  };
+
+  private readonly _onBlur = () => {
+    this.setState({
+      hasFocus: false,
+    });
+  };
 }
+
 
 export const title = 'ViewWin32';
 export const displayName = 'ViewWin32 Example';

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -54,6 +54,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
           style={this.state.hasFocus ? { backgroundColor: '#aee8fcff' } : { backgroundColor: '#00000000' }}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
+          enableFocusRing={false}
         >
           <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
         </ViewWin32>
@@ -118,6 +119,7 @@ class KeyboardTestComponent extends React.Component<{}, IFocusableComponentState
           onKeyDown={this._onKeyDown}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
+          enableFocusRing={false}
         >
           <ViewWin32 style={styles.keyEnterVisualizer}>
             <Text>OnKeyDown</Text>
@@ -245,6 +247,20 @@ const CursorExample: React.FunctionComponent = () => {
   );
 }
 
+const EnableFocusRingExample: React.FunctionComponent<{}> = () => {
+  return (
+    <ViewWin32
+      style={{
+        backgroundColor: 'red',
+        height: 100,
+        width: 100,
+      }}
+      enableFocusRing={true}
+      focusable
+    />
+  );
+}
+
 export const title = 'ViewWin32';
 export const displayName = 'ViewWin32 Example';
 export const description = 'All the stock View props plus Win32 specific ones';
@@ -288,6 +304,13 @@ export const examples = [
     description: 'Each of these boxes should display a different cursor',
     render(): JSX.Element {
       return <CursorExample />;
+    },
+  },
+  {
+    title: 'EnableFocusRing example',
+    description: 'Displays focus visuals that are driven by native',
+    render(): JSX.Element {
+      return <EnableFocusRingExample />;
     },
   },
 ];

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -211,6 +211,7 @@ export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>,
   accessibilitySetSize?: number;
   animationClass?: string;
   focusable?: boolean;
+  enableFocusRing?: boolean;
 
   /**
    * The onBlur event occurs when an element loses focus.  The opposite of onBlur is onFocus.  Note that in React


### PR DESCRIPTION
## Description
Adding the `enableFocusRing` prop for RNWin32's View.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To enable using native to implement focus visuals while giving clients the flexibility to use JS to implement focus visuals if necessary. This brings the platform closer to alignment with RNW and RNMacOS behavior, and allows us to stage the change in a way which minimizes current clients using RNWin32.

This change will be backported back to 0.64 so that it can be consumed by Office.

### What
Added `enableFocusRIng` prop to the typing for ViewWin32. Also added `enableFocusRing` to the list of `validAttributes`.

## Screenshots
Without focus:
![image](https://user-images.githubusercontent.com/4602628/141203568-96db3164-3a13-4870-b737-ca0e7383df1f.png)

With focus (visuals from native):
![image](https://user-images.githubusercontent.com/4602628/141203535-938a2e7c-1b8f-497c-8d8d-d85ad65d4d9d.png)

## Testing
Added a test for the ViewWin32 test on the react-native-win32 tester app.

_Optional_: Ran test against local changes to native. The visual changes are not implemented in native yet, they will be checked in once this change comes to Office.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9110)