### PR TITLE
Update @react-native-windows Dependency

### DIFF
--- a/change/@react-native-windows-cli-b4ab1e6f-6ab0-4cd4-9062-0c15cba7366e.json
+++ b/change/@react-native-windows-cli-b4ab1e6f-6ab0-4cd4-9062-0c15cba7366e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update CLI dependency",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -17,6 +17,7 @@
     "watch": "rnw-scripts watch"
   },
   "dependencies": {
+    "@react-native-community/cli": "^6.0.0",
     "@react-native-windows/fs": "^1.0.1",
     "@react-native-windows/package-utils": "^0.0.0-canary.24",
     "@react-native-windows/telemetry": "^0.0.0-canary.30",


### PR DESCRIPTION
## Description

### Type of Change_
- Bug fix (non-breaking change which fixes an issue)

### Why
Creating PR to start discussion if this is the right change. In #8654 and its sister issue https://github.com/react-native-webview/react-native-webview/issues/2146, there's is apparently a bug with the @react-native-windows/cli dependency on @react-native-community/cli when npm is used instead of yarn.

My understanding is @react-native-windows/cli depends on @react-native-community/cli but there is no mention of the package in @react-native-windows/cli/package.json. @react-native-community/cli is a dependency of react-native-windows though. 

I'm not super well-versed on the differences between how npm builds the dependency hierarchy vs. yarn. Is explicitly adding @react-native-community/cli to @react-native-windows/cli/package.json the right move here to solve this bug?

Resolves #8654

### What
Add @react-native-community/cli to @react-native-windows/cli/package.json 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9317)