### PR TITLE
Publish codegen spec files into win32 nuget

### DIFF
--- a/change/react-native-windows-13c812ce-c9cc-409b-94eb-467c8a6ddc80.json
+++ b/change/react-native-windows-13c812ce-c9cc-409b-94eb-467c8a6ddc80.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Publish codegen spec files into win32 nuget",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -77,6 +77,8 @@
 
     <file src="$nugetroot$\Microsoft.ReactNative.Cxx\**" target ="Microsoft.ReactNative.Cxx"/>
 
+    <file src="$nugetroot$\inc\codegen\**\*.*" target ="inc\codegen"/>
+
     <file src="$nugetroot$\natvis\Folly.natvis" target ="natvis\Folly.natvis"/>
   </files>
 </package>

--- a/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
@@ -24,6 +24,9 @@ Copy-Item -Force -Recurse -Path $ReactWindowsRoot\include -Destination $TargetRo
 # Microsoft.ReactNative.CXX project
 Copy-Item -Force -Recurse -Path $ReactWindowsRoot\Microsoft.ReactNative.Cxx -Destination $TargetRoot\
 
+# Copy native module spec files
+Copy-Item -Force -Recurse -Path $ReactWindowsRoot\codegen -Destination $TargetRoot\inc
+
 # Microsoft.ReactNative.CXX project JSI files
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\decorator.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\jsi\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\instrumentation.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\jsi\


### PR DESCRIPTION
## Description
Adding the codegen's spec files into the office nuget.  This will allow Office to use the spec files to get type verification on core TurboModules implemented within Office.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9344)