### PR TITLE
UI Manager module is not being destroyed on the UI thread

### DIFF
--- a/change/react-native-windows-8a1ddf14-de89-4434-9dc7-81bb20402521.json
+++ b/change/react-native-windows-8a1ddf14-de89-4434-9dc7-81bb20402521.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "UI Manager module is not being destroyed on the UI thread",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -530,7 +530,7 @@ UIManager::UIManager() : m_module(std::make_shared<UIManagerModule>()) {}
 UIManager::~UIManager() {
   // To make sure that we destroy UI components in UI thread.
   if (!m_context.UIDispatcher().HasThreadAccess()) {
-    m_context.UIDispatcher().Post([module = std::move(m_module)]() {});
+    m_context.UIDispatcher().Post([module = std::move(m_module)]() mutable { module = nullptr; });
   }
 }
 


### PR DESCRIPTION
## Description
Force clear the uimodule pointer in the UIDispatcher thread to ensure the UIManager Module is destroyed on the UI thread.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #8317


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9445)