### PR TITLE
Reenable low-resource builds

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -307,10 +307,7 @@ jobs:
             variables: [template: ../variables/windows.yml]
 
             ${{ if eq(matrix.lowResource, true) }}:
-              # 9079: Use Medium hardware until new drop of
-              # `@react-native-community/cli` with windows init reliability
-              # improvements.
-              pool: ${{ parameters.AgentPool.Medium }}
+              pool: ${{ parameters.AgentPool.Small }}
             ${{ else }}:
               pool: ${{ parameters.AgentPool.Medium }}
             timeoutInMinutes: 60
@@ -328,12 +325,6 @@ jobs:
                   platform: ${{ parameters.platform }}
                   configuration: ${{ parameters.configuration }}
                   buildEnvironment: ${{ parameters.buildEnvironment }}
-
-              # 9079: Force disable RNW_FASTBUILD on low resource jobs, until
-              # they are back on low-end hardware.
-              - ${{ if eq(matrix.lowResource, true) }}:
-                - powershell: Write-Host "##vso[task.setvariable variable=RNW_FASTBUILD]false"
-                  displayName: Force off RNW_FASTBUILD
 
               - template: ../templates/react-native-init.yml
                 parameters:


### PR DESCRIPTION
Fixes #9079

Validated with _7_  PR runs.

https://github.com/microsoft/react-native-windows/pull/9145 bumped the CLI package version, which should theoretically fix the EPERM issues we were seeing (with https://github.com/react-native-community/cli/pull/1495).

Reenable the lower resource hardware that was running into isues with EPERM.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9156)