### PR TITLE
Fixes crash when using `Animated.divide`

### DIFF
--- a/change/react-native-windows-e28e82a4-9e7a-45c8-bb89-3010b55711b4.json
+++ b/change/react-native-windows-e28e82a4-9e7a-45c8-bb89-3010b55711b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes crash when using `Animated.divide`",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -30,7 +30,7 @@ DivisionAnimatedNode::DivisionAnimatedNode(
       for (const auto tag : nodes) {
         const auto identifier = L"n" + std::to_wstring(tag);
         anim.SetReferenceParameter(identifier, manager->GetValueAnimatedNode(tag)->PropertySet());
-        expr = expr + L" / (" + identifier + L"." + s_valueName + L" " + identifier + L"." + s_offsetName + L")";
+        expr = expr + L" / (" + identifier + L"." + s_valueName + L" + " + identifier + L"." + s_offsetName + L")";
       }
       return expr;
     }());

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -11,7 +11,7 @@ DivisionAnimatedNode::DivisionAnimatedNode(
     int64_t tag,
     const folly::dynamic &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : ValueAnimatedNode(tag, config, manager) {
+    : ValueAnimatedNode(tag, manager) {
   for (const auto &inputNode : config.find(s_inputName).dereference().second) {
     if (m_firstInput == s_firstInputUnset) {
       m_firstInput = static_cast<int64_t>(inputNode.asDouble());


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why

When attempting to use `Animated.divide`, the app crashes in the base constructor for `ValueAnimatedNode` as it expects that the node config has an initial `value` and `offset` provided.

Resolves #9280

### What
This change just uses the correct base constructor overload for the `DivisionAnimatedNode` and adds a missing `+` operator from the animation expression.

## Testing
Tested a simple change in RNTester that introduced an innocuous `Animated.divide` node that divides the value by `1`. Before, the app crashed. Now the app no longer crashes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9281)