### PR TITLE
Fix `--version` option in react-native-windows-init

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -95,20 +95,23 @@ steps:
 
   - script: |
       yarn config set registry http://localhost:4873
-      npm config set registry http://localhost:4873
-    displayName: Modify yarn/npm config to point to local verdaccio server
+    displayName: Modify yarn config to point to local verdaccio server
 
   - ${{ if eq(parameters.useNuget, true) }}:
     - script: |
-        npx --yes --ignore-existing react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
       displayName: Apply windows template (with nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
+      env:
+        npm_config_registry: http://localhost:4873
 
   - ${{ if eq(parameters.useNuget, false) }}:
     - script: |
-        npx --yes --ignore-existing react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
+        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
       displayName: Apply windows template (without nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
+      env:
+        npm_config_registry: http://localhost:4873
 
   - ${{ if eq(parameters.projectType, 'app') }}:
     - powershell: |

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -93,8 +93,7 @@ steps:
       displayName: Update lib project react and react-native dev versions
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - script: |
-      yarn config set registry http://localhost:4873
+  - script: yarn config set registry http://localhost:4873
     displayName: Modify yarn config to point to local verdaccio server
 
   - ${{ if eq(parameters.useNuget, true) }}:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -93,18 +93,20 @@ steps:
       displayName: Update lib project react and react-native dev versions
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - script: yarn config set registry http://localhost:4873
-    displayName: Modify yarn config to point to local verdaccio server
+  - script: |
+      yarn config set registry http://localhost:4873
+      npm config set registry http://localhost:4873
+    displayName: Modify yarn/npm config to point to local verdaccio server
 
   - ${{ if eq(parameters.useNuget, true) }}:
     - script: |
-        npx --yes react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+        npx --yes --ignore-existing react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
       displayName: Apply windows template (with nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - ${{ if eq(parameters.useNuget, false) }}:
     - script: |
-        npx --yes react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
+        npx --yes --ignore-existing react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
       displayName: Apply windows template (without nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -98,13 +98,13 @@ steps:
 
   - ${{ if eq(parameters.useNuget, true) }}:
     - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+        npx --yes react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
       displayName: Apply windows template (with nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - ${{ if eq(parameters.useNuget, false) }}:
     - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
+        npx --yes react-native-windows-init --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
       displayName: Apply windows template (without nuget)
       workingDirectory: $(Agent.BuildDirectory)\testcli
 

--- a/change/react-native-windows-init-c07e0f56-99eb-4348-ba02-eb2da1977f88.json
+++ b/change/react-native-windows-init-c07e0f56-99eb-4348-ba02-eb2da1977f88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix `--version` option in react-native-windows-init",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -121,7 +121,7 @@ export const windowsInitOptions = initOptions({
     describe:
       '[internalTesting] Link rather than Add/Install the react-native-windows package. This option is for the development workflow of the developers working on react-native-windows.',
     hidden: true,
-    default: false,
+    default: undefined, // This must be undefined because we define the conflicts field below. Defining a default here will break the version option
     conflicts: 'version',
   },
 });
@@ -504,7 +504,7 @@ export async function reactNativeWindowsInit(args?: string[]) {
   try {
     const name = getReactNativeProjectName();
     const ns = options.namespace || name;
-    const useDevMode = options.useDevMode;
+    const useDevMode = !!options.useDevMode;
     let version = options.version;
 
     if (options.useWinUI3 && options.experimentalNuGetDependency) {

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -504,7 +504,7 @@ export async function reactNativeWindowsInit(args?: string[]) {
   try {
     const name = getReactNativeProjectName();
     const ns = options.namespace || name;
-    const useDevMode = !!options.useDevMode;
+    const useDevMode = options.useDevMode as unknown as boolean; // TS assumes the type is undefined
     let version = options.version;
 
     if (options.useWinUI3 && options.experimentalNuGetDependency) {

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -504,7 +504,7 @@ export async function reactNativeWindowsInit(args?: string[]) {
   try {
     const name = getReactNativeProjectName();
     const ns = options.namespace || name;
-    const useDevMode = options.useDevMode as unknown as boolean; // TS assumes the type is undefined
+    const useDevMode = !!(options.useDevMode as unknown); // TS assumes the type is undefined
     let version = options.version;
 
     if (options.useWinUI3 && options.experimentalNuGetDependency) {

--- a/packages/react-native-windows-init/src/e2etest/cli.test.ts
+++ b/packages/react-native-windows-init/src/e2etest/cli.test.ts
@@ -54,7 +54,12 @@ test('windowsInitOptions - validate options', () => {
         // Regular strings should not have defined default
         expect(option.default).not.toBeDefined();
       }
+    } else if (option.conflicts !== undefined) {
+      // Options with conflicts defined should have default = undefined
+      expect(option).toHaveProperty('default');
+      expect(option.default).toBeUndefined();
     } else {
+      // Regular options should have defined defaults
       expect(option).toHaveProperty('default');
       expect(option.default).toBeDefined();
     }


### PR DESCRIPTION
A bug was introduced in #9174 which breaks specifying the `--version` option when calling react-native-windows-init. All boolean options now have defined defaults (we even test for it) but that means the `useDevMode` option is set to false instead of undefined. `useDevMode` conflicts with the `version` option, so if it's defined, even as false, yargs will complain if you try to specify a version.

The fix is to make useDevMode an optional boolean, with a default of undefined.

This also fixes our PR pipeline which should have caught this bug in the first place and failed the checks.

Closes #9342 

## Description

A bug was introduced in #9174 which breaks specifying the `--version` option when calling react-native-windows-init. All boolean options now have defined defaults (we even test for it) but that means the `useDevMode` option is set to false instead of undefined. `useDevMode` conflicts with the `version` option, so if it's defined, even as false, yargs will complain if you try to specify a version.

The fix is to make useDevMode an optional boolean, with a default of undefined.

This also fixes our PR pipeline which should have caught this bug in the first place and failed the checks.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Fixes react-native-windows-init

### What

The fix is to make useDevMode an optional boolean, with a default of undefined, so it no longer conflicts with a specified version option.

This also fixes our PR pipeline which should have caught this bug in the first place.

## Testing
Tested locally, updated defaults

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9341)