### PR TITLE
Initial Compliance Pipeline Stub

### DIFF
--- a/.ado/compliance.yml
+++ b/.ado/compliance.yml
@@ -1,20 +1,52 @@
 name: RNW Compliance $(Date:yyyyMMdd).$(Rev:r)
 
+parameters:
+- name: stopOnNoCI
+  displayName: Stop if latest commit is ***NO_CI***
+  type: boolean
+  default: true
+- name: AgentPool
+  type: object
+  default:
+    Medium:
+      name: rnw-pool-4-microsoft
+      demands: ImageOverride -equals rnw-img-node16
+    Large:
+      name: rnw-pool-8-microsoft
+      demands: ImageOverride -equals rnw-img-node16
+
+variables:
+  - template: variables/windows.yml
+  - group: RNW Secrets
+  - name: NugetSecurityAnalysisWarningLevel
+    value: 'warn'
+
 trigger: none
 pr: none
 
 jobs:
-  - job: PreCheck
+  - job: RnwUniversalCompliance
     displayName: Halp
 
     steps:
       - template: templates/prepare-js-env.yml
 
+      - powershell: |
+          Write-Error "Stopping because commit message contains ***NO_CI***."
+        displayName: Stop pipeline if latest commit message contains ***NO_CI***
+        condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
+
+      - template: ../templates/set-version-vars.yml
+        parameters:
+          buildEnvironment: Continuous
+
+      - template: ../templates/publish-version-vars.yml
+
       - template: templates/prepare-build-env.yml
         parameters:
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          buildEnvironment: Publish
+          platform: x64
+          configuration: Release
+          buildEnvironment: Continuous
 
       - template: templates/apply-published-version-vars.yml
 
@@ -24,13 +56,7 @@ jobs:
         parameters:
           solutionDir: vnext
           solutionName: Microsoft.ReactNative.sln
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
-
-      - task: PowerShell@2
-        displayName: Make AnyCPU Reference Assemblies
-        inputs:
-          filePath: vnext/Scripts/Tfs/Make-AnyCPU-RefAssemblies.ps1
-          arguments: -TargetRoot $(Build.SourcesDirectory)\vnext\target -BuildRoot $(Build.SourcesDirectory)\vnext\target
+          buildPlatform: x64
+          buildConfiguration: Release
 
       # Insert post-build compliance here

--- a/.ado/compliance.yml
+++ b/.ado/compliance.yml
@@ -1,0 +1,36 @@
+name: RNW Compliance $(Date:yyyyMMdd).$(Rev:r)
+
+trigger: none
+pr: none
+
+jobs:
+  - job: PreCheck
+    displayName: Halp
+
+    steps:
+      - template: templates/prepare-js-env.yml
+
+      - template: templates/prepare-build-env.yml
+        parameters:
+          platform: $(BuildPlatform)
+          configuration: $(BuildConfiguration)
+          buildEnvironment: Publish
+
+      - template: templates/apply-published-version-vars.yml
+
+      # Insert pre-build compliance here
+
+      - template: templates/msbuild-sln.yml
+        parameters:
+          solutionDir: vnext
+          solutionName: Microsoft.ReactNative.sln
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
+
+      - task: PowerShell@2
+        displayName: Make AnyCPU Reference Assemblies
+        inputs:
+          filePath: vnext/Scripts/Tfs/Make-AnyCPU-RefAssemblies.ps1
+          arguments: -TargetRoot $(Build.SourcesDirectory)\vnext\target -BuildRoot $(Build.SourcesDirectory)\vnext\target
+
+      # Insert post-build compliance here


### PR DESCRIPTION
This PR creates an initial "stub" compliance pipeline for our repo that just builds Universal x64 Release. I need a file to target in order to set up the ADO side while I work through each of the compliance related tasks that need to be added.

Part of #9507 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9523)