### PR TITLE
[0.66] [NetUI] Add additional exports for react-native-win32.dll

### DIFF
--- a/change/react-native-windows-50d42888-74d9-4ac0-ad8f-60e874390f4b.json
+++ b/change/react-native-windows-50d42888-74d9-4ac0-ad8f-60e874390f4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add additional exports for react-native-win32.dll",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -5,6 +5,8 @@
 ; **************************************************************************************************
 
 EXPORTS
+??$safe_assert_terminate@$0A@@detail@folly@@YAXPEBUsafe_assert_arg@01@ZZ
+??$safe_assert_terminate@$0A@PEBD@detail@folly@@YAXAEBUsafe_assert_arg@01@PEBD@Z
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??0LayoutAnimation@react@facebook@@QEAA@Udynamic@folly@@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -5,6 +5,7 @@
 ; **************************************************************************************************
 
 EXPORTS
+??$safe_assert_terminate@$0A@@detail@folly@@YAXPBUsafe_assert_arg@01@ZZ
 ??$str_to_floating@N@detail@folly@@YG?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0LayoutAnimation@react@facebook@@QAE@Udynamic@folly@@@Z


### PR DESCRIPTION
## Description
Add additional exports for react-native-win32.dll required for Office.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9471)