### PR TITLE
Attempt to fix versioning off-by-one issue

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -84,6 +84,10 @@ jobs:
         displayName: Beachball Publish (Stable Branch)
         condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
 
+      # Beachball reverts to local state after publish, but we want the updates it added
+      - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
+        displayName: git pull
+
       - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
         displayName: Create GitHub Releases for New Tags (Stable Branch)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )


### PR DESCRIPTION
0.68 logs appear to show beachball resetting state after publish, on whatever version it uses. This adds back a step to pull latest changes after publish.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9492)