### PR TITLE
[0.66] Backport some important fixes to 0.66

### DIFF
--- a/change/react-native-windows-1ead6568-96c1-4cee-88a8-c9c273cbe5d9.json
+++ b/change/react-native-windows-1ead6568-96c1-4cee-88a8-c9c273cbe5d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Better reporting of failures to load the bundle file",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/.eslintignore
+++ b/vnext/.eslintignore
@@ -8,5 +8,6 @@
 /local-cli/lib
 /local-cli/lib-commonjs
 /packages
+/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
 /ReactCopies
 /target

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.cpp
@@ -109,6 +109,61 @@ TEST_CLASS (ReactNativeHostTests) {
 
     TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Completed", nullptr}});
   }
+
+  TEST_METHOD(LoadInstance_FiresInstanceLoaded_Success) {
+    TestEventService::Initialize();
+
+    auto reactNativeHost = TestReactNativeHostHolder(L"ReactNativeHostTests", [](ReactNativeHost const &host) noexcept {
+      host.InstanceSettings().InstanceLoaded(
+          [](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+            if (args.Failed()) {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
+            }
+          });
+      return true;
+    });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Success", nullptr}});
+  }
+
+  TEST_METHOD(LoadBundleWithError_FiresInstanceLoaded_Failed) {
+    TestEventService::Initialize();
+
+    auto reactNativeHost = TestReactNativeHostHolder(L"SyntaxError", [](ReactNativeHost const &host) noexcept {
+      host.InstanceSettings().InstanceLoaded(
+          [](auto const &, winrt::Microsoft::ReactNative::IInstanceLoadedEventArgs args) noexcept {
+            if (args.Failed()) {
+              TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+            } else {
+              TestEventService::LogEvent("InstanceLoaded::Success", nullptr);
+            }
+          });
+      return true;
+    });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Failed", nullptr}});
+  }
+
+  TEST_METHOD(LoadBundleWithError_ReloadInstance_Fails) {
+    TestEventService::Initialize();
+
+    auto reactNativeHost = TestReactNativeHostHolder(L"SyntaxError", [](ReactNativeHost const &host) noexcept {
+      host.ReloadInstance().Completed([](auto const &, winrt::Windows::Foundation::AsyncStatus status) mutable {
+        if (status == winrt::Windows::Foundation::AsyncStatus::Completed) {
+          TestEventService::LogEvent("InstanceLoaded::Completed", nullptr);
+        } else if (status == winrt::Windows::Foundation::AsyncStatus::Canceled) {
+          TestEventService::LogEvent("InstanceLoaded::Canceled", nullptr);
+        } else {
+          TestEventService::LogEvent("InstanceLoaded::Failed", nullptr);
+        }
+      });
+      return false;
+    });
+
+    TestEventService::ObserveEvents({TestEvent{"InstanceLoaded::Canceled", nullptr}});
+  }
 };
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/SyntaxError.js
@@ -1,0 +1,3 @@
+// Bundle with syntax error to test bundle load failures
+
+global.foo((); 

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -139,14 +139,9 @@ struct ReactViewInstance : public Mso::UnknownObject<Mso::RefCountStrategy::Weak
   inline Mso::Future<void> PostInUIQueue(winrt::delegate<ReactNative::IReactViewInstance> const &action) noexcept {
     Mso::Promise<void> promise;
 
-    // ReactViewInstance has shorter lifetime than ReactRootControl. Thus, we capture this WeakPtr.
-    m_uiDispatcher.Post([weakThis = Mso::WeakPtr{this}, promise, action{std::move(action)}]() mutable noexcept {
-      if (auto strongThis = weakThis.GetStrongPtr()) {
-        action(strongThis->m_rootControl);
-        promise.SetValue();
-      } else {
-        promise.TryCancel();
-      }
+    m_uiDispatcher.Post([control = m_rootControl, promise, action{std::move(action)}]() mutable noexcept {
+      action(control);
+      promise.SetValue();
     });
     return promise.AsFuture();
   }
@@ -159,9 +154,7 @@ winrt::Windows::Foundation::IAsyncAction ReactViewHost::AttachViewInstance(
 }
 
 winrt::Windows::Foundation::IAsyncAction ReactViewHost::DetachViewInstance() noexcept {
-  Mso::Promise<void> promise;
-  promise.SetValue();
-  return make<Mso::AsyncActionFutureAdapter>(promise.AsFuture());
+  return make<Mso::AsyncActionFutureAdapter>(m_viewHost->DetachViewInstance());
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -381,6 +381,11 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
 
     return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && /*value*/) noexcept {
       std::vector<Mso::Future<void>> loadCompletionList;
+
+      if (value.IsError()) {
+        return Mso::MakeFailedFuture<void>(std::move(value.TakeError()));
+      }
+
       ForEachViewHost([&loadCompletionList](auto &viewHost) noexcept {
         loadCompletionList.push_back(viewHost.UpdateViewInstanceInQueue());
       });

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -379,7 +379,7 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
       }
     }
 
-    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && /*value*/) noexcept {
+    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && value) noexcept {
       std::vector<Mso::Future<void>> loadCompletionList;
 
       if (value.IsError()) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -379,7 +379,7 @@ Mso::Future<void> ReactHost::LoadInQueue(ReactOptions &&options) noexcept {
       }
     }
 
-    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> && value) noexcept {
+    return whenLoaded.AsFuture().Then(m_executor, [this](Mso::Maybe<void> &&value) noexcept {
       std::vector<Mso::Future<void>> loadCompletionList;
 
       if (value.IsError()) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -224,9 +224,11 @@ ReactInstanceWin::ReactInstanceWin(
   m_whenLoaded.AsFuture()
       .Then<Mso::Executors::Inline>(
           [onLoaded = m_options.OnInstanceLoaded, reactContext = m_reactContext](Mso::Maybe<void> &&value) noexcept {
+            auto errCode = value.IsError() ? value.TakeError() : Mso::ErrorCode();
             if (onLoaded) {
-              onLoaded.Get()->Invoke(reactContext, value.IsError() ? value.TakeError() : Mso::ErrorCode());
+              onLoaded.Get()->Invoke(reactContext, errCode);
             }
+            return Mso::Maybe<void>(errCode);
           })
       .Then(Queue(), [whenLoaded = std::move(whenLoaded)](Mso::Maybe<void> &&value) noexcept {
         whenLoaded.SetValue(std::move(value));
@@ -468,7 +470,7 @@ void ReactInstanceWin::Initialize() noexcept {
                 m_options.TurboModuleProvider,
                 std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
                 m_jsMessageThread.Load(),
-                Mso::Copy(m_batchingUIThread),
+                m_nativeMessageThread.Load(),
                 std::move(devSettings));
 
             m_instanceWrapper.Exchange(std::move(instanceWrapper));
@@ -482,6 +484,16 @@ void ReactInstanceWin::Initialize() noexcept {
               m_options.TurboModuleProvider->getModule("FabricUIManagerBinding", m_instance.Load()->getJSCallInvoker());
             }
 #endif
+
+            // The InstanceCreated event can be used to augment the JS environment for all JS code.  So it needs to be
+            // triggered before any platform JS code is run. Using m_jsMessageThread instead of jsDispatchQueue avoids
+            // waiting for the JSCaller which can delay the event until after certain JS code has already run
+            m_jsMessageThread.Load()->runOnQueue(
+                [onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
+                  if (onCreated) {
+                    onCreated.Get()->Invoke(reactContext);
+                  }
+                });
 
             LoadJSBundles();
 
@@ -558,7 +570,9 @@ void ReactInstanceWin::LoadJSBundles() noexcept {
 
             try {
               instanceWrapper->loadBundleSync(Mso::Copy(strongThis->JavaScriptBundleFile()));
-              strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+              if (strongThis->State() != ReactInstanceState::HasError) {
+                strongThis->OnReactInstanceLoaded(Mso::ErrorCode{});
+              }
             } catch (...) {
               strongThis->OnReactInstanceLoaded(Mso::ExceptionErrorProvider().MakeErrorCode(std::current_exception()));
             }
@@ -628,13 +642,6 @@ void ReactInstanceWin::InitJSMessageThread() noexcept {
       Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError),
       Mso::Copy(m_whenDestroyed));
   auto jsDispatchQueue = Mso::DispatchQueue::MakeCustomQueue(Mso::CntPtr(scheduler));
-
-  // This work item will be processed as a first item in JS queue when the react instance is created.
-  jsDispatchQueue.Post([onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
-    if (onCreated) {
-      onCreated.Get()->Invoke(reactContext);
-    }
-  });
 
   auto jsDispatcher =
       winrt::make<winrt::Microsoft::ReactNative::implementation::ReactDispatcher>(Mso::Copy(jsDispatchQueue));

--- a/vnext/Mso/future/futureWinRT.h
+++ b/vnext/Mso/future/futureWinRT.h
@@ -27,18 +27,20 @@ struct AsyncActionFutureAdapter : winrt::implements<
           if (strongThis->m_status == AsyncStatus::Started) {
             if (result.IsValue()) {
               strongThis->m_status = AsyncStatus::Completed;
-              if (strongThis->m_completedAssigned) {
-                handler = std::move(strongThis->m_completed);
-              }
             } else {
-              strongThis->m_status = AsyncStatus::Error;
               strongThis->m_error = result.GetError();
+              strongThis->m_status = Mso::CancellationErrorProvider().TryGetErrorInfo(strongThis->m_error, false)
+                  ? AsyncStatus::Canceled
+                  : AsyncStatus::Error;
+            }
+            if (strongThis->m_completedAssigned) {
+              handler = std::move(strongThis->m_completed);
             }
           }
         }
 
         if (handler) {
-          invoke(handler, *strongThis, AsyncStatus::Completed);
+          invoke(handler, *strongThis, strongThis->m_status);
         }
       }
     });

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -61,86 +61,6 @@
 #include <tracing/tracing.h>
 namespace fs = std::filesystem;
 
-namespace {
-
-#if (defined(_MSC_VER) && !defined(WINRT))
-
-std::string GetJSBundleDirectory(
-    const std::string &jsBundleBasePath,
-    const std::string &jsBundleRelativePath) noexcept {
-  // If there is a base path, use that to calculate the absolute path.
-  if (jsBundleBasePath.length() > 0) {
-    std::string jsBundleDirectory = jsBundleBasePath;
-    if (jsBundleDirectory.back() != '\\')
-      jsBundleDirectory += '\\';
-
-    return jsBundleDirectory += jsBundleRelativePath;
-  } else if (!PathIsRelativeA(jsBundleRelativePath.c_str())) {
-    // If the given path is an absolute path, return it as-is
-    return jsBundleRelativePath;
-  }
-  // Otherwise use the path of the executable file to construct the absolute
-  // path.
-  else {
-    wchar_t modulePath[MAX_PATH];
-
-    auto len = GetModuleFileNameW(nullptr, modulePath, _countof(modulePath));
-
-    if (len == 0 || (len == _countof(modulePath) && GetLastError() == ERROR_INSUFFICIENT_BUFFER))
-      return jsBundleRelativePath;
-
-    // remove the trailing filename as we are interested in only the path
-    auto succeeded = PathRemoveFileSpecW(modulePath);
-    if (!succeeded)
-      return jsBundleRelativePath;
-
-    std::string jsBundlePath = Microsoft::Common::Unicode::Utf16ToUtf8(modulePath, wcslen(modulePath));
-    if (!jsBundlePath.empty() && jsBundlePath.back() != '\\')
-      jsBundlePath += '\\';
-
-    return jsBundlePath += jsBundleRelativePath;
-  }
-}
-
-std::string GetJSBundleFilePath(const std::string &jsBundleBasePath, const std::string &jsBundleRelativePath) {
-  auto jsBundleFilePath = GetJSBundleDirectory(jsBundleBasePath, jsBundleRelativePath);
-
-  // Usually, the module name: "module name" + "." + "platform name", for
-  // example "lpc.win32". If we can not find the the bundle.js file under the
-  // normal folder, we are trying to find it under the folder without the dot
-  // (e.g. "lpcwin32"). VSO:1997035 remove this code after we have better name
-  // convension
-  if (PathFileExistsA((jsBundleFilePath + "\\bundle.js").c_str())) {
-    jsBundleFilePath += "\\bundle.js";
-  } else {
-    // remove the dot only if is belongs to the bundle file name.
-    size_t lastDotPosition = jsBundleFilePath.find_last_of('.');
-    size_t bundleFilePosition = jsBundleFilePath.find_last_of('\\');
-    if (lastDotPosition != std::string::npos &&
-        (bundleFilePosition == std::string::npos || lastDotPosition > bundleFilePosition)) {
-      jsBundleFilePath.erase(lastDotPosition, 1);
-    }
-
-    jsBundleFilePath += "\\bundle.js";
-
-    // Back before we have base path plumbed through, we made win32 force a
-    // seperate folder for each bundle by appending bundle.js Now that we have
-    // base path, we can handle multiple SDXs with the same index name so we
-    // should switch to using the same scheme as all the other platforms (and
-    // the bundle server)
-    // TODO: We should remove all the previous logic and use the same names as
-    // the other platforms...
-    if (!PathFileExistsA(jsBundleFilePath.c_str())) {
-      jsBundleFilePath = GetJSBundleDirectory(jsBundleBasePath, jsBundleRelativePath) + ".bundle";
-    }
-  }
-
-  return jsBundleFilePath;
-}
-#endif
-
-} // namespace
-
 using namespace facebook;
 using namespace Microsoft::JSI;
 
@@ -560,22 +480,13 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       }
     } else {
 #if (defined(_MSC_VER) && !defined(WINRT))
-      auto fullBundleFilePath = GetJSBundleFilePath(m_jsBundleBasePath, jsBundleRelativePath);
-
-      // If fullBundleFilePath exists, load User bundle.
-      // Otherwise all bundles (User and Platform) are loaded through
-      // platformBundles.
-      if (PathFileExistsA(fullBundleFilePath.c_str())) {
-        auto bundleString = FileMappingBigString::fromPath(fullBundleFilePath);
-        m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(fullBundleFilePath), synchronously);
-      }
-
+      std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
+      auto bundleString = FileMappingBigString::fromPath(bundlePath);
 #else
       std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
-
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);
-      m_innerInstance->loadScriptFromString(std::move(bundleString), jsBundleRelativePath, synchronously);
 #endif
+      m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(jsBundleRelativePath), synchronously);
     }
   } catch (const std::exception &e) {
     m_devSettings->errorCallback(e.what());


### PR DESCRIPTION
## Description
Better reporting of failures to load the bundle file (#8018)
Some native modules are hitting the UI queue unnecessarily (#9124)
ReloadInstance async task and InstanceLoaded event were not correctly reporting failures (#9224)
Hook up DetachViewInstance method for custom UI implementations (#9226)
InstanceCreated should fire before any JS code is run (#9228)
Remove legacy logic to find win32 bundle (#9225)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9428)