### PR TITLE
Move web debugging integration-test-app to CI only

### DIFF
--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -12,11 +12,6 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
-          - Name: X64WebDebug
-            BuildPlatform: x64
-            BuildConfiguration: Debug
-            DeployOptions:
-            UseHermes: false
           - Name: X64ReleaseHermes
             BuildPlatform: x64
             BuildConfiguration: Release


### PR DESCRIPTION
This configuration has been a little bit flakey, seeming to be due to some timing issues. We're trying to move away from web debugging, so it isn't worth too much time for any new development to it. It is still essential we catch regressions to it in the meantime. As a compromise, this change enables it only in rolling builds.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9487)