### PR TITLE
Animate value property rather than offset

### DIFF
--- a/change/react-native-windows-f6c9b8a9-e496-4be1-a2a5-ad3a4a9bece8.json
+++ b/change/react-native-windows-f6c9b8a9-e496-4be1-a2a5-ad3a4a9bece8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Animate value property rather than offset",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
@@ -44,7 +44,7 @@ AnimationDriver::~AnimationDriver() {
 void AnimationDriver::StartAnimation() {
   const auto [animation, scopedBatch] = MakeAnimation(m_config);
   if (auto const animatedValue = GetAnimatedValue()) {
-    animatedValue->PropertySet().StartAnimation(ValueAnimatedNode::s_offsetName, animation);
+    animatedValue->PropertySet().StartAnimation(ValueAnimatedNode::s_valueName, animation);
     animatedValue->AddActiveAnimation(m_id);
   }
   scopedBatch.End();
@@ -58,7 +58,6 @@ void AnimationDriver::StartAnimation() {
         if (auto manager = weakManager.lock()) {
           if (auto const animatedValue = manager->GetValueAnimatedNode(tag)) {
             animatedValue->RemoveActiveAnimation(id);
-            animatedValue->FlattenOffset();
           }
           manager->RemoveActiveAnimation(id);
         }
@@ -70,7 +69,7 @@ void AnimationDriver::StartAnimation() {
 
 void AnimationDriver::StopAnimation(bool ignoreCompletedHandlers) {
   if (const auto animatedValue = GetAnimatedValue()) {
-    animatedValue->PropertySet().StopAnimation(ValueAnimatedNode::s_offsetName);
+    animatedValue->PropertySet().StopAnimation(ValueAnimatedNode::s_valueName);
     if (!ignoreCompletedHandlers) {
       animatedValue->RemoveActiveAnimation(m_id);
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -37,11 +37,11 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
   std::chrono::milliseconds duration(static_cast<int>(keyFrames.size() / 60.0f * 1000.0f));
   animation.Duration(duration);
   auto normalizedProgress = 0.0f;
-  // We are animating the values offset property which should start at 0.
-  animation.InsertKeyFrame(normalizedProgress, 0.0f, easingFunction);
+  auto fromValue = static_cast<float>(GetAnimatedValue()->RawValue());
+  animation.InsertKeyFrame(normalizedProgress, fromValue, easingFunction);
   for (const auto keyFrame : keyFrames) {
     normalizedProgress = std::min(normalizedProgress + 1.0f / keyFrames.size(), 1.0f);
-    animation.InsertKeyFrame(normalizedProgress, keyFrame - static_cast<float>(m_startValue), easingFunction);
+    animation.InsertKeyFrame(normalizedProgress, keyFrame, easingFunction);
   }
 
   if (m_iterations == -1) {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
@@ -40,7 +40,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimat
   auto fromValue = GetAnimatedValue()->RawValue();
   for (auto frame : m_frames) {
     normalizedProgress = std::min(normalizedProgress += step, 1.0f);
-    animation.InsertKeyFrame(normalizedProgress, static_cast<float>(frame * (m_toValue - fromValue)));
+    animation.InsertKeyFrame(normalizedProgress, static_cast<float>(fromValue + frame * (m_toValue - fromValue)));
   }
 
   if (m_iterations == -1) {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
In the RN Animated API, the offset value should not change unless explicitly set by the user (or extract offset / flatten offset is called on the value node). In the previous composition implementation for NativeAnimated, the offset property in the CompositionPropertySet was animated, meaning if the user specified an offset value, its initial value was assumed to be zero for the spring and decay drivers, and more problematically, the animation needed to implicitly flatten the offset at the end of the animation.

Resolves  #9256

### What
This change keeps a fixed offset during animations and instead animates the raw value.

## Testing
RNTester animations still behave correctly:

https://user-images.githubusercontent.com/1106239/146809792-34811924-e0b8-4d2d-9551-51f7e734c272.mp4

## Breaking Change

This is marked as a breaking change, but only if people have relied on buggy behavior where the offset value is implicitly flattened at the end of an animation. Since this is not how animations are supposed to behave on other platforms, the fact that this is "breaking" can probably be ignored by most, but it may still be useful to call out the change in release notes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9302)