### PR TITLE
Use Window::Current compositor on XAML Islands

### DIFF
--- a/change/react-native-windows-94a433f4-aa44-431d-a5a5-322479b41c9d.json
+++ b/change/react-native-windows-94a433f4-aa44-431d-a5a5-322479b41c9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use Window::Current compositor on XAML Islands",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/XamlView.cpp
+++ b/vnext/Microsoft.ReactNative/XamlView.cpp
@@ -23,13 +23,6 @@ xaml::XamlRoot TryGetXamlRoot(const XamlView &view) {
   return root;
 }
 
-comp::Compositor GetCompositor(const XamlView &view) {
-  if (auto window = xaml::Window::Current()) {
-    return window.Compositor();
-  }
-  return GetCompositor();
-}
-
 thread_local comp::Compositor tlsCompositor{nullptr};
 
 void SetCompositor(const comp::Compositor &compositor) {
@@ -41,9 +34,9 @@ void SetCompositor(const comp::Compositor &compositor) {
   }
 }
 
-comp::Compositor GetCompositor() {
-  if (!IsXamlIsland()) {
-    return xaml::Window::Current().Compositor();
+comp::Compositor GetCompositor(const XamlView &view) {
+  if (auto window = xaml::Window::Current()) {
+    return window.Compositor();
   }
 #ifndef USE_WINUI3
   assert(tlsCompositor != nullptr);

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -42,8 +42,7 @@ inline winrt::IPropertyValue GetTagAsPropertyValue(XamlView view) {
 }
 
 xaml::XamlRoot TryGetXamlRoot(const XamlView &view);
-comp::Compositor GetCompositor(const XamlView &view);
+comp::Compositor GetCompositor(const XamlView &view = nullptr);
 void SetCompositor(const comp::Compositor &compositor);
-comp::Compositor GetCompositor();
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
There is a race condition on XAML Islands where the TLS compositor may not be set at the time we use it (e.g., for NativeAnimatedModule) if ReactRootView::Loaded has not yet fired.

### What
Previously, there was an unnecessary conditional check if the app was running in a XAML Islands context, forcing XAML Islands to use the compositor stored in TLS.

This was not necessary, and causes a race condition where the compositor may not actually be set at the time it is needed (e.g., if you attempt to start a native animation in the first render pass).

This change merges the two GetCompositor overloads, and just sets a default value of null for the view in case we call the GetCompositor method with 0 arguments.

## Testing
Ran RNTester NativeAnimated and Image examples, didn't see any problems.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9201)