### PR TITLE
Cleans up unused code from DecayAnimationDriver

### DIFF
--- a/change/react-native-windows-8058cea3-1388-4535-9689-7c2adc2c16e3.json
+++ b/change/react-native-windows-8058cea3-1388-4535-9689-7c2adc2c16e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Cleans up unused code from DecayAnimationDriver",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
@@ -31,15 +31,6 @@ bool DecayAnimationDriver::IsAnimationDone(double currentValue, double /*current
 }
 
 double DecayAnimationDriver::ToValue() {
-  auto const startValue = [this]() {
-    if (auto const manager = m_manager.lock()) {
-      if (auto const valueNode = manager->GetValueAnimatedNode(m_animatedValueTag)) {
-        return valueNode->Value();
-      }
-    }
-    return 0.0;
-  }();
-
   return m_startValue + m_velocity / (1 - m_deceleration);
 }
 


### PR DESCRIPTION


## Description

### Type of Change
- Cleanup dead code

### Why
It looks like we used to previously pull the start value on the fly and then later changed CalculatedAnimatedDriver to store the starting value in `m_startValue` and migrated to using that in DecayAnimationDriver in #3482.

### What
Removes dead code for computing the startValue.

## Testing
Decay animations still work:

https://user-images.githubusercontent.com/1106239/145284090-a2752865-b5c5-4af9-8cd7-d8ee3c52e531.mp4


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9258)