### PR TITLE
Add environment variable overrides to specify telemetry setup string and proxy

### DIFF
--- a/change/@react-native-windows-telemetry-2b84c3a1-6327-4e87-9833-c8a67256ca07.json
+++ b/change/@react-native-windows-telemetry-2b84c3a1-6327-4e87-9833-c8a67256ca07.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add environment variable overrides to specify telemetry setup string and proxy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
We need a way to be able to specify different setup strings and proxy servers for the telemetry. We can do this in code, but that's not always an option, for example in the case of `react-native-windows-init` which is called by using npx.

Adding these environment variable overrides will help us test the telemetry system before (and after) we go live and turn it on.

Example:

```cmd
set RNW_TELEMETRY_SETUP=12345678-abcd-abcd-abcd-1234567890ab
set RNW_TELEMETRY_PROXY=http://localhost:8888
```

Closes #9166

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9178)