### PR TITLE
Centralize CppWinRT version setting

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -79,16 +79,6 @@ jobs:
                 feature: UseHermes
                 value: ${{ matrix.UseHermes }}
 
-            # NuGet ignores packages.config if it detects <PackageReference>.
-            # Use restore packages.config directly to keep compabitility with ReactNativePicker.
-            - pwsh: |
-                Get-ChildItem -Recurse -Path packages.config |`
-                  Foreach-Object {`
-                    NuGet.exe Restore -PackagesDirectory windows\packages $_`
-                  }
-              workingDirectory: packages/e2e-test-app
-              displayName: Restore packages.config items
-
             - template: ../templates/run-windows-with-certificates.yml
               parameters:
                 buildEnvironment: ${{ parameters.BuildEnvironment }}

--- a/change/@react-native-windows-automation-channel-b8c714c3-918d-4a57-ab51-ee7db0b831b9.json
+++ b/change/@react-native-windows-automation-channel-b8c714c3-918d-4a57-ab51-ee7db0b831b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Centralize CppWinRT version setting",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-78d2c82c-1ee1-46c2-816a-32e57b886e94.json
+++ b/change/@react-native-windows-cli-78d2c82c-1ee1-46c2-816a-32e57b886e94.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Centralize CppWinRT version setting",
+  "packageName": "@react-native-windows/cli",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-140f39a2-cef7-48cf-aeff-f57b8037b8e3.json
+++ b/change/react-native-windows-140f39a2-cef7-48cf-aeff-f57b8037b8e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Centralize CppWinRT version setting",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/AutomationChannel.vcxproj
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/AutomationChannel.vcxproj
@@ -142,7 +142,7 @@
     <None Include="PropertySheet.props" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">

--- a/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/build.ts
@@ -85,15 +85,12 @@ export function getAppSolutionFile(options: RunWindowsOptions, config: Config) {
 export function restorePackageConfigs(options: RunWindowsOptions) {
   const pkgConfigs = new Array();
 
-  if (!options.sln) {
-    return;
-  }
-
   findFiles(options.root, 'packages.config', pkgConfigs);
 
   for (const pkgConfig of pkgConfigs) {
     const cmd = `NuGet.exe Restore -PackagesDirectory ${path.join(
       options.root,
+      'windows',
       'packages',
     )}
       ${pkgConfig}`;
@@ -103,15 +100,16 @@ export function restorePackageConfigs(options: RunWindowsOptions) {
 }
 
 function findFiles(dir: any, name: string, result: Array<string>) {
-  fs.readdirSync(dir).forEach((file: any) => {
-    const stat = fs.lstatSync(file);
+  fs.readdirSync(dir).forEach((file: string) => {
+    const filePath = path.join(dir, file);
+    const stat = fs.lstatSync(filePath);
     if (stat.isDirectory()) {
-      findFiles(file, name, result);
+      findFiles(filePath, name, result);
     } else if (
       (stat.isFile() || stat.isSymbolicLink()) &&
       `${file}`.endsWith('packages.config')
     ) {
-      result.push(file);
+      result.push(filePath);
     }
   });
 }

--- a/packages/e2e-test-app/packages.config
+++ b/packages/e2e-test-app/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="boost" version="1.76.0.0" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native" />
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.211028.7" targetFramework="native" />
 </packages>

--- a/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
+++ b/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
@@ -179,7 +179,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
   </ItemGroup>

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -178,7 +178,7 @@
     -->
     <!-- <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.1-prerelease.210709001" /> -->
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.2-rc" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="0.8.1-ms.5" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />

--- a/packages/playground/windows/playground/Playground.vcxproj
+++ b/packages/playground/windows/playground/Playground.vcxproj
@@ -167,7 +167,7 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
   </ImportGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
   </ItemGroup>

--- a/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
+++ b/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
@@ -178,7 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/packages/sample-apps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj
+++ b/packages/sample-apps/windows/SampleLibraryCPP/SampleLibraryCPP.vcxproj
@@ -153,7 +153,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ReactNativeWindowsTargets">

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -164,7 +164,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -120,7 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactWindows.OpenSSL.StdCall.Static" Version="1.0.2-p.5" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -321,7 +321,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="ReactWindows.OpenSSL.StdCall.Static" Version="1.0.2-p.5" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.ComponentTests/Microsoft.ReactNative.ComponentTests.vcxproj
@@ -227,7 +227,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="boost" Version="1.76.0.0" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -161,7 +161,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8PackageVersion)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -162,7 +162,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="TestBundle.targets" />

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen.UnitTests/Microsoft.ReactNative.Managed.CodeGen.UnitTests.csproj
@@ -60,7 +60,7 @@
       <_ReactNativeManagedCodeGenUnitTestRuntimeDependencies Include="..\Microsoft.ReactNative.Managed\Microsoft.ReactNative.Managed.csproj" />
       <!--
         This project should be built as well before the unittest can run, but when building in VS this sometimes gives the following error:
-          \vnext\packages\Microsoft.Windows.CppWinRT.2.0.211028.7\build\native\Microsoft.Windows.CppWinRT.targets(158,13): error MSB4006: There is a circular dependency in the target dependency graph involving target "ComputeGetResolvedWinMD". [\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
+          \vnext\packages\Microsoft.Windows.CppWinRT.$(CppWinRTVersion)\build\native\Microsoft.Windows.CppWinRT.targets(158,13): error MSB4006: There is a circular dependency in the target dependency graph involving target "ComputeGetResolvedWinMD". [\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
         Microsoft.ReactNative.Managed.vcxproj is luckily a dependency of Microsoft.ReactNative.Managed.csproj so we can safely ommit it here.
 
         <_ReactNativeManagedCodeGenUnitTestRuntimeDependencies Include="..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -804,7 +804,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
   </ItemGroup>

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -144,7 +144,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
-    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="2.0.211028.7" />
+    <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -9,7 +9,7 @@
   ALL such projects.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+
   <!--
     Projects internal to the `react-native-windows` package should resolve
     '$(ReactNativeWindowsDir)` via "Directory.Build.Props".
@@ -28,6 +28,8 @@
   </PropertyGroup>
 
   <Import Condition="'$(JsEnginePropsDefined)' == ''" Project="$(ReactNativeWindowsDir)PropertySheets\JSEngine.props" />
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Cpp.Dependencies.props" />
 
   <PropertyGroup>
     <ProjectDir Condition="'$(ProjectDir)' == ''">$(MSBuildProjectDirectory)\</ProjectDir>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation.
+  Licensed under the MIT License.
+
+  This file will be consumed by ALL app and module projects (Desktop & UWP,
+  both inside and outside of this repo) that build on top of
+  Microsoft.ReactNative. Do not make any changes here unless it applies to
+  ALL such projects.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="CppWinRT">
+    <CppWinRTVersion>2.0.211028.7</CppWinRTVersion>
+  </PropertyGroup>
+
+</Project>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -77,6 +77,10 @@
     <Import Project="$(ConfigurationType)\$(Configuration).props" />
   </ImportGroup>
 
+  <ImportGroup Label="Dependencies">
+    <Import Project="$(MSBuildThisFileDirectory)External\Microsoft.ReactNative.Cpp.Dependencies.props" />
+  </ImportGroup>
+
   <PropertyGroup>
     <CppStandard Condition="'$(CppStandard)'==''">stdcpp17</CppStandard>
   </PropertyGroup>


### PR DESCRIPTION
This change introduces a shared `props` file to allow setting C++ NuGet depedency versions on a single place.

- Defines vnext\PropertySheets\External\Microsoft.ReactNative.Cpp.Dependencies.props
- Defines MSBuild property CppWinRTVersion
- Imports Microsoft.ReactNative.Cpp.Dependencies.props within React.Cpp.props and Microsoft.ReactNative.Common.props

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9238)