### PR TITLE
[0.67] fix(cli): fix cache not being used when there are no dependencies

### DIFF
--- a/change/@react-native-windows-cli-3aac23ad-e95a-4369-b241-c4fea1afcb7a.json
+++ b/change/@react-native-windows-cli-3aac23ad-e95a-4369-b241-c4fea1afcb7a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.67] fix(cli): fix cache not being used when there are no dependencies",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -395,13 +395,13 @@ export class AutolinkWindows {
   }
 
   /** Cache of dependencies */
-  private readonly windowsDependencies: Record<
-    string,
-    WindowsDependencyConfig
-  > = {};
+  private windowsDependencies:
+    | Record<string, WindowsDependencyConfig>
+    | undefined;
 
   private getWindowsDependencies() {
-    if (Object.keys(this.windowsDependencies).length === 0) {
+    if (!this.windowsDependencies) {
+      this.windowsDependencies = {};
       for (const dependencyName of Object.keys(this.dependenciesConfig)) {
         const windowsDependency: WindowsDependencyConfig | undefined = this
           .dependenciesConfig[dependencyName].platforms.windows;


### PR DESCRIPTION
This PR backports #9522 to 0.67.

- Bug fix (non-breaking change which fixes an issue)
This addresses a perf regression in autolinking when there are no dependencies to link.

Resolves #9518

Instead of checking whether the dependencies cache is empty, check whether it was instantiated.

| Before | After |
| -: | -: |
| 22488ms | 3561ms |

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9549)