### PR TITLE
Default `playground` to direct debugging

### DIFF
--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -121,14 +121,14 @@
             <CheckBox x:Name="x_UseWebDebuggerCheckBox"
                 Margin="8,4,4,4"
                 VerticalAlignment="Center"
-                IsChecked="true"
+                IsChecked="false"
                 Checked="x_UseWebDebuggerCheckBox_Checked"
                 Unchecked="x_UseWebDebuggerCheckBox_Unchecked"
                 Content="Web Debugger"/>
             <CheckBox x:Name="x_UseDirectDebuggerCheckBox"
                 Margin="4"
                 VerticalAlignment="Center"
-                IsChecked="false"
+                IsChecked="true"
                 Content="Direct Debugging"/>
             <CheckBox x:Name="x_BreakOnFirstLineCheckBox"
                 IsEnabled="false"


### PR DESCRIPTION
## Description

### Why
The new architecture is incompatible with web debugging, so we will be wanting to move users over to direct debugging. This also fixes longstanding inconsistencies between debug and release builds. ChakraUwp had issues around dev experience, e.g. symbolification, and debug experience. Hermes is now set up to support inspector, and DevTools integration.

### What
Default playground to use direct debugging, to help us dogfood it before we switch over the default for users.

## Testing
Playing with RNTester and comparing overall performance to web debugging. The optimized debug build I used felt a little slow but was not significantly worse than web debugging. This will also see long-term improvement with both NAPI work, where we may be able to use Hermes release-mode binaries.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9345)