### PR TITLE
Stop both raw value and offset animation

### DIFF
--- a/change/react-native-windows-0642e501-eb2a-4df5-91d4-ba64dd5b0aaa.json
+++ b/change/react-native-windows-0642e501-eb2a-4df5-91d4-ba64dd5b0aaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Stop both raw value and offset animation",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -30,7 +30,7 @@ void InterpolationAnimatedNode::OnDetachedFromNode([[maybe_unused]] int64_t anim
   assert(m_parentTag == animatedNodeTag);
   m_parentTag = s_parentTagUnset;
   m_propertySet.StopAnimation(s_valueName);
-  m_propertySet.StopAnimation(s_valueName);
+  m_propertySet.StopAnimation(s_offsetName);
   m_rawValueAnimation = nullptr;
   m_offsetAnimation = nullptr;
 }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### What
Looks like a minor bug where only the raw value animation was stopped when a node was detached from the interpolation animated node. Not sure if interpolation animated nodes are ever actually re-used, so probably doesn't manifest in any real bugs, but it's probably good to stop the correct animations anyway.

## Testing
_Optional_: Describe the tests that you ran locally to verify your changes.

Re-ran RNTester > Native Animated examples - interpolation examples still behave correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9370)