### PR TITLE
Allow OutputType `Library` to be autolinked for C# native modules

### DIFF
--- a/change/@react-native-windows-cli-ea061697-b24d-4b3f-adc6-252bb52bd67a.json
+++ b/change/@react-native-windows-cli-ea061697-b24d-4b3f-adc6-252bb52bd67a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow OutputType Library to be autolinked for C# native modules",
+  "packageName": "@react-native-windows/cli",
+  "email": "jmdalmasso7@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -277,7 +277,7 @@ export function dependencyConfigWindows(
         projectContents,
       );
 
-      if (projectType === 'dynamiclibrary' || projectType === 'winmdobj') {
+      if (projectType === 'dynamiclibrary' || projectType === 'winmdobj' || projectType === 'library') {
         const projectLang = configUtils.getProjectLanguage(projectFile);
 
         const projectName = configUtils.getProjectName(

--- a/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
+++ b/packages/@react-native-windows/cli/src/config/dependencyConfig.ts
@@ -277,7 +277,11 @@ export function dependencyConfigWindows(
         projectContents,
       );
 
-      if (projectType === 'dynamiclibrary' || projectType === 'winmdobj' || projectType === 'library') {
+      if (
+        projectType === 'dynamiclibrary' ||
+        projectType === 'winmdobj' ||
+        projectType === 'library'
+      ) {
         const projectLang = configUtils.getProjectLanguage(projectFile);
 
         const projectName = configUtils.getProjectName(


### PR DESCRIPTION
## Description

C# projects using `OutputType` `Library` are no longer able to be autolinked with 0.66. This allows them to be discovered and linked once again.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

Resolves [https://github.com/microsoft/react-native-windows/issues/9420]

### What
Added `library` as type of module that can be autolinked.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9427)