### PR TITLE
Fix telemetry unit test timeouts

### DIFF
--- a/change/@react-native-windows-telemetry-733c82bd-37df-4935-a8fd-9f0ef10dad8d.json
+++ b/change/@react-native-windows-telemetry-733c82bd-37df-4935-a8fd-9f0ef10dad8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update telemetry unittest timeouts",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -41,7 +41,6 @@
     "eslint": "7.12.0",
     "jest": "^26.6.3",
     "just-scripts": "^1.3.3",
-    "lookpath": "^1.2.1",
     "prettier": "1.19.1",
     "semver": "^7.3.5",
     "typescript": "^4.4.4"

--- a/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
@@ -7,7 +7,6 @@
 
 import * as versionUtils from '../utils/versionUtils';
 
-import {lookpath} from 'lookpath';
 import path from 'path';
 import semver from 'semver';
 
@@ -35,9 +34,6 @@ test('getNpmVersion() is valid', async () => {
   const version = await versionUtils.getNpmVersion();
   if (version) {
     expectValidVersion(version, true);
-  } else {
-    jest.setTimeout(10000); // Sometimes this lookup can run longer than the default 5000ms
-    expect(await lookpath('npm')).toBeUndefined();
   }
 });
 
@@ -45,9 +41,6 @@ test('getYarnVersion() is valid', async () => {
   const version = await versionUtils.getYarnVersion();
   if (version) {
     expectValidVersion(version, true);
-  } else {
-    jest.setTimeout(10000); // Sometimes this lookup can run longer than the default 5000ms
-    expect(await lookpath('yarn')).toBeUndefined();
   }
 });
 

--- a/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
@@ -32,24 +32,22 @@ test('getNodeVersion() is valid', async () => {
 });
 
 test('getNpmVersion() is valid', async () => {
-  const node = await lookpath('npm');
   const version = await versionUtils.getNpmVersion();
-  if (node) {
+  if (version) {
     expectValidVersion(version, true);
   } else {
-    console.log('npm not installed');
-    expect(version).toBeNull();
+    jest.setTimeout(10000); // Sometimes this lookup can run longer than the default 5000ms
+    expect(await lookpath('npm')).toBeUndefined();
   }
 });
 
 test('getYarnVersion() is valid', async () => {
-  const node = await lookpath('yarn');
   const version = await versionUtils.getYarnVersion();
-  if (node) {
+  if (version) {
     expectValidVersion(version, true);
   } else {
-    console.log('yarn not installed');
-    expect(version).toBeNull();
+    jest.setTimeout(10000); // Sometimes this lookup can run longer than the default 5000ms
+    expect(await lookpath('yarn')).toBeUndefined();
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7565,11 +7565,6 @@ loglevel@^1.6.0:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
   integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
 
-lookpath@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/lookpath/-/lookpath-1.2.2.tgz#bddcd1440b6643e07495138376d43aed38bcd454"
-  integrity sha512-k2Gmn8iV6qdME3ztZC2spubmQISimFOPLuQKiPaLcVdRz0IpdxrNClVepMlyTJlhodm/zG/VfbkWERm3kUIh+Q==
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"


### PR DESCRIPTION
Some tests were checking for the presence of npm/yarn before checking
its version. Since we almost always have those installed, I rearranged
the tests to look for the version first, and only if it returns null do
I check to confirm the tool is indeed missing.

Closes #9183

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9193)