### PR TITLE
[0.64] Fix crash loading bundle in win32

### DIFF
--- a/change/react-native-windows-b73de70e-deb8-4965-b68d-d923af8e564e.json
+++ b/change/react-native-windows-b73de70e-deb8-4965-b68d-d923af8e564e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix crash loading bundle in win32",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -559,7 +559,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       // Otherwise all bundles (User and Platform) are loaded through
       // platformBundles.
       if (PathFileExistsA(fullBundleFilePath.c_str())) {
-        auto bundleString = JSBigFileString::fromPath(fullBundleFilePath);
+        auto bundleString = FileMappingBigString::fromPath(fullBundleFilePath);
         m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(fullBundleFilePath), synchronously);
       }
 


### PR DESCRIPTION
Fixes a crash in win32 as fallout from #9094.

JSBigFileString::fromPath is stubbed out in win32, we should be using FileMapped files to load the bundle instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9116)