### PR TITLE
[0.64] Do not throw error on deprecated `acceptsKeyboardFocus` property usage 

### DIFF
--- a/change/@office-iss-react-native-win32-4fc6c3b1-a2ce-4bc8-83a4-935d9f9acf6f.json
+++ b/change/@office-iss-react-native-win32-4fc6c3b1-a2ce-4bc8-83a4-935d9f9acf6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[Win32] Move acceptsKeyboardFocus back to just a warning",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -30,14 +30,14 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
-  // [Windows
-  invariant(
-    // $FlowFixMe Wanting to catch untyped usages
-    !props || props.acceptsKeyboardFocus === undefined,
-    'Support for the "acceptsKeyboardFocus" property has been removed in favor of "focusable"',
-  );
-  // Windows]
-
+  // $FlowFixMe react-native-win32 doesn't have forked types in Flow yet
+  if (props.acceptsKeyboardFocus !== undefined) {
+    warnOnce(
+      'deprecated-acceptsKeyboardFocus',
+      '"acceptsKeyboardFocus" has been deprecated in favor of "focusable" and will be removed soon',
+    );
+  }
+  // Win32]
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See

--- a/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -15,6 +15,7 @@ import type {ViewProps} from './ViewPropTypes';
 const React = require('react');
 import ViewNativeComponent from './ViewNativeComponent';
 const TextAncestor = require('../../Text/TextAncestor');
+import warnOnce from '../../Utilities/warnOnce'; // [Windows]
 import invariant from 'invariant'; // [Windows]
 
 export type Props = ViewProps;
@@ -30,6 +31,7 @@ const View: React.AbstractComponent<
   ViewProps,
   React.ElementRef<typeof ViewNativeComponent>,
 > = React.forwardRef((props: ViewProps, forwardedRef) => {
+  // [Win32 Intercept props to warn about them going away
   // $FlowFixMe react-native-win32 doesn't have forked types in Flow yet
   if (props.acceptsKeyboardFocus !== undefined) {
     warnOnce(


### PR DESCRIPTION
## Description
#9350 made usages of `acceptsKeyboardFocus` an error instead of a warning.  -- This restores it back to a warning.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9444)