### PR TITLE
Update when telemetry populates NPM package versions

### DIFF
--- a/change/@react-native-windows-telemetry-90748cb8-547c-4e1c-ba61-57a8df530393.json
+++ b/change/@react-native-windows-telemetry-90748cb8-547c-4e1c-ba61-57a8df530393.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update when telemetry populates NPM package versions",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-0a3d283c-7dc5-4965-9de9-97362a1466ed.json
+++ b/change/react-native-windows-init-0a3d283c-7dc5-4965-9de9-97362a1466ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update when telemetry populates NPM package versions",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -14,6 +14,7 @@ import * as projectUtils from './utils/projectUtils';
 export interface TelemetryOptions {
   setupString: string;
   preserveErrorMessages: boolean;
+  populateNpmPackageVersions: boolean;
 }
 
 export interface CommandStartInfo {
@@ -79,6 +80,7 @@ export class Telemetry {
   protected static options: TelemetryOptions = {
     setupString: Telemetry.getDefaultSetupString(), // We default to our AI key, but callers can easily override it in setup
     preserveErrorMessages: false,
+    populateNpmPackageVersions: true,
   };
 
   protected static isTest: boolean = basePropUtils.isCliTest();
@@ -104,6 +106,7 @@ export class Telemetry {
     Telemetry.options = {
       setupString: Telemetry.getDefaultSetupString(),
       preserveErrorMessages: false,
+      populateNpmPackageVersions: true,
     };
     Telemetry.commandInfo = {};
     Telemetry.versionsProp = {};
@@ -194,7 +197,9 @@ export class Telemetry {
     Telemetry.client!.commonProperties.sessionId = Telemetry.getSessionId();
 
     await Telemetry.populateToolsVersions();
-    await Telemetry.populateNpmPackageVersions();
+    if (Telemetry.options.populateNpmPackageVersions) {
+      await Telemetry.populateNpmPackageVersions();
+    }
   }
 
   /** Sets up any telemetry processors. */


### PR DESCRIPTION
In order to find the versions of NPM packages, the telemetry code uses
node's require logic to find the package's package.json file.

However this means if the packages are not present, then node's resolver
cache will be populated with a false. This causes a problem if you
later install that package during the process (which is what we do with
react-native-windows-init) and try to require it - node will say it's
not there. This breaks creating new projects as node says it can't see
the newly installed react-native-windows/cli.

We were already "refreshing" the versions after we install RNW anyway,
since we know we're potentially changing them. This PR updates
react-native-windows-init to not try to get the versions at all until
after the new project generation has happened.

Closes #9271

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9337)