### PR TITLE
Use raw value for CalculatedAnimationDriver

### DIFF
--- a/change/react-native-windows-b50197bd-a2bb-423e-a088-a65afa8f7969.json
+++ b/change/react-native-windows-b50197bd-a2bb-423e-a088-a65afa8f7969.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use raw value for CalculatedAnimationDriver",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -18,7 +18,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
         compositor.CreateLinearEasingFunction());
   }();
 
-  m_startValue = GetAnimatedValue()->Value();
+  m_startValue = GetAnimatedValue()->RawValue();
   std::vector<float> keyFrames = [this]() {
     std::vector<float> keyFrames;
     bool done = false;
@@ -37,7 +37,7 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
   std::chrono::milliseconds duration(static_cast<int>(keyFrames.size() / 60.0f * 1000.0f));
   animation.Duration(duration);
   auto normalizedProgress = 0.0f;
-  auto fromValue = static_cast<float>(GetAnimatedValue()->RawValue());
+  auto fromValue = static_cast<float>(m_startValue);
   animation.InsertKeyFrame(normalizedProgress, fromValue, easingFunction);
   for (const auto keyFrame : keyFrames) {
     normalizedProgress = std::min(normalizedProgress + 1.0f / keyFrames.size(), 1.0f);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
There was a minor bug in the CalculationAnimationDriver that accounted for the value node offset when getting the start value for the animation. Animation drivers should always start from the raw value.

### What
The fixes to change from animating the offset property to the value property (#9302) missed a minor bug in CalculatedAnimationDriver, where we start the animation from the `Value` of the animated value node rather than the `RawValue`. This generally won't cause any bugs for animations that do not use the `Offset` property (via `setOffset`), as in those cases `Value` == `RawValue`.

### Testing

Re-ran RNTester NativeAnimated scenarios and they work as before (no change). Also verified that the native animation behavior diverged when using `setOffset` and no longer diverges with this fix.

Here's the before:

https://user-images.githubusercontent.com/1106239/149022722-3f058d94-5204-4d2d-8ebb-7fdd1e3d86dd.mp4

Here's the after:

https://user-images.githubusercontent.com/1106239/149022716-568b961c-72de-4159-b930-0fd7e6b579d7.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9367)