### PR TITLE
[0.66] [NetUI] Add IsPressable to native text component

### DIFF
--- a/change/@office-iss-react-native-win32-784f3d0c-1784-48e3-9f55-d7e0bc15ee23.json
+++ b/change/@office-iss-react-native-win32-784f3d0c-1784-48e3-9f55-d7e0bc15ee23.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "forward isPressble to native text component",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -445,7 +445,13 @@
       "baseHash": "afe4fc1e9aa91d08a7a1098e3bbd3b17a73b4a65"
     },
     {
-      "type": "derived",
+      "type": "patch",
+      "file": "src/Libraries/Text/Text.win32.js",
+      "baseFile": "Libraries/Text/Text.js",
+      "baseHash": "8b90eb090dcfed88a40a38bbb51cbbd1e0d9ca9e",
+      "issue": 7074
+    },
+    {
       "file": "src/Libraries/Text/TextNativeComponent.win32.js",
       "baseFile": "Libraries/Text/TextNativeComponent.js",
       "baseHash": "1a196691fb0e9b656c348b7d42427c1c6163c9bb",

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.win32.js
@@ -1,0 +1,214 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import DeprecatedTextPropTypes from '../DeprecatedPropTypes/DeprecatedTextPropTypes';
+import * as PressabilityDebug from '../Pressability/PressabilityDebug';
+import usePressability from '../Pressability/usePressability';
+import StyleSheet from '../StyleSheet/StyleSheet';
+import processColor from '../StyleSheet/processColor';
+import TextAncestor from './TextAncestor';
+import {NativeText, NativeVirtualText} from './TextNativeComponent';
+import {type TextProps} from './TextProps';
+import * as React from 'react';
+import {useContext, useMemo, useState} from 'react';
+import invariant from 'invariant';
+
+/**
+ * Text is the fundamental component for displaying text.
+ *
+ * @see https://reactnative.dev/docs/text.html
+ */
+const Text: React.AbstractComponent<
+  TextProps,
+  React.ElementRef<typeof NativeText | typeof NativeVirtualText>,
+> = React.forwardRef((props: TextProps, forwardedRef) => {
+  const {
+    accessible,
+    allowFontScaling,
+    ellipsizeMode,
+    onLongPress,
+    onPress,
+    onPressIn,
+    onPressOut,
+    onResponderGrant,
+    onResponderMove,
+    onResponderRelease,
+    onResponderTerminate,
+    onResponderTerminationRequest,
+    onStartShouldSetResponder,
+    pressRetentionOffset,
+    suppressHighlighting,
+    ...restProps
+  } = props;
+
+  const [isHighlighted, setHighlighted] = useState(false);
+
+  const isPressable =
+    (onPress != null ||
+      onLongPress != null ||
+      onStartShouldSetResponder != null) &&
+    restProps.disabled !== true;
+
+  const initialized = useLazyInitialization(isPressable);
+  const config = useMemo(
+    () =>
+      initialized
+        ? {
+            disabled: !isPressable,
+            pressRectOffset: pressRetentionOffset,
+            onLongPress,
+            onPress,
+            onPressIn(event) {
+              setHighlighted(!suppressHighlighting);
+              onPressIn?.(event);
+            },
+            onPressOut(event) {
+              setHighlighted(false);
+              onPressOut?.(event);
+            },
+            onResponderTerminationRequest_DEPRECATED: onResponderTerminationRequest,
+            onStartShouldSetResponder_DEPRECATED: onStartShouldSetResponder,
+          }
+        : null,
+    [
+      initialized,
+      isPressable,
+      pressRetentionOffset,
+      onLongPress,
+      onPress,
+      onPressIn,
+      onPressOut,
+      onResponderTerminationRequest,
+      onStartShouldSetResponder,
+      suppressHighlighting,
+    ],
+  );
+
+  const eventHandlers = usePressability(config);
+  const eventHandlersForText = useMemo(
+    () =>
+      eventHandlers == null
+        ? null
+        : {
+            onResponderGrant(event) {
+              eventHandlers.onResponderGrant(event);
+              if (onResponderGrant != null) {
+                onResponderGrant(event);
+              }
+            },
+            onResponderMove(event) {
+              eventHandlers.onResponderMove(event);
+              if (onResponderMove != null) {
+                onResponderMove(event);
+              }
+            },
+            onResponderRelease(event) {
+              eventHandlers.onResponderRelease(event);
+              if (onResponderRelease != null) {
+                onResponderRelease(event);
+              }
+            },
+            onResponderTerminate(event) {
+              eventHandlers.onResponderTerminate(event);
+              if (onResponderTerminate != null) {
+                onResponderTerminate(event);
+              }
+            },
+            onResponderTerminationRequest:
+              eventHandlers.onResponderTerminationRequest,
+            onStartShouldSetResponder: eventHandlers.onStartShouldSetResponder,
+          },
+    [
+      eventHandlers,
+      onResponderGrant,
+      onResponderMove,
+      onResponderRelease,
+      onResponderTerminate,
+    ],
+  );
+
+  // TODO: Move this processing to the view configuration.
+  const selectionColor =
+    restProps.selectionColor == null
+      ? null
+      : processColor(restProps.selectionColor);
+
+  let style = restProps.style;
+  if (__DEV__) {
+    if (PressabilityDebug.isEnabled() && onPress != null) {
+      style = StyleSheet.compose(restProps.style, {
+        color: 'magenta',
+      });
+    }
+  }
+
+  let numberOfLines = restProps.numberOfLines;
+  if (numberOfLines != null && !(numberOfLines >= 0)) {
+    console.error(
+      `'numberOfLines' in <Text> must be a non-negative number, received: ${numberOfLines}. The value will be set to 0.`,
+    );
+    numberOfLines = 0;
+  }
+
+  const hasTextAncestor = useContext(TextAncestor);
+
+  return hasTextAncestor ? (
+    <NativeVirtualText
+      {...restProps}
+      {...eventHandlersForText}
+      isHighlighted={isHighlighted}
+      isPressable={isPressable} // This was added upstream in https://github.com/facebook/react-native/commit/f3bf2e4f51897f1bb71e37002c288ebf3b23cf78
+      numberOfLines={numberOfLines}
+      selectionColor={selectionColor}
+      style={style}
+      ref={forwardedRef}
+    />
+  ) : (
+    <TextAncestor.Provider value={true}>
+      <NativeText
+        {...restProps}
+        {...eventHandlersForText}
+        accessible={accessible !== false}
+        allowFontScaling={allowFontScaling !== false}
+        ellipsizeMode={ellipsizeMode ?? 'tail'}
+        isHighlighted={isHighlighted}
+        isPressable={isPressable} // [Win32] - We use this to optimize text hit testing
+        numberOfLines={numberOfLines}
+        selectionColor={selectionColor}
+        style={style}
+        ref={forwardedRef}
+      />
+    </TextAncestor.Provider>
+  );
+});
+
+Text.displayName = 'Text';
+
+// TODO: Delete this.
+Text.propTypes = DeprecatedTextPropTypes;
+
+/**
+ * Returns false until the first time `newValue` is true, after which this will
+ * always return true. This is necessary to lazily initialize `Pressability` so
+ * we do not eagerly create one for every pressable `Text` component.
+ */
+function useLazyInitialization(newValue: boolean): boolean {
+  const [oldValue, setValue] = useState(newValue);
+  if (!oldValue && newValue) {
+    setValue(newValue);
+  }
+  return oldValue;
+}
+
+// $FlowFixMe[incompatible-cast] - No good way to type a React.AbstractComponent with statics.
+module.exports = (Text: typeof Text &
+  $ReadOnly<{
+    propTypes: typeof DeprecatedTextPropTypes,
+  }>);

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
@@ -9,6 +9,10 @@ type NativeTextProps = $ReadOnly<{
   ...TextProps,
   isHighlighted?: ?boolean,
   selectionColor?: ?ProcessedColorValue,
+  // This is only needed for platforms that optimize text hit testing, e.g.,
+  // react-native-windows. It can be used to only hit test virtual text spans
+  // that have pressable events attached to them.
+  isPressable?: ?boolean,
 }>;
 
 export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComponentClass(
@@ -18,6 +22,7 @@ export const NativeText: HostComponent<NativeTextProps> = (createReactNativeComp
     validAttributes: {
       ...ReactNativeViewAttributes.UIView,
       isHighlighted: true,
+      isPressable: true,
       numberOfLines: true,
       ellipsizeMode: true,
       allowFontScaling: true,
@@ -61,6 +66,7 @@ export const NativeVirtualText: HostComponent<NativeTextProps> =
         validAttributes: {
           ...ReactNativeViewAttributes.UIView,
           isHighlighted: true,
+          isPressable: true,
           maxFontSizeMultiplier: true,
         },
         uiViewClassName: 'RCTVirtualText',


### PR DESCRIPTION
## Description
In 0.64 we were using the presence of isHighlighted to determine isPressable.  That no longer works in 0.66.  Instead, I'm porting the change https://github.com/facebook/react-native/commit/f3bf2e4f51897f1bb71e37002c288ebf3b23cf78 to 0.66 to provide isPressable to native.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
NetUI needs a way to know if a text component isPressable.
