### PR TITLE
Fixes crash when creating DiffClampAnimatedNode

### DIFF
--- a/change/react-native-windows-332a5dcc-33ef-464e-b057-72cece380c6f.json
+++ b/change/react-native-windows-332a5dcc-33ef-464e-b057-72cece380c6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes crash when creating DiffClampAnimatedNode",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -11,7 +11,7 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, config, manager) {
+    : ValueAnimatedNode(tag, manager) {
   m_inputNodeTag = static_cast<int64_t>(config.find(s_inputName).dereference().second.asDouble());
   m_min = config.find(s_minName).dereference().second.asDouble();
   m_max = config.find(s_maxName).dereference().second.asDouble();


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Fixes #9253

### What
The base constructor call in `DiffClampAnimatedNode` calls the `ValueAnimatedNode` overload that passes in the config, which
assumes that the initial `"value"` and `"offset"` properties are available in the config map. Similar to other `ValueAnimatedNode`
derived classes, `DiffClampAnimatedNode` should use the constructor overload for `ValueAnimatedNode` that does not pass the `config` map.

## Testing
Before:

https://user-images.githubusercontent.com/1106239/145267696-ebc080af-1798-413e-8c2c-7e39b8ff6ddb.mp4

After:

https://user-images.githubusercontent.com/1106239/145267341-70bcd329-e73e-4a75-b702-071e741c3083.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9254)