### PR TITLE
Reduce scope of marking YogaNode dirty

### DIFF
--- a/change/react-native-windows-dc6afdfd-5d3f-41ff-8cbc-3ac0ad348203.json
+++ b/change/react-native-windows-dc6afdfd-5d3f-41ff-8cbc-3ac0ad348203.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reduce scope of marking YogaNode dirty",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -112,7 +112,7 @@ void ABIViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValu
 void ABIViewManager::UpdateProperties(
     ::Microsoft::ReactNative::ShadowNodeBase *nodeToUpdate,
     winrt::Microsoft::ReactNative::JSValueObject &props) {
-  if (m_viewManagerRequiresNativeLayout &&m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
+  if (m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
     MarkDirty(nodeToUpdate->m_tag);
   }
 

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -112,6 +112,10 @@ void ABIViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValu
 void ABIViewManager::UpdateProperties(
     ::Microsoft::ReactNative::ShadowNodeBase *nodeToUpdate,
     winrt::Microsoft::ReactNative::JSValueObject &props) {
+  if (m_viewManagerRequiresNativeLayout &&m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
+    MarkDirty(nodeToUpdate->m_tag);
+  }
+
   if (m_viewManagerWithNativeProperties) {
     auto view = nodeToUpdate->GetView().as<xaml::FrameworkElement>();
 

--- a/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/RawTextViewManager.cpp
@@ -43,6 +43,7 @@ bool RawTextViewManager::UpdateProperty(
     return true;
 
   if (propertyName == "text") {
+    MarkDirty(nodeToUpdate->m_tag);
     run.Text(asHstring(propertyValue));
     static_cast<RawTextShadowNode *>(nodeToUpdate)->originalText = winrt::hstring{};
     ApplyTextTransformToChild(nodeToUpdate);

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -197,6 +197,17 @@ XamlView TextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft
   return textBlock;
 }
 
+void TextViewManager::UpdateProperties(
+  ShadowNodeBase* nodeToUpdate,
+  winrt::Microsoft::ReactNative::JSValueObject& props) {
+  // This could be optimized further, but rather than paying a penalty to mark
+  // the node dirty for each relevant property in UpdateProperty (which should
+  // be reasonably cheap given it just does an O(1) lookup of the Yoga node
+  // for the tag, for now this just marks the node dirty for any prop update.
+  MarkDirty(nodeToUpdate->m_tag);
+  Super::UpdateProperties(nodeToUpdate, props);
+}
+
 bool TextViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -198,8 +198,8 @@ XamlView TextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft
 }
 
 void TextViewManager::UpdateProperties(
-  ShadowNodeBase* nodeToUpdate,
-  winrt::Microsoft::ReactNative::JSValueObject& props) {
+    ShadowNodeBase *nodeToUpdate,
+    winrt::Microsoft::ReactNative::JSValueObject &props) {
   // This could be optimized further, but rather than paying a penalty to mark
   // the node dirty for each relevant property in UpdateProperty (which should
   // be reasonably cheap given it just does an O(1) lookup of the Yoga node

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -21,6 +21,7 @@ class TextViewManager : public FrameworkElementViewManager {
   void AddView(const XamlView &parent, const XamlView &child, int64_t index) override;
   void RemoveAllChildren(const XamlView &parent) override;
   void RemoveChildAt(const XamlView &parent, int64_t index) override;
+  void UpdateProperties(ShadowNodeBase *nodeToUpdate, winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
   YGMeasureFunc GetYogaCustomMeasureFunc() const override;
 

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -240,15 +240,6 @@ void ViewManagerBase::ReplaceChild(const XamlView &parent, const XamlView &oldCh
 void ViewManagerBase::UpdateProperties(
     ShadowNodeBase *nodeToUpdate,
     winrt::Microsoft::ReactNative::JSValueObject &props) {
-  // Directly dirty this node since non-layout changes like the text property do
-  // not trigger relayout
-  //  There isn't actually a yoga node for RawText views, but it will invalidate
-  //  the ancestors which
-  //  will include the containing Text element. And that's what matters.
-  int64_t tag = GetTag(nodeToUpdate->GetView());
-  if (auto uiManager = GetNativeUIManager(GetReactContext()).lock())
-    uiManager->DirtyYogaNode(tag);
-
   for (const auto &pair : props) {
     const std::string &propertyName = pair.first;
     const auto &propertyValue = pair.second;
@@ -390,6 +381,11 @@ bool ViewManagerBase::RequiresYogaNode() const {
 
 bool ViewManagerBase::IsNativeControlWithSelfLayout() const {
   return GetYogaCustomMeasureFunc() != nullptr;
+}
+
+void ViewManagerBase::MarkDirty(int64_t tag) {
+  if (auto uiManager = GetNativeUIManager(GetReactContext()).lock())
+    uiManager->DirtyYogaNode(tag);
 }
 
 void ViewManagerBase::OnPointerEvent(

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -78,6 +78,7 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   virtual YGMeasureFunc GetYogaCustomMeasureFunc() const;
   virtual bool RequiresYogaNode() const;
   bool IsNativeControlWithSelfLayout() const;
+  void MarkDirty(int64_t tag);
 
   virtual void OnPointerEvent(ShadowNodeBase *node, const winrt::Microsoft::ReactNative::ReactPointerEventArgs &args);
 

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.cpp
@@ -56,6 +56,17 @@ XamlView VirtualTextViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Mi
   return winrt::Span();
 }
 
+void VirtualTextViewManager::UpdateProperties(
+    ShadowNodeBase *nodeToUpdate,
+    winrt::Microsoft::ReactNative::JSValueObject &props) {
+  // This could be optimized further, but rather than paying a penalty to mark
+  // the node dirty for each relevant property in UpdateProperty (which should
+  // be reasonably cheap given it just does an O(1) lookup of the Yoga node
+  // for the tag, for now this just marks the node dirty for any prop update.
+  MarkDirty(nodeToUpdate->m_tag);
+  Super::UpdateProperties(nodeToUpdate, props);
+}
+
 bool VirtualTextViewManager::UpdateProperty(
     ShadowNodeBase *nodeToUpdate,
     const std::string &propertyName,

--- a/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/VirtualTextViewManager.h
@@ -43,6 +43,8 @@ class VirtualTextViewManager : public ViewManagerBase {
 
   bool RequiresYogaNode() const override;
 
+  void UpdateProperties(ShadowNodeBase *nodeToUpdate, winrt::Microsoft::ReactNative::JSValueObject &props);
+
  protected:
   bool UpdateProperty(
       ShadowNodeBase *nodeToUpdate,


### PR DESCRIPTION
## Description

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
Currently, we mark a node dirty any time **any** prop is updated on a RN native view. In core at least, we really only need to do this for self-measuring views (Text and TextInput).

Where this causes the greatest concern is for RNW users that are forced to use the JS animation driver, either due to bugs in the NativeAnimated module or to animate props not supported by the NativeAnimated module (e.g., https://github.com/microsoft/react-native-windows/issues/3283). The JS driver aspires to fire at 60Hz, but obviously would not hit that mark because it's not a truly native animation. Even still, we should attempt to do as little work as possible.

### What
This change narrows which props we mark the YogaNode dirty for:
1. A subset of TextInputViewManager props
2. All TextViewManager props
3. All VirtualTextViewManager props
4. Only "text" changes on RawTextViewManager.
5. Any ABIViewManager that sets RequiresNativeLayout to true


## Testing
The two things I tested were:
1. Multiline text inputs that need to become dirty when the "text" prop updates.
2. Changes to virtual text that would make the text value grow.

## Breaking Change

This is technically a breaking change as any external view manager that does not set `RequireNativeLayout` does not become dirty for all prop changes. However, if the view does not use `RequireNativeLayout`, it's hard to see how a prop change (that is not an actual flex layout prop) could possibly affect layout.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9231)