### PR TITLE
[0.66] Avoid capturing raw this pointer in WebSocket module

### DIFF
--- a/change/react-native-windows-73930e56-06d0-4c76-ba71-fa122944bbd3.json
+++ b/change/react-native-windows-73930e56-06d0-4c76-ba71-fa122944bbd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.66] Avoid capturing raw this pointer in WebSocket module",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
+++ b/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Use shared pointer in MessageReceived",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
+++ b/change/react-native-windows-857f8e44-c7be-4025-827d-902572d0c205.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use shared pointer in MessageReceived",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e21dbe3d-18ab-42a0-a4a3-f96fb8c0997f.json
+++ b/change/react-native-windows-e21dbe3d-18ab-42a0-a4a3-f96fb8c0997f.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Avoid capturing raw `this` pointer in WS and AsyncStorage'",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-e21dbe3d-18ab-42a0-a4a3-f96fb8c0997f.json
+++ b/change/react-native-windows-e21dbe3d-18ab-42a0-a4a3-f96fb8c0997f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid capturing raw `this` pointer in WS and AsyncStorage'",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -22,7 +22,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UEBA?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YAX$$QEAV?$function@$$A6AXW4RCTLogLevel@react@facebook@@PEBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YAXPEAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SA?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@XZ
 ?Make@JSBigAbiString@react@facebook@@SA?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QEAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?at@dynamic@folly@@QEGBAAEBU12@V?$Range@PEBD@2@@Z
 ?atImpl@dynamic@folly@@AEGBAAEBU12@AEBU12@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -22,7 +22,7 @@ EXPORTS
 ?GetConstants@ViewManagerBase@react@facebook@@UBE?AUdynamic@folly@@XZ
 ?InitializeLogging@react@facebook@@YGX$$QAV?$function@$$A6GXW4RCTLogLevel@react@facebook@@PBD@Z@std@@@Z
 ?InitializeTracing@react@facebook@@YGXPAUINativeTraceHandler@12@@Z
-?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@@Z
+?Make@IWebSocketResource@React@Microsoft@@SG?AV?$shared_ptr@UIWebSocketResource@React@Microsoft@@@std@@XZ
 ?Make@JSBigAbiString@react@facebook@@SG?AV?$unique_ptr@$$CBUJSBigAbiString@react@facebook@@U?$default_delete@$$CBUJSBigAbiString@react@facebook@@@std@@@std@@$$QAV?$unique_ptr@U?$IAbiArray@D@AbiSafe@@UAbiObjectDeleter@2@@5@@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QAE?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
 ?at@dynamic@folly@@QGBEABU12@V?$Range@PBD@2@@Z

--- a/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
+++ b/vnext/Desktop.IntegrationTests/WebSocketResourcePerformanceTests.cpp
@@ -71,7 +71,7 @@ TEST_CLASS (WebSocketResourcePerformanceTest) {
     {
       vector<shared_ptr<IWebSocketResource>> resources;
       for (int i = 0; i < resourceTotal; i++) {
-        auto ws = IWebSocketResource::Make("ws://localhost:5555/"); // TODO: Switch to port 5556
+        auto ws = IWebSocketResource::Make();
         ws->SetOnMessage([this, &threadCount, &errorFound](size_t size, const string &message, bool isBinary) {
           if (errorFound)
             return;
@@ -103,7 +103,7 @@ TEST_CLASS (WebSocketResourcePerformanceTest) {
           errorFound = true;
           errorMessage = error.Message;
         });
-        ws->Connect();
+        ws->Connect("ws://localhost:5555"); // TODO: Switch to port 5556
 
         resources.push_back(std::move(ws));
       } // Create and store WS resources.

--- a/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
+++ b/vnext/Desktop.UnitTests/BaseWebSocketTests.cpp
@@ -15,6 +15,12 @@ using std::make_unique;
 using std::promise;
 using std::string;
 
+namespace {
+
+constexpr char testUrl[] = "ws://localhost";
+
+} // namespace
+
 namespace Microsoft::React::Test {
 
 using CloseCode = IWebSocketResource::CloseCode;
@@ -30,7 +36,7 @@ TEST_CLASS(BaseWebSocketTest){
   END_TEST_CLASS_ATTRIBUTE()
 
   TEST_METHOD(CreateAndSetHandlers){
-    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url(testUrl));
 
     Assert::IsFalse(nullptr == ws);
     ws->SetOnConnect([]() {});
@@ -44,11 +50,11 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(ConnectSucceeds) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url(testUrl));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
 
-    ws->Connect({}, {});
+    ws->Connect(testUrl, {}, {});
     ws->Close(CloseCode::Normal, {});
 
     Assert::AreEqual({}, errorMessage);
@@ -58,14 +64,14 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(ConnectFails) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url(testUrl));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
     ws->SetConnectResult([]() -> error_code {
       return make_error_code(errc::state_not_recoverable);
     });
 
-    ws->Connect({}, {});
+    ws->Connect(testUrl, {}, {});
     ws->Close(CloseCode::Normal, {});
 
     Assert::AreNotEqual({}, errorMessage);
@@ -78,14 +84,14 @@ TEST_CLASS(BaseWebSocketTest){
   TEST_METHOD(HandshakeFails) {
     string errorMessage;
     bool connected = false;
-    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url(testUrl));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected = true; });
     ws->SetHandshakeResult([](string, string) -> error_code {
       return make_error_code(errc::state_not_recoverable);
     });
 
-    ws->Connect({}, {});
+    ws->Connect(testUrl, {}, {});
     ws->Close(CloseCode::Normal, {});
 
     Assert::AreNotEqual({}, errorMessage);
@@ -99,7 +105,7 @@ TEST_CLASS(BaseWebSocketTest){
     string errorMessage;
     promise<void> connected;
     bool closed = false;
-    auto ws = make_unique<TestWebSocketResource>(Url("ws://localhost"));
+    auto ws = make_unique<TestWebSocketResource>(Url(testUrl));
     ws->SetOnError([&errorMessage](Error err) { errorMessage = err.Message; });
     ws->SetOnConnect([&connected]() { connected.set_value(); });
     ws->SetOnClose(
@@ -108,7 +114,7 @@ TEST_CLASS(BaseWebSocketTest){
     ws->SetCloseResult(
         []() -> error_code { return make_error_code(errc::success); });
 
-    ws->Connect({}, {});
+    ws->Connect(testUrl, {}, {});
     connected.get_future().wait();
 
     ws->Close(CloseCode::Normal, "Normal");

--- a/vnext/Desktop.UnitTests/WebSocketMocks.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.cpp
@@ -10,10 +10,13 @@ MockWebSocketResource::~MockWebSocketResource() {}
 
 #pragma region IWebSocketResource overrides
 
-void MockWebSocketResource::Connect(const Protocols &protocols, const Options &options) noexcept /*override*/
+void MockWebSocketResource::Connect(
+    string &&url,
+    const Protocols &protocols,
+    const Options &options) noexcept /*override*/
 {
   if (Mocks.Connect)
-    return Mocks.Connect(protocols, options);
+    return Mocks.Connect(std::move(url), protocols, options);
 }
 
 void MockWebSocketResource::Ping() noexcept /*override*/

--- a/vnext/Desktop.UnitTests/WebSocketMocks.h
+++ b/vnext/Desktop.UnitTests/WebSocketMocks.h
@@ -7,7 +7,7 @@ struct MockWebSocketResource : public IWebSocketResource {
   ~MockWebSocketResource();
 
   struct Mocks {
-    std::function<void(const Protocols &, const Options &)> Connect;
+    std::function<void(std::string &&url, const Protocols &, const Options &)> Connect;
     std::function<void()> Ping;
     std::function<void(const std::string &)> Send;
     std::function<void(const std::string &)> SendBinary;
@@ -25,7 +25,7 @@ struct MockWebSocketResource : public IWebSocketResource {
 
 #pragma region IWebSocketResource overrides
 
-  void Connect(const Protocols &, const Options &) noexcept override;
+  void Connect(std::string &&url, const Protocols &, const Options &) noexcept override;
 
   void Ping() noexcept override;
 

--- a/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
+++ b/vnext/Desktop.UnitTests/WebSocketModuleTest.cpp
@@ -74,7 +74,7 @@ TEST_CLASS (WebSocketModuleTest) {
     module->setInstance(instance);
     module->SetResourceFactory([](const string &) {
       auto rc = make_shared<MockWebSocketResource>();
-      rc->Mocks.Connect = [rc](const IWebSocketResource::Protocols &, const IWebSocketResource::Options &) {
+      rc->Mocks.Connect = [rc](string &&, const IWebSocketResource::Protocols &, const IWebSocketResource::Options &) {
         rc->OnConnect();
       };
 

--- a/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
+++ b/vnext/Desktop.UnitTests/WinRTWebSocketResourceUnitTest.cpp
@@ -32,6 +32,8 @@ IAsyncAction ThrowAsync() {
   co_return;
 }
 
+constexpr char testUrl[] = "ws://host:0";
+
 } // namespace
 
 namespace Microsoft::React::Test {
@@ -51,12 +53,11 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
     mws->Mocks.Close = [](uint16_t, const hstring &) {};
 
     // Test APIs
-    auto rc =
-        make_shared<WinRTWebSocketResource>(std::move(imws), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
+    auto rc = make_shared<WinRTWebSocketResource>(std::move(imws), MockDataWriter{}, CertExceptions{});
     rc->SetOnConnect([&connected]() { connected = true; });
     rc->SetOnError([&errorMessage](Error &&error) { errorMessage = error.Message; });
 
-    rc->Connect({}, {});
+    rc->Connect(testUrl, {}, {});
     rc->Close(CloseCode::Normal, {});
 
     Assert::AreEqual({}, errorMessage);
@@ -77,12 +78,11 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
     mws->Mocks.Close = [](uint16_t, const hstring &) {};
 
     // Test APIs
-    auto rc =
-        make_shared<WinRTWebSocketResource>(std::move(imws), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
+    auto rc = make_shared<WinRTWebSocketResource>(std::move(imws), MockDataWriter{}, CertExceptions{});
     rc->SetOnConnect([&connected]() { connected = true; });
     rc->SetOnError([&errorMessage](Error &&error) { errorMessage = error.Message; });
 
-    rc->Connect({}, {});
+    rc->Connect(testUrl, {}, {});
     rc->Close(CloseCode::Normal, {});
 
     Assert::AreEqual({"[0x80004005] Expected Failure"}, errorMessage);
@@ -95,7 +95,7 @@ TEST_CLASS (WinRTWebSocketResourceUnitTest) {
 
     auto lambda = [&rc]() mutable {
       rc = make_shared<WinRTWebSocketResource>(
-          winrt::make<ThrowingMessageWebSocket>(), MockDataWriter{}, Uri{L"ws://host:0"}, CertExceptions{});
+          winrt::make<ThrowingMessageWebSocket>(), MockDataWriter{}, CertExceptions{});
     };
 
     Assert::ExpectException<winrt::hresult_error>(lambda);

--- a/vnext/Desktop/BeastWebSocketResource.cpp
+++ b/vnext/Desktop/BeastWebSocketResource.cpp
@@ -30,6 +30,90 @@ using std::unique_ptr;
 
 namespace Microsoft::React {
 
+#pragma region BeastWebSocketResource
+
+BeastWebSocketResource::BeastWebSocketResource() noexcept {}
+
+#pragma region IWebSocketResource members
+
+void BeastWebSocketResource::Connect(
+    std::string &&urlString,
+    const Protocols &protocols,
+    const Options &options) noexcept {
+  Url url(std::move(urlString));
+
+  if (url.scheme == "ws") {
+    if (url.port.empty())
+      url.port = "80";
+
+    m_concreteResource = std::make_shared<Beast::WebSocketResource>(std::move(url));
+  } else if (url.scheme == "wss") {
+    if (url.port.empty())
+      url.port = "443";
+
+    m_concreteResource = std::make_shared<Beast::SecureWebSocketResource>(std::move(url));
+  }
+
+  m_concreteResource->SetOnClose(std::move(m_closeHandler));
+  m_concreteResource->SetOnConnect(std::move(m_connectHandler));
+  m_concreteResource->SetOnError(std::move(m_errorHandler));
+  m_concreteResource->SetOnMessage(std::move(m_readHandler));
+  m_concreteResource->SetOnPing(std::move(m_pingHandler));
+  m_concreteResource->SetOnSend(std::move(m_writeHandler));
+}
+
+void BeastWebSocketResource::Close(CloseCode code, const string &reason) noexcept {
+  m_concreteResource->Close(code, reason);
+}
+
+void BeastWebSocketResource::Send(string &&message) noexcept {
+  m_concreteResource->Send(std::move(message));
+}
+
+void BeastWebSocketResource::SendBinary(string &&base64String) noexcept {
+  m_concreteResource->SendBinary(std::move(base64String));
+}
+
+void BeastWebSocketResource::Ping() noexcept {
+  m_concreteResource->Ping();
+}
+
+#pragma endregion IWebSocketResource members
+
+#pragma region Handler setters
+
+void BeastWebSocketResource::SetOnConnect(function<void()> &&handler) noexcept {
+  m_connectHandler = std::move(handler);
+}
+
+void BeastWebSocketResource::SetOnPing(function<void()> &&handler) noexcept {
+  m_pingHandler = std::move(handler);
+}
+
+void BeastWebSocketResource::SetOnSend(function<void(size_t)> &&handler) noexcept {
+  m_writeHandler = std::move(handler);
+}
+
+void BeastWebSocketResource::SetOnMessage(function<void(size_t, const string &, bool isBinary)> &&handler) noexcept {
+  m_readHandler = std::move(handler);
+}
+
+void BeastWebSocketResource::SetOnClose(function<void(CloseCode, const string &)> &&handler) noexcept {
+  m_closeHandler = std::move(handler);
+}
+
+void BeastWebSocketResource::SetOnError(function<void(Error &&)> &&handler) noexcept {
+  m_errorHandler = std::move(handler);
+}
+
+IWebSocketResource::ReadyState BeastWebSocketResource::GetReadyState() const noexcept {
+  return m_concreteResource->GetReadyState();
+}
+
+#pragma endregion Handler setters
+
+#pragma endregion BeastWebSocketResource
+
 namespace Beast {
 
 #pragma region BaseWebSocketResource members
@@ -314,13 +398,16 @@ websocket::close_code BaseWebSocketResource<SocketLayer, Stream>::ToBeastCloseCo
 #pragma region IWebSocketResource members
 
 template <typename SocketLayer, typename Stream>
-void BaseWebSocketResource<SocketLayer, Stream>::Connect(const Protocols &protocols, const Options &options) noexcept {
+void BaseWebSocketResource<SocketLayer, Stream>::Connect(
+    std::string &&url,
+    const Protocols &protocols,
+    const Options &options) noexcept {
   // "Cannot call Connect more than once");
   assert(ReadyState::Connecting == m_readyState);
 
   // TODO: Enable?
   // m_stream->set_option(websocket::stream_base::timeout::suggested(role_type::client));
-  m_stream->set_option(websocket::stream_base::decorator([options = std::move(options)](websocket::request_type &req) {
+  m_stream->set_option(websocket::stream_base::decorator([options = options](websocket::request_type &req) {
     // Collect headers
     for (const auto &header : options) {
       req.insert(Microsoft::Common::Unicode::Utf16ToUtf8(header.first), header.second);
@@ -433,34 +520,34 @@ void BaseWebSocketResource<SocketLayer, Stream>::Ping() noexcept {
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnConnect(function<void()> &&handler) noexcept {
-  m_connectHandler = handler;
+  m_connectHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnPing(function<void()> &&handler) noexcept {
-  m_pingHandler = handler;
+  m_pingHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnSend(function<void(size_t)> &&handler) noexcept {
-  m_writeHandler = handler;
+  m_writeHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnMessage(
     function<void(size_t, const string &, bool isBinary)> &&handler) noexcept {
-  m_readHandler = handler;
+  m_readHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnClose(
     function<void(CloseCode, const string &)> &&handler) noexcept {
-  m_closeHandler = handler;
+  m_closeHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>
 void BaseWebSocketResource<SocketLayer, Stream>::SetOnError(function<void(Error &&)> &&handler) noexcept {
-  m_errorHandler = handler;
+  m_errorHandler = std::move(handler);
 }
 
 template <typename SocketLayer, typename Stream>

--- a/vnext/Desktop/BeastWebSocketResource.h
+++ b/vnext/Desktop/BeastWebSocketResource.h
@@ -13,7 +13,9 @@
 #include "IWebSocketResource.h"
 #include "Utils.h"
 
-namespace Microsoft::React::Beast {
+namespace Microsoft::React {
+
+namespace Beast {
 
 template <
     typename SocketLayer = boost::beast::tcp_stream,
@@ -156,7 +158,7 @@ class BaseWebSocketResource : public IWebSocketResource {
   /// <summary>
   /// <see cref="IWebSocketResource::Connect" />
   /// </summary>
-  void Connect(const Protocols &protocols, const Options &options) noexcept override;
+  void Connect(std::string &&url, const Protocols &protocols, const Options &options) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Ping" />
@@ -341,4 +343,81 @@ class TestWebSocketResource : public BaseWebSocketResource<
 
 } // namespace Test
 
-} // namespace Microsoft::React::Beast
+} // namespace Beast
+
+class BeastWebSocketResource : public IWebSocketResource, public std::enable_shared_from_this<BeastWebSocketResource> {
+  std::function<void()> m_connectHandler;
+  std::function<void()> m_pingHandler;
+  std::function<void(std::size_t)> m_writeHandler;
+  std::function<void(std::size_t, const std::string &, bool)> m_readHandler;
+  std::function<void(CloseCode, const std::string &)> m_closeHandler;
+  std::function<void(Error &&)> m_errorHandler;
+
+  std::shared_ptr<IWebSocketResource> m_concreteResource;
+
+ public:
+  BeastWebSocketResource() noexcept;
+
+#pragma region IWebSocketResource
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Connect" />
+  /// </summary>
+  void Connect(std::string &&url, const Protocols &protocols, const Options &options) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Ping" />
+  /// </summary>
+  void Ping() noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Send" />
+  /// </summary>
+  void Send(std::string &&message) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SendBinary" />
+  /// </summary>
+  void SendBinary(std::string &&base64String) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::Close" />
+  /// </summary>
+  void Close(CloseCode code, const std::string &reason) noexcept override;
+
+  ReadyState GetReadyState() const noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnConnect" />
+  /// </summary>
+  void SetOnConnect(std::function<void()> &&handler) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnPing" />
+  /// </summary>
+  void SetOnPing(std::function<void()> &&handler) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnSend" />
+  /// </summary>
+  void SetOnSend(std::function<void(std::size_t)> &&handler) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnMessage" />
+  /// </summary>
+  void SetOnMessage(std::function<void(std::size_t, const std::string &, bool isBinary)> &&handler) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnClose" />
+  /// </summary>
+  void SetOnClose(std::function<void(CloseCode, const std::string &)> &&handler) noexcept override;
+
+  /// <summary>
+  /// <see cref="IWebSocketResource::SetOnError" />
+  /// </summary>
+  void SetOnError(std::function<void(Error &&)> &&handler) noexcept override;
+
+#pragma endregion IWebSocketResource
+};
+
+} // namespace Microsoft::React

--- a/vnext/Desktop/WebSocketResourceFactory.cpp
+++ b/vnext/Desktop/WebSocketResourceFactory.cpp
@@ -7,7 +7,6 @@
 #include <WinRTWebSocketResource.h>
 #include "BeastWebSocketResource.h"
 
-using std::make_shared;
 using std::shared_ptr;
 using std::string;
 
@@ -15,24 +14,10 @@ namespace Microsoft::React {
 #pragma region IWebSocketResource static members
 
 /*static*/
-shared_ptr<IWebSocketResource> IWebSocketResource::Make(string &&urlString) {
+shared_ptr<IWebSocketResource> IWebSocketResource::Make() {
 #if ENABLE_BEAST
   if (GetRuntimeOptionBool("UseBeastWebSocket")) {
-    Url url(std::move(urlString));
-
-    if (url.scheme == "ws") {
-      if (url.port.empty())
-        url.port = "80";
-
-      return make_shared<Beast::WebSocketResource>(std::move(url));
-    } else if (url.scheme == "wss") {
-      if (url.port.empty())
-        url.port = "443";
-
-      return make_shared<Beast::SecureWebSocketResource>(std::move(url));
-    } else {
-      throw std::invalid_argument((string("Incorrect URL scheme: ") + url.scheme).c_str());
-    }
+    return std::make_shared<BeastWebSocketResource>();
   } else {
 #endif // ENABLE_BEAST
     std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
@@ -42,7 +27,7 @@ shared_ptr<IWebSocketResource> IWebSocketResource::Make(string &&urlString) {
       certExceptions.emplace_back(
           winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult::InvalidName);
     }
-    return make_shared<WinRTWebSocketResource>(std::move(urlString), std::move(certExceptions));
+    return std::make_shared<WinRTWebSocketResource>(std::move(certExceptions));
 #if ENABLE_BEAST
   }
 #endif // ENABLE_BEAST

--- a/vnext/Microsoft.ReactNative/Modules/CreateModules.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/CreateModules.cpp
@@ -19,9 +19,9 @@ using winrt::Microsoft::ReactNative::implementation::QuirkSettings;
 
 namespace Microsoft::React {
 
-std::shared_ptr<IWebSocketResource> IWebSocketResource::Make(std::string &&urlString) {
+std::shared_ptr<IWebSocketResource> IWebSocketResource::Make() {
   std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
-  return std::make_shared<WinRTWebSocketResource>(std::move(urlString), std::move(certExceptions));
+  return std::make_shared<WinRTWebSocketResource>(std::move(certExceptions));
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/IWebSocketResource.h
+++ b/vnext/Shared/IWebSocketResource.h
@@ -79,17 +79,17 @@ struct IWebSocketResource {
   /// <summary>
   /// Creates an <c>IWebSocketResource</c> instance.
   /// </summary>
-  /// <param name="url">
-  /// WebSocket URL address the instance will connect to.
-  /// The address's scheme can be either ws:// or wss://.
-  /// </param>
-  static std::shared_ptr<IWebSocketResource> Make(std::string &&url);
+  static std::shared_ptr<IWebSocketResource> Make();
 
   virtual ~IWebSocketResource() noexcept {}
 
   /// <summary>
   /// Establishes a continuous connection with the remote endpoint.
   /// </summary>
+  /// <param name="url">
+  /// WebSocket URL address the instance will connect to.
+  /// The address's scheme can be either ws:// or wss://.
+  /// </param>
   /// <param name="protocols">
   /// Currently unused
   /// </param>
@@ -97,7 +97,7 @@ struct IWebSocketResource {
   /// HTTP header fields passed by the remote endpoint, to be used in the
   /// handshake process.
   /// </param>
-  virtual void Connect(const Protocols &protocols = {}, const Options &options = {}) noexcept = 0;
+  virtual void Connect(std::string &&url, const Protocols &protocols = {}, const Options &options = {}) noexcept = 0;
 
   /// <summary>
   /// Sends a ping frame to the remote endpoint.

--- a/vnext/Shared/InspectorPackagerConnection.cpp
+++ b/vnext/Shared/InspectorPackagerConnection.cpp
@@ -204,8 +204,7 @@ winrt::fire_and_forget InspectorPackagerConnection::connectAsync() {
   co_await winrt::resume_background();
 
   std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> certExceptions;
-  m_packagerWebSocketConnection =
-      std::make_shared<Microsoft::React::WinRTWebSocketResource>(m_url, std::move(certExceptions));
+  m_packagerWebSocketConnection = std::make_shared<Microsoft::React::WinRTWebSocketResource>(std::move(certExceptions));
 
   m_packagerWebSocketConnection->SetOnError([](const Microsoft::React::IWebSocketResource::Error &err) {
     facebook::react::tracing::error(err.Message.c_str());
@@ -270,7 +269,7 @@ winrt::fire_and_forget InspectorPackagerConnection::connectAsync() {
 
   Microsoft::React::IWebSocketResource::Protocols protocols;
   Microsoft::React::IWebSocketResource::Options options;
-  m_packagerWebSocketConnection->Connect(protocols, options);
+  m_packagerWebSocketConnection->Connect(std::string{m_url}, protocols, options);
 
   co_return;
 }

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -14,7 +14,9 @@
 #include <iomanip>
 
 using namespace facebook::xplat;
-using namespace folly;
+
+using facebook::react::Instance;
+using folly::dynamic;
 
 using Microsoft::Common::Unicode::Utf16ToUtf8;
 using Microsoft::Common::Unicode::Utf8ToUtf16;
@@ -24,17 +26,111 @@ using std::string;
 using std::weak_ptr;
 
 namespace {
+using Microsoft::React::IWebSocketResource;
+using Microsoft::React::WebSocketModule;
+
 constexpr char moduleName[] = "WebSocketModule";
+
+static void SendEvent(weak_ptr<Instance> weakInstance, string &&eventName, dynamic &&args) {
+  if (auto instance = weakInstance.lock()) {
+    instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(std::move(eventName), std::move(args)));
+  }
+}
+
+static shared_ptr<IWebSocketResource>
+GetOrCreateWebSocket(int64_t id, string &&url, weak_ptr<WebSocketModule::SharedState> weakState) {
+  auto state = weakState.lock();
+  if (!state) {
+    return nullptr;
+  }
+
+  auto itr = state->ResourceMap.find(id);
+  if (itr == state->ResourceMap.end()) {
+    if (!state->Module) {
+      return nullptr;
+    }
+    auto weakInstance = state->Module->getInstance();
+
+    shared_ptr<IWebSocketResource> ws;
+    try {
+      ws = state->ResourceFactory(std::move(url));
+    } catch (const winrt::hresult_error &e) {
+      std::stringstream ss;
+      ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << "] "
+         << winrt::to_string(e.message());
+
+      SendEvent(weakInstance, "webSocketFailed", dynamic::object("id", id)("message", std::move(ss.str())));
+
+      return nullptr;
+    } catch (const std::exception &e) {
+      SendEvent(weakInstance, "webSocketFailed", dynamic::object("id", id)("message", e.what()));
+
+      return nullptr;
+    } catch (...) {
+      SendEvent(
+          weakInstance,
+          "webSocketFailed",
+          dynamic::object("id", id)("message", "Unidentified error creating IWebSocketResource"));
+
+      return nullptr;
+    }
+
+    ws->SetOnError([id, weakInstance](const IWebSocketResource::Error &err) {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
+      auto errorObj = dynamic::object("id", id)("message", err.Message);
+      SendEvent(weakInstance, "websocketFailed", std::move(errorObj));
+    });
+    ws->SetOnConnect([id, weakInstance]() {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
+      auto args = dynamic::object("id", id);
+      SendEvent(weakInstance, "websocketOpen", std::move(args));
+    });
+    ws->SetOnMessage([id, weakInstance](size_t length, const string &message, bool isBinary) {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
+      auto args = dynamic::object("id", id)("data", message)("type", isBinary ? "binary" : "text");
+      SendEvent(weakInstance, "websocketMessage", std::move(args));
+    });
+    ws->SetOnClose([id, weakInstance](IWebSocketResource::CloseCode code, const string &reason) {
+      auto strongInstance = weakInstance.lock();
+      if (!strongInstance)
+        return;
+
+      auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
+      SendEvent(weakInstance, "websocketClosed", std::move(args));
+    });
+
+    state->ResourceMap.emplace(id, ws);
+    return ws;
+  }
+
+  return itr->second;
+}
+
 } // anonymous namespace
 
 namespace Microsoft::React {
 
-WebSocketModule::WebSocketModule()
-    : m_resourceFactory{[](string &&url) { return IWebSocketResource::Make(std::move(url)); }} {}
+WebSocketModule::WebSocketModule() : m_sharedState{std::make_shared<SharedState>()} {
+  m_sharedState->ResourceFactory = [](string &&url) { return IWebSocketResource::Make(); };
+  m_sharedState->Module = this;
+}
+
+WebSocketModule::~WebSocketModule() noexcept /*override*/ {
+  m_sharedState->Module = nullptr;
+}
 
 void WebSocketModule::SetResourceFactory(
     std::function<shared_ptr<IWebSocketResource>(const string &)> &&resourceFactory) {
-  m_resourceFactory = std::move(resourceFactory);
+  m_sharedState->ResourceFactory = std::move(resourceFactory);
 }
 
 string WebSocketModule::getName() {
@@ -50,9 +146,9 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
 {
   return
   {
-    Method(
+    {
       "connect",
-      [this](dynamic args) // const string& url, dynamic protocols, dynamic options, int64_t id
+      [weakState = weak_ptr<SharedState>(m_sharedState)](dynamic args) // const string& url, dynamic protocols, dynamic options, int64_t id
       {
         IWebSocketResource::Protocols protocols;
         dynamic protocolsDynamic = jsArgAsDynamic(args, 1);
@@ -75,20 +171,21 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
           }
         }
 
-        weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0));
+        weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 3), jsArgAsString(args, 0), weakState);
         if (auto sharedWs = weakWs.lock())
         {
-          sharedWs->Connect(protocols, options);
+          sharedWs->Connect(jsArgAsString(args, 0), protocols, options);
         }
-      }),
-    Method(
+      }
+    },
+    {
       "close",
-      [this](dynamic args) // [int64_t code, string reason,] int64_t id
+      [weakState = weak_ptr<SharedState>(m_sharedState)](dynamic args) // [int64_t code, string reason,] int64_t id
       {
         // See react-native\Libraries\WebSocket\WebSocket.js:_close
         if (args.size() == 3) // WebSocketModule.close(statusCode, closeReason, this._socketId);
         {
-          weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 2));
+          weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 2), {}, weakState);
           if (auto sharedWs = weakWs.lock())
           {
             sharedWs->Close(static_cast<IWebSocketResource::CloseCode>(jsArgAsInt(args, 0)), jsArgAsString(args, 1));
@@ -96,7 +193,7 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
         }
         else if (args.size() == 1) // WebSocketModule.close(this._socketId);
         {
-          weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 0));
+          weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 0), {}, weakState);
           if (auto sharedWs = weakWs.lock())
           {
             sharedWs->Close(IWebSocketResource::CloseCode::Normal, {});
@@ -104,137 +201,53 @@ std::vector<facebook::xplat::module::CxxModule::Method> WebSocketModule::getMeth
         }
         else
         {
-          auto errorObj = dynamic::object("id", -1)("message", "Incorrect number of parameters");
-          this->SendEvent("websocketFailed", std::move(errorObj));
+          auto state = weakState.lock();
+          if (state && state->Module) {
+            auto errorObj = dynamic::object("id", -1)("message", "Incorrect number of parameters");
+            SendEvent(state->Module->getInstance(), "websocketFailed", std::move(errorObj));
+          }
         }
-      }),
-    Method(
+      }
+    },
+    {
       "send",
-      [this](dynamic args) // const string& message, int64_t id
+      [weakState = weak_ptr<SharedState>(m_sharedState)](dynamic args) // const string& message, int64_t id
       {
-        weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 1));
+        weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 1), {}, weakState);
         if (auto sharedWs = weakWs.lock())
         {
           sharedWs->Send(jsArgAsString(args, 0));
         }
-      }),
-    Method(
+      }
+    },
+    {
       "sendBinary",
-      [this](dynamic args) // const string& base64String, int64_t id
+      [weakState = weak_ptr<SharedState>(m_sharedState)](dynamic args) // const string& base64String, int64_t id
       {
-        weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 1));
+        weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 1), {}, weakState);
         if (auto sharedWs = weakWs.lock())
         {
           sharedWs->SendBinary(jsArgAsString(args, 0));
         }
-      }),
-    Method(
+      }
+    },
+    {
       "ping",
-      [this](dynamic args) // int64_t id
+      [weakState = weak_ptr<SharedState>(m_sharedState)](dynamic args) // int64_t id
       {
-        weak_ptr weakWs = this->GetOrCreateWebSocket(jsArgAsInt(args, 0));
+        weak_ptr weakWs = GetOrCreateWebSocket(jsArgAsInt(args, 0), {}, weakState);
         if (auto sharedWs = weakWs.lock())
         {
           sharedWs->Ping();
         }
-      })
+      }
+    }
   };
 } // getMethods
 // clang-format on
 
-#pragma region private members
-
-void WebSocketModule::SendEvent(string &&eventName, dynamic &&args) {
-  auto weakInstance = this->getInstance();
-  if (auto instance = weakInstance.lock()) {
-    instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(std::move(eventName), std::move(args)));
-  }
-}
-
-// clang-format off
-shared_ptr<IWebSocketResource> WebSocketModule::GetOrCreateWebSocket(int64_t id, string&& url)
-{
-  auto itr = m_webSockets.find(id);
-  if (itr == m_webSockets.end())
-  {
-    shared_ptr<IWebSocketResource> ws;
-    try
-    {
-      ws = m_resourceFactory(std::move(url));
-    }
-    catch (const winrt::hresult_error& e)
-    {
-      std::stringstream ss;
-      ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(e.code()) << "] " <<
-        winrt::to_string(e.message());
-
-      SendEvent("webSocketFailed", dynamic::object("id", id)("message", std::move(ss.str())));
-
-      return nullptr;
-    }
-    catch (const std::exception& e)
-    {
-      SendEvent("webSocketFailed", dynamic::object("id", id)("message", e.what()));
-
-      return nullptr;
-    }
-    catch (...)
-    {
-      SendEvent("webSocketFailed", dynamic::object("id", id)("message", "Unidentified error creating IWebSocketResource"));
-
-      return nullptr;
-    }
-
-    auto weakInstance = this->getInstance();
-    ws->SetOnError([this, id, weakInstance](const IWebSocketResource::Error& err)
-    {
-      auto strongInstance = weakInstance.lock();
-      if (!strongInstance)
-        return;
-
-      auto errorObj = dynamic::object("id", id)("message", err.Message);
-      this->SendEvent("websocketFailed", std::move(errorObj));
-    });
-    ws->SetOnConnect([this, id, weakInstance]()
-    {
-      auto strongInstance = weakInstance.lock();
-      if (!strongInstance)
-        return;
-
-      auto args = dynamic::object("id", id);
-      this->SendEvent("websocketOpen", std::move(args));
-    });
-    ws->SetOnMessage([this, id, weakInstance](size_t length, const string& message, bool isBinary)
-    {
-      auto strongInstance = weakInstance.lock();
-      if (!strongInstance)
-        return;
-
-      auto args = dynamic::object("id", id)("data", message)("type", isBinary ? "binary" : "text");
-      this->SendEvent("websocketMessage", std::move(args));
-    });
-    ws->SetOnClose([this, id, weakInstance](IWebSocketResource::CloseCode code, const string& reason)
-    {
-      auto strongInstance = weakInstance.lock();
-      if (!strongInstance)
-        return;
-
-      auto args = dynamic::object("id", id)("code", static_cast<uint16_t>(code))("reason", reason);
-      this->SendEvent("websocketClosed", std::move(args));
-    });
-
-    m_webSockets.emplace(id, ws);
-    return ws;
-  }
-
-  return itr->second;
-}
-// clang-format on
-
-#pragma endregion private members
-
 /*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule() noexcept {
-  return make_unique<WebSocketModule>();
+  return std::make_unique<WebSocketModule>();
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketModule.h
+++ b/vnext/Shared/Modules/WebSocketModule.h
@@ -18,6 +18,26 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
 
   WebSocketModule();
 
+  ~WebSocketModule() noexcept override;
+
+  struct SharedState {
+    /// <summary>
+    /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.
+    /// As defined in WebSocket.js.
+    /// </summary>
+    std::map<int64_t, std::shared_ptr<IWebSocketResource>> ResourceMap{};
+
+    /// <summary>
+    /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
+    /// </summary>
+    std::function<std::shared_ptr<IWebSocketResource>(std::string &&)> ResourceFactory;
+
+    /// <summary>
+    /// Keeps a raw reference to the module object to lazily retrieve the React Instance as needed.
+    /// </summary>
+    CxxModule *Module{nullptr};
+  };
+
 #pragma region CxxModule overrides
 
   /// <summary>
@@ -42,25 +62,15 @@ class WebSocketModule : public facebook::xplat::module::CxxModule {
 
  private:
   /// <summary>
-  /// Notifies an event to the current React Instance.
-  /// </summary>
-  void SendEvent(std::string &&eventName, folly::dynamic &&parameters);
-
-  /// <summary>
-  /// Creates or retrieves a raw <c>IWebSocketResource</c> pointer.
-  /// </summary>
-  std::shared_ptr<IWebSocketResource> GetOrCreateWebSocket(std::int64_t id, std::string &&url = {});
-
-  /// <summary>
   /// Keeps <c>IWebSocketResource</c> instances identified by <c>id</c>.
   /// As defined in WebSocket.js.
   /// </summary>
   std::map<int64_t, std::shared_ptr<IWebSocketResource>> m_webSockets;
 
   /// <summary>
-  /// Generates IWebSocketResource instances, defaulting to IWebSocketResource::Make.
+  /// Keeps members that can be accessed threads other than this module's owner accessible.
   /// </summary>
-  std::function<std::shared_ptr<IWebSocketResource>(std::string &&)> m_resourceFactory;
+  std::shared_ptr<SharedState> m_sharedState;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -17,7 +17,6 @@
 namespace Microsoft::React {
 
 class WinRTWebSocketResource : public IWebSocketResource, public std::enable_shared_from_this<WinRTWebSocketResource> {
-  winrt::Windows::Foundation::Uri m_uri;
   winrt::Windows::Networking::Sockets::IMessageWebSocket m_socket;
   // TODO: Use or remove.
   winrt::Windows::Networking::Sockets::IMessageWebSocket::MessageReceived_revoker m_revoker;
@@ -45,10 +44,9 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
 
   WinRTWebSocketResource(
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
-      winrt::Windows::Foundation::Uri &&uri,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
-  winrt::Windows::Foundation::IAsyncAction PerformConnect() noexcept;
+  winrt::Windows::Foundation::IAsyncAction PerformConnect(winrt::Windows::Foundation::Uri &&uri) noexcept;
   winrt::fire_and_forget PerformPing() noexcept;
   winrt::fire_and_forget PerformWrite(std::string &&message, bool isBinary) noexcept;
   winrt::fire_and_forget PerformClose() noexcept;
@@ -62,11 +60,9 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   WinRTWebSocketResource(
       winrt::Windows::Networking::Sockets::IMessageWebSocket &&socket,
       winrt::Windows::Storage::Streams::IDataWriter &&writer,
-      winrt::Windows::Foundation::Uri &&uri,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
   WinRTWebSocketResource(
-      const std::string &urlString,
       std::vector<winrt::Windows::Security::Cryptography::Certificates::ChainValidationResult> &&certExceptions);
 
   ~WinRTWebSocketResource() noexcept override;
@@ -76,7 +72,7 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   /// <summary>
   /// <see cref="IWebSocketResource::Connect" />
   /// </summary>
-  void Connect(const Protocols &protocols, const Options &options) noexcept override;
+  void Connect(std::string &&url, const Protocols &protocols, const Options &options) noexcept override;
 
   /// <summary>
   /// <see cref="IWebSocketResource::Ping" />

--- a/vnext/Shared/WinRTWebSocketResource.h
+++ b/vnext/Shared/WinRTWebSocketResource.h
@@ -51,9 +51,6 @@ class WinRTWebSocketResource : public IWebSocketResource, public std::enable_sha
   winrt::fire_and_forget PerformWrite(std::string &&message, bool isBinary) noexcept;
   winrt::fire_and_forget PerformClose() noexcept;
 
-  void OnMessageReceived(
-      winrt::Windows::Networking::Sockets::IWebSocket const &sender,
-      winrt::Windows::Networking::Sockets::IMessageWebSocketMessageReceivedEventArgs const &args);
   void Synchronize() noexcept;
 
  public:


### PR DESCRIPTION
- Avoid capturing raw `this` pointer in WebSocket module (#9247)
- Use shared pointer in WebSocket MessageReceived (#9293)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9298)