### PR TITLE
[0.64] Fix E2ETest app hanging during PR/CI

### DIFF
--- a/.ado/templates/e2e-test-job.yml
+++ b/.ado/templates/e2e-test-job.yml
@@ -23,6 +23,11 @@ jobs:
         clean: true
         fetchDepth: 1 # the depth of commits to ask Git to fetch
         submodules: false
+
+      - task: NodeTool@0
+        displayName: Set Node Version
+        inputs:
+          versionSpec: '12.x' # The version of WDIO used in RNW 0.64 will assert and fail on Node > 12
             
       - template: prepare-env.yml
 


### PR DESCRIPTION
This PR fixes the hangs/timeout for the E2E test run in  e2e-test-job.yml.

The version of wdio used in 0.64 requires Node 12. See
https://github.com/webdriverio/webdriverio/issues/6113

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9553)