### PR TITLE
[0.68] fix(cli): fix cache not being used when there are no dependencies

### DIFF
--- a/change/@react-native-windows-cli-401a1aee-fc62-4128-b881-42b970e6102e.json
+++ b/change/@react-native-windows-cli-401a1aee-fc62-4128-b881-42b970e6102e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.68] Fix cache not being used when there are no dependencies",
+  "packageName": "@react-native-windows/cli",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -398,13 +398,13 @@ export class AutolinkWindows {
   }
 
   /** Cache of dependencies */
-  private readonly windowsDependencies: Record<
-    string,
-    WindowsDependencyConfig
-  > = {};
+  private windowsDependencies:
+    | Record<string, WindowsDependencyConfig>
+    | undefined;
 
   private getWindowsDependencies() {
-    if (Object.keys(this.windowsDependencies).length === 0) {
+    if (!this.windowsDependencies) {
+      this.windowsDependencies = {};
       for (const dependencyName of Object.keys(this.dependenciesConfig)) {
         const windowsDependency: WindowsDependencyConfig | undefined =
           this.dependenciesConfig[dependencyName].platforms.windows;


### PR DESCRIPTION
This PR backports #9522 to 0.68.

- Bug fix (non-breaking change which fixes an issue)
This addresses a perf regression in autolinking when there are no dependencies to link.

Resolves #9518

Instead of checking whether the dependencies cache is empty, check whether it was instantiated.

| Before | After |
| -: | -: |
| 22488ms | 3561ms |

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9548)