### PR TITLE
InstanceCreated should fire before any JS code is run

### DIFF
--- a/change/react-native-windows-385ca057-498f-49e9-97b7-8961b3304e68.json
+++ b/change/react-native-windows-385ca057-498f-49e9-97b7-8961b3304e68.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "InstanceCreated should fire before any JS code is run",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -444,6 +444,16 @@ void ReactInstanceWin::Initialize() noexcept {
 
             m_instanceWrapper.Exchange(std::move(instanceWrapper));
 
+            // The InstanceCreated event can be used to augment the JS environment for all JS code.  So it needs to be
+            // triggered before any platform JS code is run. Using m_jsMessageThread instead of jsDispatchQueue avoids
+            // waiting for the JSCaller which can delay the event until after certain JS code has already run
+            m_jsMessageThread.Load()->runOnQueue(
+                [onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
+                  if (onCreated) {
+                    onCreated.Get()->Invoke(reactContext);
+                  }
+                });
+
 #ifdef USE_FABRIC
             // Eagerly init the FabricUI binding
             if (!m_options.UseWebDebugger()) {
@@ -599,13 +609,6 @@ void ReactInstanceWin::InitJSMessageThread() noexcept {
       Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError),
       Mso::Copy(m_whenDestroyed));
   auto jsDispatchQueue = Mso::DispatchQueue::MakeCustomQueue(Mso::CntPtr(scheduler));
-
-  // This work item will be processed as a first item in JS queue when the react instance is created.
-  jsDispatchQueue.Post([onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
-    if (onCreated) {
-      onCreated.Get()->Invoke(reactContext);
-    }
-  });
 
   auto jsDispatcher =
       winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));


### PR DESCRIPTION
## Description

The InstanceCreated event can be used to augment the JS environment for all JS code.  So it needs to be triggered before any platform JS code is run. Using m_jsMessageThread instead of jsDispatchQueue avoids waiting for the JSCaller which can delay the event until after certain JS code has already run.


### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We need this to be able to consistently inject the platform bundles in Office.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9228)