### PR TITLE
Terminate decay animation when value change is less than 0.1

### DIFF
--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -23,13 +23,15 @@ std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedA
     std::vector<float> keyFrames;
     bool done = false;
     double time = 0;
+    std::optional<double> previousValue = std::nullopt;
     while (!done) {
       time += 1.0f / 60.0f;
       auto [currentValue, currentVelocity] = GetValueAndVelocityForTime(time);
       keyFrames.push_back(currentValue);
-      if (IsAnimationDone(currentValue, currentVelocity)) {
+      if (IsAnimationDone(currentValue, previousValue, currentVelocity)) {
         done = true;
       }
+      previousValue = currentValue;
     }
     return keyFrames;
   }();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
@@ -18,7 +18,7 @@ class CalculatedAnimationDriver : public AnimationDriver {
  protected:
   virtual std::tuple<float, double> GetValueAndVelocityForTime(double time) = 0;
 
-  virtual bool IsAnimationDone(double currentValue, double currentVelocity) = 0;
+  virtual bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) = 0;
   double m_startValue{0};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
@@ -26,12 +26,11 @@ std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(doubl
                          42.0f); // we don't need the velocity, so set it to a dummy value
 }
 
-bool DecayAnimationDriver::IsAnimationDone(double currentValue, double /*currentVelocity*/) {
-  return (std::abs(ToValue() - currentValue) < 0.1);
-}
-
-double DecayAnimationDriver::ToValue() {
-  return m_startValue + m_velocity / (1 - m_deceleration);
+bool DecayAnimationDriver::IsAnimationDone(
+    double currentValue,
+    std::optional<double> previousValue,
+    double /*currentVelocity*/) {
+  return previousValue.has_value() && std::abs(currentValue - previousValue.value()) < 0.1;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
@@ -16,11 +16,9 @@ class DecayAnimationDriver : public CalculatedAnimationDriver {
       const folly::dynamic &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
-  double ToValue() override;
-
  protected:
   std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
-  bool IsAnimationDone(double currentValue, double currentVelocity) override;
+  bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) override;
 
  private:
   double m_velocity{0};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
@@ -29,7 +29,10 @@ SpringAnimationDriver::SpringAnimationDriver(
   m_iterations = static_cast<int>(config.find(s_iterationsParameterName).dereference().second.asDouble());
 }
 
-bool SpringAnimationDriver::IsAnimationDone(double currentValue, double currentVelocity) {
+bool SpringAnimationDriver::IsAnimationDone(
+    double currentValue,
+    std::optional<double> /*previousValue*/,
+    double currentVelocity) {
   return (
       IsAtRest(currentVelocity, currentValue, m_endValue) ||
       (m_overshootClampingEnabled && IsOvershooting(currentValue)));

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
@@ -22,7 +22,7 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
 
  protected:
   std::tuple<float, double> GetValueAndVelocityForTime(double time) override;
-  bool IsAnimationDone(double currentValue, double currentVelocity) override;
+  bool IsAnimationDone(double currentValue, std::optional<double> previousValue, double currentVelocity) override;
 
  private:
   bool IsAtRest(double currentVelocity, double currentPosition, double endValue);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Previously, we compute the theoretical stopping point of the animation if the decay animation ran infinitely, and stop the animation when the animation is within 0.1 of the limit. The JS animation driver (and the decay animation driver on iOS and Android) actually stop the decay animation when the change in value is less than 0.1. 

For reference, here is the termination logic:
JS: https://github.com/facebook/react-native/blob/main/Libraries/Animated/animations/DecayAnimation.js#L107
Android: https://github.com/facebook/react-native/blob/main/ReactAndroid/src/main/java/com/facebook/react/animated/DecayAnimation.java#L62
iOS: https://github.com/facebook/react-native/blob/main/Libraries/NativeAnimation/Drivers/RCTDecayAnimation.m#L108

### What
This change passes the previous value to the `IsAnimationDone` function to produce the correct cross-platform behavior.

## Testing
Here's the before, notice the example in RNTester drifts a bit farther in the native example:

Here's the after: