### PR TITLE
Fixes onMouseEnter/Leave to fire when pointer down

### DIFF
--- a/change/react-native-windows-cd6b59e4-a2d9-492a-b011-e534519b7714.json
+++ b/change/react-native-windows-cd6b59e4-a2d9-492a-b011-e534519b7714.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes onMouseEnter/Leave to fire when pointer down",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -127,9 +127,6 @@ void TouchEventHandler::OnPointerPressed(
     assert(!tagsForBranch.empty());
     const auto tag = tagsForBranch.front();
 
-    // Pointer pressing updates the enter/leave state
-    UpdatePointersInViews(args, sourceElement, std::move(tagsForBranch));
-
     size_t pointerIndex = AddReactPointer(args, tag, sourceElement);
 
     // For now, when using the mouse we only want to send click events for the left button.
@@ -189,10 +186,11 @@ void TouchEventHandler::OnPointerMoved(
   if (optPointerIndex) {
     UpdateReactPointer(m_pointers[*optPointerIndex], args, sourceElement);
     DispatchTouchEvent(eventType, *optPointerIndex);
-  } else {
-    // Move with no buttons pressed
-    UpdatePointersInViews(args, sourceElement, std::move(tagsForBranch));
   }
+
+  // If we re-introduce onMouseMove to react-native-windows, we should add an
+  // argument to ensure we do not emit these events while the pointer is down.
+  UpdatePointersInViews(args, sourceElement, std::move(tagsForBranch));
 }
 
 void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt::PointerRoutedEventArgs &args) {
@@ -227,9 +225,6 @@ void TouchEventHandler::OnPointerConcluded(TouchEventType eventType, const winrt
     m_touchId = 0;
 
   m_xamlView.as<xaml::FrameworkElement>().ReleasePointerCapture(args.Pointer());
-
-  // Updates the enter/leave state when pointer was being tracked
-  UpdatePointersInViews(args, sourceElement, std::move(tagsForBranch));
 }
 
 size_t TouchEventHandler::AddReactPointer(


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


### Why
We fire `onMouseEnter/Leave` from `UpdatePointersInViews`, which historically was suppressed on `PointerMove` because we wanted to prevent `onMouseMove` from firing while the pointer was down. Since we no longer have `onMouseMove` behavior in react-native-windows, this change ensures that `onMouseEnter` / `onMouseLeave` (and thus hover states) update regardless of the pointer being up or down.

Resolves #9171

### What
Always call `UpdatePointersInViews` from `OnPointerMoved` even if there is an active pointer.

## Testing

https://user-images.githubusercontent.com/1106239/142494799-7bcdbe11-e5c0-4efc-a8b9-a51bdff3cc43.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9173)