### PR TITLE
[0.65] Fix crash loading bundle in win32

### DIFF
--- a/change/react-native-windows-ac49a748-6516-4a80-8251-89f2de56b5d1.json
+++ b/change/react-native-windows-ac49a748-6516-4a80-8251-89f2de56b5d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix crash loading bundle in win32",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -500,7 +500,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       // Otherwise all bundles (User and Platform) are loaded through
       // platformBundles.
       if (PathFileExistsA(fullBundleFilePath.c_str())) {
-        auto bundleString = JSBigFileString::fromPath(fullBundleFilePath);
+        auto bundleString = FileMappingBigString::fromPath(fullBundleFilePath);
         m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(fullBundleFilePath), synchronously);
       }
 


### PR DESCRIPTION
Backport of #9120.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9123)