### PR TITLE
Playground controls disabled on boot

### DIFF
--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -131,7 +131,6 @@
                 IsChecked="true"
                 Content="Direct Debugging"/>
             <CheckBox x:Name="x_BreakOnFirstLineCheckBox"
-                IsEnabled="false"
                 Margin="4"
                 VerticalAlignment="Center"
                 IsChecked="false"
@@ -146,7 +145,6 @@
                 VerticalAlignment="Center"
                 Text="Debugger Port"/>
             <TextBox x:Name="x_DebuggerPort"
-                IsEnabled="false"
                 Margin="4"
                 VerticalAlignment="Center"
                 InputScope="Number"
@@ -157,7 +155,6 @@
                 Text="JS Engine:"/>
             <ComboBox
                 x:Name="x_JsEngine"
-                IsEnabled="false"
                 Margin="4"
                 MinWidth="150"
                 HorizontalAlignment="Stretch"


### PR DESCRIPTION
## Description
Several of the controls in the playground app are disabled on boot.  If you check and uncheck webdebugging, they would be enabled.  But they should be enabled on boot.  This was fallout from the change in default state away from using webdebugging.  The default state of these controls should have been updated at the same time.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9425)