### PR TITLE
Fixes AllowAutoRedirect should be false #9310

### DIFF
--- a/vnext/Shared/Modules/NetworkingModule.cpp
+++ b/vnext/Shared/Modules/NetworkingModule.cpp
@@ -7,6 +7,7 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Web.Http.Filters.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Windows.Web.Http.h>
 #include "NetworkingModule.h"
@@ -30,7 +31,9 @@ namespace Microsoft::React {
 //
 class NetworkingModule::NetworkingHelper : public std::enable_shared_from_this<NetworkingHelper> {
  public:
-  NetworkingHelper(NetworkingModule *parent) : m_parent(parent) {}
+  NetworkingHelper(NetworkingModule *parent) : m_httpClient(m_httpFilter), m_parent(parent) {
+      m_httpFilter.AllowAutoRedirect(false);
+  }
 
   void Disconnect() {
     m_parent = nullptr;
@@ -80,6 +83,7 @@ class NetworkingModule::NetworkingHelper : public std::enable_shared_from_this<N
  private:
   NetworkingModule *m_parent;
 
+  winrt::Windows::Web::Http::Filters::HttpBaseProtocolFilter m_httpFilter;
   winrt::Windows::Web::Http::HttpClient m_httpClient;
   std::unordered_map<
       int64_t,


### PR DESCRIPTION
## Description

Fixes #9310 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

AllowAutoRedirect is true by default, and this causes network requests to fail without much information other than "Unhandled exception during request" . Using the debugger, I found this was due to 0x80072F88 - The HTTP redirect request must be confirmed by the user.

react-native on iOS/Android/macOS does not automatically follow redirects.
Resolves #9310

### What
Uses HttpBaseProtocolFilter to disable auto redirects.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9353)