### PR TITLE
Fix integration by tag of newer RN Builds

### DIFF
--- a/change/react-native-platform-override-52d0e542-568b-4b4a-b83f-e67962dd6fb6.json
+++ b/change/react-native-platform-override-52d0e542-568b-4b4a-b83f-e67962dd6fb6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix integration by tag of newer RN Builds",
+  "packageName": "react-native-platform-override",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -219,11 +219,8 @@ export default class GitReactFileRepository
     const gitRef = await fetchFullRef(reactNativeVersion, {githubToken});
 
     try {
-      await this.gitClient.fetch([
-        RN_GITHUB_URL,
-        `${gitRef}:${reactNativeVersion}`,
-        '--depth=1',
-      ]);
+      await this.gitClient.fetch([RN_GITHUB_URL, gitRef, '--depth=1']);
+      await this.gitClient.checkout(['-b', reactNativeVersion, 'FETCH_HEAD']);
     } catch (ex) {
       throw new Error(
         `Failed to fetch '${gitRef}'. Does it exist? (${


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Integrating new stable branch builds of RN produces an error in the form of `trying to write non-commit object <hash> to branch <branch>`.  This is due to a switch from "lightweight" git tags, to "annotated" git tags, which do not allow the previous syntax we were using for shallow fetching into a new branch. 

### What
Update the syntax to create the branch from FETCH_HEAD, instead of the tag refspec.

## Testing
Locally tested integrating 0.67.1. End to end tests exist that will exercise this logic for older versions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9421)