### PR TITLE
Removes unused calls from NativeAnimated

### DIFF
--- a/change/react-native-windows-364ebba2-c500-41cd-87b0-cebc1bec0f6d.json
+++ b/change/react-native-windows-364ebba2-c500-41cd-87b0-cebc1bec0f6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removes unused calls from NativeAnimated",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
@@ -43,12 +43,7 @@ AnimationDriver::~AnimationDriver() {
 
 void AnimationDriver::StartAnimation() {
   const auto [animation, scopedBatch] = MakeAnimation(m_config);
-
   if (auto const animatedValue = GetAnimatedValue()) {
-    auto const previousValue = animatedValue->Value();
-    auto const rawValue = animatedValue->RawValue();
-    auto const offsetValue = animatedValue->Offset();
-
     animatedValue->PropertySet().StartAnimation(ValueAnimatedNode::s_offsetName, animation);
     animatedValue->AddActiveAnimation(m_id);
   }


### PR DESCRIPTION
We query for scalar values from the ValueAnimatedNode PropertySet but
then never use them. This change deletes these unused values.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9189)