### PR TITLE
Removes unnecessary conditional from NativeAnimatedNodeManager

### DIFF
--- a/change/react-native-windows-6aef389f-13f4-4dba-ad02-0e7eb18adf64.json
+++ b/change/react-native-windows-6aef389f-13f4-4dba-ad02-0e7eb18adf64.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removes unnecessary conditional from NativeAnimatedNodeManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -134,7 +134,11 @@ void NativeAnimatedNodeManager::StopAnimation(int64_t animationId, bool isTracki
       const auto nodeTag = animation->AnimatedValueTag();
       if (nodeTag != -1) {
         const auto deferredAnimation = m_deferredAnimationForValues.find(nodeTag);
-        if (deferredAnimation != m_deferredAnimationForValues.end() && deferredAnimation->second == animationId) {
+        if (deferredAnimation != m_deferredAnimationForValues.end()) {
+          // We can assume that the currently deferred animation is the one
+          // being stopped given the constraint that only one animation can
+          // be active for a given value node.
+          assert(deferredAnimation->second == animationId);
           // If the animation is deferred, just remove the deferred animation
           // entry as two animations cannot animate the same value concurrently.
           m_deferredAnimationForValues.erase(nodeTag);


### PR DESCRIPTION
## Description

### Why
There was a superfluous conditional check on the deferred animation ID for a given value node. This check was not required as we already assume in many other places that each value node can have either an active animation, a deferred animation, or neither, so we know if we're stopping an animation that the deferred animation tag must match the animation being stopped. 

### What
Removes the conditional check and adds an assert instead.

## Testing
RNTester > NativeAnimated examples run in Debug without failing the assert.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9368)