### PR TITLE
Update Issue Template to include option for VS2022

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -74,6 +74,7 @@ body:
       options:
         - "Visual Studio 2017"
         - "Visual Studio 2019"
+        - "Visual Studio 2022"
     id: vs
   - type: dropdown
     attributes:


### PR DESCRIPTION
Adding VS 2022 as an option for Visual Studio Version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9476)