### PR TITLE
React-native-windows-init reuses existing projectGUIDs by default

### DIFF
--- a/change/@react-native-windows-cli-46d66f80-8f36-4e1f-aa9e-fbb83eda5a5b.json
+++ b/change/@react-native-windows-cli-46d66f80-8f36-4e1f-aa9e-fbb83eda5a5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "checks for old project guid",
+  "packageName": "@react-native-windows/cli",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -83,6 +83,7 @@ export async function copyProjectTemplateAndReplace(
   }
 
   const projectType = options.projectType;
+  const language = options.language;
 
   // React-native init only allows alphanumerics in project names, but other
   // new project tools (like create-react-native-module) are less strict.
@@ -96,30 +97,19 @@ export async function copyProjectTemplateAndReplace(
   }
 
   // Checking if we're overwriting an existing project and re-uses their projectGUID
-  const projectPathVcx = path.join(
+  const existingProjectPath = path.join(
+    destPath,
     windowsDir,
     newProjectName,
-    newProjectName + '.vcxproj',
+    newProjectName + (language === 'cs' ? '.csproj' : '.vcxproj'),
   );
-  const projectPathCs = path.join(
-    windowsDir,
-    newProjectName,
-    newProjectName + '.csproj',
-  );
-  let reuseProjectGuid;
-  if (fs.existsSync(projectPathVcx)) {
-    console.log('Found exisitng C++ project, using old projectGUID');
-    reuseProjectGuid = findPropertyValue(
-      readProjectFile(projectPathVcx),
+  let existingProjectGuid: string | undefined;
+  if (fs.existsSync(existingProjectPath)) {
+    console.log('Found existing project, extracting ProjectGuid.');
+    existingProjectGuid = findPropertyValue(
+      readProjectFile(existingProjectPath),
       'ProjectGuid',
-      projectPathVcx,
-    ).replace(/[{}]/g, '');
-  } else if (fs.existsSync(projectPathCs)) {
-    console.log('Found exisitng C# project, using old projectGUID');
-    reuseProjectGuid = findPropertyValue(
-      readProjectFile(projectPathCs),
-      'ProjectGuid',
-      projectPathCs,
+      existingProjectPath,
     ).replace(/[{}]/g, '');
   }
 
@@ -131,7 +121,6 @@ export async function copyProjectTemplateAndReplace(
     createDir(path.join(destPath, windowsDir, newProjectName, 'BundleBuilder'));
   }
 
-  const language = options.language;
   const namespaceCpp = toCppNamespace(namespace);
   if (options.experimentalNuGetDependency) {
     console.log('Using experimental NuGet dependency.');
@@ -143,7 +132,7 @@ export async function copyProjectTemplateAndReplace(
   const projDir = 'proj';
   const srcPath = path.join(srcRootPath, `${language}-${projectType}`);
   const sharedPath = path.join(srcRootPath, `shared-${projectType}`);
-  const projectGuid = reuseProjectGuid || uuid.v4();
+  const projectGuid = existingProjectGuid || uuid.v4();
   const rnwVersion = require(resolveRnwPath('package.json')).version;
   const nugetVersion = options.nuGetTestVersion || rnwVersion;
   const packageGuid = uuid.v4();


### PR DESCRIPTION
## Description
If there is an existing project that react-native-init is going to overwrite, reuse the old projectGUID instead of generating a new one.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #8621
TLDR - creating a new projectGUID can create issues when upgrading lib projects by creating unnecesary changes in the project and solution file.

### What
Checks if we're overwriting a project file, extracts the projectGUID and uses that in the template


## Testing
Tested locally if projectGUID gets overwritten or not

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9453)