### PR TITLE
Capture MSBuild properties in telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,8 @@ packages/
 *project.lock.json
 jsconfig.json
 package-lock.json
+*.metaproj
+*.metaproj.tmp
 
 # VS Code
 .vscode/*

--- a/change/@react-native-windows-cli-bfddb2a2-3f9f-4251-932f-84c3a4dd88d2.json
+++ b/change/@react-native-windows-cli-bfddb2a2-3f9f-4251-932f-84c3a4dd88d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Capture MSBuild properties in telemetry",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-ce55d8f0-2ae7-4fde-b722-58bec7970aa3.json
+++ b/change/react-native-windows-ce55d8f0-2ae7-4fde-b722-58bec7970aa3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Capture MSBuild properties in telemetry",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/powershell/Eval-MsBuildProperties.ps1
+++ b/packages/@react-native-windows/cli/powershell/Eval-MsBuildProperties.ps1
@@ -1,0 +1,156 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+#
+# Eval-MsBuildProperties.ps1
+#
+# This script lets you determine the final values of MSBUILD properties for a
+# given solution and project file. Simply pass in a comma delimited list of
+# property names and you'll get a JSON blob of evaluated values.
+#
+# For example, from the root of the repo:
+#
+# .\packages\@react-native-windows\cli\powershell\Eval-MsBuildProperties.ps1 -SolutionFile 'vnext\Microsoft.ReactNative.sln' -ProjectFile 'vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj' -PropertyNames 'ProjectGUID,ProjectName'
+#
+# will output:
+#
+# {
+#     "ProjectGuid":  "{f7d32bd0-2749-483e-9a0d-1635ef7e3136}",
+#     "ProjectName":  "Microsoft.ReactNative"
+# }
+#
+
+param(
+    [Parameter(Mandatory = $true)]
+    [String]$SolutionFile,
+    [Parameter(Mandatory = $true)]
+    [String]$ProjectFile,
+    [Parameter()]
+    [String]$PropertyNames = "",
+    [Parameter()]
+    [String]$MSBuildPath,
+    [Parameter()]
+    [String]$ExtraMSBuildProps
+)
+
+function Get-MSBuildPath {
+    $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+    if (!(Test-Path $vsWhere)) {
+        throw "Unable to find vswhere.exe."
+    }
+    $vsPath = & $vsWhere -version 16.5 -property installationPath;
+    return "$vsPath\MSBuild\Current\Bin";
+}
+
+function Get-MSBuildProperties {
+    param (
+        [Parameter(Mandatory = $true)]
+        [String]$MSBuildPath,
+        [Parameter(Mandatory = $true)]
+        [String]$SolutionPath,
+        [Parameter(Mandatory = $true)]
+        [String]$ProjectPath,
+        [Parameter()]
+        [String[]]$PropertyNames = @(),
+        [Parameter()]
+        [String]$ExtraMSBuildProps
+    )
+
+    if (!(Test-Path (Join-Path $MSBuildPath "MSBuild.exe"))) {
+        throw "Unable to find MSBuild.exe in $MSBuildPath"
+    }
+
+    if (!(Test-Path (Join-Path $MSBuildPath "MSBuild.exe"))) {
+        throw "Unable to find Microsoft.Build.dll in $MSBuildPath"
+    }
+
+    # Method to intercept resolution of assemblies to add MSBuild's path
+    $onAssemblyResolveEventHandler = [System.ResolveEventHandler] {
+        param($s, $e)
+
+        # Figure out which assembly to look for
+        $assemblyName = $e.Name.Substring(0, $e.Name.IndexOf(", "));
+        $assemblyPath = "$MSBuildPath\$assemblyName.dll"
+
+        # Search for the assembly in the MSBuild directory
+        if (Test-Path $assemblyPath) {
+            # Found the assembly!
+            return [System.Reflection.Assembly]::LoadFrom("$MSBuildPath\$assemblyName.dll");
+        }
+
+        # Unable to find the assembly
+        return $null
+    }
+
+    # Wire-up assembly resolution event handler
+    [System.AppDomain]::CurrentDomain.add_AssemblyResolve($onAssemblyResolveEventHandler)
+
+    # Load Microsoft.Build.dll into script
+    Add-Type -Path "$MSBuildPath\Microsoft.Build.dll" | Out-Null
+
+    # Build a local project collection
+    $projectCollection = [Microsoft.Build.Evaluation.ProjectCollection]::new()
+
+    try {
+        # Build a temporary "metaproj" of the solution file so it can be processed
+        ${env:MSBUILDEMITSOLUTION} = 1
+        & $MSBuildPath\MSBuild.exe $SolutionPath | Out-Null
+
+        # Process solution
+        $solution = [Microsoft.Build.Evaluation.Project]::new("$SolutionPath.metaproj", $null, "Current", $projectCollection)
+    }
+    finally {
+        # Clean up "metaproj" files
+        ${env:MSBUILDEMITSOLUTION} = 0
+        Remove-Item -Path @("$SolutionPath.metaproj", "$SolutionPath.metaproj.tmp") | Out-Null
+        Get-ChildItem * -Include *.metaproj -Recurse | Remove-Item | Out-Null
+    }
+
+    # Evaluate all of the Solution* properties and save into a collection
+    $globalProps = New-Object 'System.Collections.Generic.Dictionary[String,String]'
+    $solution.Properties | ForEach-Object -Process {
+        if ($_.Name.StartsWith("Solution")) {
+            $globalProps.Add($_.Name, $_.EvaluatedValue)
+        }
+    }
+
+    # Evaluate all extra build props and save into the collection
+    $extraPropsTable = ConvertFrom-StringData -StringData $ExtraMSBuildProps.Replace(',', "`n")
+    $extraPropsTable.Keys | ForEach-Object -Process {
+        $globalProps[$_] = $extraPropsTable[$_]
+    }
+
+    # Process the project file (with the Solution* properties we calculated before)
+    $project = [Microsoft.Build.Evaluation.Project]::new("$ProjectPath", $globalProps, "Current", $projectCollection)
+
+    # Create object to hold evaluated property key value pairs
+    $evaluatedProps = @{}
+
+    # Look for the specified PropertyNames and evaluate them
+    $project.Properties | ForEach-Object -Process {
+        if (($PropertyNames.Length -eq 0) -or ($PropertyNames -contains $_.Name)) {
+            $evaluatedProps[$_.Name] = $_.EvaluatedValue;
+        }
+    }
+
+    # Output as JSON
+    Write-Output (ConvertTo-Json $evaluatedProps)
+}
+
+# Main
+
+if ($MSBuildPath -and (Test-Path $MSBuildPath)) {
+    if (Test-Path $MSBuildPath -PathType Leaf) {
+        # It's a file (probably msbuild.exe), just get the folder path
+        $MSBuildPath = [System.IO.Path]::GetDirectoryName($MSBuildPath)
+    }
+}
+else {
+    # Use simple fallback logic in this script to find MSBuild path
+    $MSBuildPath = Get-MSBuildPath
+}
+
+# Get the full absolute paths to the solution and projects
+$SolutionPath = Convert-Path $SolutionFile
+$ProjectPath = Convert-Path $ProjectFile
+
+Get-MSBuildProperties -MSBuildPath $MSBuildPath -SolutionPath $SolutionPath -ProjectPath $ProjectPath -PropertyNames $PropertyNames.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) -ExtraMSBuildProps $ExtraMSBuildProps

--- a/packages/@react-native-windows/cli/src/runWindows/utils/telemetryHelpers.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/telemetryHelpers.ts
@@ -134,6 +134,11 @@ export async function endTelemetrySession(
   error?: Error,
   getExtraProps?: () => Promise<Record<string, any>>,
 ) {
+  if (!Telemetry.isEnabled()) {
+    // Bail early so don't waste time here
+    return;
+  }
+
   const endInfo: CommandEndInfo = {
     resultCode: 'Success',
   };

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -46,4 +46,6 @@
   </Target>
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
+
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\OutputMSBuildProperties.targets" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -47,6 +47,7 @@
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\CppAppConsumeCSharpModule.targets" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\FixupRoslynCscWarnings.targets" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\OutputMSBuildProperties.targets" />
 
   <ItemDefinitionGroup>
     <Reference>

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -10,7 +10,6 @@
     <!--
       These are the properties we will report in telemetry. Do NOT add properties that may contain PII.
       You can add new properties following the format "PropertyName": "$(PropertyName)",
-      CODESYNC packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
     -->
       <MSBuildPropertiesJSON>
       {

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -5,11 +5,11 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="OutputMSBuildProperties" BeforeTargets="Build">
+  <Target Name="OutputMSBuildProperties" AfterTargets="PrepareForBuild">
     <PropertyGroup>
     <!--
-      These are the properties we want to track in telemetry. You can add new properties following
-      the format "PropertyName": "$(PropertyName)",
+      These are the properties we will report in telemetry. Do NOT add properties that may contain PII.
+      You can add new properties following the format "PropertyName": "$(PropertyName)",
       CODESYNC packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
     -->
       <MSBuildPropertiesJSON>

--- a/vnext/PropertySheets/OutputMSBuildProperties.targets
+++ b/vnext/PropertySheets/OutputMSBuildProperties.targets
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+  Copyright (c) Microsoft Corporation. All rights reserved.
+ Licensed under the MIT License.. 
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="OutputMSBuildProperties" BeforeTargets="Build">
+    <PropertyGroup>
+    <!--
+      These are the properties we want to track in telemetry. You can add new properties following
+      the format "PropertyName": "$(PropertyName)",
+      CODESYNC packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+    -->
+      <MSBuildPropertiesJSON>
+      {
+        "WinUIPackageName": "$(WinUIPackageName)",
+        "WinUIPackageVersion": "$(WinUIPackageVersion)",
+        "WindowsTargetPlatformVersion": "$(WindowsTargetPlatformVersion)",
+        "UseExperimentalNuGet": "$(UseExperimentalNuGet)",
+        "UseHermes": "$(UseHermes)",
+        "UseWinUI3": "$(UseWinUI3)"
+      }
+      </MSBuildPropertiesJSON>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="$([MSBuild]::NormalizePath($(ProjectDir)\Generated Files))\msbuildproperties.g.json"
+        Overwrite="true"
+        Lines="$(MSBuildPropertiesJSON)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
## Description

This PR adds certain values of important MSBuild properties to the telemetry of `run-windows`.

Resolves #9165

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
There are some key MSBuild properties that would make it easier for us to debug and troubleshoot build problems if we knew their values.

Resolves #9165

### What
A new OutputMSBuildProperties.targets file to run before Build, which outputs the properties we want to capture to a JSON file, to be consumed by run-windows and reported.

If the file can't be found, a new Eval-MsBuildProperties.ps1 script is added which loads the Microsoft.Build.dll and uses it to correctly process the build tree and get the correct value of specified properties. It's slow but should work even if the build fails.

There is a new wrapper method in msbuildtools to load the JSON file, or as a fallback call the script, and we set up a callback to only call this method at the end of the `run-windows` command.

## Testing

Verified that the new properties get pushed into the telemetry with a local Fiddler proxy server.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9470)