### PR TITLE
Enable fixup debug information

### DIFF
--- a/change/react-native-windows-8c590cd0-5e06-4d46-ba8a-c145231e47c6.json
+++ b/change/react-native-windows-8c590cd0-5e06-4d46-ba8a-c145231e47c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable fixup debug information",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -151,6 +151,7 @@
       <AdditionalOptions>%(AdditionalOptions) /noattributename</AdditionalOptions>
     </Midl>
   </ItemDefinitionGroup>
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PkgESCompliance.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ReactCommunity.cpp.props" />
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
@@ -19,4 +19,5 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\CppAppConsumeCSharpModule.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PkgESCompliance.props" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
@@ -19,4 +19,5 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PkgESCompliance.props" />
 </Project>

--- a/vnext/PropertySheets/PkgESCompliance.props
+++ b/vnext/PropertySheets/PkgESCompliance.props
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    Enable fixup debug information, which is required by PkgES compliance
+    tasks.
+  -->
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <Link>
+      <AdditionalOptions>/DEBUGTYPE:CV,FIXUP %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+
+</Project>


### PR DESCRIPTION
This enables the inclusion of fixup debug information for `Microsoft.ReactNative`, along with any projects built external to the ABI. This allows out-of-the-box usage with PkgES compliance tooling, including in our officially distributed binary.

**Package size impact:** _measuring_
**Compile time impact:** _measuring_




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9267)