### PR TITLE
Fix telemetry path sanitization to handle our packages in the npx cache

### DIFF
--- a/change/@react-native-windows-telemetry-2bc4bbb3-d817-4598-86cc-786b31a14866.json
+++ b/change/@react-native-windows-telemetry-2bc4bbb3-d817-4598-86cc-786b31a14866.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix telemetry path sanitization to handle our packages in the npx cache",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
@@ -145,7 +145,7 @@ test("sanitizeErrorMessage() 'other path'", () => {
   ).toBe(`this is another path: [path]`);
 });
 
-test('sanitizeErrorMessage() multiple known paths', () => {
+test('sanitizeErrorMessage() tracked packages in the npx cache', () => {
   expect(
     errorUtils.sanitizeErrorMessage(
       `Cannot find module 'react-native/package.json'
@@ -155,14 +155,8 @@ test('sanitizeErrorMessage() multiple known paths', () => {
     ),
   ).toBe(`Cannot find module react-native/package.json
       Require stack:
-      - [AppData]\\???(${
-        '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\lib-commonjs\\Cli.js'
-          .length
-      })
-      - [AppData]\\???(${
-        '\\npm-cache\\_npx\\1384\\node_modules\\react-native-windows-init\\bin.js'
-          .length
-      })`);
+      - [node_modules]\\react-native-windows-init\\lib-commonjs\\Cli.js
+      - [node_modules]\\react-native-windows-init\\bin.js`);
 });
 
 test('sanitizeErrorMessage() forward slashes', () => {

--- a/packages/@react-native-windows/telemetry/src/test/sanitizeUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/sanitizeUtils.test.ts
@@ -81,6 +81,20 @@ test('getAnonymizedPath() with path under %%LocalAppData%% is anonymized', () =>
   expect(anonymizedPath.startsWith('[LocalAppData]\\???')).toBe(true);
 });
 
+test('getAnonymizedPath() with a tracked npm package under %%LocalAppData%% is anonymized', () => {
+  const originalPath = path.normalize(
+    path.join(
+      process.env.LocalAppData!,
+      'node_modules/@react-native-windows/cli/index.js',
+    ),
+  );
+  const anonymizedPath = sanitizeUtils.getAnonymizedPath(originalPath);
+  expect(anonymizedPath).not.toBe(originalPath);
+  expect(anonymizedPath).toBe(
+    '[node_modules]\\@react-native-windows\\cli\\index.js',
+  );
+});
+
 test('getAnonymizedPath() with arbitrary path not under project dir is anonymized', () => {
   const originalPath = 'test.sln';
   const anonymizedPath = sanitizeUtils.getAnonymizedPath(originalPath);

--- a/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
@@ -35,29 +35,40 @@ export function getAnonymizedPath(
     : projectRoot;
   filepath = filepath.replace(/\//g, '\\');
 
+  const ext = path.extname(filepath);
+
+  // Check if we're under node_modules
+  const nodeModulesIndex = filepath.toLowerCase().lastIndexOf(nodeModules);
+  if (nodeModulesIndex >= 0) {
+    // We are under node_modules
+
+    // Check if it's an npm package we're tracking
+    for (const trackedNpmPackage of NpmPackagesWeTrack) {
+      const startIndex = filepath
+        .toLowerCase()
+        .lastIndexOf(
+          nodeModules + trackedNpmPackage.replace(/\//g, '\\') + '\\',
+        );
+      if (startIndex >= 0) {
+        // We are under node_modules within an npm package we're tracking, anonymize by removing root
+        return (
+          '[node_modules]\\' + filepath.slice(startIndex + nodeModules.length)
+        );
+      }
+    }
+
+    // It's an npm package we're not tracking, anonymize with [node_modules]
+    return `[node_modules]\\???${ext}(${filepath.slice(nodeModulesIndex)
+      .length - nodeModules.length})`;
+  }
+
+  // Check if we're under the projectRoot
   if (filepath.toLowerCase().startsWith(projectRoot)) {
     // We are under the projectRoot
-    const ext = path.extname(filepath);
     const rest = filepath.slice(projectRoot.length);
     if (rest.toLowerCase().startsWith(windows)) {
       // We are under the windows path, anonymize with [windows]
       return `[windows]\\???${ext}(${rest.length - windows.length - 1})`;
-    } else if (rest.toLowerCase().startsWith(nodeModules)) {
-      // We are under the node_modules path
-      for (const trackedNpmPackage of NpmPackagesWeTrack) {
-        if (
-          rest
-            .toLowerCase()
-            .startsWith(
-              nodeModules + trackedNpmPackage.replace(/\//g, '\\') + '\\',
-            )
-        ) {
-          // We are under node_modules within an npm package we're tracking, anonymize by removing root
-          return '[node_modules]' + rest.slice(nodeModules.length - 1);
-        }
-      }
-      // We are under node_modules within an npm package we're not tracking, anonymize with [node_modules]
-      return `[node_modules]\\???${ext}(${rest.length - nodeModules.length})`;
     } else {
       // We are just within the projectRoot, anonymize with [project_dir]
       if (rest === '' || rest === '\\') {
@@ -67,17 +78,19 @@ export function getAnonymizedPath(
           (rest.startsWith('\\') ? 1 : 0)})`;
       }
     }
-  } else {
-    for (const knownPath of knownEnvironmentVariablePaths) {
-      if (
-        process.env[knownPath] &&
-        filepath.toLowerCase().startsWith(process.env[knownPath]!.toLowerCase())
-      ) {
-        return `[${knownPath}]\\???(${filepath.length -
-          process.env[knownPath]!.length})`;
-      }
+  }
+
+  // Check if we're under a known environmental variable path
+  for (const knownPath of knownEnvironmentVariablePaths) {
+    if (
+      process.env[knownPath] &&
+      filepath.toLowerCase().startsWith(process.env[knownPath]!.toLowerCase())
+    ) {
+      return `[${knownPath}]\\???(${filepath.length -
+        process.env[knownPath]!.length})`;
     }
   }
+
   // We are somewhere else, anonymize with [path]
   return '[path]';
 }


### PR DESCRIPTION
When calling `npx react-native-windows-init`, npx installs files into the users AppData folder, which we completely anonymize. This PR changes our sanitization to check if it's an npm package we own first, before checking if it's under AppData.

One new test added for this scenario, one test modified to expect this new behaviour, the rest of the tests still pass.

Closes #9180

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9200)