### PR TITLE
MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early

### DIFF
--- a/change/react-native-windows-5e2cc7a5-b37d-49cc-b01b-c3669a0686c3.json
+++ b/change/react-native-windows-5e2cc7a5-b37d-49cc-b01b-c3669a0686c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/dispatchQueue/dispatchQueue.h
+++ b/vnext/Mso/dispatchQueue/dispatchQueue.h
@@ -723,9 +723,14 @@ inline DispatchTaskImpl<TInvoke, TOnCancel>::~DispatchTaskImpl() noexcept {
   }
 }
 
+namespace details {
+template <typename>
+constexpr bool always_false = false;
+}
+
 template <typename T>
 inline void MustBeNoExceptVoidFunctor() {
-  static_assert(false, __FUNCTION__ ": not a noexcept callable functor returning void");
+  static_assert(details::always_false<T>, __FUNCTION__ ": not a noexcept callable functor returning void");
 }
 
 template <typename TInvoke, typename TOnCancel>


### PR DESCRIPTION
## Description

Fixes #9559 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
VS 17.1 introduces stricter requirements on `static_assert`, which are causing a build break in the M.RN project. This fixes the previously invalid C++ code.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9562)