### PR TITLE
Adds Rendering driver option to NativeAnimated

### DIFF
--- a/change/react-native-windows-bf20335c-eccd-487b-bbcf-9fcc46a3b849.json
+++ b/change/react-native-windows-bf20335c-eccd-487b-bbcf-9fcc46a3b849.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds Rendering driver option to NativeAnimated",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples-win/NativeAnimation/CompositionBugsExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/NativeAnimation/CompositionBugsExample.js
@@ -1,0 +1,476 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+
+const {
+  View,
+  Text,
+  Animated,
+  StyleSheet,
+  TouchableWithoutFeedback,
+} = require('react-native');
+
+class Tester extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
+  state = {
+    native: new Animated.Value(0),
+    tick: new Animated.Value(0),
+    js: new Animated.Value(0),
+  };
+
+  current = 0;
+
+  onPress = () => {
+    const animConfig =
+      this.current && this.props.reverseConfig
+        ? this.props.reverseConfig
+        : this.props.config;
+    this.current = this.current ? 0 : 1;
+    const config: Object = {
+      ...animConfig,
+      toValue: this.current,
+    };
+
+    Animated[this.props.type](this.state.native, {
+      ...config,
+      useNativeDriver: true,
+    }).start();
+    Animated[this.props.type](this.state.tick, {
+      ...config,
+      useNativeDriver: true,
+      platformConfig: {
+        useComposition: false,
+      },
+    }).start();
+    Animated[this.props.type](this.state.js, {
+      ...config,
+      useNativeDriver: false,
+    }).start();
+
+    if (this.props.onPress) {
+      this.props.onPress(this.state.native);
+      this.props.onPress(this.state.tick);
+      this.props.onPress(this.state.js);
+    }
+  };
+
+  render() {
+    return (
+      <TouchableWithoutFeedback onPress={this.onPress}>
+        <View>
+          <View>
+            <Text>Composition:</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(this.state.native)}
+          </View>
+          <View>
+            <Text>UI Tick{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.tick)}</View>
+          <View>
+            <Text>JavaScript{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.js)}</View>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+class ValueListenerTester extends Tester {
+  state = {
+    native: new Animated.Value(0),
+    tick: new Animated.Value(0),
+    js: new Animated.Value(0),
+    nativeValue: 0,
+    tickValue: 0,
+    jsValue: 0,
+  };
+
+  componentDidMount() {
+    this.state.native.addListener(e => this.setState({nativeValue: e.value}));
+    this.state.tick.addListener(e => this.setState({tickValue: e.value}));
+    this.state.js.addListener(e => this.setState({jsValue: e.value}));
+  }
+
+  componentWillUnmount() {
+    this.state.native.removeAllListeners();
+    this.state.tick.removeAllListeners();
+    this.state.js.removeAllListeners();
+  }
+
+  render() {
+    return (
+      <TouchableWithoutFeedback onPress={this.onPress}>
+        <View>
+          <View>
+            <Text>Composition:</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(this.state.native)}
+          </View>
+          <Text>
+            Value: {this.state.nativeValue}
+            {'\n'}
+          </Text>
+          <View>
+            <Text>UI Tick{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.tick)}</View>
+          <Text>
+            Value: {this.state.tickValue}
+            {'\n'}
+          </Text>
+          <View>
+            <Text>JavaScript{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.js)}</View>
+          <Text>
+            Value: {this.state.jsValue}
+            {'\n'}
+          </Text>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+class RevertToStaticPropsExample extends React.Component<
+  $FlowFixMeProps,
+  $FlowFixMeState,
+> {
+  state = {
+    native: new Animated.Value(0),
+    tick: new Animated.Value(0),
+    js: new Animated.Value(0),
+    resetProp: false,
+  };
+
+  current = 0;
+
+  onPress = () => {
+    if (this.current) {
+      this.state.native.setValue(0);
+      this.state.tick.setValue(0);
+      this.state.js.setValue(0);
+      this.setState({resetProp: true});
+    } else {
+      this.setState({resetProp: false});
+      const config: Object = {
+        ...this.props.config,
+        toValue: 50,
+      };
+
+      Animated[this.props.type](this.state.native, {
+        ...config,
+        useNativeDriver: true,
+      }).start();
+      Animated[this.props.type](this.state.tick, {
+        ...config,
+        useNativeDriver: true,
+        platformConfig: {
+          useComposition: false,
+        },
+      }).start();
+      Animated[this.props.type](this.state.js, {
+        ...config,
+        useNativeDriver: false,
+      }).start();
+
+      if (this.props.onPress) {
+        this.props.onPress(this.state.native);
+        this.props.onPress(this.state.tick);
+        this.props.onPress(this.state.js);
+      }
+    }
+    this.current = this.current ? 0 : 1;
+  };
+
+  render() {
+    return (
+      <TouchableWithoutFeedback onPress={this.onPress}>
+        <View>
+          <View>
+            <Text>Composition:</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(
+              this.state.resetProp ? undefined : this.state.native,
+            )}
+          </View>
+          <View>
+            <Text>UI Tick{':'}</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(
+              this.state.resetProp ? undefined : this.state.tick,
+            )}
+          </View>
+          <View>
+            <Text>JavaScript{':'}</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(
+              this.state.resetProp ? undefined : this.state.js,
+            )}
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+class StopAnimationCallbackTester extends Tester {
+  onPress = () => {
+    const animConfig =
+      this.current && this.props.reverseConfig
+        ? this.props.reverseConfig
+        : this.props.config;
+    this.current = this.current ? 0 : 1;
+    const config: Object = {
+      ...animConfig,
+      toValue: this.current,
+    };
+
+    Animated[this.props.type](this.state.native, {
+      ...config,
+      useNativeDriver: true,
+    }).start();
+    Animated[this.props.type](this.state.tick, {
+      ...config,
+      useNativeDriver: true,
+      platformConfig: {
+        useComposition: false,
+      },
+    }).start();
+    Animated[this.props.type](this.state.js, {
+      ...config,
+      useNativeDriver: false,
+    }).start();
+
+    setTimeout(() => {
+      this.state.native.stopAnimation(nativeValue =>
+        this.setState({nativeValue}),
+      );
+      this.state.tick.stopAnimation(tickValue => this.setState({tickValue}));
+      this.state.js.stopAnimation(jsValue => this.setState({jsValue}));
+    }, config.duration / 2);
+  };
+
+  render() {
+    return (
+      <TouchableWithoutFeedback onPress={this.onPress}>
+        <View>
+          <View>
+            <Text>Composition:</Text>
+          </View>
+          <View style={styles.row}>
+            {this.props.children(this.state.native)}
+          </View>
+          <Text>
+            Final Value: {this.state.nativeValue}
+            {'\n'}
+          </Text>
+          <View>
+            <Text>UI Tick{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.tick)}</View>
+          <Text>
+            Final Value: {this.state.tickValue}
+            {'\n'}
+          </Text>
+          <View>
+            <Text>JavaScript{':'}</Text>
+          </View>
+          <View style={styles.row}>{this.props.children(this.state.js)}</View>
+          <Text>
+            Final Value: {this.state.jsValue}
+            {'\n'}
+          </Text>
+        </View>
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  row: {
+    padding: 10,
+    zIndex: 1,
+  },
+  block: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'blue',
+  },
+  line: {
+    position: 'absolute',
+    left: 35,
+    top: 0,
+    bottom: 0,
+    width: 1,
+    backgroundColor: 'red',
+  },
+});
+
+exports.framework = 'React';
+exports.title = 'Composition Bugs Example';
+exports.category = 'UI';
+exports.description = 'See bugs in UI.Composition driven native animations';
+
+exports.examples = [
+  {
+    title: 'Animated value listener',
+    render: function (): React.Node {
+      return (
+        <ValueListenerTester type="timing" config={{duration: 1000}}>
+          {anim => (
+            <Animated.View
+              style={[
+                styles.block,
+                {
+                  opacity: anim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [1, 0],
+                  }),
+                },
+              ]}
+            />
+          )}
+        </ValueListenerTester>
+      );
+    },
+  },
+  {
+    title: "Arbitrary props (e.g., 'borderRadius')",
+    render: function (): React.Node {
+      return (
+        <Tester type="timing" config={{duration: 1000}}>
+          {anim => (
+            <Animated.View
+              style={[
+                styles.block,
+                {
+                  borderRadius: anim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0, 25],
+                  }),
+                },
+              ]}
+            />
+          )}
+        </Tester>
+      );
+    },
+  },
+  {
+    title: 'diffClamp',
+    render: function (): React.Node {
+      return (
+        <Tester type="timing" config={{duration: 1000}}>
+          {anim => (
+            <Animated.View
+              style={[
+                styles.block,
+                {
+                  opacity: Animated.diffClamp(
+                    anim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [1, 0],
+                    }),
+                    0,
+                    0.5,
+                  ),
+                },
+              ]}
+            />
+          )}
+        </Tester>
+      );
+    },
+  },
+  {
+    title: 'setValue in active animation',
+    render: function (): React.Node {
+      return (
+        <Tester
+          type="timing"
+          config={{duration: 1000}}
+          onPress={anim => setTimeout(() => anim.setValue(0.5), 500)}>
+          {anim => {
+            return (
+              <Animated.View
+                style={[
+                  styles.block,
+                  {
+                    opacity: anim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [1, 0],
+                    }),
+                  },
+                ]}
+              />
+            );
+          }}
+        </Tester>
+      );
+    },
+  },
+  {
+    title: 'stopAnimation callback',
+    render: function (): React.Node {
+      return (
+        <StopAnimationCallbackTester type="timing" config={{duration: 1000}}>
+          {anim => {
+            return (
+              <Animated.View
+                style={[
+                  styles.block,
+                  {
+                    opacity: anim.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [1, 0],
+                    }),
+                  },
+                ]}
+              />
+            );
+          }}
+        </StopAnimationCallbackTester>
+      );
+    },
+  },
+  {
+    title: "Animated 'transform' prop value persisted",
+    render: function (): React.Node {
+      return (
+        <RevertToStaticPropsExample type="timing" config={{duration: 1000}}>
+          {value => {
+            return (
+              <Animated.View
+                style={[
+                  styles.block,
+                  value
+                    ? {
+                        transform: [{translateX: value}],
+                      }
+                    : {},
+                ]}
+              />
+            );
+          }}
+        </RevertToStaticPropsExample>
+      );
+    },
+  },
+];

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -300,6 +300,11 @@ const APIs: Array<RNTesterModuleInfo> = [
     module: require('../examples/NativeAnimation/NativeAnimationsExample'),
   },
   {
+    key: 'CompositionBugsExample',
+    category: 'UI',
+    module: require('../examples-win/NativeAnimation/CompositionBugsExample'),
+  },
+  {
     key: 'PanResponderExample',
     category: 'Basic',
     module: require('../examples/PanResponder/PanResponderExample'),

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -233,9 +233,11 @@
     <ClInclude Include="Modules\AlertModule.h" />
     <ClInclude Include="Modules\Animated\AdditionAnimatedNode.h" />
     <ClInclude Include="Modules\Animated\AnimatedNode.h" />
+    <ClInclude Include="Modules\Animated\AnimatedPlatformConfig.h" />
     <ClInclude Include="Modules\Animated\AnimatedNodeType.h" />
     <ClInclude Include="Modules\Animated\AnimationDriver.h" />
     <ClInclude Include="Modules\Animated\AnimationType.h" />
+    <ClInclude Include="Modules\Animated\AnimationUtils.h" />
     <ClInclude Include="Modules\Animated\CalculatedAnimationDriver.h" />
     <ClInclude Include="Modules\Animated\DecayAnimationDriver.h" />
     <ClInclude Include="Modules\Animated\DiffClampAnimatedNode.h" />
@@ -466,6 +468,7 @@
     <ClCompile Include="Modules\AlertModule.cpp" />
     <ClCompile Include="Modules\Animated\AdditionAnimatedNode.cpp" />
     <ClCompile Include="Modules\Animated\AnimatedNode.cpp" />
+    <ClCompile Include="Modules\Animated\AnimatedPlatformConfig.cpp" />
     <ClCompile Include="Modules\Animated\AnimationDriver.cpp" />
     <ClCompile Include="Modules\Animated\CalculatedAnimationDriver.cpp" />
     <ClCompile Include="Modules\Animated\DecayAnimationDriver.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="Modules\Animated\AnimatedNode.cpp">
       <Filter>Modules\Animated</Filter>
     </ClCompile>
+    <ClCompile Include="Modules\Animated\AnimatedPlatformConfig.cpp">
+      <Filter>Modules\Animated</Filter>
+    </ClCompile>
     <ClCompile Include="Modules\Animated\AnimationDriver.cpp">
       <Filter>Modules\Animated</Filter>
     </ClCompile>
@@ -412,6 +415,9 @@
     <ClInclude Include="Modules\Animated\AnimatedNode.h">
       <Filter>Modules\Animated</Filter>
     </ClInclude>
+    <ClInclude Include="Modules\Animated\AnimatedPlatformConfig.h">
+      <Filter>Modules\Animated</Filter>
+    </ClInclude>
     <ClInclude Include="Modules\Animated\AnimatedNodeType.h">
       <Filter>Modules\Animated</Filter>
     </ClInclude>
@@ -419,6 +425,9 @@
       <Filter>Modules\Animated</Filter>
     </ClInclude>
     <ClInclude Include="Modules\Animated\AnimationType.h">
+      <Filter>Modules\Animated</Filter>
+    </ClInclude>
+    <ClInclude Include="Modules\Animated\AnimationUtils.h">
       <Filter>Modules\Animated</Filter>
     </ClInclude>
     <ClInclude Include="Modules\Animated\CalculatedAnimationDriver.h">

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
@@ -12,24 +12,41 @@ AdditionAnimatedNode::AdditionAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   for (const auto &inputNode : config[s_inputName].AsArray()) {
-    m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
+    const auto inputTag = inputNode.AsInt64();
+    assert(HasCompatibleAnimationDriver(inputTag));
+    m_inputNodes.insert(inputTag);
   }
 
-  m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
 
-    anim.Expression([nodes, manager, anim]() {
-      winrt::hstring expr = L"0";
-      for (const auto tag : nodes) {
-        const auto identifier = L"n" + std::to_wstring(tag);
-        anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
-        expr = expr + L" + " + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName;
-      }
-      return expr;
+      anim.Expression([nodes, manager, anim]() {
+        winrt::hstring expr = L"0";
+        for (const auto tag : nodes) {
+          const auto identifier = L"n" + std::to_wstring(tag);
+          anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
+          expr = expr + L" + " + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName;
+        }
+        return expr;
+      }());
+      return anim;
     }());
-    return anim;
-  }());
+  }
+}
+
+void AdditionAnimatedNode::Update() {
+  assert(!m_useComposition);
+  auto rawValue = 0.0;
+  if (const auto manager = m_manager.lock()) {
+    for (const auto tag : m_inputNodes) {
+      if (const auto node = manager->GetValueAnimatedNode(tag)) {
+        rawValue += node->Value();
+      }
+    }
+  }
+  RawValue(rawValue);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
@@ -12,6 +12,8 @@ class AdditionAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   std::unordered_set<int64_t> m_inputNodes{};
 };

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.cpp
@@ -4,12 +4,18 @@
 #include "pch.h"
 
 #include "AnimatedNode.h"
+#include "AnimatedPlatformConfig.h"
 #include "NativeAnimatedNodeManager.h"
 
 namespace Microsoft::ReactNative {
 
-AnimatedNode::AnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : m_tag(tag), m_manager(manager) {}
+AnimatedNode::AnimatedNode(
+    int64_t tag,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
+    const std::shared_ptr<NativeAnimatedNodeManager> &manager)
+    : m_tag(tag), m_manager(manager) {
+  m_useComposition = AnimatedPlatformConfig::ShouldUseComposition(config);
+}
 
 int64_t AnimatedNode::Tag() {
   return m_tag;
@@ -35,5 +41,14 @@ AnimatedNode *AnimatedNode::GetChildNode(int64_t tag) {
   }
 
   return static_cast<AnimatedNode *>(nullptr);
+}
+
+bool AnimatedNode::HasCompatibleAnimationDriver(int64_t tag) {
+#if DEBUG
+  if (const auto manager = m_manager.lock()) {
+    return manager->GetAnimatedNode(tag)->UseComposition() == m_useComposition;
+  }
+#endif
+  return true;
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedNode.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <JSValue.h>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -11,10 +12,21 @@ namespace Microsoft::ReactNative {
 class NativeAnimatedNodeManager;
 class AnimatedNode {
  public:
-  AnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager);
+  AnimatedNode(
+      int64_t tag,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
+      const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   int64_t Tag();
   void AddChild(int64_t animatedNode);
   void RemoveChild(int64_t animatedNode);
+
+  std::vector<int64_t> &Children() {
+    return m_children;
+  }
+
+  virtual bool UseComposition() const noexcept {
+    return m_useComposition;
+  }
 
   virtual void Update(){};
   virtual void OnDetachedFromNode(int64_t /*animatedNodeTag*/){};
@@ -26,5 +38,11 @@ class AnimatedNode {
   int64_t m_tag{0};
   const std::weak_ptr<NativeAnimatedNodeManager> m_manager;
   std::vector<int64_t> m_children{};
+  bool m_useComposition{false};
+
+  bool HasCompatibleAnimationDriver(int64_t tag);
+
+  static constexpr std::string_view s_platformConfigName{"platformConfig"};
+  static constexpr std::string_view s_useCompositionName{"useComposition"};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedPlatformConfig.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedPlatformConfig.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "AnimatedPlatformConfig.h"
+
+namespace Microsoft::ReactNative {
+
+// We could consider converting this value to a quirk setting in the future if
+// we want to change the default behavior to use the frame rendering approach.
+static constexpr auto DEFAULT_USE_COMPOSITION = true;
+
+/*static*/ bool AnimatedPlatformConfig::ShouldUseComposition(
+    const winrt::Microsoft::ReactNative::JSValueObject &config) {
+  if (config.count(s_platformConfigName)) {
+    const auto &platformConfig = config[s_platformConfigName].AsObject();
+    if (platformConfig.count(s_useCompositionName)) {
+      return platformConfig[s_useCompositionName].AsBoolean();
+    }
+  }
+  return DEFAULT_USE_COMPOSITION;
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedPlatformConfig.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimatedPlatformConfig.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <JSValue.h>
+
+namespace Microsoft::ReactNative {
+class AnimatedPlatformConfig {
+ public:
+  static bool ShouldUseComposition(const winrt::Microsoft::ReactNative::JSValueObject &config);
+
+ private:
+  static constexpr std::string_view s_platformConfigName{"platformConfig"};
+  static constexpr std::string_view s_useCompositionName{"useComposition"};
+};
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -47,10 +47,22 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
   };
 
   virtual std::vector<double> Frames() {
+    assert(m_useComposition);
     return std::vector<double>();
   }
 
   void DoCallback(bool value);
+
+  bool UseComposition() const noexcept {
+    return m_useComposition;
+  }
+
+  bool IsComplete() {
+    assert(!m_useComposition);
+    return m_isComplete;
+  }
+
+  void RunAnimationStep(winrt::TimeSpan renderingTime);
 
  private:
   Callback m_endCallback{};
@@ -60,12 +72,21 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
 
  protected:
   ValueAnimatedNode *GetAnimatedValue();
+  virtual bool Update(double timeDeltaMs, bool restarting) {
+    return true;
+  };
 
+  bool m_useComposition{};
   int64_t m_id{0};
   int64_t m_animatedValueTag{};
   int64_t m_iterations{0};
   winrt::Microsoft::ReactNative::JSValueObject m_config{};
   std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
+
+  bool m_isComplete{false};
+  int64_t m_iteration{0};
+  double m_startFrameTimeMs{-1};
+  std::optional<double> m_originalValue{};
 
   comp::CompositionAnimation m_animation{nullptr};
   comp::CompositionScopedBatch m_scopedBatch{nullptr};
@@ -75,5 +96,7 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
   bool m_started{false};
   bool m_stopped{false};
   bool m_ignoreCompletedHandlers{false};
+
+  static constexpr double s_frameDurationMs = 1000.0 / 60.0;
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationUtils.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationUtils.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+static constexpr std::string_view ExtrapolateTypeIdentity = "identity";
+static constexpr std::string_view ExtrapolateTypeClamp = "clamp";
+static constexpr std::string_view ExtrapolateTypeExtend = "extend";
+
+static double Interpolate(
+    double value,
+    double inputMin,
+    double inputMax,
+    double outputMin,
+    double outputMax,
+    std::string_view const &extrapolateLeft,
+    std::string_view const &extrapolateRight) {
+  auto result = value;
+
+  // Extrapolate
+  if (result < inputMin) {
+    if (extrapolateLeft == ExtrapolateTypeIdentity) {
+      return result;
+    } else if (extrapolateLeft == ExtrapolateTypeClamp) {
+      result = inputMin;
+    }
+  }
+
+  if (result > inputMax) {
+    if (extrapolateRight == ExtrapolateTypeIdentity) {
+      return result;
+    } else if (extrapolateRight == ExtrapolateTypeClamp) {
+      result = inputMax;
+    }
+  }
+
+  if (inputMin == inputMax) {
+    if (value <= inputMin) {
+      return outputMin;
+    }
+    return outputMax;
+  }
+
+  return outputMin + (outputMax - outputMin) * (result - inputMin) / (inputMax - inputMin);
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -10,6 +10,7 @@ namespace Microsoft::ReactNative {
 
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
     const winrt::Microsoft::ReactNative::JSValueObject & /*config*/) {
+  assert(m_useComposition);
   const auto [scopedBatch, animation, easingFunction] = []() {
     const auto compositor = Microsoft::ReactNative::GetCompositor();
     return std::make_tuple(
@@ -18,7 +19,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
         compositor.CreateLinearEasingFunction());
   }();
 
-  m_startValue = GetAnimatedValue()->RawValue();
+  m_originalValue = GetAnimatedValue()->RawValue();
   std::vector<float> keyFrames = [this]() {
     std::vector<float> keyFrames;
     bool done = false;
@@ -39,7 +40,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
   std::chrono::milliseconds duration(static_cast<int>(keyFrames.size() / 60.0f * 1000.0f));
   animation.Duration(duration);
   auto normalizedProgress = 0.0f;
-  auto fromValue = static_cast<float>(m_startValue);
+  auto fromValue = static_cast<float>(m_originalValue.value());
   animation.InsertKeyFrame(normalizedProgress, fromValue, easingFunction);
   for (const auto keyFrame : keyFrames) {
     normalizedProgress = std::min(normalizedProgress + 1.0f / keyFrames.size(), 1.0f);

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
@@ -17,8 +17,6 @@ class CalculatedAnimationDriver : public AnimationDriver {
 
  protected:
   virtual std::tuple<float, double> GetValueAndVelocityForTime(double time) = 0;
-
   virtual bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) = 0;
-  double m_startValue{0};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
@@ -20,8 +20,8 @@ DecayAnimationDriver::DecayAnimationDriver(
 }
 
 std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(double time) {
-  const auto value =
-      m_startValue + m_velocity / (1 - m_deceleration) * (1 - std::exp(-(1 - m_deceleration) * (1000 * time)));
+  const auto value = m_originalValue.value() +
+      m_velocity / (1 - m_deceleration) * (1 - std::exp(-(1 - m_deceleration) * (1000 * time)));
   return std::make_tuple(static_cast<float>(value),
                          42.0f); // we don't need the velocity, so set it to a dummy value
 }
@@ -31,6 +31,32 @@ bool DecayAnimationDriver::IsAnimationDone(
     std::optional<double> previousValue,
     double /*currentVelocity*/) {
   return previousValue.has_value() && std::abs(currentValue - previousValue.value()) < 0.1;
+}
+
+bool DecayAnimationDriver::Update(double timeDeltaMs, bool restarting) {
+  if (const auto node = GetAnimatedValue()) {
+    if (restarting) {
+      const auto value = node->RawValue();
+      if (!m_originalValue) {
+        // First iteration, assign m_fromValue based on AnimatedValue
+        m_originalValue = value;
+      } else {
+        // Not the first iteration, reset AnimatedValue based on m_originalValue
+        node->RawValue(m_originalValue.value());
+      }
+
+      m_lastValue = value;
+    }
+
+    const auto [value, velocity] = GetValueAndVelocityForTime(timeDeltaMs / 1000.0);
+    if (restarting || IsAnimationDone(value, m_lastValue, 0.0 /* ignored */)) {
+      m_lastValue = value;
+      node->RawValue(value);
+      return false;
+    }
+  }
+
+  return true;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
@@ -17,12 +17,14 @@ class DecayAnimationDriver : public CalculatedAnimationDriver {
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  protected:
+  bool Update(double timeDeltaMs, bool restarting) override;
   std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
   bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) override;
 
  private:
   double m_velocity{0};
   double m_deceleration{0};
+  double m_lastValue{0};
 
   static constexpr std::string_view s_velocityName{"velocity"};
   static constexpr std::string_view s_decelerationName{"deceleration"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -11,20 +11,35 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   m_inputNodeTag = static_cast<int64_t>(config[s_inputName].AsDouble());
+  assert(HasCompatibleAnimationDriver(m_inputNodeTag));
   m_min = config[s_minName].AsDouble();
   m_max = config[s_maxName].AsDouble();
 
-  m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, min = m_min, max = m_max, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
-    anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
-    anim.SetScalarParameter(s_minParameterName, static_cast<float>(min));
-    anim.SetScalarParameter(s_maxParameterName, static_cast<float>(max));
-    anim.Expression(
-        static_cast<winrt::hstring>(L"Clamp(") + s_inputParameterName + L"." + s_valueName + L" + " +
-        s_inputParameterName + L"." + s_offsetName + L", " + s_minParameterName + L", " + s_maxParameterName + L")");
-    return anim;
-  }());
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, min = m_min, max = m_max, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+      anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
+      anim.SetScalarParameter(s_minParameterName, static_cast<float>(min));
+      anim.SetScalarParameter(s_maxParameterName, static_cast<float>(max));
+      anim.Expression(
+          static_cast<winrt::hstring>(L"Clamp(") + s_inputParameterName + L"." + s_valueName + L" + " +
+          s_inputParameterName + L"." + s_offsetName + L", " + s_minParameterName + L", " + s_maxParameterName + L")");
+      return anim;
+    }());
+  }
+}
+
+void DiffClampAnimatedNode::Update() {
+  assert(!m_useComposition);
+  if (const auto manager = m_manager.lock()) {
+    if (const auto node = manager->GetValueAnimatedNode(m_inputNodeTag)) {
+      const auto value = node->Value();
+      const auto diff = value - m_lastValue;
+      m_lastValue = value;
+      RawValue(std::clamp(Value() + diff, m_min, m_max));
+    }
+  }
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
@@ -12,10 +12,13 @@ class DiffClampAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   int64_t m_inputNodeTag{};
   double m_min{};
   double m_max{};
+  double m_lastValue{};
 
   static constexpr std::string_view s_minName{"min"};
   static constexpr std::string_view s_maxName{"max"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -11,30 +11,53 @@ DivisionAnimatedNode::DivisionAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   for (const auto &inputNode : config[s_inputName].AsArray()) {
+    const auto inputTag = inputNode.AsInt64();
+    assert(HasCompatibleAnimationDriver(inputTag));
     if (m_firstInput == s_firstInputUnset) {
-      m_firstInput = static_cast<int64_t>(inputNode.AsDouble());
+      m_firstInput = inputTag;
     } else {
-      m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
+      m_inputNodes.insert(inputTag);
     }
   }
 
-  m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
 
-    anim.Expression([firstNode, nodes, manager, anim]() {
-      anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());
-      winrt::hstring expr = static_cast<winrt::hstring>(L"(") + s_baseName + L"." + s_valueName + L" + " + s_baseName +
-          L"." + s_offsetName + L")";
-      for (const auto tag : nodes) {
-        const auto identifier = L"n" + std::to_wstring(tag);
-        anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
-        expr = expr + L" / (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
-      }
-      return expr;
+      anim.Expression([firstNode, nodes, manager, anim]() {
+        anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());
+        winrt::hstring expr = static_cast<winrt::hstring>(L"(") + s_baseName + L"." + s_valueName + L" + " +
+            s_baseName + L"." + s_offsetName + L")";
+        for (const auto tag : nodes) {
+          const auto identifier = L"n" + std::to_wstring(tag);
+          anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
+          expr = expr + L" / (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
+        }
+        return expr;
+      }());
+      return anim;
     }());
-    return anim;
-  }());
+  }
+}
+
+void DivisionAnimatedNode::Update() {
+  assert(!m_useComposition);
+  if (const auto manager = m_manager.lock()) {
+    auto rawValue = 0.0;
+    if (const auto firstNode = manager->GetValueAnimatedNode(m_firstInput)) {
+      rawValue = firstNode->Value();
+    }
+
+    for (const auto tag : m_inputNodes) {
+      if (const auto node = manager->GetValueAnimatedNode(tag)) {
+        const auto value = node->Value();
+        rawValue /= value;
+      }
+    }
+
+    RawValue(rawValue);
+  }
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
@@ -12,6 +12,8 @@ class DivisionAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   int64_t m_firstInput{s_firstInputUnset};
   std::unordered_set<int64_t> m_inputNodes{};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 
+#include "AnimationUtils.h"
 #include "FrameAnimationDriver.h"
 #include "Utils/Helpers.h"
 
@@ -22,6 +23,7 @@ FrameAnimationDriver::FrameAnimationDriver(
 
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimationDriver::MakeAnimation(
     const winrt::Microsoft::ReactNative::JSValueObject & /*config*/) {
+  assert(m_useComposition);
   const auto [scopedBatch, animation] = []() {
     const auto compositor = Microsoft::ReactNative::GetCompositor();
     return std::make_tuple(
@@ -32,7 +34,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimat
 
   // Frames contains 60 values per second of duration of the animation, convert
   // the size of frames to duration in ms.
-  std::chrono::milliseconds duration(static_cast<int>(m_frames.size() * 1000.0 / 60.0));
+  std::chrono::milliseconds duration(static_cast<int>(m_frames.size() * s_frameDurationMs));
   animation.Duration(duration);
 
   auto normalizedProgress = 0.0f;
@@ -55,6 +57,41 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimat
 
 double FrameAnimationDriver::ToValue() {
   return m_toValue;
+}
+
+bool FrameAnimationDriver::Update(double timeDeltaMs, bool restarting) {
+  assert(!m_useComposition);
+  if (const auto node = GetAnimatedValue()) {
+    if (!m_startValue) {
+      m_startValue = node->RawValue();
+    }
+
+    const auto startValue = m_startValue.value();
+    const auto startIndex = static_cast<size_t>(timeDeltaMs / s_frameDurationMs);
+    assert(startIndex >= 0);
+    const auto nextIndex = startIndex + 1;
+
+    double nextValue;
+    auto isComplete = false;
+    if (nextIndex >= m_frames.size()) {
+      nextValue = m_toValue;
+      isComplete = true;
+    } else {
+      const auto fromInterval = startIndex * s_frameDurationMs;
+      const auto toInterval = nextIndex * s_frameDurationMs;
+      const auto fromValue = m_frames[startIndex];
+      const auto toValue = m_frames[nextIndex];
+      const auto frameOutput = Interpolate(
+          timeDeltaMs, fromInterval, toInterval, fromValue, toValue, ExtrapolateTypeExtend, ExtrapolateTypeExtend);
+      nextValue = Interpolate(frameOutput, 0, 1, startValue, m_toValue, ExtrapolateTypeExtend, ExtrapolateTypeExtend);
+    }
+
+    node->RawValue(nextValue);
+
+    return isComplete;
+  }
+
+  return true;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
@@ -22,11 +22,16 @@ class FrameAnimationDriver : public AnimationDriver {
   double ToValue() override;
 
   inline std::vector<double> Frames() override {
+    assert(m_useComposition);
     return m_frames;
   }
+
+ protected:
+  bool Update(double timeDeltaMs, bool restarting) override;
 
  private:
   std::vector<double> m_frames{};
   double m_toValue{0};
+  std::optional<double> m_startValue{};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 
+#include "AnimationUtils.h"
 #include "ExtrapolationType.h"
 #include "InterpolationAnimatedNode.h"
 #include "NativeAnimatedNodeManager.h"
@@ -12,7 +13,7 @@ InterpolationAnimatedNode::InterpolationAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   for (const auto &rangeValue : config[s_inputRangeName].AsArray()) {
     m_inputRanges.push_back(rangeValue.AsDouble());
   }
@@ -24,49 +25,66 @@ InterpolationAnimatedNode::InterpolationAnimatedNode(
   m_extrapolateRight = config[s_extrapolateRightName].AsString();
 }
 
-void InterpolationAnimatedNode::Update() {}
+void InterpolationAnimatedNode::Update() {
+  assert(!m_useComposition);
+  if (m_parentTag == s_parentTagUnset) {
+    return;
+  }
+
+  if (const auto manager = m_manager.lock()) {
+    if (const auto node = manager->GetValueAnimatedNode(m_parentTag)) {
+      RawValue(InterpolateValue(node->Value()));
+    }
+  }
+}
 
 void InterpolationAnimatedNode::OnDetachedFromNode([[maybe_unused]] int64_t animatedNodeTag) {
   assert(m_parentTag == animatedNodeTag);
   m_parentTag = s_parentTagUnset;
-  m_propertySet.StopAnimation(s_valueName);
-  m_propertySet.StopAnimation(s_offsetName);
-  m_rawValueAnimation = nullptr;
-  m_offsetAnimation = nullptr;
+
+  if (m_useComposition) {
+    m_propertySet.StopAnimation(s_valueName);
+    m_propertySet.StopAnimation(s_offsetName);
+    m_rawValueAnimation = nullptr;
+    m_offsetAnimation = nullptr;
+  }
 }
 
 void InterpolationAnimatedNode::OnAttachToNode(int64_t animatedNodeTag) {
+  assert(HasCompatibleAnimationDriver(animatedNodeTag));
   assert(m_parentTag == s_parentTagUnset);
   m_parentTag = animatedNodeTag;
 
-  const auto [rawValueAnimation, offsetAnimation] = [this]() {
-    if (const auto manager = m_manager.lock()) {
-      if (const auto parent = manager->GetValueAnimatedNode(m_parentTag)) {
-        const auto compositor = Microsoft::ReactNative::GetCompositor();
+  if (m_useComposition) {
+    const auto [rawValueAnimation, offsetAnimation] = [this]() {
+      if (const auto manager = m_manager.lock()) {
+        if (const auto parent = manager->GetValueAnimatedNode(m_parentTag)) {
+          const auto compositor = Microsoft::ReactNative::GetCompositor();
 
-        const auto rawValueAnimation = CreateExpressionAnimation(compositor, *parent);
-        rawValueAnimation.Expression(
-            GetExpression(s_parentPropsName + static_cast<winrt::hstring>(L".") + s_valueName));
+          const auto rawValueAnimation = CreateExpressionAnimation(compositor, *parent);
+          rawValueAnimation.Expression(
+              GetExpression(s_parentPropsName + static_cast<winrt::hstring>(L".") + s_valueName));
 
-        const auto offsetAnimation = CreateExpressionAnimation(compositor, *parent);
-        offsetAnimation.Expression(
-            L"(" +
-            GetExpression(
-                s_parentPropsName + static_cast<winrt::hstring>(L".") + s_offsetName + L" + " + s_parentPropsName +
-                L"." + s_valueName) +
-            L") - this.target." + s_valueName);
+          const auto offsetAnimation = CreateExpressionAnimation(compositor, *parent);
+          offsetAnimation.Expression(
+              L"(" +
+              GetExpression(
+                  s_parentPropsName + static_cast<winrt::hstring>(L".") + s_offsetName + L" + " + s_parentPropsName +
+                  L"." + s_valueName) +
+              L") - this.target." + s_valueName);
 
-        return std::make_tuple(rawValueAnimation, offsetAnimation);
+          return std::make_tuple(rawValueAnimation, offsetAnimation);
+        }
       }
-    }
-    return std::tuple<comp::ExpressionAnimation, comp::ExpressionAnimation>(nullptr, nullptr);
-  }();
+      return std::tuple<comp::ExpressionAnimation, comp::ExpressionAnimation>(nullptr, nullptr);
+    }();
 
-  m_propertySet.StartAnimation(s_valueName, rawValueAnimation);
-  m_propertySet.StartAnimation(s_offsetName, offsetAnimation);
+    m_propertySet.StartAnimation(s_valueName, rawValueAnimation);
+    m_propertySet.StartAnimation(s_offsetName, offsetAnimation);
 
-  m_rawValueAnimation = rawValueAnimation;
-  m_offsetAnimation = offsetAnimation;
+    m_rawValueAnimation = rawValueAnimation;
+    m_offsetAnimation = offsetAnimation;
+  }
 }
 
 comp::ExpressionAnimation InterpolationAnimatedNode::CreateExpressionAnimation(
@@ -166,6 +184,26 @@ winrt::hstring InterpolationAnimatedNode::GetRightExpression(
     default:
       return L"";
   }
+}
+
+double InterpolationAnimatedNode::InterpolateValue(double value) {
+  // Compute range index
+  size_t index = 1;
+  for (; index < m_inputRanges.size() - 1; ++index) {
+    if (m_inputRanges[index] >= value) {
+      break;
+    }
+  }
+  index--;
+
+  return Interpolate(
+      value,
+      m_inputRanges[index],
+      m_inputRanges[index + 1],
+      m_outputRanges[index],
+      m_outputRanges[index + 1],
+      m_extrapolateLeft,
+      m_extrapolateRight);
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
@@ -17,9 +17,9 @@ class InterpolationAnimatedNode final : public ValueAnimatedNode {
   virtual void OnDetachedFromNode(int64_t animatedNodeTag) override;
   virtual void OnAttachToNode(int64_t animatedNodeTag) override;
 
-  static constexpr std::wstring_view ExtrapolateTypeIdentity = L"identity";
-  static constexpr std::wstring_view ExtrapolateTypeClamp = L"clamp";
-  static constexpr std::wstring_view ExtrapolateTypeExtend = L"extend";
+  static constexpr std::string_view ExtrapolateTypeIdentity = "identity";
+  static constexpr std::string_view ExtrapolateTypeClamp = "clamp";
+  static constexpr std::string_view ExtrapolateTypeExtend = "extend";
 
  private:
   comp::ExpressionAnimation CreateExpressionAnimation(const winrt::Compositor &compositor, ValueAnimatedNode &parent);
@@ -33,6 +33,8 @@ class InterpolationAnimatedNode final : public ValueAnimatedNode {
       const std::wstring &outputMax);
   winrt::hstring GetLeftExpression(const winrt::hstring &value, const winrt::hstring &leftInterpolateExpression);
   winrt::hstring GetRightExpression(const winrt::hstring &, const winrt::hstring &rightInterpolateExpression);
+
+  double InterpolateValue(double value);
 
   comp::ExpressionAnimation m_rawValueAnimation{nullptr};
   comp::ExpressionAnimation m_offsetAnimation{nullptr};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
@@ -11,18 +11,30 @@ ModulusAnimatedNode::ModulusAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
-  m_inputNodeTag = static_cast<int64_t>(config[s_inputName].AsDouble());
-  m_modulus = static_cast<int64_t>(config[s_modulusName].AsDouble());
+    : ValueAnimatedNode(tag, config, manager) {
+  m_inputNodeTag = config[s_inputName].AsInt64();
+  assert(HasCompatibleAnimationDriver(m_inputNodeTag));
+  m_modulus = config[s_modulusName].AsInt64();
 
-  m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, mod = m_modulus, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
-    anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
-    anim.SetScalarParameter(s_modName, static_cast<float>(mod));
-    anim.Expression(
-        static_cast<winrt::hstring>(L"(") + s_inputParameterName + L"." + s_valueName + L" + " + s_inputParameterName +
-        L"." + s_offsetName + L") % " + s_modName);
-    return anim;
-  }());
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, mod = m_modulus, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+      anim.SetReferenceParameter(s_inputParameterName, manager->GetValueAnimatedNode(node)->PropertySet());
+      anim.SetScalarParameter(s_modName, static_cast<float>(mod));
+      anim.Expression(
+          static_cast<winrt::hstring>(L"(") + s_inputParameterName + L"." + s_valueName + L" + " +
+          s_inputParameterName + L"." + s_offsetName + L") % " + s_modName);
+      return anim;
+    }());
+  }
+}
+
+void ModulusAnimatedNode::Update() {
+  assert(!m_useComposition);
+  if (const auto manager = m_manager.lock()) {
+    if (const auto node = manager->GetValueAnimatedNode(m_inputNodeTag)) {
+      RawValue(std::fmod(node->Value(), m_modulus));
+    }
+  }
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
@@ -13,6 +13,8 @@ class ModulusAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   int64_t m_inputNodeTag{};
   int64_t m_modulus{};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
@@ -11,24 +11,41 @@ MultiplicationAnimatedNode::MultiplicationAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   for (const auto &inputNode : config[s_inputName].AsArray()) {
-    m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
+    const auto inputTag = inputNode.AsInt64();
+    assert(HasCompatibleAnimationDriver(inputTag));
+    m_inputNodes.insert(inputTag);
   }
 
-  m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
 
-    anim.Expression([nodes, manager, anim]() {
-      winrt::hstring expr = L"1";
-      for (const auto tag : nodes) {
-        auto identifier = L"n" + std::to_wstring(tag);
-        anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
-        expr = expr + L" * (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
-      }
-      return expr;
+      anim.Expression([nodes, manager, anim]() {
+        winrt::hstring expr = L"1";
+        for (const auto tag : nodes) {
+          auto identifier = L"n" + std::to_wstring(tag);
+          anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
+          expr = expr + L" * (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
+        }
+        return expr;
+      }());
+      return anim;
     }());
-    return anim;
-  }());
+  }
+}
+
+void MultiplicationAnimatedNode::Update() {
+  assert(!m_useComposition);
+  auto rawValue = 1.0;
+  if (const auto manager = m_manager.lock()) {
+    for (const auto tag : m_inputNodes) {
+      if (const auto node = manager->GetValueAnimatedNode(tag)) {
+        rawValue *= node->Value();
+      }
+    }
+  }
+  RawValue(rawValue);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
@@ -12,6 +12,8 @@ class MultiplicationAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   std::unordered_set<int64_t> m_inputNodes{};
 };

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -25,6 +25,7 @@
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
 #include <Windows.Foundation.h>
+#include <queue>
 
 namespace Microsoft::ReactNative {
 void NativeAnimatedNodeManager::CreateAnimatedNode(
@@ -103,22 +104,41 @@ void NativeAnimatedNodeManager::GetValue(
 }
 
 void NativeAnimatedNodeManager::ConnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag) {
-  m_propsNodes.at(propsNodeTag)->ConnectToView(viewTag);
+  const auto &propsNode = m_propsNodes.at(propsNodeTag);
+  propsNode->ConnectToView(viewTag);
+  if (!propsNode->UseComposition()) {
+    m_updatedNodes.insert(propsNodeTag);
+    EnsureRendering();
+  }
 }
 
 void NativeAnimatedNodeManager::DisconnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag) {
   m_propsNodes.at(propsNodeTag)->DisconnectFromView(viewTag);
 }
 
+void NativeAnimatedNodeManager::RestoreDefaultValues(int64_t tag) {
+  if (const auto propsNode = GetPropsAnimatedNode(tag)) {
+    propsNode->RestoreDefaultValues();
+  }
+}
+
 void NativeAnimatedNodeManager::ConnectAnimatedNode(int64_t parentNodeTag, int64_t childNodeTag) {
   if (const auto parentNode = GetAnimatedNode(parentNodeTag)) {
     parentNode->AddChild(childNodeTag);
+    if (!parentNode->UseComposition()) {
+      m_updatedNodes.insert(childNodeTag);
+      EnsureRendering();
+    }
   }
 }
 
 void NativeAnimatedNodeManager::DisconnectAnimatedNode(int64_t parentNodeTag, int64_t childNodeTag) {
   if (const auto parentNode = GetAnimatedNode(parentNodeTag)) {
     parentNode->RemoveChild(childNodeTag);
+    if (!parentNode->UseComposition()) {
+      m_updatedNodes.insert(childNodeTag);
+      EnsureRendering();
+    }
   }
 }
 
@@ -127,33 +147,38 @@ void NativeAnimatedNodeManager::StopAnimation(int64_t animationId, bool isTracki
     if (const auto animation = m_activeAnimations.at(animationId)) {
       animation->StopAnimation(isTrackingAnimation);
 
-      // Insert the animation into the pending completion set to ensure it is
-      // not destroyed before the callback occurs. It's safe to assume the
-      // scoped batch completion callback has not run, since if it had, the
-      // animation would have been removed from the set of active animations.
-      m_pendingCompletionAnimations.insert({animationId, animation});
+      // We need to update the node manager state for composition animations
+      // to ensure new animations on the same animated value do not start until
+      // the completion callback has fired for the stopped animation.
+      if (animation->UseComposition()) {
+        // Insert the animation into the pending completion set to ensure it is
+        // not destroyed before the callback occurs. It's safe to assume the
+        // scoped batch completion callback has not run, since if it had, the
+        // animation would have been removed from the set of active animations.
+        m_pendingCompletionAnimations.insert({animationId, animation});
 
-      const auto nodeTag = animation->AnimatedValueTag();
-      if (nodeTag != -1) {
-        const auto deferredAnimation = m_deferredAnimationForValues.find(nodeTag);
-        if (deferredAnimation != m_deferredAnimationForValues.end()) {
-          // We can assume that the currently deferred animation is the one
-          // being stopped given the constraint that only one animation can
-          // be active for a given value node.
-          assert(deferredAnimation->second == animationId);
-          // If the animation is deferred, just remove the deferred animation
-          // entry as two animations cannot animate the same value concurrently.
-          m_deferredAnimationForValues.erase(nodeTag);
-        } else {
-          // Since only one animation can be active at a time, there shouldn't
-          // be any stopped animations for the value node if the animation has
-          // not been deferred.
-          assert(!m_valuesWithStoppedAnimation.count(nodeTag));
-          // In this case, add the value tag to the set of values with stopped
-          // animations. This is used to optimize the lookup when determining
-          // if an animation needs to be deferred (rather than iterating over
-          // the map of pending completion animations).
-          m_valuesWithStoppedAnimation.insert(nodeTag);
+        const auto nodeTag = animation->AnimatedValueTag();
+        if (nodeTag != -1) {
+          const auto deferredAnimation = m_deferredAnimationForValues.find(nodeTag);
+          if (deferredAnimation != m_deferredAnimationForValues.end()) {
+            // We can assume that the currently deferred animation is the one
+            // being stopped given the constraint that only one animation can
+            // be active for a given value node.
+            assert(deferredAnimation->second == animationId);
+            // If the animation is deferred, just remove the deferred animation
+            // entry as two animations cannot animate the same value concurrently.
+            m_deferredAnimationForValues.erase(nodeTag);
+          } else {
+            // Since only one animation can be active at a time, there shouldn't
+            // be any stopped animations for the value node if the animation has
+            // not been deferred.
+            assert(!m_valuesWithStoppedAnimation.count(nodeTag));
+            // In this case, add the value tag to the set of values with stopped
+            // animations. This is used to optimize the lookup when determining
+            // if an animation needs to be deferred (rather than iterating over
+            // the map of pending completion animations).
+            m_valuesWithStoppedAnimation.insert(nodeTag);
+          }
         }
       }
 
@@ -168,6 +193,7 @@ void NativeAnimatedNodeManager::RestartTrackingAnimatedNode(
     const std::shared_ptr<NativeAnimatedNodeManager> &manager) {
   if (m_activeAnimations.count(animationId)) {
     if (const auto animation = m_activeAnimations.at(animationId).get()) {
+      assert(animation->UseComposition());
       auto const animatedValueTag = animation->AnimatedValueTag();
       auto const &animationConfig = animation->AnimationConfig();
       auto const endCallback = animation->EndCallback();
@@ -273,14 +299,19 @@ void NativeAnimatedNodeManager::StartAnimatingNode(
   // If the animated value node has any stopped animations, defer start until
   // all stopped animations fire completion callback and have latest values.
   if (m_activeAnimations.count(animationId)) {
-    if (m_valuesWithStoppedAnimation.count(animatedNodeTag)) {
-      // Since only one animation can be active per value at a time, there will
-      // not be any other deferred animations for the value node.
-      assert(!m_deferredAnimationForValues.count(animatedNodeTag));
-      // Add the animation to the deferred animation map for the value tag.
-      m_deferredAnimationForValues.insert({animatedNodeTag, animationId});
+    const auto &animation = m_activeAnimations.at(animationId);
+    if (animation->UseComposition()) {
+      if (m_valuesWithStoppedAnimation.count(animatedNodeTag)) {
+        // Since only one animation can be active per value at a time, there will
+        // not be any other deferred animations for the value node.
+        assert(!m_deferredAnimationForValues.count(animatedNodeTag));
+        // Add the animation to the deferred animation map for the value tag.
+        m_deferredAnimationForValues.insert({animatedNodeTag, animationId});
+      } else {
+        StartAnimationAndTrackingNodes(animationId, animatedNodeTag, manager);
+      }
     } else {
-      StartAnimationAndTrackingNodes(animationId, animatedNodeTag, manager);
+      EnsureRendering();
     }
   }
 }
@@ -290,17 +321,27 @@ void NativeAnimatedNodeManager::DropAnimatedNode(int64_t tag) {
   m_propsNodes.erase(tag);
   m_styleNodes.erase(tag);
   m_transformNodes.erase(tag);
+  m_updatedNodes.erase(tag);
 }
 
 void NativeAnimatedNodeManager::SetAnimatedNodeValue(int64_t tag, double value) {
   if (const auto valueNode = m_valueNodes.at(tag).get()) {
     valueNode->RawValue(static_cast<float>(value));
+    if (!valueNode->UseComposition()) {
+      StopAnimationsForNode(tag);
+      m_updatedNodes.insert(tag);
+      EnsureRendering();
+    }
   }
 }
 
 void NativeAnimatedNodeManager::SetAnimatedNodeOffset(int64_t tag, double offset) {
   if (const auto valueNode = m_valueNodes.at(tag).get()) {
     valueNode->Offset(static_cast<float>(offset));
+    if (!valueNode->UseComposition()) {
+      m_updatedNodes.insert(tag);
+      EnsureRendering();
+    }
   }
 }
 
@@ -313,6 +354,18 @@ void NativeAnimatedNodeManager::FlattenAnimatedNodeOffset(int64_t tag) {
 void NativeAnimatedNodeManager::ExtractAnimatedNodeOffset(int64_t tag) {
   if (const auto valueNode = m_valueNodes.at(tag).get()) {
     valueNode->ExtractOffset();
+  }
+}
+
+void NativeAnimatedNodeManager::StartListeningToAnimatedNodeValue(int64_t tag, const ValueListenerCallback &callback) {
+  if (const auto valueNode = m_valueNodes.at(tag).get()) {
+    valueNode->ValueListener(callback);
+  }
+}
+
+void NativeAnimatedNodeManager::StopListeningToAnimatedNodeValue(int64_t tag) {
+  if (const auto valueNode = m_valueNodes.at(tag).get()) {
+    valueNode->ValueListener(nullptr);
   }
 }
 
@@ -374,6 +427,9 @@ void NativeAnimatedNodeManager::ProcessDelayedPropsNodes() {
 void NativeAnimatedNodeManager::AddDelayedPropsNode(
     int64_t propsNodeTag,
     const winrt::Microsoft::ReactNative::ReactContext &context) {
+#if DEBUG
+  assert(m_propsNodes.at(propsNodeTag)->UseComposition());
+#endif
   m_delayedPropsNodes.push_back(propsNodeTag);
   if (m_delayedPropsNodes.size() <= 1) {
     if (const auto uiManger = Microsoft::ReactNative::GetNativeUIManager(context).lock()) {
@@ -477,5 +533,177 @@ void NativeAnimatedNodeManager::StartAnimationAndTrackingNodes(
       }
     }
   }
+}
+
+void NativeAnimatedNodeManager::RunUpdates(winrt::TimeSpan renderingTime) {
+  auto hasFinishedAnimations = false;
+  std::unordered_set<int64_t> updatingNodes{};
+  updatingNodes = std::move(m_updatedNodes);
+
+  // Increment animation drivers
+  for (auto id : m_activeAnimationIds) {
+    auto &animation = m_activeAnimations.at(id);
+    animation->RunAnimationStep(renderingTime);
+    updatingNodes.insert(animation->AnimatedValueTag());
+    if (animation->IsComplete()) {
+      hasFinishedAnimations = true;
+    }
+  }
+
+  UpdateNodes(updatingNodes);
+
+  if (hasFinishedAnimations) {
+    for (auto id : m_activeAnimationIds) {
+      auto &animation = m_activeAnimations.at(id);
+      if (animation->IsComplete()) {
+        animation->DoCallback(true);
+        m_activeAnimations.erase(id);
+      }
+    }
+  }
+}
+
+void NativeAnimatedNodeManager::EnsureRendering() {
+  m_renderingRevoker =
+      xaml::Media::CompositionTarget::Rendering(winrt::auto_revoke, {this, &NativeAnimatedNodeManager::OnRendering});
+}
+
+void NativeAnimatedNodeManager::OnRendering(winrt::IInspectable const &sender, winrt::IInspectable const &args) {
+  // The `UpdateActiveAnimationIds` method only tracks animations where
+  // composition is not used, so if only UI.Composition animations are active,
+  // this rendering callback will not run.
+  UpdateActiveAnimationIds();
+  if (m_activeAnimationIds.size() > 0 || m_updatedNodes.size() > 0) {
+    if (const auto renderingArgs = args.try_as<xaml::Media::RenderingEventArgs>()) {
+      RunUpdates(renderingArgs.RenderingTime());
+    }
+  } else {
+    m_renderingRevoker.revoke();
+  }
+}
+
+void NativeAnimatedNodeManager::StopAnimationsForNode(int64_t tag) {
+  UpdateActiveAnimationIds();
+  for (auto id : m_activeAnimationIds) {
+    auto &animation = m_activeAnimations.at(id);
+    if (tag == animation->AnimatedValueTag()) {
+      animation->DoCallback(false);
+      m_activeAnimations.erase(id);
+    }
+  }
+}
+
+void NativeAnimatedNodeManager::UpdateActiveAnimationIds() {
+  m_activeAnimationIds.clear();
+  for (const auto &pair : m_activeAnimations) {
+    if (!pair.second->UseComposition()) {
+      m_activeAnimationIds.push_back(pair.first);
+    }
+  }
+}
+
+void NativeAnimatedNodeManager::UpdateNodes(std::unordered_set<int64_t> &nodes) {
+  auto activeNodesCount = 0;
+  auto updatedNodesCount = 0;
+
+  // BFS state
+  std::unordered_map<int64_t, int64_t> bfsColors;
+  std::unordered_map<int64_t, int64_t> incomingNodeCounts;
+
+  // STEP 1.
+  // BFS over graph of nodes starting from IDs in `nodes` argument and IDs that are attached to
+  // active animations (from `m_activeAnimations)`. Update `incomingNodeCounts` map for each node
+  // during that BFS. Store number of visited nodes in `activeNodesCount`. We "execute" active
+  // animations as a part of this step.
+
+  m_animatedGraphBFSColor++; /* use new color */
+  if (m_animatedGraphBFSColor == 0) {
+    // value "0" is used as an initial color for a new node, using it in BFS may cause some nodes to be skipped.
+    m_animatedGraphBFSColor++;
+  }
+
+  std::queue<int64_t> nodesQueue{};
+  for (auto id : nodes) {
+    if (!bfsColors.count(id) || bfsColors.at(id) != m_animatedGraphBFSColor) {
+      bfsColors[id] = m_animatedGraphBFSColor;
+      activeNodesCount++;
+      nodesQueue.push(id);
+    }
+  }
+
+  while (nodesQueue.size() > 0) {
+    auto id = nodesQueue.front();
+    nodesQueue.pop();
+    if (auto node = GetAnimatedNode(id)) {
+      for (auto &childId : node->Children()) {
+        if (!incomingNodeCounts.count(childId)) {
+          incomingNodeCounts[childId] = 1;
+        } else {
+          incomingNodeCounts.at(childId)++;
+        }
+
+        if (!bfsColors.count(childId) || bfsColors.at(childId) != m_animatedGraphBFSColor) {
+          bfsColors[childId] = m_animatedGraphBFSColor;
+          activeNodesCount++;
+          nodesQueue.push(childId);
+        }
+      }
+    }
+  }
+
+  // STEP 2
+  // BFS over the graph of active nodes in topological order -> visit node only when all its
+  // "predecessors" in the graph have already been visited. It is important to visit nodes in that
+  // order as they may often use values of their predecessors in order to calculate "next state"
+  // of their own. We start by determining the starting set of nodes by looking for nodes with
+  // `incomingNodeCounts[id] = 0` (those can only be the ones that we start BFS in the previous
+  // step). We store number of visited nodes in this step in `updatedNodesCount`
+
+  m_animatedGraphBFSColor++;
+  if (m_animatedGraphBFSColor == 0) {
+    // see reasoning for this check a few lines above
+    m_animatedGraphBFSColor++;
+  }
+
+  // find nodes with zero "incoming nodes", those can be either nodes from `m_updatedNodes` or
+  // ones connected to active animations
+  for (auto id : nodes) {
+    if (!incomingNodeCounts.count(id) ||
+        incomingNodeCounts.at(id) == 0 && bfsColors.at(id) != m_animatedGraphBFSColor) {
+      bfsColors[id] = m_animatedGraphBFSColor;
+      updatedNodesCount++;
+      nodesQueue.push(id);
+    }
+  }
+
+  // Run main "update" loop
+  while (nodesQueue.size() > 0) {
+    auto id = nodesQueue.front();
+    nodesQueue.pop();
+    if (auto node = GetAnimatedNode(id)) {
+      node->Update();
+      if (auto propsNode = GetPropsAnimatedNode(id)) {
+        propsNode->UpdateView();
+      } else if (auto valueNode = GetValueAnimatedNode(id)) {
+        valueNode->OnValueUpdate();
+      }
+
+      for (auto &childId : node->Children()) {
+        auto &incomingCount = incomingNodeCounts.at(childId);
+        auto &bfsColor = bfsColors.at(childId);
+        incomingCount--;
+        if (bfsColor != m_animatedGraphBFSColor && incomingCount == 0) {
+          bfsColor = m_animatedGraphBFSColor;
+          updatedNodesCount++;
+          nodesQueue.push(childId);
+        }
+      }
+    }
+  }
+
+  // Verify that we've visited *all* active nodes. Throw otherwise as this would mean there is a
+  // cycle in animated node graph. We also take advantage of the fact that all active nodes are
+  // visited in the step above so that `incomingNodeCounts` for all node IDs are set to zero
+  assert(activeNodesCount == updatedNodesCount);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
@@ -5,6 +5,7 @@
 // Licensed under the MIT License.
 
 #include <IReactInstance.h>
+#include <UI.Xaml.Media.h>
 #include <cxxreact/CxxModule.h>
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
@@ -30,6 +31,7 @@ namespace Microsoft::ReactNative {
 /// </summary>
 
 typedef std::function<void(bool)> EndCallback;
+typedef std::function<void(double)> ValueListenerCallback;
 
 class AnimatedNode;
 class StyleAnimatedNode;
@@ -49,6 +51,7 @@ class NativeAnimatedNodeManager {
   void GetValue(int64_t animatedNodeTag, std::function<void(double)> const &endCallback);
   void ConnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag);
   void DisconnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag);
+  void RestoreDefaultValues(int64_t tag);
   void ConnectAnimatedNode(int64_t parentNodeTag, int64_t childNodeTag);
   void DisconnectAnimatedNode(int64_t parentNodeTag, int64_t childNodeTag);
   void StopAnimation(int64_t animationId, bool isTrackingAnimation = false);
@@ -75,6 +78,8 @@ class NativeAnimatedNodeManager {
   void SetAnimatedNodeOffset(int64_t tag, double offset);
   void FlattenAnimatedNodeOffset(int64_t tag);
   void ExtractAnimatedNodeOffset(int64_t tag);
+  void StartListeningToAnimatedNodeValue(int64_t tag, const ValueListenerCallback &callback);
+  void StopListeningToAnimatedNodeValue(int64_t tag);
   void AddAnimatedEventToView(
       int64_t viewTag,
       const std::string &eventName,
@@ -102,6 +107,13 @@ class NativeAnimatedNodeManager {
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:
+  void EnsureRendering();
+  void OnRendering(winrt::IInspectable const &sender, winrt::IInspectable const &args);
+  void RunUpdates(winrt::TimeSpan renderingTime);
+  void StopAnimationsForNode(int64_t tag);
+  void UpdateActiveAnimationIds();
+  void UpdateNodes(std::unordered_set<int64_t> &nodes);
+
   std::unordered_map<int64_t, std::unique_ptr<ValueAnimatedNode>> m_valueNodes{};
   std::unordered_map<int64_t, std::unique_ptr<PropsAnimatedNode>> m_propsNodes{};
   std::unordered_map<int64_t, std::unique_ptr<StyleAnimatedNode>> m_styleNodes{};
@@ -115,6 +127,11 @@ class NativeAnimatedNodeManager {
   std::unordered_map<int64_t, int64_t> m_deferredAnimationForValues{};
   std::vector<std::tuple<int64_t, int64_t>> m_trackingAndLeadNodeTags{};
   std::vector<int64_t> m_delayedPropsNodes{};
+
+  std::unordered_set<int64_t> m_updatedNodes{};
+  std::vector<int64_t> m_activeAnimationIds{};
+  int64_t m_animatedGraphBFSColor{};
+  xaml::Media::CompositionTarget::Rendering_revoker m_renderingRevoker;
 
   static constexpr std::string_view s_toValueIdName{"toValue"};
   static constexpr std::string_view s_framesName{"frames"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -18,25 +18,29 @@ PropsAnimatedNode::PropsAnimatedNode(
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const winrt::Microsoft::ReactNative::ReactContext &context,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : AnimatedNode(tag, manager), m_context(context) {
+    : AnimatedNode(tag, config, manager), m_context(context) {
   for (const auto &entry : config["props"].AsObject()) {
-    m_propMapping.insert({entry.first, static_cast<int64_t>(entry.second.AsDouble())});
+    const auto inputTag = entry.second.AsInt64();
+    m_propMapping.insert({entry.first, inputTag});
   }
-  auto compositor = Microsoft::ReactNative::GetCompositor();
-  m_subchannelPropertySet = compositor.CreatePropertySet();
-  m_subchannelPropertySet.InsertScalar(L"TranslationX", 0.0f);
-  m_subchannelPropertySet.InsertScalar(L"TranslationY", 0.0f);
-  m_subchannelPropertySet.InsertScalar(L"ScaleX", 1.0f);
-  m_subchannelPropertySet.InsertScalar(L"ScaleY", 1.0f);
 
-  m_translationCombined =
-      compositor.CreateExpressionAnimation(L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
-  m_translationCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
-  m_translationCombined.Target(L"Translation");
+  if (m_useComposition) {
+    auto compositor = Microsoft::ReactNative::GetCompositor();
+    m_subchannelPropertySet = compositor.CreatePropertySet();
+    m_subchannelPropertySet.InsertScalar(L"TranslationX", 0.0f);
+    m_subchannelPropertySet.InsertScalar(L"TranslationY", 0.0f);
+    m_subchannelPropertySet.InsertScalar(L"ScaleX", 1.0f);
+    m_subchannelPropertySet.InsertScalar(L"ScaleY", 1.0f);
 
-  m_scaleCombined = compositor.CreateExpressionAnimation(L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
-  m_scaleCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
-  m_scaleCombined.Target(L"Scale");
+    m_translationCombined =
+        compositor.CreateExpressionAnimation(L"Vector3(subchannels.TranslationX, subchannels.TranslationY, 0.0)");
+    m_translationCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
+    m_translationCombined.Target(L"Translation");
+
+    m_scaleCombined = compositor.CreateExpressionAnimation(L"Vector3(subchannels.ScaleX, subchannels.ScaleY, 1.0)");
+    m_scaleCombined.SetReferenceParameter(L"subchannels", m_subchannelPropertySet);
+    m_scaleCombined.Target(L"Scale");
+  }
 }
 
 void PropsAnimatedNode::ConnectToView(int64_t viewTag) {
@@ -46,7 +50,10 @@ void PropsAnimatedNode::ConnectToView(int64_t viewTag) {
     return;
   }
   m_connectedViewTag = viewTag;
-  UpdateView();
+
+  if (m_useComposition) {
+    UpdateView();
+  }
 }
 
 void PropsAnimatedNode::DisconnectFromView(int64_t viewTag) {
@@ -58,26 +65,36 @@ void PropsAnimatedNode::DisconnectFromView(int64_t viewTag) {
     return;
   }
 
-  std::vector<int64_t> keys{};
-  for (const auto &anim : m_expressionAnimations) {
-    keys.push_back(anim.first);
-  }
-  for (const auto &key : keys) {
-    DisposeCompletedAnimation(key);
-  }
-
-  if (m_centerPointAnimation) {
-    if (const auto target = GetUIElement()) {
-      target.StopAnimation(m_centerPointAnimation);
+  if (m_useComposition) {
+    std::vector<int64_t> keys{};
+    for (const auto &anim : m_expressionAnimations) {
+      keys.push_back(anim.first);
     }
-    m_centerPointAnimation = nullptr;
+    for (const auto &key : keys) {
+      DisposeCompletedAnimation(key);
+    }
+
+    if (m_centerPointAnimation) {
+      if (const auto target = GetUIElement()) {
+        target.StopAnimation(m_centerPointAnimation);
+      }
+      m_centerPointAnimation = nullptr;
+    }
+    m_needsCenterPointAnimation = false;
   }
 
   m_connectedViewTag = s_connectedViewTagUnset;
-  m_needsCenterPointAnimation = false;
 }
 
-void PropsAnimatedNode::RestoreDefaultValues() {}
+void PropsAnimatedNode::RestoreDefaultValues() {
+  if (!m_useComposition) {
+    for (const auto &entry : m_props) {
+      m_props[entry.first] = nullptr;
+    }
+
+    CommitProps();
+  }
+}
 
 void PropsAnimatedNode::UpdateView() {
   if (m_connectedViewTag == s_connectedViewTagUnset) {
@@ -87,19 +104,31 @@ void PropsAnimatedNode::UpdateView() {
   if (const auto manager = std::shared_ptr<NativeAnimatedNodeManager>(m_manager)) {
     for (const auto &entry : m_propMapping) {
       if (const auto &styleNode = manager->GetStyleAnimatedNode(entry.second)) {
-        for (const auto &styleEntry : styleNode->GetMapping()) {
-          MakeAnimation(styleEntry.second, styleEntry.first);
+        if (m_useComposition) {
+          for (const auto &styleEntry : styleNode->GetMapping()) {
+            MakeAnimation(styleEntry.second, styleEntry.first);
+          }
+        } else {
+          styleNode->CollectViewUpdates(m_props);
         }
       } else if (const auto &valueNode = manager->GetValueAnimatedNode(entry.second)) {
-        const auto &facade = StringToFacadeType(entry.first);
-        if (facade != FacadeType::None) {
-          MakeAnimation(entry.second, facade);
+        if (m_useComposition) {
+          const auto &facade = StringToFacadeType(entry.first);
+          if (facade != FacadeType::None) {
+            MakeAnimation(entry.second, facade);
+          }
+        } else {
+          m_props[entry.first] = valueNode->Value();
         }
       }
     }
   }
 
-  StartAnimations();
+  if (m_useComposition) {
+    StartAnimations();
+  } else {
+    CommitProps();
+  }
 }
 
 static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
@@ -117,6 +146,7 @@ static void EnsureUIElementDirtyForRender(xaml::UIElement uiElement) {
 }
 
 void PropsAnimatedNode::StartAnimations() {
+  assert(m_useComposition);
   if (m_expressionAnimations.size()) {
     if (const auto uiElement = GetUIElement()) {
       // Work around for https://github.com/microsoft/microsoft-ui-xaml/issues/2511
@@ -161,6 +191,7 @@ void PropsAnimatedNode::StartAnimations() {
 }
 
 void PropsAnimatedNode::DisposeCompletedAnimation(int64_t valueTag) {
+  assert(m_useComposition);
   /*
   if (m_expressionAnimations.count(valueTag)) {
     if (const auto target = GetUIElement()) {
@@ -180,6 +211,7 @@ void PropsAnimatedNode::DisposeCompletedAnimation(int64_t valueTag) {
 }
 
 void PropsAnimatedNode::ResumeSuspendedAnimations(int64_t valueTag) {
+  assert(m_useComposition);
   /*
   const auto iterator =
       std::find(m_suspendedExpressionAnimationTags.begin(), m_suspendedExpressionAnimationTags.end(), valueTag);
@@ -285,5 +317,13 @@ xaml::UIElement PropsAnimatedNode::GetUIElement() {
     }
   }
   return nullptr;
+}
+
+void PropsAnimatedNode::CommitProps() {
+  if (const auto node = GetShadowNodeBase()) {
+    if (!node->m_zombie) {
+      node->updateProperties(m_props);
+    }
+  }
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
@@ -7,8 +7,8 @@
 #include <ReactContext.h>
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
-
 #include "FacadeType.h"
+#include "JSValue.h"
 
 namespace Microsoft::ReactNative {
 struct ShadowNodeBase;
@@ -31,13 +31,14 @@ class PropsAnimatedNode final : public AnimatedNode {
   void ResumeSuspendedAnimations(int64_t valueTag);
 
  private:
+  void CommitProps();
   void MakeAnimation(int64_t valueNodeTag, FacadeType facadeType);
   Microsoft::ReactNative::ShadowNodeBase *GetShadowNodeBase();
   xaml::UIElement GetUIElement();
 
   winrt::Microsoft::ReactNative::ReactContext m_context;
   std::map<std::string, int64_t> m_propMapping{};
-  folly::dynamic m_propMap{};
+  winrt::Microsoft::ReactNative::JSValueObject m_props{};
 
   int64_t m_connectedViewTag{s_connectedViewTagUnset};
   std::unordered_map<int64_t, comp::CompositionAnimation> m_expressionAnimations{};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
@@ -8,6 +8,9 @@
 #include "SpringAnimationDriver.h"
 
 namespace Microsoft::ReactNative {
+
+static constexpr auto MAX_DELTA_TIME_MS = 4.0 * 1000.0 / 60.0;
+
 SpringAnimationDriver::SpringAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
@@ -38,10 +41,13 @@ bool SpringAnimationDriver::IsAnimationDone(
 }
 
 std::tuple<float, double> SpringAnimationDriver::GetValueAndVelocityForTime(double time) {
-  const auto toValue = [this, time]() {
-    const auto frameFromTime = static_cast<int>(time * 60.0);
-    if (frameFromTime < static_cast<int>(m_dynamicToValues.size())) {
-      return m_startValue + (m_dynamicToValues[frameFromTime].AsDouble() * (m_endValue - m_startValue));
+  const auto startValue = m_originalValue.value();
+  const auto toValue = [this, startValue, time]() {
+    if (m_useComposition) {
+      const auto frameFromTime = static_cast<int>(time * 60.0);
+      if (frameFromTime < static_cast<int>(m_dynamicToValues.size())) {
+        return startValue + (m_dynamicToValues[frameFromTime].AsDouble() * (m_endValue - startValue));
+      }
     }
     return m_endValue;
   }();
@@ -53,7 +59,7 @@ std::tuple<float, double> SpringAnimationDriver::GetValueAndVelocityForTime(doub
   const auto zeta = c / (2 * std::sqrt(k * m));
   const auto omega0 = std::sqrt(k / m);
   const auto omega1 = omega0 * std::sqrt(1.0 - (zeta * zeta));
-  const auto x0 = toValue - m_startValue;
+  const auto x0 = toValue - startValue;
 
   if (zeta < 1) {
     const auto envelope = std::exp(-zeta * omega0 * time);
@@ -72,15 +78,62 @@ std::tuple<float, double> SpringAnimationDriver::GetValueAndVelocityForTime(doub
   }
 }
 
+bool SpringAnimationDriver::Update(double timeDeltaMs, bool restarting) {
+  assert(!m_useComposition);
+  if (const auto node = GetAnimatedValue()) {
+    if (restarting) {
+      if (!m_originalValue) {
+        m_originalValue = node->RawValue();
+      } else {
+        node->RawValue(m_originalValue.value());
+      }
+
+      // Spring animations run a frame behind JS driven animations if we do
+      // not start the first frame at 16ms.
+      m_lastTime = timeDeltaMs - s_frameDurationMs;
+      m_timeAccumulator = 0.0;
+    }
+
+    // clamp the amount of timeDeltaMs to avoid stuttering in the UI.
+    // We should be able to catch up in a subsequent advance if necessary.
+    auto adjustedDeltaTime = timeDeltaMs - m_lastTime;
+    if (adjustedDeltaTime > MAX_DELTA_TIME_MS) {
+      adjustedDeltaTime = MAX_DELTA_TIME_MS;
+    }
+    m_timeAccumulator += adjustedDeltaTime;
+    m_lastTime = timeDeltaMs;
+
+    auto [value, velocity] = GetValueAndVelocityForTime(m_timeAccumulator / 1000.0);
+
+    auto isComplete = false;
+    if (IsAnimationDone(value, std::nullopt, velocity)) {
+      if (m_springStiffness > 0) {
+        value = static_cast<float>(m_endValue);
+      } else {
+        m_endValue = value;
+      }
+
+      isComplete = true;
+    }
+
+    node->RawValue(value);
+
+    return isComplete;
+  }
+
+  return true;
+}
+
 bool SpringAnimationDriver::IsAtRest(double currentVelocity, double currentValue, double endValue) {
   return std::abs(currentVelocity) <= m_restSpeedThreshold &&
       (std::abs(currentValue - endValue) <= m_displacementFromRestThreshold || m_springStiffness == 0);
 }
 
 bool SpringAnimationDriver::IsOvershooting(double currentValue) {
+  const auto startValue = m_originalValue.value();
   return m_springStiffness > 0 &&
-      ((m_startValue < m_endValue && currentValue > m_endValue) ||
-       (m_startValue > m_endValue && currentValue < m_endValue));
+      ((startValue < m_endValue && currentValue > m_endValue) ||
+       (startValue > m_endValue && currentValue < m_endValue));
 }
 
 double SpringAnimationDriver::ToValue() {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
@@ -21,6 +21,7 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
   double ToValue() override;
 
  protected:
+  bool Update(double timeDeltaMs, bool restarting) override;
   std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
   bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) override;
 
@@ -38,6 +39,9 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
   bool m_overshootClampingEnabled{0};
   int m_iterations{0};
   winrt::Microsoft::ReactNative::JSValueArray m_dynamicToValues{};
+
+  double m_lastTime{0};
+  double m_timeAccumulator{0};
 
   static constexpr std::string_view s_springStiffnessParameterName{"stiffness"};
   static constexpr std::string_view s_springDampingParameterName{"damping"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
@@ -11,15 +11,30 @@ StyleAnimatedNode::StyleAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : AnimatedNode(tag, manager) {
+    : AnimatedNode(tag, config, manager) {
   for (const auto &entry : config[s_styleName].AsObject()) {
-    m_propMapping.insert({entry.first, static_cast<int64_t>(entry.second.AsDouble())});
+    const auto inputTag = entry.second.AsInt64();
+    assert(HasCompatibleAnimationDriver(inputTag));
+    m_propMapping.insert({entry.first, inputTag});
   }
 }
 
-void StyleAnimatedNode::CollectViewUpdates(const folly::dynamic & /*propsMap*/) {}
+void StyleAnimatedNode::CollectViewUpdates(winrt::Microsoft::ReactNative::JSValueObject &propsMap) {
+  assert(!m_useComposition);
+  auto rawValue = 0.0;
+  for (const auto &propMapping : m_propMapping) {
+    if (const auto manager = m_manager.lock()) {
+      if (const auto transformNode = manager->GetTransformAnimatedNode(propMapping.second)) {
+        transformNode->CollectViewUpdates(propsMap);
+      } else if (const auto node = manager->GetValueAnimatedNode(propMapping.second)) {
+        propsMap[propMapping.first] = node->Value();
+      }
+    }
+  }
+}
 
 std::unordered_map<FacadeType, int64_t> StyleAnimatedNode::GetMapping() {
+  assert(m_useComposition);
   std::unordered_map<FacadeType, int64_t> mapping;
   for (const auto &prop : m_propMapping) {
     if (const auto manager = m_manager.lock()) {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
@@ -5,6 +5,7 @@
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
 #include "FacadeType.h"
+#include "JSValue.h"
 
 namespace Microsoft::ReactNative {
 class StyleAnimatedNode final : public AnimatedNode {
@@ -13,7 +14,7 @@ class StyleAnimatedNode final : public AnimatedNode {
       int64_t tag,
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
-  void CollectViewUpdates(const folly::dynamic &propsMap);
+  void CollectViewUpdates(winrt::Microsoft::ReactNative::JSValueObject &propsMap);
 
   std::unordered_map<FacadeType, int64_t> GetMapping();
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
@@ -11,30 +11,52 @@ SubtractionAnimatedNode::SubtractionAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, manager) {
+    : ValueAnimatedNode(tag, config, manager) {
   for (const auto &inputNode : config[s_inputName].AsArray()) {
+    const auto inputTag = inputNode.AsInt64();
+    assert(HasCompatibleAnimationDriver(inputTag));
     if (m_firstInput == s_firstInputUnset) {
-      m_firstInput = static_cast<int64_t>(inputNode.AsDouble());
+      m_firstInput = inputTag;
     } else {
-      m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
+      m_inputNodes.insert(inputTag);
     }
   }
 
-  m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
-    const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
+  if (m_useComposition) {
+    m_propertySet.StartAnimation(s_valueName, [firstNode = m_firstInput, nodes = m_inputNodes, manager]() {
+      const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();
 
-    anim.Expression([firstNode, nodes, manager, anim]() {
-      anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());
-      winrt::hstring expr = static_cast<winrt::hstring>(L"(") + s_baseName + L"." + s_valueName + L" + " + s_baseName +
-          L"." + s_offsetName + L")";
-      for (const auto tag : nodes) {
-        const auto identifier = L"n" + std::to_wstring(tag);
-        anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
-        expr = expr + L" - (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
-      }
-      return expr;
+      anim.Expression([firstNode, nodes, manager, anim]() {
+        anim.SetReferenceParameter(s_baseName, manager->GetValueAnimatedNode(firstNode)->PropertySet());
+        winrt::hstring expr = static_cast<winrt::hstring>(L"(") + s_baseName + L"." + s_valueName + L" + " +
+            s_baseName + L"." + s_offsetName + L")";
+        for (const auto tag : nodes) {
+          const auto identifier = L"n" + std::to_wstring(tag);
+          anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
+          expr = expr + L" - (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
+        }
+        return expr;
+      }());
+      return anim;
     }());
-    return anim;
-  }());
+  }
+}
+
+void SubtractionAnimatedNode::Update() {
+  assert(!m_useComposition);
+  if (const auto manager = m_manager.lock()) {
+    auto rawValue = 0.0;
+    if (const auto firstNode = manager->GetValueAnimatedNode(m_firstInput)) {
+      rawValue = firstNode->Value();
+    }
+
+    for (const auto &tag : m_inputNodes) {
+      if (const auto node = manager->GetValueAnimatedNode(tag)) {
+        rawValue -= node->Value();
+      }
+    }
+
+    RawValue(rawValue);
+  }
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
@@ -13,6 +13,8 @@ class SubtractionAnimatedNode final : public ValueAnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
+  virtual void Update() override;
+
  private:
   int64_t m_firstInput{s_firstInputUnset};
   std::unordered_set<int64_t> m_inputNodes{};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
@@ -11,13 +11,18 @@ TrackingAnimatedNode::TrackingAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : AnimatedNode(tag, manager) {
-  m_animationId = static_cast<int64_t>(config[s_animationIdName].AsDouble());
-  m_toValueId = static_cast<int64_t>(config[s_toValueIdName].AsDouble());
-  m_valueId = static_cast<int64_t>(config[s_valueIdName].AsDouble());
+    : AnimatedNode(tag, config, manager) {
+  m_animationId = config[s_animationIdName].AsInt64();
+  m_toValueId = config[s_toValueIdName].AsInt64();
+  m_valueId = config[s_valueIdName].AsInt64();
   m_animationConfig = std::move(config[s_animationConfigName].AsObject().Copy());
+  if (config.count(s_platformConfigName) && !m_animationConfig.count(s_platformConfigName)) {
+    m_animationConfig[s_platformConfigName] = std::move(config[s_platformConfigName].Copy());
+  }
 
-  StartAnimation();
+  if (m_useComposition) {
+    StartAnimation();
+  }
 }
 
 void TrackingAnimatedNode::Update() {
@@ -30,10 +35,14 @@ void TrackingAnimatedNode::StartAnimation() {
       // In case the animation is already running, we need to stop it to free up the
       // animationId key in the active animations map in the animation manager.
       strongManager->StopAnimation(m_animationId, true);
-      toValueNode->AddActiveTrackingNode(m_tag);
       m_animationConfig[s_toValueIdName] = toValueNode->Value();
-      strongManager->StartTrackingAnimatedNode(
-          m_animationId, m_valueId, m_toValueId, m_animationConfig, nullptr, strongManager);
+      if (m_useComposition) {
+        toValueNode->AddActiveTrackingNode(m_tag);
+        strongManager->StartTrackingAnimatedNode(
+            m_animationId, m_valueId, m_toValueId, m_animationConfig, nullptr, strongManager);
+      } else {
+        strongManager->StartAnimatingNode(m_animationId, m_valueId, m_animationConfig, nullptr, strongManager);
+      }
     }
   }
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
@@ -13,11 +13,10 @@ class TrackingAnimatedNode final : public AnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
-  void Update() override;
-
- private:
+  virtual void Update() override;
   void StartAnimation();
 
+ private:
   int64_t m_animationId{};
   int64_t m_toValueId{};
   int64_t m_valueId{};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 
 #include "FacadeType.h"
+#include "NativeAnimatedNodeManager.h"
 #include "TransformAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -11,12 +12,13 @@ TransformAnimatedNode::TransformAnimatedNode(
     int64_t tag,
     const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : AnimatedNode(tag, manager) {
+    : AnimatedNode(tag, config, manager) {
   for (const auto &transform : config[s_transformsName].AsArray()) {
     const auto property = transform[s_propertyName].AsString();
     if (transform[s_typeName].AsString() == s_animatedName) {
-      m_transformConfigs.push_back(
-          TransformConfig{property, static_cast<int64_t>(transform[s_nodeTagName].AsDouble()), 0});
+      const auto inputTag = transform[s_nodeTagName].AsInt64();
+      assert(HasCompatibleAnimationDriver(inputTag));
+      m_transformConfigs.push_back(TransformConfig{property, inputTag, 0});
     } else {
       m_transformConfigs.push_back(TransformConfig{property, s_unsetNodeTag, transform[s_valueName].AsDouble()});
     }
@@ -24,6 +26,7 @@ TransformAnimatedNode::TransformAnimatedNode(
 }
 
 std::unordered_map<FacadeType, int64_t> TransformAnimatedNode::GetMapping() {
+  assert(m_useComposition);
   std::unordered_map<FacadeType, int64_t> mapping;
   for (const auto &config : m_transformConfigs) {
     if (config.nodeTag != s_unsetNodeTag) {
@@ -35,4 +38,29 @@ std::unordered_map<FacadeType, int64_t> TransformAnimatedNode::GetMapping() {
   }
   return mapping;
 }
+
+void TransformAnimatedNode::CollectViewUpdates(winrt::Microsoft::ReactNative::JSValueObject &props) {
+  assert(!m_useComposition);
+  winrt::Microsoft::ReactNative::JSValueArray transforms;
+  if (const auto manager = m_manager.lock()) {
+    for (const auto &transformConfig : m_transformConfigs) {
+      std::optional<double> value;
+      if (transformConfig.nodeTag == s_unsetNodeTag) {
+        value = transformConfig.value;
+      } else {
+        if (const auto node = manager->GetValueAnimatedNode(transformConfig.nodeTag)) {
+          value = node->Value();
+        }
+      }
+
+      if (value) {
+        transforms.emplace_back(
+            winrt::Microsoft::ReactNative::JSValueObject{{transformConfig.property, value.value()}});
+      }
+    }
+  }
+
+  props[s_transformPropName] = std::move(transforms);
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
@@ -5,6 +5,7 @@
 #include <JSValue.h>
 #include "AnimatedNode.h"
 #include "FacadeType.h"
+#include "JSValue.h"
 
 namespace Microsoft::ReactNative {
 struct TransformConfig {
@@ -21,6 +22,7 @@ class TransformAnimatedNode final : public AnimatedNode {
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   std::unordered_map<FacadeType, int64_t> GetMapping();
+  void CollectViewUpdates(winrt::Microsoft::ReactNative::JSValueObject &props);
 
  private:
   std::vector<TransformConfig> m_transformConfigs;
@@ -33,5 +35,6 @@ class TransformAnimatedNode final : public AnimatedNode {
   static constexpr std::string_view s_animatedName{"animated"};
   static constexpr std::string_view s_nodeTagName{"nodeTag"};
   static constexpr std::string_view s_valueName{"value"};
+  static constexpr std::string_view s_transformPropName{"transform"};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
@@ -12,13 +12,14 @@ using namespace comp;
 }
 
 namespace Microsoft::ReactNative {
+typedef std::function<void(double)> ValueListenerCallback;
+
 class ValueAnimatedNode : public AnimatedNode {
  public:
   ValueAnimatedNode(
       int64_t tag,
       const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
-  ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   double Value();
   double RawValue();
   void RawValue(double value);
@@ -26,6 +27,9 @@ class ValueAnimatedNode : public AnimatedNode {
   void Offset(double offset);
   void FlattenOffset();
   void ExtractOffset();
+  void OnValueUpdate();
+  void ValueListener(const ValueListenerCallback &callback);
+
   comp::CompositionPropertySet PropertySet() {
     return m_propertySet;
   };
@@ -42,7 +46,6 @@ class ValueAnimatedNode : public AnimatedNode {
 
  protected:
   comp::CompositionPropertySet m_propertySet{nullptr};
-
   static constexpr std::string_view s_inputName{"input"};
 
   static constexpr std::string_view s_jsValueName{"value"};
@@ -53,5 +56,8 @@ class ValueAnimatedNode : public AnimatedNode {
   std::unordered_set<int64_t> m_dependentPropsNodes{};
   std::unordered_set<int64_t> m_activeAnimations{};
   std::unordered_set<int64_t> m_activeTrackingNodes{};
+  double m_value{0.0};
+  double m_offset{0.0};
+  ValueListenerCallback m_valueListener{};
 };
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Currently, NativeAnimated compiles the animation graph into CompositionAnimations from UI.Composition. While this approach likely provides the ideal performance for native animations on Windows, it suffers a few insurmountable limitations:

1. #8419: Creating a new animation on an animated value after stopping a previous animation on the same value does not retain the current value.
  a. Even with a fix like #9190, because UI.Composition values cannot be queried synchronously, starting a new animation on an animated value immediately after stopping a previous animation causes jitter in the animation, because it takes 1-2 frames for the completion callback to fire, signaling that the animated value has an up-to-date value.
2. #3283: UI.Composition can only animate supported properties, like opacity and transforms. NativeAnimated provides a prop "hook" (the prop name is `progress`) to allow arbitrary views to subscribe to animation value changes synchronously. This is not possible with UI.Composition.
3. #4311: Similar to the limitation for starting new animations synchronously after stopping a previous animation on the same animated value (#8419), animated value listeners will always be 1-2 frames out of sync while waiting for an up-to-date composition value. This feature is currently not implemented for the UI.Composition approach, but I suspect it would require a frame callback via CompositionTarget::Rendering, so not only would the values be out of sync, but the approach would have a similar performance profile to the CompositionTarget::Rendering driven animations.
4. #9255: Similar to #3283, it's actually possible to animate arbitrary props with Animated (e.g., `borderRadius`). It's unlikely that it would be possible to support such an animation with UI.Composition.

There are also a few bugs that are likely possible to workaround for UI.Composition, but would be fixed immediately by this CompositionTarget::Rendering approach:
1. #3460: Animated values persist even after the animation is unmounted with UI.Composition. The CompositionTarget::Rendering approach uses the view's shadow node as the source of truth for the prop value, and resets the prop to null when the animation is unmounted.
2. #9256: The UI.Composition implementation for NativeAnimated commandeers the `Offset` value for animated nodes, using it to drive progress on an animation. Animated value offsets are not intended for this purpose and can cause bugs as demonstrated in the linked issue.
3. #9251: Calling `setValue` on an animated value should stop any active animations, but currently does not in the UI.Composition implementation.
4. #9252: Animated.diffClamp nodes are intended to clamp the difference between the last value and the current value, but the UI.Composition `clamp` expression only has the capability to clamp the current value.
5. #9250: Calling `getValue` on an animated value does not return the current value for the UI.Composition approach (because values are not available until the animation has been stopped and the completion callback fires).
6. A more minor issue that I haven't filed an issue for, is that `Animated.decay` animations work slightly differently in NativeAnimated vs. JS-driven animations. The NativeAnimated approach is a bit more "accurate", in that it stops the animation when its value is within 0.1 of the final value if the decay ran infinitely. The JS-driven approach stops the animation more eagerly when the value differential (the difference between the current value and the previous value) is 0.1.

Resolves #3283
Resolves #3460
Resolves #4311
Resolves #5958
Resolves #8419
Resolves #9250
Resolves #9251
Resolves #9252
Resolves #9255
Resolves #9256

### What
This change allows each animation node and driver to be used in either composition mode or frame callback / CompositionTarget::Rendering mode. The latter approach is largely derived from the Android implementation of NativeAnimated (and the C# implementation in react-native-windows v0.59 and earlier).

This change will leverage WIP changes to the Animated APIs in RN core that pass a property bag to each AnimationDriver and AnimatedNode signaling which mode to use. The API surface will look something like the following:

```js
const value = Animated.value(0);

Animated.timing(value, {
  ...,
  useNativeDriver: true,
  platformConfig: {
    useComposition: false,
  });
```

We will also likely complement this API change with a way to set default `platformConfig` values for all Animated APIs using `useNativeDriver: true`:
```js
Animated.unstable_setDefaultPlatformConfig({useComposition: false});
```

For now, in order to not regress performance on existing react-native-windows applications, using the CompositionTarget::Rendering approach will be strictly opt-in. As of this commit, these two approaches cannot be blended together. I.e., you cannot connect a node using UI.Composition to a node using CompositionTarget::Rendering, and it's unlikely these two approaches could be combined until the UI.Composition approach supports synchronous queries of values (at which point, quite a few of the justifications for the CompositionTarget::Rendering approach will be resolved).

## Testing
There is no change in the animation behavior before and after this change, as this just sets up for the option to configure the animation type.

Before:

https://user-images.githubusercontent.com/1106239/146243274-da952be7-b098-401d-ad17-c427dc533700.mp4

After:

https://user-images.githubusercontent.com/1106239/146242972-f332afa7-524d-4b75-a59c-8188c749ad13.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9249)

Here is a video of composition bugs that are mitigated with tick based animations:

https://user-images.githubusercontent.com/1106239/182472062-05d1daf5-4dbc-42b5-9aea-3de73ce14162.mp4

## Notes

Please note, this change leaves the NativeAnimated behavior effectively unchanged - i.e., native animations still default to UI.Composition, and there is no public API surface to allow users to force the CompositionTarget::Rendering driver until #9285 is merged.