### PR TITLE
Fix VS hang when switching Platform within IDE

### DIFF
--- a/change/react-native-windows-98e7ec7d-e4f1-4295-a50e-58d8bab9a679.json
+++ b/change/react-native-windows-98e7ec7d-e4f1-4295-a50e-58d8bab9a679.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix VS hang when switching Platform within IDE",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/sample-apps/windows/SampleAppCS/packages.lock.json
+++ b/packages/sample-apps/windows/SampleAppCS/packages.lock.json
@@ -127,25 +127,8 @@
         "resolved": "2.2.9",
         "contentHash": "qF6RRZKaflI+LR1YODNyWYjq5YoX8IJ2wx5y8O+AW2xO+1t/Q6Mm+jQ38zJbWnmXbrcOqUYofn7Y3/KC6lTLBQ=="
       },
-      "common": {
-        "type": "Project"
-      },
-      "fmt": {
-        "type": "Project"
-      },
-      "folly": {
-        "type": "Project",
-        "dependencies": {
-          "fmt": "1.0.0"
-        }
-      },
       "microsoft.reactnative": {
-        "type": "Project",
-        "dependencies": {
-          "Common": "1.0.0",
-          "Folly": "1.0.0",
-          "ReactCommon": "1.0.0"
-        }
+        "type": "Project"
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
@@ -154,17 +137,8 @@
           "Microsoft.ReactNative": "1.0.0"
         }
       },
-      "reactcommon": {
-        "type": "Project",
-        "dependencies": {
-          "Folly": "1.0.0"
-        }
-      },
       "samplelibrarycpp": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.ReactNative": "1.0.0"
-        }
+        "type": "Project"
       },
       "samplelibrarycs": {
         "type": "Project",

--- a/packages/sample-apps/windows/SampleLibraryCS/packages.lock.json
+++ b/packages/sample-apps/windows/SampleLibraryCS/packages.lock.json
@@ -115,37 +115,14 @@
         "resolved": "2.2.9",
         "contentHash": "qF6RRZKaflI+LR1YODNyWYjq5YoX8IJ2wx5y8O+AW2xO+1t/Q6Mm+jQ38zJbWnmXbrcOqUYofn7Y3/KC6lTLBQ=="
       },
-      "common": {
-        "type": "Project"
-      },
-      "fmt": {
-        "type": "Project"
-      },
-      "folly": {
-        "type": "Project",
-        "dependencies": {
-          "fmt": "1.0.0"
-        }
-      },
       "microsoft.reactnative": {
-        "type": "Project",
-        "dependencies": {
-          "Common": "1.0.0",
-          "Folly": "1.0.0",
-          "ReactCommon": "1.0.0"
-        }
+        "type": "Project"
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9",
           "Microsoft.ReactNative": "1.0.0"
-        }
-      },
-      "reactcommon": {
-        "type": "Project",
-        "dependencies": {
-          "Folly": "1.0.0"
         }
       }
     },

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -4,15 +4,21 @@
   <!-- This import will noop when customer code is built. This import is here to help building the bits in the react-native-windows repository. -->
   <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../')))" Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-  <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
+  <!--Allow implicitly restoring NuGet dependencies in C++ projects using the Visual Studio IDE.-->
   <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
-    <Message Importance="High" Text="OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO" />
-    <Message Importance="High" Text="SolutionDir [$(SolutionDir)]" />
-    <Message Importance="High" Text="MSBuildProjectFullPath [$(MSBuildProjectFullPath)]" />
-    <Message Importance="High" Text="PreRef ===========================>]" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <Message Importance="High" Text="PreConf ===========================>]" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;SolutionDir=$(SolutionDir);RestoreUseStaticGraphEvaluation=false" />
+    <!--
+      Ensure restoring of PackageReference dependencies.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+
+    <!--
+      Ensure restoring of packages.config dependencies.
+
+      RestoreProjectStyle=PackagesConfig    - Required to use the packages.config mechanism
+      RestorePackagesConfig=true            - Required to use the packages.config mechanism
+      RestoreUseStaticGraphEvaluation=false - Override setting from Directory.Build.props
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" />
   </Target>
 
 </Project>

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -6,8 +6,13 @@
 
   <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
   <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
+    <Message Importance="High" Text="OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO" />
+    <Message Importance="High" Text="SolutionDir [$(SolutionDir)]" />
+    <Message Importance="High" Text="MSBuildProjectFullPath [$(MSBuildProjectFullPath)]" />
+    <Message Importance="High" Text="PreRef ===========================>]" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+    <Message Importance="High" Text="PreConf ===========================>]" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;SolutionDir=$(SolutionDir);RestoreUseStaticGraphEvaluation=false" />
   </Target>
 
 </Project>

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -5,9 +5,9 @@
   <Import Condition="Exists($([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../')))" Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
   <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
-  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <MSBuild Projects="$(SolutionPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <MSBuild Projects="$(SolutionPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
+  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
@@ -14,15 +14,21 @@
   </Target>
 
   <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.targets -->
-  <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
+  <!--Allow implicitly restoring NuGet dependencies in C++ projects using the Visual Studio IDE.-->
   <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
-    <Message Importance="High" Text="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
-    <Message Importance="High" Text="SolutionDir [$(SolutionDir)]" />
-    <Message Importance="High" Text="MSBuildProjectFullPath [$(MSBuildProjectFullPath)]" />
-    <Message Importance="High" Text="PreRef ===========================>]" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <Message Importance="High" Text="PreConf ===========================>]" />
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;SolutionDir=$(SolutionDir);RestoreUseStaticGraphEvaluation=false" />
+    <!--
+      Ensure restoring of PackageReference dependencies.
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+
+    <!--
+      Ensure restoring of packages.config dependencies.
+
+      RestoreProjectStyle=PackagesConfig    - Required to use the packages.config mechanism
+      RestorePackagesConfig=true            - Required to use the packages.config mechanism
+      RestoreUseStaticGraphEvaluation=false - Override setting from Microsoft.ReactNative.Common.props
+    -->
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" />
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
@@ -16,8 +16,13 @@
   <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.targets -->
   <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
   <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
+    <Message Importance="High" Text="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
+    <Message Importance="High" Text="SolutionDir [$(SolutionDir)]" />
+    <Message Importance="High" Text="MSBuildProjectFullPath [$(MSBuildProjectFullPath)]" />
+    <Message Importance="High" Text="PreRef ===========================>]" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+    <Message Importance="High" Text="PreConf ===========================>]" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;SolutionDir=$(SolutionDir);RestoreUseStaticGraphEvaluation=false" />
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
@@ -15,9 +15,9 @@
 
   <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.targets -->
   <!--Allow implicitly restoring PackageReference dependencies in C++ projects using the Visual Studio IDE.-->
-  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <MSBuild Projects="$(SolutionPath)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
-    <MSBuild Projects="$(SolutionPath)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
+  <Target Name="BeforeResolveReferences" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(MSBuildProjectExtension)' == '.vcxproj'">
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Description

Restore ability to switch platforms within Visual Studio.
Fix dependency restoration from within Visual Studio.

### Type of Change
- Bug fix

Follow up on #8195.

### Why
There are developer experience regressions introduced by usage of `PackageReference` C++ dependencies when building exclusively with the Visual Studio IDE.

Resolves #9424
Resolves #9436

### What
- Implicitly restore VCXPROJ when using Visual Studio
- Don't use RestoreUseStaticGraphEvaluation when dealing with `packages.config`

## Testing

### Sample Apps
Using a clean clone and a completely empty user NuGet cache (`globalPackagesFolder`):
- Run `yarn; yarn build`.
- Open solution `packages\sample-apps\windows\SampleApps.sln`.
- Wait for solution to load.
- Switch the platform to `x86`.
- Build solution.

### Playground
Using a clean clone and a completely empty user NuGet cache (`globalPackagesFolder`):
- Run `yarn; yarn build`.
- Open solution `packages\playground\windows\playground.sln`.
- Wait for solution to load.
- Build solution.
- Switch the platform to `x86`.
- Build solution.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9442)