### PR TITLE
[0.66] UI Manager module is not being destroyed on the UI thread

### DIFF
--- a/change/react-native-windows-2c7c5197-58c8-4868-b554-c2801540c955.json
+++ b/change/react-native-windows-2c7c5197-58c8-4868-b554-c2801540c955.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "UI Manager module is not being destroyed on the UI thread",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -514,7 +514,7 @@ UIManager::UIManager() : m_module(std::make_shared<UIManagerModule>()) {}
 UIManager::~UIManager() {
   // To make sure that we destroy UI components in UI thread.
   if (!m_context.UIDispatcher().HasThreadAccess()) {
-    m_context.UIDispatcher().Post([module = std::move(m_module)]() {});
+    m_context.UIDispatcher().Post([module = std::move(m_module)]() mutable { module = nullptr; });
   }
 }
 


### PR DESCRIPTION
## Description
Port of #9445 to 0.66


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9450)