### PR TITLE
[Early WIP] Simplify Repo-Wide Versioning Scheme 

### DIFF
--- a/change/react-native-windows-cb00141f-f6a2-4c19-955d-ea1325bc8a33.json
+++ b/change/react-native-windows-cb00141f-f6a2-4c19-955d-ea1325bc8a33.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Lazy Install `sourcemap-support` when `react-native-windows` config is hooked",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,22 +1,21 @@
-This directory contains the npm packages hosted by the react-native-windows repo. 
+This directory contains the npm packages hosted by the react-native-windows repo. By convention, the directory naming structure maps 1:1 to the published or workspace names of the npm packages.
 
 ## Scoped Packages
 
-Several packages are organized into specific package scopes:
+Several packages are organized into specific [package scopes](https://docs.npmjs.com/cli/v8/using-npm/scope):
 
 - `@office-iss`: Office internal packages
-- `@react-native`: Copies of private upstream packages already using the `@react-native` scope. E.g. `@react-native/tester` for the RNTester package.
-- `@react-native-windows`: Internal packages used by react-native-windows itself. Versioned and published alongside RNW.
-- `@rnw-scripts`: Scripts for repository tooling. Published as part of the main branch.
+- `@react-native`: Copies of private upstream packages that are referenced under the `@react-native` scope. E.g. `@react-native/tester` for the "RNTester" npm package.
+- `@react-native-windows`: Packages associated with the `react-native-windows` project (both public and private)
+- `@rnw-scripts`: Private scripts used by `react-native-windows` infrastructure.
 
 ## Unscoped packages
 
-Several packages do not belong to a scope for intentional (or historical) reasons. E.g. `react-native-platform-override` isn't RNW-specific and
-is unscoped. `react-native-windows-init` is run by name, and as such makes sense to be unscoped.
+Several packages do not belong to a scope for intentional (or historical) reasons. E.g. `react-native-windows-init` is executed by package name. 
 
 ## Adding a new scope
 
-> ⚠ Caution: Failing to create and give access to an NPM organization will break CI.
+> ⚠ Caution: Failing to create and give access to an NPM organization will lead to publishing failures, and will cause future PRs and rolling builds to fail.
 
 New package scopes for related packages can be added by adding a new directory with the scope name and prefixing the
 packages name in `package.json` with the scope.
@@ -42,4 +41,3 @@ After adding a scope directory, add the scope to the list of yarn workspaces in 
 
 Publishing a scoped package requires that the **rnbot** NPM user is an owner of an **npm organization** with the
 same name as the scope. You can check whether an organization exists by viewing [npmjs.com/org/<scope>](https://www.npmjs.com/org/rnw-scripts).
-See acoates for granting permissions to rnbot.

--- a/vnext/react-native.config.js
+++ b/vnext/react-native.config.js
@@ -1,18 +1,50 @@
-// @ts-check
-require('source-map-support').install();
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @ts check
+ * @format
+ */
 
 const cli = require('@react-native-windows/cli');
 
 module.exports = {
   // **** This section defined commands and options on how to provide the Windows platform to external applications
-  commands: cli.commands,
+  commands: cli.commands.map((command) => ({
+    ...command,
+    func: lazyInstallSourcemaps(command.func),
+  })),
   platforms: {
     windows: {
       linkConfig: () => null,
-      projectConfig: cli.projectConfig,
-      dependencyConfig: cli.dependencyConfig,
+      projectConfig: lazyInstallSourcemaps(cli.projectConfig),
+      dependencyConfig: lazyInstallSourcemaps(cli.dependencyConfig),
       npmPackageName: 'react-native-windows',
     },
   },
-  healthChecks: cli.getHealthChecks()
+  get healthChecks() { return cli.getHealthChecks(); },
 };
+
+// We ship compiled JavaScript to end-users running the CLI. We use
+// "source-map-support" to install a sourcemap-aware exception handler, so that
+// stack traces shown to end-users (and included in our issues), resolve
+// correctly to the TS sources. Resolution is only done when an exception occurs,
+// but there is some initial overhead to installing the exception handler.
+//
+// We want to do this before our code is hooked, to ensure the handler is
+// installed, but doing this as part of global initialization adds a cost to
+// anyone who depends on `react-native-windows`, and parses their
+// `react-native.config`, regardless of whether they call the functions. We
+// delay installing the support from require-time, to function invocation time,
+// which should catch most cases without the penalty.
+let sourcemapSupportInstalled = false;
+function lazyInstallSourcemaps(fn) {
+  return (...args) => {
+    if (!sourcemapSupportInstalled) {
+      require('source-map-support').install();
+      sourcemapSupportInstalled = true;
+    }
+
+    return fn(...args);
+  };
+}


### PR DESCRIPTION
We publish many packages from the RNW repo. Different packages have different bumping constraints, servicing methods, version schemes, etc. It's hard to reason about, and makes it harder to add new packages without intricate understanding of the system.

We also have quite a few packages we've been publishing for years, without known external users. We can reduce some of the live version mutation, which can be conflict/error prone, by making these packages private. With these packages private, we have a more limited set of public packages, that we can align to the same version snapping process as the rest of the repo. This allows beachball config sharing to a greater degree.

This roughly boils down to a few changes:
1. Stop publishing/versioning our repo-specific config files
2. Move some public-facing packages out of @rnw-scripts, to allow @rnw-scripts to be unpublished by convention

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9531)