### PR TITLE
Categorize Vars target's items

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -102,7 +102,7 @@
         FollyDir;
         YogaDir;
       " />
-      <_VarsItemsJSEngine Include="
+      <JSEngineItems Include="
         PkgReactNative_Hermes_Windows;
         EnableHermesInspectorInReleaseFlavor;
         UseHermes;
@@ -168,7 +168,7 @@
 
     <Message Text="%0A" />
     <Message Text="JS Engine" />
-    <Message Text="=> @(_VarsItemsJSEngine->PadRight(40)) [$(%(_VarsItemsJSEngine.Identity))]" />
+    <Message Text="=> @(JSEngineItems->PadRight(40)) [$(%(JSEngineItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="NuGet" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -61,7 +61,7 @@
   <Target Name="Vars">
 
     <ItemGroup>
-      <GeneralItems Include="
+      <_VarsGeneral Include="
         ApplicationType;
         Configuration;
         Platform;
@@ -86,7 +86,7 @@
         UserRootDir;
         ProjectHome;
       " />
-      <CustomItems Include="
+      <_VarsCustom Include="
         RootDir;
         RootIntDir;
         RootOutDir;
@@ -98,11 +98,11 @@
         YogaDir;
         WinVer;
       " />
-      <WinRTItems Include="
+      <_VarsWinRT Include="
         UnmergedWinmdDirectory;
         MergedWinmdDirectory;
       " />
-      <JSEngineItems Include="
+      <_VarsJSEngine Include="
         PkgReactNative_Hermes_Windows;
         EnableHermesInspectorInReleaseFlavor;
         UseHermes;
@@ -115,7 +115,7 @@
         V8Version;
         V8AppPlatform;
       " />
-      <NuGetItems Include="
+      <_VarsNuGet Include="
         AssetTargetFallback;
         IncludeFrameworkReferencesFromNuGet;
         NuGetPackageRoot;
@@ -133,7 +133,7 @@
         RestoreProjectStyle;
         RestoreUseStaticGraphEvaluation;
       " />
-      <WinUIItems Include="
+      <_VarsWinUI Include="
         UseWinUI3;
         WinUI3Version;
         WinUI2xVersion;
@@ -144,11 +144,11 @@
     </ItemGroup>
 
     <Message Text="General" />
-    <Message Text="=> @(GeneralItems->PadRight(24)) [$(%(GeneralItems.Identity))]" />
+    <Message Text="=> @(_VarsGeneral->PadRight(24)) [$(%(_VarsGeneral.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="Custom" />
-    <Message Text="=> @(CustomItems->PadRight(24)) [$(%(CustomItems.Identity))]" />
+    <Message Text="=> @(_VarsCustom->PadRight(24)) [$(%(_VarsCustom.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="Microsoft.CppBuild.targets/MakeDirsForCl" />
@@ -164,19 +164,19 @@
 
     <Message Text="%0A" />
     <Message Text="WinRT" />
-    <Message Text="=> @(WinRTItems->PadRight(24)) [$(%(WinRTItems.Identity))]" />
+    <Message Text="=> @(_VarsWinRT->PadRight(24)) [$(%(_VarsWinRT.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="JS Engine" />
-    <Message Text="=> @(JSEngineItems->PadRight(40)) [$(%(JSEngineItems.Identity))]" />
+    <Message Text="=> @(_VarsJSEngine->PadRight(40)) [$(%(_VarsJSEngine.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="NuGet" />
-    <Message Text="=> @(NuGetItems->PadRight(40)) [$(%(NuGetItems.Identity))]" />
+    <Message Text="=> @(_VarsNuGet->PadRight(40)) [$(%(_VarsNuGet.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="WinUI" />
-    <Message Text="=> @(WinUIItems->PadRight(40)) [$(%(WinUIItems.Identity))]" />
+    <Message Text="=> @(_VarsWinUI->PadRight(40)) [$(%(_VarsWinUI.Identity))]" />
 
   </Target>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -58,91 +58,93 @@
   </Target>
 
   <!-- For build debugging purposes. -->
-  <ItemGroup>
-    <_VarsItemsGeneral Include="
-      ApplicationType;
-      Configuration;
-      Platform;
-      PlatformTarget;
-      PlatformName;
-      DefaultPlatformToolset;
-      PlatformToolset;
-      SolutionDir;
-      RootDir;
-      RootIntDir;
-      RootOutDir;
-      BaseIntDir;
-      BaseOutDir;
-      IntDir;
-      OutDir;
-      TargetDir;
-      TargetPath;
-      TLogLocation;
-      LastBuildUnsuccessful;
-      LastBuildState;
-      GeneratedFilesDir;
-      WinVer;
-      TargetFrameworkMoniker;
-      MSBuildExtensionsPath;
-      MSBuildExtensionsPath32;
-      MSBuildExtensionsPath64;
-      VCTargetsPath;
-      ReactNativeWindowsDir;
-      UserRootDir;
-      ProjectHome;
-    " />
-    <_VarsItemsWinRT Include="
-      UnmergedWinmdDirectory;
-      MergedWinmdDirectory;
-    " />
-    <_VarsItemsReactNative Include="
-      ReactNativeDir;
-      FollyDir;
-      YogaDir;
-    " />
-    <_VarsItemsJSEngine Include="
-      PkgReactNative_Hermes_Windows;
-      EnableHermesInspectorInReleaseFlavor;
-      UseHermes;
-      HermesVersion;
-      HermesPackage;
-      HermesArch;
-      UseFabric;
-      UseV8;
-      V8Package;
-      V8Version;
-      V8AppPlatform;
-    " />
-    <_VarsItemsNuGet Include="
-      AssetTargetFallback;
-      IncludeFrameworkReferencesFromNuGet;
-      NuGetPackageRoot;
-      NuGetPackagesDirectory;
-      NuGetRuntimeIdentifier;
-      ProjectLockFile;
-      IntermediateOutputPath;
-      NuGetTargetMoniker;
-      TargetFramework;
-      TargetFrameworks;
-      TargetFrameworkIdentifier;
-      BaseNuGetRuntimeIdentifier;
-      TargetPlatformIdentifier;
-      MSBuildProjectExtensionsPath;
-      RestoreProjectStyle;
-      RestoreUseStaticGraphEvaluation;
-    " />
-    <_VarsItemsWinUI Include="
-      UseWinUI3;
-      WinUI3Version;
-      WinUI2xVersion;
-      WinUIPackageName;
-      WinUIPackageVersion;
-      IsWinUIAlpha;
-    " />
-  </ItemGroup>
   <Target Name="Vars">
+
+    <ItemGroup>
+      <GeneralItems Include="
+        ApplicationType;
+        Configuration;
+        Platform;
+        PlatformTarget;
+        PlatformName;
+        DefaultPlatformToolset;
+        PlatformToolset;
+        SolutionDir;
+        RootDir;
+        RootIntDir;
+        RootOutDir;
+        BaseIntDir;
+        BaseOutDir;
+        IntDir;
+        OutDir;
+        TargetDir;
+        TargetPath;
+        TLogLocation;
+        LastBuildUnsuccessful;
+        LastBuildState;
+        GeneratedFilesDir;
+        WinVer;
+        TargetFrameworkMoniker;
+        MSBuildExtensionsPath;
+        MSBuildExtensionsPath32;
+        MSBuildExtensionsPath64;
+        VCTargetsPath;
+        ReactNativeWindowsDir;
+        UserRootDir;
+        ProjectHome;
+      " />
+      <WinRTItems Include="
+        UnmergedWinmdDirectory;
+        MergedWinmdDirectory;
+      " />
+      <ReactNativeItems Include="
+        ReactNativeDir;
+        FollyDir;
+        YogaDir;
+      " />
+      <_VarsItemsJSEngine Include="
+        PkgReactNative_Hermes_Windows;
+        EnableHermesInspectorInReleaseFlavor;
+        UseHermes;
+        HermesVersion;
+        HermesPackage;
+        HermesArch;
+        UseFabric;
+        UseV8;
+        V8Package;
+        V8Version;
+        V8AppPlatform;
+      " />
+      <NuGetItems Include="
+        AssetTargetFallback;
+        IncludeFrameworkReferencesFromNuGet;
+        NuGetPackageRoot;
+        NuGetPackagesDirectory;
+        NuGetRuntimeIdentifier;
+        ProjectLockFile;
+        IntermediateOutputPath;
+        NuGetTargetMoniker;
+        TargetFramework;
+        TargetFrameworks;
+        TargetFrameworkIdentifier;
+        BaseNuGetRuntimeIdentifier;
+        TargetPlatformIdentifier;
+        MSBuildProjectExtensionsPath;
+        RestoreProjectStyle;
+        RestoreUseStaticGraphEvaluation;
+      " />
+      <WinUIItems Include="
+        UseWinUI3;
+        WinUI3Version;
+        WinUI2xVersion;
+        WinUIPackageName;
+        WinUIPackageVersion;
+        IsWinUIAlpha;
+      " />
+    </ItemGroup>
+
     <Message Text="General" />
-    <Message Text="=> @(_VarsItemsGeneral->PadRight(24)) [$(%(_VarsItemsGeneral.Identity))]" />
+    <Message Text="=> @(GeneralItems->PadRight(24)) [$(%(GeneralItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="Microsoft.CppBuild.targets/MakeDirsForCl" />
@@ -158,11 +160,11 @@
 
     <Message Text="%0A" />
     <Message Text="React Native" />
-    <Message Text="=> @(_VarsItemsReactNative->PadRight(24)) [$(%(_VarsItemsReactNative.Identity))]" />
+    <Message Text="=> @(ReactNativeItems->PadRight(24)) [$(%(ReactNativeItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="WinRT" />
-    <Message Text="=> @(_VarsItemsWinRT->PadRight(24)) [$(%(_VarsItemsWinRT.Identity))]" />
+    <Message Text="=> @(WinRTItems->PadRight(24)) [$(%(WinRTItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="JS Engine" />
@@ -170,11 +172,11 @@
 
     <Message Text="%0A" />
     <Message Text="NuGet" />
-    <Message Text="=> @(_VarsItemsNuGet->PadRight(40)) [$(%(_VarsItemsNuGet.Identity))]" />
+    <Message Text="=> @(NuGetItems->PadRight(40)) [$(%(NuGetItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="WinUI" />
-    <Message Text="=> @(_VarsItemsWinUI->PadRight(40)) [$(%(_VarsItemsWinUI.Identity))]" />
+    <Message Text="=> @(WinUIItems->PadRight(40)) [$(%(WinUIItems.Identity))]" />
 
   </Target>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -148,15 +148,15 @@
 
     <Message Text="%0A" />
     <Message Text="Microsoft.CppBuild.targets/MakeDirsForCl" />
-    <Message Text="=> PrecompiledHeaderOutputFile [@(CLCompile->Metadata('PrecompiledHeaderOutputFile')->DirectoryName()->Distinct())]" />
-    <Message Text="=> AssemblerListingLocation    [@(CLCompile->Metadata('AssemblerListingLocation')->DirectoryName()->Distinct())]" />
-    <Message Text="=> ObjectFileName              [@(CLCompile->Metadata('ObjectFileName')->DirectoryName()->Distinct())]" />
-    <Message Text="=> ProgramDataBaseFileName     [@(CLCompile->Metadata('ProgramDataBaseFileName')->DirectoryName()->Distinct())]" />
-    <Message Text="=> XMLDocumentationFileName    [@(CLCompile->Metadata('XMLDocumentationFileName')->DirectoryName()->Distinct())]" />
-    <Message Text="=> BrowseInformationFile       [@(CLCompile->Metadata('BrowseInformationFile')->DirectoryName()->Distinct())]" />
-    <Message Text="=> PreprocessOutputPath        [@(CLCompile->Metadata('PreprocessOutputPath')->DirectoryName()->Distinct())]" />
-    <Message Text="=> PreprocessorDefinitions     [@(CLCompile->Metadata('PreprocessorDefinitions')->Distinct())]" />
-    <Message Text="=> ClDirsToMake                [@(ClDirsToMake)]" />
+    <Message Text="=> PrecompiledHeaderOutputFile  [@(CLCompile->Metadata('PrecompiledHeaderOutputFile')->DirectoryName()->Distinct())]" />
+    <Message Text="=> AssemblerListingLocation     [@(CLCompile->Metadata('AssemblerListingLocation')->DirectoryName()->Distinct())]" />
+    <Message Text="=> ObjectFileName               [@(CLCompile->Metadata('ObjectFileName')->DirectoryName()->Distinct())]" />
+    <Message Text="=> ProgramDataBaseFileName      [@(CLCompile->Metadata('ProgramDataBaseFileName')->DirectoryName()->Distinct())]" />
+    <Message Text="=> XMLDocumentationFileName     [@(CLCompile->Metadata('XMLDocumentationFileName')->DirectoryName()->Distinct())]" />
+    <Message Text="=> BrowseInformationFile        [@(CLCompile->Metadata('BrowseInformationFile')->DirectoryName()->Distinct())]" />
+    <Message Text="=> PreprocessOutputPath         [@(CLCompile->Metadata('PreprocessOutputPath')->DirectoryName()->Distinct())]" />
+    <Message Text="=> PreprocessorDefinitions      [@(CLCompile->Metadata('PreprocessorDefinitions')->Distinct())]" />
+    <Message Text="=> ClDirsToMake                 [@(ClDirsToMake)]" />
 
     <Message Text="%0A" />
     <Message Text="React Native" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -70,11 +70,6 @@
         DefaultPlatformToolset;
         PlatformToolset;
         SolutionDir;
-        RootDir;
-        RootIntDir;
-        RootOutDir;
-        BaseIntDir;
-        BaseOutDir;
         IntDir;
         OutDir;
         TargetDir;
@@ -83,24 +78,29 @@
         LastBuildUnsuccessful;
         LastBuildState;
         GeneratedFilesDir;
-        WinVer;
         TargetFrameworkMoniker;
         MSBuildExtensionsPath;
         MSBuildExtensionsPath32;
         MSBuildExtensionsPath64;
         VCTargetsPath;
-        ReactNativeWindowsDir;
         UserRootDir;
         ProjectHome;
+      " />
+      <CustomItems Include="
+        RootDir;
+        RootIntDir;
+        RootOutDir;
+        BaseIntDir;
+        BaseOutDir;
+        ReactNativeDir;
+        ReactNativeWindowsDir;
+        FollyDir;
+        YogaDir;
+        WinVer;
       " />
       <WinRTItems Include="
         UnmergedWinmdDirectory;
         MergedWinmdDirectory;
-      " />
-      <ReactNativeItems Include="
-        ReactNativeDir;
-        FollyDir;
-        YogaDir;
       " />
       <JSEngineItems Include="
         PkgReactNative_Hermes_Windows;
@@ -147,6 +147,10 @@
     <Message Text="=> @(GeneralItems->PadRight(24)) [$(%(GeneralItems.Identity))]" />
 
     <Message Text="%0A" />
+    <Message Text="Custom" />
+    <Message Text="=> @(CustomItems->PadRight(24)) [$(%(CustomItems.Identity))]" />
+
+    <Message Text="%0A" />
     <Message Text="Microsoft.CppBuild.targets/MakeDirsForCl" />
     <Message Text="=> PrecompiledHeaderOutputFile  [@(CLCompile->Metadata('PrecompiledHeaderOutputFile')->DirectoryName()->Distinct())]" />
     <Message Text="=> AssemblerListingLocation     [@(CLCompile->Metadata('AssemblerListingLocation')->DirectoryName()->Distinct())]" />
@@ -157,10 +161,6 @@
     <Message Text="=> PreprocessOutputPath         [@(CLCompile->Metadata('PreprocessOutputPath')->DirectoryName()->Distinct())]" />
     <Message Text="=> PreprocessorDefinitions      [@(CLCompile->Metadata('PreprocessorDefinitions')->Distinct())]" />
     <Message Text="=> ClDirsToMake                 [@(ClDirsToMake)]" />
-
-    <Message Text="%0A" />
-    <Message Text="React Native" />
-    <Message Text="=> @(ReactNativeItems->PadRight(24)) [$(%(ReactNativeItems.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="WinRT" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -58,31 +58,91 @@
   </Target>
 
   <!-- For build debugging purposes. -->
+  <ItemGroup>
+    <_VarsItemsGeneral Include="
+      ApplicationType;
+      Configuration;
+      Platform;
+      PlatformTarget;
+      PlatformName;
+      DefaultPlatformToolset;
+      PlatformToolset;
+      SolutionDir;
+      RootDir;
+      RootIntDir;
+      RootOutDir;
+      BaseIntDir;
+      BaseOutDir;
+      IntDir;
+      OutDir;
+      TargetDir;
+      TargetPath;
+      TLogLocation;
+      LastBuildUnsuccessful;
+      LastBuildState;
+      GeneratedFilesDir;
+      WinVer;
+      TargetFrameworkMoniker;
+      MSBuildExtensionsPath;
+      MSBuildExtensionsPath32;
+      MSBuildExtensionsPath64;
+      VCTargetsPath;
+      ReactNativeWindowsDir;
+      UserRootDir;
+      ProjectHome;
+    " />
+    <_VarsItemsWinRT Include="
+      UnmergedWinmdDirectory;
+      MergedWinmdDirectory;
+    " />
+    <_VarsItemsReactNative Include="
+      ReactNativeDir;
+      FollyDir;
+      YogaDir;
+    " />
+    <_VarsItemsJSEngine Include="
+      PkgReactNative_Hermes_Windows;
+      EnableHermesInspectorInReleaseFlavor;
+      UseHermes;
+      HermesVersion;
+      HermesPackage;
+      HermesArch;
+      UseFabric;
+      UseV8;
+      V8Package;
+      V8Version;
+      V8AppPlatform;
+    " />
+    <_VarsItemsNuGet Include="
+      AssetTargetFallback;
+      IncludeFrameworkReferencesFromNuGet;
+      NuGetPackageRoot;
+      NuGetPackagesDirectory;
+      NuGetRuntimeIdentifier;
+      ProjectLockFile;
+      IntermediateOutputPath;
+      NuGetTargetMoniker;
+      TargetFramework;
+      TargetFrameworks;
+      TargetFrameworkIdentifier;
+      BaseNuGetRuntimeIdentifier;
+      TargetPlatformIdentifier;
+      MSBuildProjectExtensionsPath;
+      RestoreProjectStyle;
+      RestoreUseStaticGraphEvaluation;
+    " />
+    <_VarsItemsWinUI Include="
+      UseWinUI3;
+      WinUI3Version;
+      WinUI2xVersion;
+      WinUIPackageName;
+      WinUIPackageVersion;
+      IsWinUIAlpha;
+    " />
+  </ItemGroup>
   <Target Name="Vars">
     <Message Text="General" />
-    <Message Text="=> ApplicationType         [$(ApplicationType)]" />
-    <Message Text="=> Configuration           [$(Configuration)]" />
-    <Message Text="=> Platform                [$(Platform)]" />
-    <Message Text="=> PlatformTarget          [$(PlatformTarget)]" />
-    <Message Text="=> PlatformName            [$(PlatformName)]" />
-    <Message Text="=> DefaultPlatformToolset  [$(DefaultPlatformToolset)]" />
-    <Message Text="=> PlatformToolset         [$(PlatformToolset)]" />
-    <Message Text="=> SolutionDir             [$(SolutionDir)]" />
-    <Message Text="=> RootDir                 [$(RootDir)]" />
-    <Message Text="=> RootIntDir              [$(RootIntDir)]" />
-    <Message Text="=> RootOutDir              [$(RootOutDir)]" />
-    <Message Text="=> BaseIntDir              [$(BaseIntDir)]" />
-    <Message Text="=> BaseOutDir              [$(BaseOutDir)]" />
-    <Message Text="=> IntDir                  [$(IntDir)]" />
-    <Message Text="=> OutDir                  [$(OutDir)]" />
-    <Message Text="=> TargetDir               [$(TargetDir)]" />
-    <Message Text="=> TargetPath              [$(TargetPath)]" />
-    <Message Text="=> TLogLocation            [$(TLogLocation)]" />
-    <Message Text="=> LastBuildUnsuccessful   [$(LastBuildUnsuccessful)]" />
-    <Message Text="=> LastBuildState          [$(LastBuildState)]" />
-    <Message Text="=> GeneratedFilesDir       [$(GeneratedFilesDir)]" />
-    <Message Text="=> WinVer                  [$(WinVer)]" />
-    <Message Text="=> TargetFrameworkMoniker  [$(TargetFrameworkMoniker)]" />
+    <Message Text="=> @(_VarsItemsGeneral->PadRight(24)) [$(%(_VarsItemsGeneral.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="Microsoft.CppBuild.targets/MakeDirsForCl" />
@@ -97,62 +157,24 @@
     <Message Text="=> ClDirsToMake                [@(ClDirsToMake)]" />
 
     <Message Text="%0A" />
-    <Message Text="=> UnmergedWinmdDirectory  [$(UnmergedWinmdDirectory)]" />
-    <Message Text="=> MergedWinmdDirectory    [$(MergedWinmdDirectory)]" />
-    <Message Text="=> FollyDir                [$(FollyDir)]" />
-    <Message Text="=> ReactNativeWindowsDir   [$(ReactNativeWindowsDir)]" />
-    <Message Text="=> ReactNativeDir          [$(ReactNativeDir)]" />
-    <Message Text="=> YogaDir                 [$(YogaDir)]" />
-    <Message Text="=> ProjectHome             [$(ProjectHome)]" />
-    <Message Text="=> UserRootDir             [$(UserRootDir)]" />
-    <Message Text="=> MSBuildExtensionsPath   [$(MSBuildExtensionsPath)]" />
-    <Message Text="=> MSBuildExtensionsPath32 [$(MSBuildExtensionsPath32)]" />
-    <Message Text="=> MSBuildExtensionsPath64 [$(MSBuildExtensionsPath64)]" />
-    <Message Text="=> VCTargetsPath           [$(VCTargetsPath)]" />
+    <Message Text="React Native" />
+    <Message Text="=> @(_VarsItemsReactNative->PadRight(24)) [$(%(_VarsItemsReactNative.Identity))]" />
+
+    <Message Text="%0A" />
+    <Message Text="WinRT" />
+    <Message Text="=> @(_VarsItemsWinRT->PadRight(24)) [$(%(_VarsItemsWinRT.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="JS Engine" />
-    <Message Text="=> PkgReactNative_Hermes_Windows        [$(PkgReactNative_Hermes_Windows)]" />
-    <Message Text="=> EnableHermesInspectorInReleaseFlavor [$(EnableHermesInspectorInReleaseFlavor)]" />
-    <Message Text="=> UseHermes     [$(UseHermes)]" />
-    <Message Text="=> UseFabric     [$(UseFabric)]" />
-    <Message Text="=> HermesVersion [$(HermesVersion)]" />
-    <Message Text="=> HermesPackage [$(HermesPackage)]" />
-    <Message Text="=> HermesArch    [$(HermesArch)]" />
-    <Message Text="=> UseFabric     [$(UseFabric)]" />
-    <Message Text="=> UseV8         [$(UseV8)]" />
-    <Message Text="=> V8Package     [$(V8Package)]" />
-    <Message Text="=> V8Version     [$(V8Version)]" />
-    <Message Text="=> V8AppPlatform [$(V8AppPlatform)]" />
+    <Message Text="=> @(_VarsItemsJSEngine->PadRight(40)) [$(%(_VarsItemsJSEngine.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="NuGet" />
-    <Message Text="=> AssetTargetFallback                 [$(AssetTargetFallback)]" />
-    <Message Text="=> IncludeFrameworkReferencesFromNuGet [$(IncludeFrameworkReferencesFromNuGet)]" />
-    <Message Text="=> NuGetPackageRoot                    [$(NuGetPackageRoot)]" />
-    <Message Text="=> NuGetPackagesDirectory              [$(NuGetPackagesDirectory)]" />
-    <Message Text="=> NuGetRuntimeIdentifier              [$(NuGetRuntimeIdentifier)]" />
-    <Message Text="=> ProjectLockFile                     [$(ProjectLockFile)]" />
-    <Message Text="=> IntermediateOutputPath              [$(IntermediateOutputPath)]" />
-    <Message Text="=> NuGetTargetMoniker                  [$(NuGetTargetMoniker)]" />
-    <Message Text="=> TargetFramework                     [$(TargetFramework)]" />
-    <Message Text="=> TargetFrameworks                    [$(TargetFrameworks)]" />
-    <Message Text="=> TargetFrameworkIdentifier           [$(TargetFrameworkIdentifier)]" />
-    <Message Text="=> BaseNuGetRuntimeIdentifier          [$(BaseNuGetRuntimeIdentifier)]" />
-    <Message Text="=> NuGetRuntimeIdentifier              [$(NuGetRuntimeIdentifier)]" />
-    <Message Text="=> TargetPlatformIdentifier            [$(TargetPlatformIdentifier)]" />
-    <Message Text="=> MSBuildProjectExtensionsPath        [$(MSBuildProjectExtensionsPath)]" />
-    <Message Text="=> RestoreProjectStyle                 [$(RestoreProjectStyle)]" />
-    <Message Text="=> RestoreUseStaticGraphEvaluation     [$(RestoreUseStaticGraphEvaluation)]" />
+    <Message Text="=> @(_VarsItemsNuGet->PadRight(40)) [$(%(_VarsItemsNuGet.Identity))]" />
 
     <Message Text="%0A" />
     <Message Text="WinUI" />
-    <Message Text="=> UseWinUI3           [$(UseWinUI3)]" />
-    <Message Text="=> WinUI3Version       [$(WinUI3Version)]" />
-    <Message Text="=> WinUI2xVersion      [$(WinUI2xVersion)]" />
-    <Message Text="=> WinUIPackageName    [$(WinUIPackageName)]" />
-    <Message Text="=> WinUIPackageVersion [$(WinUIPackageVersion)]" />
-    <Message Text="=> IsWinUIAlpha        [$(IsWinUIAlpha)]" />
+    <Message Text="=> @(_VarsItemsWinUI->PadRight(40)) [$(%(_VarsItemsWinUI.Identity))]" />
 
   </Target>
 


### PR DESCRIPTION
- Use ItemGroup to print Vars properties

## Description
Trivial change for build debugging purposes only.
Upgrades the custom `Vars` target to use collections of MSBuild items instead of manually adding a new `Message` task for each MSBuild property to print.

### Type of Change
- Informational

### Why
Adding new properties to the `Vars` target resulted in a lot of boilerplate code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9316)