### PR TITLE
Bump Hermes version to 0.11

### DIFF
--- a/change/react-native-windows-aa5ba522-5922-4c4c-8d70-dfdb18b69cca.json
+++ b/change/react-native-windows-aa5ba522-5922-4c4c-8d70-dfdb18b69cca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump Hermes version to 0.11",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
+++ b/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
@@ -152,7 +152,7 @@
       <Version>1.0.9</Version>
     </PackageReference>
     <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.10.0-ms.1</Version>
+      <Version>0.11.0-ms.2</Version>
     </PackageReference>
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">

--- a/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
+++ b/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
@@ -22,8 +22,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Direct",
-        "requested": "[0.10.0-ms.1, )",
-        "resolved": "0.10.0-ms.1",
+        "requested": "[0.11.0-ms.2, )",
+        "resolved": "0.11.0-ms.2",
         "contentHash": "U+0FecIUFhmuLDNGT+kIhQdzoIgOvaGHU5gQOl66G5JdbO8xpful+E5OH/NL9Ue6N1l+ecqTH9shGrVDsdG5ow=="
       },
       "XamlTreeDump": {

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -179,7 +179,7 @@
     <!-- <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.1-prerelease.210709001" /> -->
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.2-rc" />
-    <PackageReference Include="ReactNative.Hermes.Windows" Version="0.10.0-ms.1" />
+    <PackageReference Include="ReactNative.Hermes.Windows" Version="0.11.0-ms.2" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.10.0-ms.1" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.11.0-ms.2" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.10.0-ms.1" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.11.0-ms.2" targetFramework="native"/>
 </packages>

--- a/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
@@ -161,7 +161,7 @@
       <Version>6.2.9</Version>
     </PackageReference>
     <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.10.0-ms.1</Version>
+      <Version>0.11.0-ms.2</Version>
     </PackageReference>
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">

--- a/packages/sample-apps/windows/SampleAppCS/packages.lock.json
+++ b/packages/sample-apps/windows/SampleAppCS/packages.lock.json
@@ -22,8 +22,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Direct",
-        "requested": "[0.10.0-ms.1, )",
-        "resolved": "0.10.0-ms.1",
+        "requested": "[0.11.0-ms.2, )",
+        "resolved": "0.11.0-ms.2",
         "contentHash": "U+0FecIUFhmuLDNGT+kIhQdzoIgOvaGHU5gQOl66G5JdbO8xpful+E5OH/NL9Ue6N1l+ecqTH9shGrVDsdG5ow=="
       },
       "Microsoft.Net.Native.Compiler": {

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -8,7 +8,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.10.0-ms.1</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.11.0-ms.2</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\ReactNative.Hermes.Windows\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Bringing in new Hermes version, which includes updated security flags for SDL compliance.

## Testing
Manual runs with the new Hermes binary pass JSITests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9524)