### PR TITLE
Ensure native animations fire completion callbacks

### DIFF
--- a/change/react-native-windows-bb5ddd31-2e47-4031-b9da-27d8ec921ec8.json
+++ b/change/react-native-windows-bb5ddd31-2e47-4031-b9da-27d8ec921ec8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure native animations fire completion callbacks",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -10,7 +10,7 @@ namespace Microsoft::ReactNative {
 typedef std::function<void(std::vector<folly::dynamic>)> Callback;
 
 class ValueAnimatedNode;
-class AnimationDriver : std::enable_shared_from_this<AnimationDriver> {
+class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
  public:
   AnimationDriver(
       int64_t id,

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -218,12 +218,12 @@ void NativeAnimatedNodeManager::StartAnimatingNode(
     case AnimationType::Decay:
       m_activeAnimations.emplace(
           animationId,
-          std::make_unique<DecayAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
+          std::make_shared<DecayAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
       break;
     case AnimationType::Frames:
       m_activeAnimations.emplace(
           animationId,
-          std::make_unique<FrameAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
+          std::make_shared<FrameAnimationDriver>(animationId, animatedNodeTag, endCallback, animationConfig, manager));
       break;
     case AnimationType::Spring: {
       folly::dynamic dynamicValues = [animationConfig]() {
@@ -232,7 +232,7 @@ void NativeAnimatedNodeManager::StartAnimatingNode(
       }();
       m_activeAnimations.emplace(
           animationId,
-          std::make_unique<SpringAnimationDriver>(
+          std::make_shared<SpringAnimationDriver>(
               animationId, animatedNodeTag, endCallback, animationConfig, manager, dynamicValues));
       break;
     }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
@@ -98,7 +98,7 @@ class NativeAnimatedNodeManager {
   std::unordered_map<int64_t, std::unique_ptr<TrackingAnimatedNode>> m_trackingNodes{};
   std::unordered_map<std::tuple<int64_t, std::string>, std::vector<std::unique_ptr<EventAnimationDriver>>>
       m_eventDrivers{};
-  std::unordered_map<int64_t, std::unique_ptr<AnimationDriver>> m_activeAnimations{};
+  std::unordered_map<int64_t, std::shared_ptr<AnimationDriver>> m_activeAnimations{};
   std::vector<std::tuple<int64_t, int64_t>> m_trackingAndLeadNodeTags{};
   std::vector<int64_t> m_delayedPropsNodes{};
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Native animations must fire completion callbacks when they finish.

Resolves  #9157

### What
The AnimationDrivers were being stored as unique_ptrs, but internally use a weak_ptr to handle completion callbacks. When attempting to convert the weak_ptr to a shared_ptr, the conversion would always return an empty pointer because the constructor was not called from a shared_ptr.

This changes the NativeAnimatedNodeManager to hold shared_ptrs to AnimationDrivers to ensure that callbacks fire when the composition scoped batch completes for the animation.

## Testing

Here's a recording to contrast with the "before" video in the linked issue:

https://user-images.githubusercontent.com/1106239/142242239-d8f9751f-80b9-4ee0-8589-38a660b0a9e5.mp4




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9158)