### PR TITLE
[0.65] Make ADK dependency optional in dependency script

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -123,7 +123,7 @@
                   inputs:
                     targetType: filePath
                     filePath: $(Build.SourcesDirectory)\vnext\Scripts\rnw-dependencies.ps1
-                    arguments: -NoPrompt -Tags buildLab -Install
+                    arguments: -NoPrompt -Tags buildLab
                     
                 - template: ../templates/prepare-env.yml
 

--- a/change/react-native-windows-6ee7207e-33bb-4654-9f55-1a007584f2a0.json
+++ b/change/react-native-windows-6ee7207e-33bb-4654-9f55-1a007584f2a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.65] Make ADK dependency optional in dependency script",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -331,6 +331,7 @@ $requirements = @(
         Tags = @('buildLab');
         Valid = (Test-Path "${env:ProgramFiles(x86)}\Windows Kits\10\Windows Performance Toolkit\wpr.exe");
         Install = { choco install -y windows-adk };
+        Optional = $true
     },
     @{
         Id=[CheckId]::RNWClone;


### PR DESCRIPTION
This PR backports part of #8343 so that CI can build RNW 65 on our private machines.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9202)