### PR TITLE
ReloadInstance async task and InstanceLoaded event were not correctly reporting failures

### DIFF
--- a/change/react-native-windows-59359221-7fe0-4ed1-8380-000be6c2162b.json
+++ b/change/react-native-windows-59359221-7fe0-4ed1-8380-000be6c2162b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ReloadInstance async task and InstanceLoaded event were not correctly reporting failures",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/.eslintignore
+++ b/vnext/.eslintignore
@@ -8,6 +8,7 @@
 /local-cli/lib
 /local-cli/lib-commonjs
 /packages
+/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
 /ReactCopies
 /RNTester.d.ts
 /src/rntypes

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -112,6 +112,49 @@ TEST_CLASS (ReactNativeHostTests) {
 
     TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Completed", nullptr}});
   }
+
+  TEST_METHOD(LoadBundleWithError_FiresInstanceLoaded_Failed) {
+    TestEventService::Initialize();
+
+    auto options = TestReactNativeHostHolder::Options{};
+    auto reactNativeHost = TestReactNativeHostHolder(
+        L"SyntaxError",
+        [](ReactNativeHost const &host) noexcept {
+
+            host.InstanceSettings().InstanceLoaded([](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+            if (args.Failed()) {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
+            }
+          });
+        });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Failed", nullptr}});
+  }
+
+  TEST_METHOD(LoadBundleWithError_ReloadInstance_Fails) {
+    TestEventService::Initialize();
+
+    auto options = TestReactNativeHostHolder::Options{};
+    options.LoadInstance = false;
+    auto reactNativeHost = TestReactNativeHostHolder(
+        L"SyntaxError",
+        [](ReactNativeHost const &host) noexcept {
+          host.ReloadInstance().Completed([](auto const &, winrt::Windows::Foundation::AsyncStatus status) mutable {
+            if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
+              TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
+            } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {
+              TestEventService::LogEvent("InstanceLoaded::Canceled", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            }
+          });
+        },
+        std::move(options));
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Canceled", nullptr}});
+  }
 };
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -117,18 +117,16 @@ TEST_CLASS (ReactNativeHostTests) {
     TestEventService::Initialize();
 
     auto options = TestReactNativeHostHolder::Options{};
-    auto reactNativeHost = TestReactNativeHostHolder(
-        L"ReactNativeHostTests",
-        [](ReactNativeHost const &host) noexcept {
-
-            host.InstanceSettings().InstanceLoaded([](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+    auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
+      host.InstanceSettings().InstanceLoaded(
+          [](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
             if (args.Failed()) {
               TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
             } else {
               TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
             }
           });
-        });
+    });
 
     TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Success", nullptr}});
   }
@@ -137,18 +135,16 @@ TEST_CLASS (ReactNativeHostTests) {
     TestEventService::Initialize();
 
     auto options = TestReactNativeHostHolder::Options{};
-    auto reactNativeHost = TestReactNativeHostHolder(
-        L"SyntaxError",
-        [](ReactNativeHost const &host) noexcept {
-
-            host.InstanceSettings().InstanceLoaded([](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+    auto reactNativeHost = TestReactNativeHostHolder(L"SyntaxError", [](ReactNativeHost const &host) noexcept {
+      host.InstanceSettings().InstanceLoaded(
+          [](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
             if (args.Failed()) {
               TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
             } else {
               TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
             }
           });
-        });
+    });
 
     TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Failed", nullptr}});
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -113,6 +113,26 @@ TEST_CLASS (ReactNativeHostTests) {
     TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Completed", nullptr}});
   }
 
+  TEST_METHOD(LoadInstance_FiresInstanceLoaded_Success) {
+    TestEventService::Initialize();
+
+    auto options = TestReactNativeHostHolder::Options{};
+    auto reactNativeHost = TestReactNativeHostHolder(
+        L"ReactNativeHostTests",
+        [](ReactNativeHost const &host) noexcept {
+
+            host.InstanceSettings().InstanceLoaded([](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+            if (args.Failed()) {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
+            }
+          });
+        });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Success", nullptr}});
+  }
+
   TEST_METHOD(LoadBundleWithError_FiresInstanceLoaded_Failed) {
     TestEventService::Initialize();
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
@@ -1,0 +1,3 @@
+// Bundle with syntax error to test bundle load failures
+
+global.foo(();

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -379,8 +379,13 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
       }
     }
 
-    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && /*value*/) noexcept {
+    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && value) noexcept {
       std::vector<Mso::Future<void>> loadCompletionList;
+
+      if (value.IsError()) {
+        return Mso::MakeFailedFuture<void>(std::move(value.TakeError()));
+      }
+
       ForEachViewHost([&loadCompletionList](auto &viewHost) noexcept {
         loadCompletionList.push_back(viewHost.UpdateViewInstanceInQueue());
       });

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -379,7 +379,7 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
       }
     }
 
-    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && value) noexcept {
+    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> &&value) noexcept {
       std::vector<Mso::Future<void>> loadCompletionList;
 
       if (value.IsError()) {

--- a/vnext/Mso/future/futureWinRT.h
+++ b/vnext/Mso/future/futureWinRT.h
@@ -27,18 +27,20 @@ struct AsyncActionFutureAdapter : winrt::implements<
           if (strongThis->m_status == AsyncStatus::Started) {
             if (result.IsValue()) {
               strongThis->m_status = AsyncStatus::Completed;
-              if (strongThis->m_completedAssigned) {
-                handler = std::move(strongThis->m_completed);
-              }
             } else {
-              strongThis->m_status = AsyncStatus::Error;
               strongThis->m_error = result.GetError();
+              strongThis->m_status = Mso::CancellationErrorProvider().TryGetErrorInfo(strongThis->m_error, false)
+                  ? AsyncStatus::Canceled
+                  : AsyncStatus::Error;
+            }
+            if (strongThis->m_completedAssigned) {
+              handler = std::move(strongThis->m_completed);
             }
           }
         }
 
         if (handler) {
-          invoke(handler, *strongThis, AsyncStatus::Completed);
+          invoke(handler, *strongThis, strongThis->m_status);
         }
       }
     });


### PR DESCRIPTION
## Description

- The async task returned by ReactHost.ReloadInstance() reports success, even if the bundle failed to load.
- The InstanceLoaded event has args that would report Failed() == false, even if the bundle failed to load.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Some error cases were not properly being reported up the to the application.

### What
Fixing several places where future continuations were not bubbling errors up.

## Testing
Added some UTs.
Two to test the value of the Failed property on InstanceLoadedEventArgs.
And one that tests the async task of ReloadInstance does not succeed.  (there is already one to test the success case)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9224)