### PR TITLE
[0.64] Add `enableFocusRing` to RNWin32

### DIFF
--- a/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
+++ b/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Add enableFocusRing prop for View and test",
   "packageName": "@office-iss/react-native-win32",
   "email": "ruaraki@microsoft.com",

--- a/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
+++ b/change/@office-iss-react-native-win32-c738962f-151a-4e5e-a805-db5e73f40dda.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add enableFocusRing prop for View and test",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/ReactNativeViewViewConfig.win32.js
@@ -380,6 +380,7 @@ const ReactNativeViewConfig = {
     accessibilityDescription: true,
     accessibilityControls: true,
     accessibilityItemType: true,
+    enableFocusRing: true,
     // Windows]
   },
 };

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -54,6 +54,7 @@ class FocusMoverTestComponent extends React.Component<{}, IFocusableComponentSta
           style={this.state.hasFocus ? { backgroundColor: '#aee8fcff' } : { backgroundColor: '#00000000' }}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
+          enableFocusRing={false}
         >
           <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
         </ViewWin32>
@@ -118,6 +119,7 @@ class KeyboardTestComponent extends React.Component<{}, IFocusableComponentState
           onKeyDown={this._onKeyDown}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
+          enableFocusRing={false}
         >
           <ViewWin32 style={styles.keyEnterVisualizer}>
             <Text>OnKeyDown</Text>
@@ -244,6 +246,61 @@ const CursorExample: React.FunctionComponent = () => {
     </ViewWin32>
   );
 }
+class EnableFocusRingExample extends React.Component<{}, IFocusableComponentState> {
+  public constructor(props) {
+    super(props);
+    this.state = {
+      hasFocus: false,
+    };
+  }
+  
+  public render() {
+    return (
+      <ViewWin32 style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around', marginVertical: 5 }}>
+        <ViewWin32
+          style={{
+            backgroundColor: 'pink',
+            height: 100,
+            width: 100,
+          }}
+          enableFocusRing={true}
+          focusable
+        >
+          <Text>enableFocusRing set to true</Text>
+        </ViewWin32>
+        <ViewWin32
+          style={{
+            backgroundColor: 'pink',
+            height: 100,
+            width: 100,
+          }}
+          enableFocusRing={true}
+          focusable
+          onFocus={this._onFocus}
+          onBlur={this._onBlur}
+        >
+          <>
+            <Text>enableFocusRing set to false</Text>
+            <Text>{this.state.hasFocus ? 'Focus: Yes' : 'Focus: No'}</Text>
+          </>
+        </ViewWin32>
+      </ViewWin32>
+    );
+  }
+
+  private readonly _onFocus = () => {
+    this.setState({
+      hasFocus: true,
+    });
+  };
+
+  private readonly _onBlur = () => {
+    this.setState({
+      hasFocus: false,
+    });
+  };
+}
+
 
 export const title = 'ViewWin32';
 export const displayName = 'ViewWin32 Example';
@@ -288,6 +345,13 @@ export const examples = [
     description: 'Each of these boxes should display a different cursor',
     render(): JSX.Element {
       return <CursorExample />;
+    },
+  },
+  {
+    title: 'EnableFocusRing example',
+    description: 'Displays focus visuals that are driven by native',
+    render(): JSX.Element {
+      return <EnableFocusRingExample />;
     },
   },
 ];

--- a/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
+++ b/packages/react-native-win32/src/Libraries/Components/View/Tests/ViewWin32Test.tsx
@@ -274,7 +274,7 @@ class EnableFocusRingExample extends React.Component<{}, IFocusableComponentStat
             height: 100,
             width: 100,
           }}
-          enableFocusRing={true}
+          enableFocusRing={false}
           focusable
           onFocus={this._onFocus}
           onBlur={this._onBlur}

--- a/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -217,6 +217,7 @@ export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>,
   accessibilitySetSize?: number;
   animationClass?: string;
   focusable?: boolean;
+  enableFocusRing?: boolean;
 
   /**
    * The onBlur event occurs when an element loses focus.  The opposite of onBlur is onFocus.  Note that in React


### PR DESCRIPTION
Backport of #9110 and #9114 for Office.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9127)