### PR TITLE
Hook up DetachViewInstance method for custom UI implementations

### DIFF
--- a/change/react-native-windows-ffc796ec-456f-4aeb-9c7f-7603c237f26b.json
+++ b/change/react-native-windows-ffc796ec-456f-4aeb-9c7f-7603c237f26b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Hook up DetachViewInstance method for custom UI implementations",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -139,14 +139,9 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   inline Mso::Future<void> PostInUIQueue(winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
 
-    // ReactViewInstance has shorter lifetime than ReactRootControl. Thus, we capture this WeakPtr.
-    m_uiDispatcher.Post([weakThis = Mso::WeakPtr{this}, promise, action{std::move(action)}]() mutable noexcept {
-      if (auto strongThis = weakThis.GetStrongPtr()) {
-        action(strongThis->m_rootControl);
-        promise.SetValue();
-      } else {
-        promise.TryCancel();
-      }
+    m_uiDispatcher.Post([control = m_rootControl, promise, action{std::move(action)}]() mutable noexcept {
+      action(control);
+      promise.SetValue();
     });
     return promise.AsFuture();
   }
@@ -159,9 +154,7 @@ winrt::Windows::Foundation::IAsyncAction ReactViewHost::AttachViewInstance(
 }
 
 winrt::Windows::Foundation::IAsyncAction ReactViewHost::DetachViewInstance() noexcept {
-  Mso::Promise<void> promise;
-  promise.SetValue();
-  return make<Mso::AsyncActionFutureAdapter>(promise.AsFuture());
+  return make<Mso::AsyncActionFutureAdapter>(m_viewHost->DetachViewInstance());
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
## Description

When using a non-xaml UI implementation, the DetachViewInstance method does not get forwarded to the UI implementations.  This is required for Office to switch to using the RNW ABI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9226)