### PR TITLE
Fix 0.65 CI

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -109,7 +109,7 @@
               displayName: Universal Test ${{ matrix.Name }}
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
-              pool: $(AgentPool.Medium)
+              pool: $(AgentPool.Large)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -145,7 +145,7 @@
                     artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}-fast_${{ matrix.FastBuild }}"
                     
                 - powershell: |
-                    Get-ChildItem -Recursive
+                    Get-ChildItem -Recurse
                   workingDirectory: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
 
                 - powershell: |

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -109,8 +109,7 @@
               displayName: Universal Test ${{ matrix.Name }}
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
-              pool:
-                vmImage: $(VmImage)
+              pool: $(AgentPool.Medium)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -143,10 +142,6 @@
                   inputs:
                     targetPath: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
                     artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}-fast_${{ matrix.FastBuild }}"
-                    
-                - powershell: |
-                    Get-ChildItem -Recurse
-                  workingDirectory: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
 
                 - powershell: |
                     Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -144,14 +144,6 @@
                     targetPath: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
                     artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}-fast_${{ matrix.FastBuild }}"
 
-                # The WinDevBuild Agents run on the c-drive and the hosted agents run on the d-drive.
-                # Some of the output files have the c-drive expanded in the outputs, which results in file not found errors when running tests
-                # This script fixes those files to point to the d-drive of the hosted agents.
-                # We unfortunately can't run the tests on the WinDev  build pool because it lacks UI support
-                - powershell: |
-                    Get-ChildItem *.appxrecipe -recurse | ForEach { (Get-Content -Path $_) -replace "c:\\a\\1\\s", "$(System.DefaultWorkingDirectory)" | Set-Content -Path $_ }
-                  displayName: Fix Paths in appx files to deal with different enlistments between agent types.
-
                 - powershell: |
                     Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
                     Write-Host "##vso[task.setvariable variable=GoogleTestAdapterPath]$(Invoke-Expression $env:GOOGLETESTADAPTERPATHEXPRESSION)"

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -143,6 +143,10 @@
                   inputs:
                     targetPath: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
                     artifactName: "Universal-${{ matrix.BuildPlatform }}-${{ matrix.BuildConfiguration }}-fast_${{ matrix.FastBuild }}"
+                    
+                - powershell: |
+                    Get-ChildItem -Recursive
+                  workingDirectory: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
 
                 - powershell: |
                     Write-Debug "Using expression $($env:GOOGLETESTADAPTERPATHEXPRESSION)"
@@ -175,7 +179,7 @@
                   inputs:
                     testSelector: testAssemblies
                     testAssemblyVer2: |
-                      Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
+                      Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
                     searchFolder: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
                     runTestsInIsolation: true
                     platform: ${{ matrix.BuildPlatform }}

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -175,7 +175,7 @@
                   inputs:
                     testSelector: testAssemblies
                     testAssemblyVer2: |
-                      Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
+                      Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.build.appxrecipe
                     searchFolder: $(Build.SourcesDirectory)/vnext/target/${{ matrix.BuildPlatform }}/${{ matrix.BuildConfiguration }}
                     runTestsInIsolation: true
                     platform: ${{ matrix.BuildPlatform }}

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -109,7 +109,7 @@
               displayName: Universal Test ${{ matrix.Name }}
               dependsOn:
                 - UniversalBuild${{ matrix.Name }}
-              pool: $(AgentPool.Large)
+              pool: $(AgentPool.Medium)
               timeoutInMinutes: 60
               cancelTimeoutInMinutes: 5
 
@@ -123,7 +123,7 @@
                   inputs:
                     targetType: filePath
                     filePath: $(Build.SourcesDirectory)\vnext\Scripts\rnw-dependencies.ps1
-                    arguments: -NoPrompt -Tags buildLab
+                    arguments: -NoPrompt -Tags buildLab -Install
                     
                 - template: ../templates/prepare-env.yml
 


### PR DESCRIPTION
It looks like we had to do some directory swapping magic when using the old windev build agents so the test tasks could find the binaries. That's no longer required now that we're off that pool.

Also apparently the new pool doesn't have all of the dependencies to build/test RNW 0.65? So changing the dependency check to install those missing bits.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9188)