### PR TITLE
Block old telemetry events from firing

### DIFF
--- a/change/@react-native-windows-telemetry-59ec6aad-e0df-4b25-9435-3e02e2d6296b.json
+++ b/change/@react-native-windows-telemetry-59ec6aad-e0df-4b25-9435-3e02e2d6296b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Block old telemetry events from firing",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -43,6 +43,15 @@ const ENV_SETUP_OVERRIDE = 'RNW_TELEMETRY_SETUP';
 // Environment variable to override the http proxy (such as http://localhost:8888 for Fiddler debugging)
 const ENV_PROXY_OVERRIDE = 'RNW_TELEMETRY_PROXY';
 
+export const CommandEventName = 'RNWCLI.Command';
+export const CodedErrorEventName = 'RNWCLI.CodedError';
+
+// These are the event names we're tracking
+export const EventNamesWeTrack: string[] = [
+  CommandEventName,
+  CodedErrorEventName,
+];
+
 // These are NPM packages we care about, in terms of capturing versions used
 // and getting more details about when reporting errors
 export const NpmPackagesWeTrack: string[] = [
@@ -205,7 +214,17 @@ export class Telemetry {
     },
   ): boolean {
     delete envelope.tags['ai.cloud.roleInstance'];
-    return true;
+
+    // Filter out "legacy" events from older stable branches
+    const properties = envelope.data.baseData?.properties;
+    if (
+      properties?.eventName &&
+      EventNamesWeTrack.includes(properties.eventName)
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -361,7 +380,7 @@ export class Telemetry {
 
   private static trackCommandEvent(extraProps?: Record<string, any>) {
     const props: Record<string, any> = {
-      eventName: 'RNWCLI.Command',
+      eventName: CommandEventName,
     };
 
     // Set command props
@@ -391,7 +410,7 @@ export class Telemetry {
     }
 
     const props: Record<string, any> = {
-      eventName: 'RNWCLI.CodedError',
+      eventName: CodedErrorEventName,
     };
 
     // Save off CodedError info

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -9,7 +9,13 @@ import * as appInsights from 'applicationinsights';
 import CorrelationIdManager from 'applicationinsights/out/Library/CorrelationIdManager';
 import * as path from 'path';
 
-import {Telemetry, CommandStartInfo, CommandEndInfo} from '../telemetry';
+import {
+  Telemetry,
+  CommandStartInfo,
+  CommandEndInfo,
+  CommandEventName,
+  CodedErrorEventName,
+} from '../telemetry';
 import * as basePropUtils from '../utils/basePropUtils';
 import * as errorUtils from '../utils/errorUtils';
 import * as projectUtils from '../utils/projectUtils';
@@ -345,7 +351,7 @@ function verifyTestCommandTelemetryProcessor(
 
       if (envelope.data.baseType === 'ExceptionData') {
         // Verify event name
-        expect(properties.eventName).toBe('RNWCLI.CodedError');
+        expect(properties.eventName).toBe(CodedErrorEventName);
 
         // Verify coded error info
         const codedError = JSON.parse(properties.codedError);
@@ -364,8 +370,8 @@ function verifyTestCommandTelemetryProcessor(
         );
       } else {
         // Verify event name
-        expect(envelope.data.baseData?.name).toBe('RNWCLI.Command');
-        expect(properties.eventName).toBe('RNWCLI.Command');
+        expect(envelope.data.baseData?.name).toBe(CommandEventName);
+        expect(properties.eventName).toBe(CommandEventName);
 
         // Verify command info
         const expectedInfo = getTestCommandStartInfo();


### PR DESCRIPTION
Sometimes when running `react-native-windows-init` for a version of RNW prior to the telemetry refactor, an old 'generate-windows' even gets fired from the old cli module, and gets picked up by the new telemetry.

This PR adds a filter to only allow the new events that were defined in the refactor.

Closes #9179

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9199)