### PR TITLE
[0.67] Update Component Governance to only run when needed

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -101,6 +101,9 @@ jobs:
                 displayName: Build react-native-win32 RNTester bundle
                 workingDirectory: packages/@office-iss/react-native-win32
 
+            - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+              - template: ../templates/component-governance.yml
+
             - template: ../templates/discover-google-test-adapter.yml
 
             - ${{ if ne(matrix.BuildPlatform, 'ARM64') }}:
@@ -166,5 +169,3 @@ jobs:
                   React.Windows.Desktop\**
                   React.Windows.Desktop.DLL\**
                   React.Windows.Desktop.Test.DLL\**
-
-            - template: ../templates/component-governance.yml

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -40,6 +40,9 @@ jobs:
           msbuildArguments: /p:UseWinUI3=true
           warnAsError: false # Disable warn as error until we fix #8312
 
+      - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+        - template: ../templates/component-governance.yml
+
       - task: CopyFiles@2
         displayName: Copy NuGet artifacts
         inputs:
@@ -83,6 +86,3 @@ jobs:
           artifactName: ReunionNuGet
           pathToPublish: $(Build.SourcesDirectory)/NugetRootFinal/Microsoft.ReactNative.ProjectReunion.0.0.1-pr.nupkg
           parallel: true
-
-
-      - template: ../templates/component-governance.yml

--- a/.ado/jobs/project-reunion.yml
+++ b/.ado/jobs/project-reunion.yml
@@ -40,7 +40,7 @@ jobs:
           msbuildArguments: /p:UseWinUI3=true
           warnAsError: false # Disable warn as error until we fix #8312
 
-      - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+      - ${{ if eq(parameters.BuildEnvironment, 'Continuous') }}:
         - template: ../templates/component-governance.yml
 
       - task: CopyFiles@2

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -85,6 +85,9 @@
                     multicoreBuild: true
                     msbuildArguments: /p:RNW_FASTBUILD=${{ matrix.FastBuild }}
 
+                - ${{ if eq(config.BuildEnvironment, 'Continuous') }}:
+                  - template: ../templates/component-governance.yml
+
                 - ${{ if eq(matrix.CreateApiDocs, true) }}: 
                   - powershell: |
                       $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.13/winmd2md.exe"
@@ -124,8 +127,6 @@
                       Microsoft.ReactNative\**
                       Microsoft.ReactNative.Managed\**
                       Microsoft.ReactNative.Managed.CodeGen\**
-
-                - template: ../templates/component-governance.yml
 
             - job: UniversalTest${{ matrix.Name }}
               variables:


### PR DESCRIPTION
This PR backports #9215 to 0.67.

CG can't run during PRs because the author doesn't have permission
to connect to the CG service. For this reason we only get (and track)
alerts from CI and Publish. So right now were wasting anywhere from
1-3 minutes running CG in PRs.

This PR fixes that, and also moves CG to run after the code has built.
We were (in universal and reunion) instead running during the test
phase, which operates on downloaded artifacts and not the complete
original build output, which is necessary (by policy) for using CG.

Closes #9208

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9221)