### PR TITLE
[0.66] Hermes inspector is not starting when Hermes engine is used (#9426)

### DIFF
--- a/change/react-native-windows-8dceffc6-04bc-4bc3-9d5c-9835ae7f8a9c.json
+++ b/change/react-native-windows-8dceffc6-04bc-4bc3-9d5c-9835ae7f8a9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing hermes inspector [#9407](https://github.com/microsoft/react-native-windows/issues/)",
+  "packageName": "react-native-windows",
+  "email": "anandrag@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-8dceffc6-04bc-4bc3-9d5c-9835ae7f8a9c.json
+++ b/change/react-native-windows-8dceffc6-04bc-4bc3-9d5c-9835ae7f8a9c.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Fixing hermes inspector [#9407](https://github.com/microsoft/react-native-windows/issues/)",
-  "packageName": "react-native-windows",
-  "email": "anandrag@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-ff1c1368-6245-4003-8937-fb5ab3a17c76.json
+++ b/change/react-native-windows-ff1c1368-6245-4003-8937-fb5ab3a17c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Hermes inspector is not starting when Hermes engine is used (#9426)",
+  "packageName": "react-native-windows",
+  "email": "anandrag@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.cpp
+++ b/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.cpp
@@ -7,6 +7,10 @@ using namespace facebook::react;
 
 namespace Microsoft::React::Test {
 
+facebook::react::JSIEngineOverride ChakraRuntimeHolder::getRuntimeType() noexcept {
+  return facebook::react::JSIEngineOverride::Chakra;
+}
+
 std::shared_ptr<facebook::jsi::Runtime> ChakraRuntimeHolder::getRuntime() noexcept {
   std::call_once(once_flag_, [this]() { initRuntime(); });
 

--- a/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
+++ b/vnext/Desktop.IntegrationTests/ChakraRuntimeHolder.h
@@ -9,9 +9,10 @@
 
 namespace Microsoft::React::Test {
 
-class ChakraRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+class ChakraRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+  facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
   ChakraRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,

--- a/vnext/Microsoft.ReactNative/JsiApi.cpp
+++ b/vnext/Microsoft.ReactNative/JsiApi.cpp
@@ -395,7 +395,7 @@ facebook::jsi::JSError const &jsError) {                             \
 }
 
 /*static*/ ReactNative::JsiRuntime JsiRuntime::GetOrCreate(
-    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+    std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
     std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
   {
     std::scoped_lock lock{s_mutex};
@@ -409,7 +409,7 @@ facebook::jsi::JSError const &jsError) {                             \
 }
 
 /*static*/ ReactNative::JsiRuntime JsiRuntime::Create(
-    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+    std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
     std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept {
   // There are some functions that we cannot do using JSI such as
   // defining a property or using Symbol as a key.
@@ -445,7 +445,7 @@ ReactNative::JsiRuntime JsiRuntime::MakeChakraRuntime() {
 }
 
 JsiRuntime::JsiRuntime(
-    std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> &&runtimeHolder,
+    std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> &&runtimeHolder,
     std::shared_ptr<facebook::jsi::Runtime> &&runtime) noexcept
     : m_runtimeHolder{std::move(runtimeHolder)},
       m_runtime{std::move(runtime)},

--- a/vnext/Microsoft.ReactNative/JsiApi.h
+++ b/vnext/Microsoft.ReactNative/JsiApi.h
@@ -58,16 +58,16 @@ struct RuntimeAccessor;
 
 struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   JsiRuntime(
-      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> &&runtimeHolder,
+      std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> &&runtimeHolder,
       std::shared_ptr<facebook::jsi::Runtime> &&runtime) noexcept;
   ~JsiRuntime() noexcept;
 
   static ReactNative::JsiRuntime FromRuntime(facebook::jsi::Runtime &runtime) noexcept;
   static ReactNative::JsiRuntime GetOrCreate(
-      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+      std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
       std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept;
   static ReactNative::JsiRuntime Create(
-      std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
+      std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> const &jsiRuntimeHolder,
       std::shared_ptr<facebook::jsi::Runtime> const &jsiRuntime) noexcept;
 
  public: // JsiRuntime
@@ -168,7 +168,7 @@ struct JsiRuntime : JsiRuntimeT<JsiRuntime> {
   void SetError(facebook::jsi::JSINativeException const &nativeException) noexcept;
 
  private:
-  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_runtimeHolder;
+  std::shared_ptr<::Microsoft::JSI::RuntimeHolderLazyInit> m_runtimeHolder;
   std::shared_ptr<facebook::jsi::Runtime> m_runtime;
   RuntimeAccessor *m_runtimeAccessor{};
   std::mutex m_mutex;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -5,9 +5,9 @@
 
 #include "React.h"
 
-namespace facebook::jsi {
+namespace Microsoft::JSI {
 struct RuntimeHolderLazyInit;
-} // namespace facebook::jsi
+} // namespace Microsoft::JSI
 
 namespace Mso::React {
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -893,7 +893,7 @@ void ReactInstanceWin::DispatchEvent(int64_t viewTag, std::string &&eventName, f
 }
 
 winrt::Microsoft::ReactNative::JsiRuntime ReactInstanceWin::JsiRuntime() noexcept {
-  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> jsiRuntimeHolder;
+  std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> jsiRuntimeHolder;
   {
     std::scoped_lock lock{m_mutex};
     if (m_jsiRuntime) {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -184,7 +184,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   Mso::CntPtr<Mso::React::IDispatchQueue2> m_uiQueue;
   std::deque<JSCallEntry> m_jsCallQueue;
 
-  std::shared_ptr<facebook::jsi::RuntimeHolderLazyInit> m_jsiRuntimeHolder;
+  std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> m_jsiRuntimeHolder;
   winrt::Microsoft::ReactNative::JsiRuntime m_jsiRuntime{nullptr};
 };
 

--- a/vnext/Shared/ChakraRuntimeHolder.cpp
+++ b/vnext/Shared/ChakraRuntimeHolder.cpp
@@ -9,6 +9,10 @@
 
 namespace Microsoft::JSI {
 
+facebook::react::JSIEngineOverride ChakraRuntimeHolder::getRuntimeType() noexcept {
+  return facebook::react::JSIEngineOverride::Chakra;
+}
+
 std::shared_ptr<facebook::jsi::Runtime> ChakraRuntimeHolder::getRuntime() noexcept {
   std::call_once(once_flag_, [this]() { initRuntime(); });
 

--- a/vnext/Shared/ChakraRuntimeHolder.h
+++ b/vnext/Shared/ChakraRuntimeHolder.h
@@ -12,9 +12,10 @@
 
 namespace Microsoft::JSI {
 
-class ChakraRuntimeHolder final : public facebook::jsi::RuntimeHolderLazyInit {
+class ChakraRuntimeHolder final : public Microsoft::JSI::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+  facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
   ChakraRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -14,11 +14,9 @@
 #define STRING_(s) #s
 #define STRING(s) STRING_(s)
 
-namespace facebook {
-namespace jsi {
+namespace Microsoft::JSI {
 struct RuntimeHolderLazyInit;
-}
-} // namespace facebook
+} // namespace Microsoft::JSI
 
 namespace facebook {
 namespace react {
@@ -81,7 +79,7 @@ struct DevSettings {
   /// instance. This object should in general be used only from the JS engine
   /// thread, unless the specific runtime implementation explicitly guarantees
   /// reentrancy.
-  std::shared_ptr<jsi::RuntimeHolderLazyInit> jsiRuntimeHolder;
+  std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> jsiRuntimeHolder;
 
   // Until the ABI story is addressed we'll use this instead of the above for
   // the purposes of selecting a JSI Runtime to use.

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -72,6 +72,10 @@ class HermesExecutorRuntimeAdapter final : public facebook::hermes::inspector::R
 
 } // namespace
 
+facebook::react::JSIEngineOverride HermesRuntimeHolder::getRuntimeType() noexcept {
+  return facebook::react::JSIEngineOverride::Hermes;
+}
+
 std::shared_ptr<jsi::Runtime> HermesRuntimeHolder::getRuntime() noexcept {
   std::call_once(m_once_flag, [this]() { initRuntime(); });
 

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -12,9 +12,10 @@
 namespace facebook {
 namespace react {
 
-class HermesRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+  facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
@@ -96,7 +96,11 @@ void NapiJsiV8RuntimeHolder::InitRuntime() noexcept {
   m_ownThreadId = std::this_thread::get_id();
 }
 
-#pragma region facebook::jsi::RuntimeHolderLazyInit
+#pragma region Microsoft::JSI::RuntimeHolderLazyInit
+
+facebook::react::JSIEngineOverride NapiJsiV8RuntimeHolder::getRuntimeType() noexcept {
+  return facebook::react::JSIEngineOverride::V8NodeApi;
+}
 
 shared_ptr<Runtime> NapiJsiV8RuntimeHolder::getRuntime() noexcept /*override*/
 {
@@ -112,6 +116,6 @@ shared_ptr<Runtime> NapiJsiV8RuntimeHolder::getRuntime() noexcept /*override*/
   return m_runtime;
 }
 
-#pragma endregion facebook::jsi::RuntimeHolderLazyInit
+#pragma endregion Microsoft::JSI::RuntimeHolderLazyInit
 
 } // namespace Microsoft::JSI

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -10,9 +10,10 @@
 
 namespace Microsoft::JSI {
 
-class NapiJsiV8RuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+  facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
   NapiJsiV8RuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,

--- a/vnext/Shared/JSI/RuntimeHolder.h
+++ b/vnext/Shared/JSI/RuntimeHolder.h
@@ -3,8 +3,9 @@
 #include <jsi/jsi.h>
 #include <memory>
 
-namespace facebook {
-namespace jsi {
+#include <DevSettings.h>
+
+namespace Microsoft::JSI {
 
 // An instance of this interface is expected to
 // a. lazily create a JSI Runtime on the first call to getRuntime
@@ -15,7 +16,7 @@ namespace jsi {
 
 struct RuntimeHolderLazyInit {
   virtual std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept = 0;
+  virtual facebook::react::JSIEngineOverride getRuntimeType() noexcept = 0;
 };
 
-} // namespace jsi
-} // namespace facebook
+} // namespace Microsoft::JSI

--- a/vnext/Shared/V8JSIRuntimeHolder.cpp
+++ b/vnext/Shared/V8JSIRuntimeHolder.cpp
@@ -31,6 +31,10 @@ class TaskRunnerAdapter : public v8runtime::JSITaskRunner {
   std::shared_ptr<facebook::react::MessageQueueThread> jsQueue_;
 };
 
+facebook::react::JSIEngineOverride V8JSIRuntimeHolder::getRuntimeType() noexcept {
+  return facebook::react::JSIEngineOverride::V8;
+}
+
 std::shared_ptr<facebook::jsi::Runtime> V8JSIRuntimeHolder::getRuntime() noexcept {
   std::call_once(once_flag_, [this]() { initRuntime(); });
 

--- a/vnext/Shared/V8JSIRuntimeHolder.h
+++ b/vnext/Shared/V8JSIRuntimeHolder.h
@@ -13,9 +13,10 @@
 namespace facebook {
 namespace react {
 
-class V8JSIRuntimeHolder : public facebook::jsi::RuntimeHolderLazyInit {
+class V8JSIRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
  public:
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
+  facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
   V8JSIRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,


### PR DESCRIPTION
* Fixing hermes inspector [#9407](https://github.com/microsoft/react-native-windows/issues/)

The check to start the hermes inspector assumed that the jsiEngineOverride field to be set in the devSetting.
But, the field won't be set when using the override jsi runtime provided by the host.

The fix requires us to dynamically inspect the jsi runtime instance to find the engine type. This change adds
a field into the runtime implementation to explicitly provide the runtime type.

One alternative solution is to use RTTI which is not enabled in RNW builds.
Another alternative is to use the jsi::Runtime::description() value. We can't easily use this field as the usage of it is restricted to JS thread.

* Change files

* Incorporating feedbacks

* Fixing desktop build

* Fixing build break in Desktop integration tests

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9477)