### PR TITLE
Fix TurboModule codegen document

### DIFF
--- a/change/@react-native-windows-codegen-fabf9411-e605-4506-8bec-969f10262da4.json
+++ b/change/@react-native-windows-codegen-fabf9411-e605-4506-8bec-969f10262da4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix TurboModule codegen document",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/Document.md
+++ b/packages/@react-native-windows/codegen/Document.md
@@ -219,7 +219,7 @@ then a single `REACT_GET_CONSTANTS` becomes the only way to implement this membe
 ### REACT_CONSTANT_PROVIDER
 
 `REACT_CONSTANT_PROVIDER` is a weak-typed version of `REACT_GET_CONSTANTS`.
-The applied function must returns `void`
+The applied function must return `void`
 and its only argument must be `winrt::Microsoft::ReactNative::ReactConstantProvider& provider`.
 
 The syntax of `REACT_CONSTANT_PROVIDER` is `REACT_CONSTANT_PROVIDER(method)`.


### PR DESCRIPTION
This PR fixes some known issues mentioned in [the last PR](https://github.com/microsoft/react-native-windows/pull/9433), which was merged before I addressed all review comments.

Then document fix affects only one file `packages\@react-native-windows\codegen\Document.md`, no code is changed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9498)