### PR TITLE
Crash when getting Platform.osVersion on Windows 8.1

### DIFF
--- a/change/react-native-windows-25e9c3ca-7257-4815-931b-f339b9e70b3c.json
+++ b/change/react-native-windows-25e9c3ca-7257-4815-931b-f339b9e70b3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Crash when getting osVersion on win 8.1",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/PlatformConstantsModule.cpp
+++ b/vnext/Shared/Modules/PlatformConstantsModule.cpp
@@ -46,6 +46,10 @@ std::map<std::string, folly::dynamic> PlatformConstantsModule::getConstants() {
 }
 
 /*static*/ int32_t PlatformConstantsModule::OsVersion() noexcept {
+  if (!IsWindows10OrGreater()) {
+    return -1;
+  }
+
   for (uint16_t i = 1;; ++i) {
     if (!ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", i)) {
       return i - 1;


### PR DESCRIPTION
## Description
The PlatformConstants module crashes when trying to work out the osVersion when running on Windows 8.1.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
This prevents Office from using the NativeModule.

### What
Add a Windows > 10 version check before calling ApiInformation::IsApiContractPresent which was introduced in Win10.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9567)