### PR TITLE
Fix `ViewWin32` test for `enableFocusRing`

### DIFF
--- a/change/@office-iss-react-native-win32-3442d9c5-966e-4f0c-9ae5-5e779e1edc4a.json
+++ b/change/@office-iss-react-native-win32-3442d9c5-966e-4f0c-9ae5-5e779e1edc4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix test case to have correct state",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -274,7 +274,7 @@ class EnableFocusRingExample extends React.Component<{}, IFocusableComponentStat
             height: 100,
             width: 100,
           }}
-          enableFocusRing={true}
+          enableFocusRing={false}
           focusable
           onFocus={this._onFocus}
           onBlur={this._onBlur}


### PR DESCRIPTION
## Description
Fix test case that I forgot to change and checked in as part of #9110 

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
One of the test cases I added for enableFocusRing is supposed to test it in the false case, but I accidentally set it to true

### What
Change to test to set enableFocusRing to false for the relevant test

## Testing
Tested app locally

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9114)