### PR TITLE
Built in turbomodules should not override app provided versions

### DIFF
--- a/change/react-native-windows-12b8ebce-b24a-4945-aabb-3021ecb46003.json
+++ b/change/react-native-windows-12b8ebce-b24a-4945-aabb-3021ecb46003.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Built in turbomodules should not override app provided versions",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -258,7 +258,7 @@ void ReactInstanceWin::LoadModules(
     if (m_options.UseWebDebugger()) {
       nativeModulesProvider->AddModuleProvider(name, provider);
     } else {
-      turboModulesProvider->AddModuleProvider(name, provider);
+      turboModulesProvider->AddModuleProvider(name, provider, false);
     }
   };
 

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -38,7 +38,7 @@ void ReactPackageBuilder::AddViewManager(
 void ReactPackageBuilder::AddTurboModule(
     hstring const &moduleName,
     ReactModuleProvider const &moduleProvider) noexcept {
-  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider);
+  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -335,12 +335,13 @@ void TurboModulesProvider::SetReactContext(const IReactContext &reactContext) no
 
 void TurboModulesProvider::AddModuleProvider(
     winrt::hstring const &moduleName,
-    ReactModuleProvider const &moduleProvider) noexcept {
+    ReactModuleProvider const &moduleProvider,
+    bool overwriteExisting) noexcept {
   auto key = to_string(moduleName);
   auto it = m_moduleProviders.find(key);
   if (it == m_moduleProviders.end()) {
     m_moduleProviders.insert({key, moduleProvider});
-  } else {
+  } else if (overwriteExisting) {
     // turbo modules should be replaceable before the first time it is requested
     it->second = moduleProvider;
   }

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -26,7 +26,10 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
 
  public:
   void SetReactContext(const IReactContext &reactContext) noexcept;
-  void AddModuleProvider(winrt::hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+  void AddModuleProvider(
+      winrt::hstring const &moduleName,
+      ReactModuleProvider const &moduleProvider,
+      bool overwriteExisting) noexcept;
 
  private:
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;


### PR DESCRIPTION
## Description
Built in TurboModules are overridding modules provided by the user application. 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Applications should be able to provide their own implementation of built in modules.
