### PR TITLE
Re-enable WebSocket RNTester integration test

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -64,7 +64,6 @@ jobs:
               value: >
                 (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
                 (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
 
             #6799 -


### PR DESCRIPTION
## Description
Re-enables test `RNTesterIntegrationTests::WebSocket`.


### Type of Change
- Tests coverage

### Why
Limitations by older Azure-provided VM images made some networking tests hang.

### What
Re-enables the JavaScript-driven test, which passes consistently on development machines.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9533)