### PR TITLE
Couple of fixes to get fabric running again

### DIFF
--- a/change/react-native-windows-29044745-85ed-49fc-9fb2-1056b5f77d22.json
+++ b/change/react-native-windows-29044745-85ed-49fc-9fb2-1056b5f77d22.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "backgroundExecutor now required for fabric",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -483,8 +483,7 @@ void FabricUIManager::schedulerDidDispatchCommand(
 void FabricUIManager::schedulerDidSetIsJSResponder(
     facebook::react::ShadowView const &shadowView,
     bool isJSResponder,
-    bool blockNativeResponder) {
-}
+    bool blockNativeResponder) {}
 
 void FabricUIManager::schedulerDidSendAccessibilityEvent(
     const facebook::react::ShadowView &shadowView,

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -708,6 +708,7 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactSourceBranch(
   assert(pTagsForBranch != nullptr);
   assert(pSourceElement != nullptr);
 
+#ifdef USE_FABRIC
   if (m_fabric) {
     int64_t tag;
     if (TagFromOriginalSource(args.Args(), &tag, pSourceElement)) {
@@ -717,6 +718,7 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactSourceBranch(
     }
     return pSourceElement != nullptr;
   }
+#endif
 
   if (const auto uiManager = GetNativeUIManager(*m_context).lock()) {
     xaml::UIElement sourceElement = args.Args().OriginalSource().try_as<xaml::UIElement>();

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -479,10 +479,7 @@ winrt::IPropertyValue TestHit(
   return tag;
 }
 
-bool TagFromOriginalSource(
-    const winrt::PointerRoutedEventArgs &args,
-    int64_t *pTag,
-    xaml::UIElement *pSourceElement) {
+bool TagFromOriginalSource(const winrt::PointerRoutedEventArgs &args, int64_t *pTag, xaml::UIElement *pSourceElement) {
   assert(pTag != nullptr);
   assert(pSourceElement != nullptr);
 
@@ -531,12 +528,12 @@ bool TagFromOriginalSource(
 
 bool TouchEventHandler::IsEndishEventType(TouchEventType eventType) noexcept {
   switch (eventType) {
-        case TouchEventType::End:
-        case TouchEventType::Cancel:
-        case TouchEventType::CaptureLost:
-          return true;
-        default:
-        return false;
+    case TouchEventType::End:
+    case TouchEventType::Cancel:
+    case TouchEventType::CaptureLost:
+      return true;
+    default:
+      return false;
   }
 }
 #endif
@@ -711,11 +708,9 @@ bool TouchEventHandler::PropagatePointerEventAndFindReactSourceBranch(
   assert(pTagsForBranch != nullptr);
   assert(pSourceElement != nullptr);
 
-  if (m_fabric)
-  {
+  if (m_fabric) {
     int64_t tag;
-    if (TagFromOriginalSource(args.Args(), &tag, pSourceElement))
-    {
+    if (TagFromOriginalSource(args.Args(), &tag, pSourceElement)) {
       std::vector<int64_t> tagsForBranch;
       tagsForBranch.push_back(tag);
       *pTagsForBranch = std::move(tagsForBranch);

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -80,10 +80,11 @@ class TouchEventHandler {
       xaml::UIElement sourceElement,
       std::vector<int64_t> &&newViews);
 
+  enum class TouchEventType { Start = 0, End, Move, Cancel, CaptureLost, PointerEntered, PointerExited, PointerMove };
 #ifdef USE_FABRIC
   facebook::react::Touch TouchForPointer(const ReactPointer &pointer) noexcept;
+  static bool IsEndishEventType(TouchEventType eventType) noexcept;
 #endif
-  enum class TouchEventType { Start = 0, End, Move, Cancel, CaptureLost, PointerEntered, PointerExited, PointerMove };
   void OnPointerConcluded(TouchEventType eventType, const winrt::PointerRoutedEventArgs &args);
   void DispatchTouchEvent(TouchEventType eventType, size_t pointerIndex);
   bool DispatchBackEvent();


### PR DESCRIPTION
## Description
Newer versions of fabric require `toolbox.backgroundExecutor` to be set.  Previously it was behind a feature flag.
Fixing an error `Cannot find single active touch`, which was being fired becuase the touch end event was including the touch that just ended in the active touch array.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Gets fabric able to run RNTester again


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9520)