### PR TITLE
Fix crash loading bundle in win32

### DIFF
--- a/change/react-native-windows-a3e7fa27-57ec-4eb0-b036-c7da150c5239.json
+++ b/change/react-native-windows-a3e7fa27-57ec-4eb0-b036-c7da150c5239.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash loading bundle in win32",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -566,7 +566,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       // Otherwise all bundles (User and Platform) are loaded through
       // platformBundles.
       if (PathFileExistsA(fullBundleFilePath.c_str())) {
-        auto bundleString = JSBigFileString::fromPath(fullBundleFilePath);
+        auto bundleString = FileMappingBigString::fromPath(fullBundleFilePath);
         m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(fullBundleFilePath), synchronously);
       }
 


### PR DESCRIPTION
Fixes a crash in win32 as fallout from #9094.

JSBigFileString::fromPath is stubbed out in win32, we should be using FileMapped files to load the bundle instead.

Forward-port of #9116.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9120)