### PR TITLE
Update Component Governance to only run when needed

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -112,6 +112,9 @@ jobs:
                 displayName: Build react-native-win32 RNTester bundle
                 workingDirectory: packages/@office-iss/react-native-win32
 
+            - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+              - template: ../templates/component-governance.yml
+
             - template: ../templates/discover-google-test-adapter.yml
 
             - ${{ if ne(matrix.BuildPlatform, 'ARM64') }}:
@@ -177,5 +180,3 @@ jobs:
                   React.Windows.Desktop\**
                   React.Windows.Desktop.DLL\**
                   React.Windows.Desktop.Test.DLL\**
-
-            - template: ../templates/component-governance.yml

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -56,6 +56,9 @@ jobs:
                 msbuildArguments: /p:UseWinUI3=true
                 warnAsError: false # Disable warn as error until we fix #8312
 
+            - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+              - template: ../templates/component-governance.yml
+
             - template: ../templates/publish-build-artifacts.yml
               parameters:
                 artifactName: ProjectReunion
@@ -79,6 +82,3 @@ jobs:
                 artifactName: ReunionNuGet
                 pathToPublish: $(Build.SourcesDirectory)/NugetRootFinal/Microsoft.ReactNative.ProjectReunion.0.0.1-pr.nupkg
                 parallel: true
-
-
-            - template: ../templates/component-governance.yml

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -71,6 +71,9 @@
                     solutionName: Microsoft.ReactNative.sln
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
+                
+                - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+                  - template: ../templates/component-governance.yml
 
                 - ${{ if eq(matrix.CreateApiDocs, true) }}:
                   - powershell: |
@@ -155,8 +158,6 @@
                       AnalyzeTarget: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative\Microsoft.ReactNative.dll'
                       AnalyzeVerbose: true
                       toolVersion: 'LatestPreRelease'
-
-                - template: ../templates/component-governance.yml
 
                 - template: ../templates/discover-google-test-adapter.yml
 


### PR DESCRIPTION
CG can't run during PRs because the author doesn't have permission
to connect to the CG service. For this reason we only get (and track)
alerts from CI and Publish. So right now were wasting anywhere from
1-3 minutes running CG in PRs.

This PR fixes that, and also moves CG to run after the code has built.
We were (in universal and reunion) instead running during the test
phase, which operates on downloaded artifacts and not the complete
original build output, which is necessary (by policy) for using CG.

Closes #9208

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9215)