### PR TITLE
Adds .gitattributes file to templates

### DIFF
--- a/change/@react-native-windows-cli-a4f4e783-319b-4b66-b8ec-61babec49e7a.json
+++ b/change/@react-native-windows-cli-a4f4e783-319b-4b66-b8ec-61babec49e7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "adds .gitattributes file to templates",
+  "packageName": "@react-native-windows/cli",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-1a16e82d-0c15-4c01-bb61-83d438cf95d0.json
+++ b/change/react-native-windows-1a16e82d-0c15-4c01-bb61-83d438cf95d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "adds .gitattributes file to templates",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -263,6 +263,10 @@ export async function copyProjectTemplateAndReplace(
             to: path.join(windowsDir, newProjectName, '.gitignore'),
           },
           {
+            from: path.join(srcRootPath, '_gitattributes'),
+            to: path.join(windowsDir, '.gitattributes'),
+          },
+          {
             from: path.join(srcRootPath, 'index.windows.bundle'),
             to: path.join(
               windowsDir,
@@ -270,6 +274,7 @@ export async function copyProjectTemplateAndReplace(
               bundleDir,
               'index.windows.bundle',
             ),
+            //"C:\Users\tatianakapos\Documents\Work\react-native-windows\vnext\template\_gitattributes.txt"
           },
           {
             from: path.join(srcPath, projDir, 'MyApp.sln'),
@@ -281,6 +286,10 @@ export async function copyProjectTemplateAndReplace(
           {
             from: path.join(srcRootPath, '_gitignore'),
             to: path.join(windowsDir, '.gitignore'),
+          },
+          {
+            from: path.join(srcRootPath, '_gitattributes'),
+            to: path.join(windowsDir, '.gitattributes'),
           },
           {
             from: path.join(srcPath, projDir, 'MyLib.sln'),

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -274,7 +274,6 @@ export async function copyProjectTemplateAndReplace(
               bundleDir,
               'index.windows.bundle',
             ),
-            //"C:\Users\tatianakapos\Documents\Work\react-native-windows\vnext\template\_gitattributes.txt"
           },
           {
             from: path.join(srcPath, projDir, 'MyApp.sln'),

--- a/vnext/template/_gitattributes
+++ b/vnext/template/_gitattributes
@@ -1,0 +1,42 @@
+# Auto detect text files and perform LF normalization
+
+*       text=auto
+
+# C++ files should use CRLF.
+*.c   text eol=crlf
+*.cpp text eol=crlf
+*.h   text eol=crlf
+*.hpp text eol=crlf
+
+# Spec Codegen uses LF
+*Spec.g.h eol=lf
+
+# Force Visual Studio project files (mostly XML) to CRLF
+#   This helps avoid conflict which occurs when Xmarian/Mac contributors with AutoCRLF=input (or off)
+#   check in these files as CRLFs, and then Windows contributors with AutoCRLF=true end up checking then
+#   files in as LFs  (due to AutoCRLF=true normalizing CRLF->LF on check-in).
+
+*.sln text eol=crlf
+*.csproj text eol=crlf
+*.vbproj text eol=crlf
+*.fsproj text eol=crlf
+*.pyproj text eol=crlf
+*.dbproj text eol=crlf
+*.vcxproj text eol=crlf
+*.shproj text eol=crlf
+*.projitems text eol=crlf
+*.vcxitems text eol=crlf
+*.props text eol=crlf
+*.filters text eol=crlf
+
+*.js  text eol=lf
+*.jsx  text eol=lf
+*.ts  text eol=lf
+*.tsx  text eol=lf
+*.ps1 text eol=lf
+*.yml text eol=lf
+.editorconfig text eol=lf
+.gitattributes text eol=lf
+package.json text eol=lf
+
+*.pbxproj -text

--- a/vnext/template/_gitattributes
+++ b/vnext/template/_gitattributes
@@ -17,17 +17,12 @@
 #   files in as LFs  (due to AutoCRLF=true normalizing CRLF->LF on check-in).
 
 *.sln text eol=crlf
-*.csproj text eol=crlf
-*.vbproj text eol=crlf
-*.fsproj text eol=crlf
-*.pyproj text eol=crlf
-*.dbproj text eol=crlf
-*.vcxproj text eol=crlf
-*.shproj text eol=crlf
+*.*proj text eol=crlf
 *.projitems text eol=crlf
 *.vcxitems text eol=crlf
 *.props text eol=crlf
 *.filters text eol=crlf
+*.targets text eol=crlf
 
 *.js  text eol=lf
 *.jsx  text eol=lf


### PR DESCRIPTION
## Description
Adds .gitattributes to templates (.gitattrubutes file taken from [RNGallery](https://github.com/microsoft/react-native-gallery/blob/main/.gitattributes))

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #8590

### What
Adds .gitattributes file to _vnext/templates_ folder and registers it in _packages/@react-native-windows/cli/src/generator-windows/index.ts_ 

## Testing
Tested locally using steps described in [Contributing to CI Docs](https://github.com/microsoft/react-native-windows/wiki/Contributing-to-the-CLI#4-run-your-local-react-native-windows-init-to-create-the-windows-project) by creating new app/module using local changes

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9330)