### PR TITLE
[NativeAnimated][3/3] Adds NativeAnimated value listeners for rendering driven events

### DIFF
--- a/change/react-native-windows-6471425b-0fc9-4e69-a265-b027c011248d.json
+++ b/change/react-native-windows-6471425b-0fc9-4e69-a265-b027c011248d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds NativeAnimated value listeners for rendering driven events",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
@@ -228,11 +228,20 @@ void NativeAnimatedModule::RemoveAnimatedEventFromView(
   m_nodesManager->RemoveAnimatedEventFromView(tag, eventName, animatedValueTag);
 }
 
-void NativeAnimatedModule::StartListeningToAnimatedNodeValue(int64_t /*tag*/) {
-  // NotImplemented
+void NativeAnimatedModule::StartListeningToAnimatedNodeValue(int64_t tag) {
+  m_nodesManager->StartListeningToAnimatedNodeValue(tag, [context = m_context, tag](double value) {
+    if (context->IsLoaded()) {
+      // This event could be coalesced, however it doesn't appear to be
+      // coalesced on Android or iOS, so leaving it without coalescing.
+      context->CallJSFunction(
+          "RCTDeviceEventEmitter",
+          "emit",
+          folly::dynamic::array("onAnimatedValueUpdate", folly::dynamic::object("tag", tag)("value", value)));
+    }
+  });
 }
 
-void NativeAnimatedModule::StopListeningToAnimatedNodeValue(int64_t /*tag*/) {
-  // NotImplemented
+void NativeAnimatedModule::StopListeningToAnimatedNodeValue(int64_t tag) {
+  m_nodesManager->StopListeningToAnimatedNodeValue(tag);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -283,6 +283,18 @@ void NativeAnimatedNodeManager::ExtractAnimatedNodeOffset(int64_t tag) {
   }
 }
 
+void NativeAnimatedNodeManager::StartListeningToAnimatedNodeValue(int64_t tag, const ValueListenerCallback &callback) {
+  if (const auto valueNode = m_valueNodes.at(tag).get()) {
+    valueNode->ValueListener(callback);
+  }
+}
+
+void NativeAnimatedNodeManager::StopListeningToAnimatedNodeValue(int64_t tag) {
+  if (const auto valueNode = m_valueNodes.at(tag).get()) {
+    valueNode->ValueListener(nullptr);
+  }
+}
+
 void NativeAnimatedNodeManager::AddAnimatedEventToView(
     int64_t viewTag,
     const std::string &eventName,

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
@@ -28,6 +28,7 @@ namespace Microsoft::ReactNative {
 /// </summary>
 
 typedef std::function<void(std::vector<folly::dynamic>)> Callback;
+typedef std::function<void(double)> ValueListenerCallback;
 
 class AnimatedNode;
 class StyleAnimatedNode;
@@ -73,6 +74,8 @@ class NativeAnimatedNodeManager {
   void SetAnimatedNodeOffset(int64_t tag, double offset);
   void FlattenAnimatedNodeOffset(int64_t tag);
   void ExtractAnimatedNodeOffset(int64_t tag);
+  void StartListeningToAnimatedNodeValue(int64_t tag, const ValueListenerCallback &callback);
+  void StopListeningToAnimatedNodeValue(int64_t tag);
   void AddAnimatedEventToView(
       int64_t viewTag,
       const std::string &eventName,

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
@@ -74,6 +74,16 @@ void ValueAnimatedNode::ExtractOffset() {
   RawValue(0.0f);
 }
 
+void ValueAnimatedNode::OnValueUpdate() {
+  if (m_valueListener) {
+    m_valueListener(Value());
+  }
+}
+
+void ValueAnimatedNode::ValueListener(const ValueListenerCallback &callback) {
+  m_valueListener = callback;
+}
+
 void ValueAnimatedNode::AddDependentPropsNode(int64_t propsNodeTag) {
   m_dependentPropsNodes.insert(propsNodeTag);
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
@@ -11,6 +11,8 @@ using namespace comp;
 }
 
 namespace Microsoft::ReactNative {
+typedef std::function<void(double)> ValueListenerCallback;
+
 class ValueAnimatedNode : public AnimatedNode {
  public:
   ValueAnimatedNode(
@@ -25,6 +27,9 @@ class ValueAnimatedNode : public AnimatedNode {
   void Offset(double offset);
   void FlattenOffset();
   void ExtractOffset();
+  void OnValueUpdate();
+  void ValueListener(const ValueListenerCallback &callback);
+
   comp::CompositionPropertySet PropertySet() {
     return m_propertySet;
   };
@@ -52,5 +57,6 @@ class ValueAnimatedNode : public AnimatedNode {
   std::unordered_set<int64_t> m_dependentPropsNodes{};
   std::unordered_set<int64_t> m_activeAnimations{};
   std::unordered_set<int64_t> m_activeTrackingNodes{};
+  ValueListenerCallback m_valueListener{};
 };
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The Animated APIs support the attachment of value listeners for various use cases, but the current UI.Composition APIs do not accommodate this.

This change is functionally dependent on #9249, which introduces the option to run native animations on the UI thread via CompositionTarget::Rendering callbacks.

Resolves #4311

### What
Extends the ValueAnimatedNode with a callback that is invoked after calling `OnValueUpdated` (this occurs in the rendering driver in #9249). The callback is wired up to the `NativeAnimatedModule`, which calls `RCTDeviceEventEmitter.emit("onAnimatedValueUpdate", { value: X });`.

## Testing

Will attach before and after videos.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9286)