### PR TITLE
Some native modules are hitting the UI queue unnecessarily

### DIFF
--- a/change/react-native-windows-d97a7383-5070-4493-9ce2-305b9f6430a9.json
+++ b/change/react-native-windows-d97a7383-5070-4493-9ce2-305b9f6430a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Websocket is hitting the UI queue unnecessarily",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -439,7 +439,7 @@ void ReactInstanceWin::Initialize() noexcept {
                 m_options.TurboModuleProvider,
                 std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
                 m_jsMessageThread.Load(),
-                Mso::Copy(m_batchingUIThread),
+                m_nativeMessageThread.Load(),
                 std::move(devSettings));
 
             m_instanceWrapper.Exchange(std::move(instanceWrapper));


### PR DESCRIPTION
Several native modules are currently hooked up in a way that causes them to queue up on the batching UI queue, even though they do not need to.  This can cause some modules to be slower than they need to be.  For example Websocket ends up posting its tasks to the UI queue, then the actual module will trigger async tasks on a background thread.  This increases the delay on websocket responses.

Internally, as part of moving Office to use code more in alignment with react-native-windows, I hit some issues with internal unit tests that break due to this.  In Office we've been running these modules on a background queue for years.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9124)