### PR TITLE
[0.67] Remove ADO NuGet feed from config for new projects

### DIFF
--- a/change/@react-native-windows-cli-2e64e8b9-4efb-4a44-a73d-3964c5bbea3b.json
+++ b/change/@react-native-windows-cli-2e64e8b9-4efb-4a44-a73d-3964c5bbea3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.67] Remove ADO NuGet feed from config for new projects",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-43c5ac53-664f-46ea-9e13-4278d5eff38f.json
+++ b/change/react-native-windows-43c5ac53-664f-46ea-9e13-4278d5eff38f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.67] Remove ADO NuGet feed from config for new projects",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -242,6 +242,7 @@ export async function copyProjectTemplateAndReplace(
 
     useExperimentalNuget: options.experimentalNuGetDependency,
     nuGetTestFeed: options.nuGetTestFeed,
+    nuGetADOFeed: nugetVersion.startsWith('0.0.0-'),
 
     // cpp template variables
     useWinUI3: options.useWinUI3,

--- a/vnext/template/shared-app/proj/NuGet.Config
+++ b/vnext/template/shared-app/proj/NuGet.Config
@@ -8,7 +8,9 @@
     {{#nuGetTestFeed}}
     <add key="NuGetTestFeed" value="{{ nuGetTestFeed }}" />
     {{/nuGetTestFeed}}
+    {{#nuGetADOFeed}}
     <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+    {{/nuGetADOFeed}}
     <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
This PR backports #9385 to 0.67.

## Original Description

This PR changes the template for new projects to only include the ADO NuGet feed if the project is created against master/canary builds.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
It's technically a security vulnerability to have more than one NuGet feed in a projects NuGet.config file. In fact, Microsoft ADO pipelines auto-inject a task that will fail a job if multiple feeds are detected.

In the past we needed this functionality to make sure that projects that wanted to consume our experimental NuGet packages could get them from our ADO feed, since they weren't available on NuGet.org. Now however our stable release packages are published to NuGet.org and so the ADO feed is only necessary to consume/test our daily/master/canary builds.

Resolves #8529

### What
This PR changes our new project code to only include the ADO feed if the project is targeting daily/master/canary builds.

## Screenshots
N/A

## Testing
Verified new projects no longer add the unnecessary feed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9385)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9386)