### PR TITLE
[0.65] Fix autolinking to support solution files using LF instead of CRLF

### DIFF
--- a/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
+++ b/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "Fix autolinking to support solution files using LF instead of CRLF",
+  "type": "patch",
+  "comment": "[0.65] Fix autolinking to support solution files using LF instead of CRLF",
   "packageName": "@react-native-windows/cli",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
+++ b/change/@react-native-windows-cli-e4154948-d0ed-4b5e-8b9e-07f6541511da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix autolinking to support solution files using LF instead of CRLF",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vstools.ts
@@ -115,10 +115,11 @@ export function addProjectToSolution(
     );
   }
 
-  const slnLines = fs
-    .readFileSync(slnFile)
-    .toString()
-    .split('\r\n');
+  const originalSlnContents = fs.readFileSync(slnFile).toString();
+
+  const isCRLF = originalSlnContents.includes('\r\n');
+
+  const slnLines = originalSlnContents.split(isCRLF ? '\r\n' : '\n');
 
   let contentsChanged = false;
 
@@ -219,7 +220,7 @@ export function addProjectToSolution(
         );
       }
 
-      const slnContents = slnLines.join('\r\n');
+      const slnContents = slnLines.join(isCRLF ? '\r\n' : '\n');
       fs.writeFileSync(slnFile, slnContents, {
         encoding: 'utf8',
         flag: 'w',


### PR DESCRIPTION
This PR backports #8587 to 0.65.

This PR fixes autolinking to properly handle modifying solution files
that have LF line endings (which can happen when cloning a repo that
didn't maintain the CRLF we use in our template).

Closes #8530

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9119)