### PR TITLE
Use shared pointer in WebSocket MessageReceived

### DIFF
--- a/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
+++ b/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use shared pointer in MessageReceived",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -98,8 +98,6 @@ WinRTWebSocketResource::WinRTWebSocketResource(
     IDataWriter &&writer,
     vector<ChainValidationResult> &&certExceptions)
     : m_socket{std::move(socket)}, m_writer{std::move(writer)} {
-  m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
-
   for (const auto &certException : certExceptions) {
     m_socket.Control().IgnorableServerCertificateErrors().Append(certException);
   }
@@ -288,36 +286,6 @@ fire_and_forget WinRTWebSocketResource::PerformClose() noexcept {
   m_closePerformed.Set();
 }
 
-void WinRTWebSocketResource::OnMessageReceived(
-    IWebSocket const &sender,
-    IMessageWebSocketMessageReceivedEventArgs const &args) {
-  try {
-    string response;
-    IDataReader reader = args.GetDataReader();
-    auto len = reader.UnconsumedBufferLength();
-    if (args.MessageType() == SocketMessageType::Utf8) {
-      reader.UnicodeEncoding(UnicodeEncoding::Utf8);
-      vector<uint8_t> data(len);
-      reader.ReadBytes(data);
-
-      response = string(CheckedReinterpretCast<char *>(data.data()), data.size());
-    } else {
-      auto buffer = reader.ReadBuffer(len);
-      winrt::hstring data = CryptographicBuffer::EncodeToBase64String(buffer);
-
-      response = winrt::to_string(std::wstring_view(data));
-    }
-
-    if (m_readHandler) {
-      m_readHandler(response.length(), response, args.MessageType() == SocketMessageType::Binary);
-    }
-  } catch (hresult_error const &e) {
-    if (m_errorHandler) {
-      m_errorHandler({HResultToString(e), ErrorType::Receive});
-    }
-  }
-}
-
 void WinRTWebSocketResource::Synchronize() noexcept {
   // Ensure sequence of other operations
   if (m_connectRequested) {
@@ -330,6 +298,35 @@ void WinRTWebSocketResource::Synchronize() noexcept {
 #pragma region IWebSocketResource
 
 void WinRTWebSocketResource::Connect(string &&url, const Protocols &protocols, const Options &options) noexcept {
+  m_socket.MessageReceived(
+      [self = shared_from_this()](IWebSocket const &sender, IMessageWebSocketMessageReceivedEventArgs const &args) {
+        try {
+          string response;
+          IDataReader reader = args.GetDataReader();
+          auto len = reader.UnconsumedBufferLength();
+          if (args.MessageType() == SocketMessageType::Utf8) {
+            reader.UnicodeEncoding(UnicodeEncoding::Utf8);
+            vector<uint8_t> data(len);
+            reader.ReadBytes(data);
+
+            response = string(CheckedReinterpretCast<char *>(data.data()), data.size());
+          } else {
+            auto buffer = reader.ReadBuffer(len);
+            winrt::hstring data = CryptographicBuffer::EncodeToBase64String(buffer);
+
+            response = winrt::to_string(std::wstring_view(data));
+          }
+
+          if (self->m_readHandler) {
+            self->m_readHandler(response.length(), response, args.MessageType() == SocketMessageType::Binary);
+          }
+        } catch (hresult_error const &e) {
+          if (self->m_errorHandler) {
+            self->m_errorHandler({HResultToString(e), ErrorType::Receive});
+          }
+        }
+  });
+
   m_readyState = ReadyState::Connecting;
 
   for (const auto &header : options) {

--- a/vnext/Shared/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/WinRTWebSocketResource.cpp
@@ -325,7 +325,7 @@ void WinRTWebSocketResource::Connect(string &&url, const Protocols &protocols, c
             self->m_errorHandler({HResultToString(e), ErrorType::Receive});
           }
         }
-  });
+      });
 
   m_readyState = ReadyState::Connecting;
 

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -51,9 +51,6 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   winrt::fire_and_forget PerformWrite(std::string &&message, bool isBinary) noexcept;
   winrt::fire_and_forget PerformClose() noexcept;
 
-  void OnMessageReceived(
-      winrt::Windows::Networking::Sockets::IWebSocket const &sender,
-      winrt::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs const &args);
   void Synchronize() noexcept;
 
  public:


### PR DESCRIPTION
Currently, the asynchronous callback for incoming WebSocket messages is defined in a member function and registered as follows:
```
m_socket.MessageReceived({this, &WinRTWebSocketResource::OnMessageReceived});
```

This will make access to `WinRTWebSocketResource`'s callbacks invalid if the class instance has already been destroyed.

This change prevents an access violation during `IMessageWebSocket::MessageReceived` by keeping a strong reference to the `WinRTWebSocketResource` instance, moving the definition from a member method to a capturing lambda:
```
  m_socket.MessageReceived(
      [self = shared_from_this()](IWebSocket const &sender, IMessageWebSocketMessageReceivedEventArgs const &args) {
...
```

See https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/handle-events#delegate-types-for-asynchronous-actions-and-operations

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9293)