### PR TITLE
Ensure onMouseLeave doesn't fire when pointer down

### DIFF
--- a/change/react-native-windows-709e775b-53b1-42fc-9819-2385ffa71155.json
+++ b/change/react-native-windows-709e775b-53b1-42fc-9819-2385ffa71155.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure onMouseLeave doesn't fire when pointer down",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -165,6 +165,13 @@ void TouchEventHandler::OnPointerExited(
   if (m_context->State() == Mso::React::ReactInstanceState::HasError)
     return;
 
+  // Do not fire `onMouseLeave` events while the pointer is still active.
+  // `UpdatePointersInViews` is fired OnPointerConcluded, so the `onMouseLeave`
+  // events will fire from any of the concluded events.
+  auto optPointerIndex = IndexOfPointerWithId(args.Pointer().PointerId());
+  if (optPointerIndex)
+    return;
+
   std::vector<int64_t> tagsForBranch;
   UpdatePointersInViews(args, nullptr, std::move(tagsForBranch));
 }


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Generally, `onMouseLeave` does not fire until pointer up if `onMouseEnter` previously fired while pointer down.

However, the `TouchEventHandler` also wires up the `PointerExited` event to clear all hover states. Since we now also clean up hover states in `TouchEventHandler::OnPointerConcluded` (#8526), we can safely make the behavior more consistent with hover state handling inside the bounds of the `ReactRootView` and suppress calling `onMouseLeave` while pointer is down from `OnPointerExited`.

Resolves #9171

### What
Checks if the pointer ID of the `PointerExited` `PointerRoutedEventArgs` is attached to an active gesture, and if so, suppresses the call to `UpdatePointersInViews` which would clear all hover states.

## Testing

https://user-images.githubusercontent.com/1106239/142458747-06481569-2dd7-4fdf-8d81-bcad682f946f.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9172)