### PR TITLE
[0.65] Force Node 14 in build, as Node 16 fails codegen task of react-native-windows

### DIFF
--- a/.ado/jobs/jschecks.yml
+++ b/.ado/jobs/jschecks.yml
@@ -22,6 +22,11 @@ jobs:
         submodules: false # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: false # set to 'true' to leave the OAuth token in the Git config after the initial fetch
 
+      - task: NodeTool@0
+        displayName: Installing Node
+        inputs:
+          versionSpec: '14.x'
+
       - template: ../templates/yarn-install.yml
 
       - template: ../templates/compute-beachball-branch-name.yml

--- a/.ado/jobs/macos-tests.yml
+++ b/.ado/jobs/macos-tests.yml
@@ -16,7 +16,12 @@ jobs:
       - checkout: self
         clean: true
         submodules: false
-            
+
+      - task: NodeTool@0
+        displayName: Installing Node
+        inputs:
+          versionSpec: '14.x'
+
       - template: ../templates/yarn-install.yml
 
       - script: yarn build


### PR DESCRIPTION
## Description
Node16 fails  the codegen task in react-native-windows proejct during `yarn build`:

```
d:\src\r2\vnext> npx --no-install @react-native-windows/codegen --files Libraries/**/*Native*.js --namespace Microsoft::ReactNativeSpecs --libraryName rnwcore
npm ERR! canceled

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\dannyvv\AppData\Local\npm-cache\_logs\2021-12-14T06_34_56_144Z-debug-0.log
```

The images have been updated to use node16 by default, so the CI is failing..
This change 'pins' node14 for our older branches.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9278)