### PR TITLE
Add TypeScript turbo module definition as new codegen target

### DIFF
--- a/change/@react-native-windows-codegen-c2c652de-c0b5-4c7e-9655-56a42b7088a1.json
+++ b/change/@react-native-windows-codegen-c2c652de-c0b5-4c7e-9655-56a42b7088a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add TypeScript turbo module definition as new codegen traget",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -24,6 +24,11 @@ const argv = yargs.options({
     type: 'array',
     describe: 'glob patterns for files which contains specs',
   },
+  outdir: {
+    type: 'string',
+    describe: 'output directory',
+    default: 'codegen',
+  },
   test: {
     type: 'boolean',
     describe: 'Verify that the generated output is unchanged',
@@ -273,7 +278,7 @@ if (argv.file) {
 
 const libraryName = argv.libraryName;
 const moduleSpecName = 'moduleSpecName';
-const outputDirectory = 'codegen';
+const outputDirectory = argv.outdir;
 generate(
   {libraryName, schema, outputDirectory, moduleSpecName},
   {generators: [], test: false},

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -10,7 +10,7 @@ import path from 'path';
 import fs from '@react-native-windows/fs';
 import globby from 'globby';
 import {createNM2Generator} from './generators/GenerateNM2';
-import {createTypeScriptGenerator} from './generators/GenerateTypeScript';
+import {generateTypeScript} from './generators/GenerateTypeScript';
 // @ts-ignore
 import {parseFile} from 'react-native-tscodegen/lib/rncodegen/src/parsers/flow';
 // @ts-ignore
@@ -220,7 +220,6 @@ function generate(
   );
 
   const generateNM2 = createNM2Generator({namespace: argv.namespace});
-  const generateTypeScript = createTypeScriptGenerator();
 
   const generatorPropsH =
     require('react-native-tscodegen/lib/rncodegen/src/generators/components/GeneratePropsH').generate;

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import fs from '@react-native-windows/fs';
 import globby from 'globby';
 import {createNM2Generator} from './generators/GenerateNM2';
+import {createTypeScriptGenerator} from './generators/GenerateTypeScript';
 // @ts-ignore
 import {parseFile} from 'react-native-tscodegen/lib/rncodegen/src/parsers/flow';
 // @ts-ignore
@@ -23,6 +24,11 @@ const argv = yargs.options({
   files: {
     type: 'array',
     describe: 'glob patterns for files which contains specs',
+  },
+  ts: {
+    type: 'boolean',
+    describe: 'generate turbo module definition files in TypeScript',
+    default: false,
   },
   outdir: {
     type: 'string',
@@ -214,6 +220,8 @@ function generate(
   );
 
   const generateNM2 = createNM2Generator({namespace: argv.namespace});
+  const generateTypeScript = createTypeScriptGenerator();
+
   const generatorPropsH =
     require('react-native-tscodegen/lib/rncodegen/src/generators/components/GeneratePropsH').generate;
   const generatorPropsCPP =
@@ -232,6 +240,14 @@ function generate(
     outputDirectory,
     generatedFiles,
   );
+
+  if (argv.ts) {
+    normalizeFileMap(
+      generateTypeScript(libraryName, schema, moduleSpecName),
+      outputDirectory,
+      generatedFiles,
+    );
+  }
 
   if (
     Object.keys(schema.modules).some(

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -46,10 +46,10 @@ export function createTypeScriptGenerator() {
         : moduleName;
 
       if (nativeModule.type === 'NativeModule') {
-        console.log(`Generating Native${preferredModuleName}Spec.g.ts`);
+        console.log(`Generating ${preferredModuleName}Spec.g.ts`);
 
         files.set(
-          `Native${preferredModuleName}Spec.g.ts`,
+          `${preferredModuleName}Spec.g.ts`,
           moduleTemplate
             .replace(/::_MODULE_MEMBERS_::/g, '')
             .replace(/::_MODULE_NAME_::/g, preferredModuleName),

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -25,9 +25,9 @@ const moduleTemplate = `
  * This is a TypeScript turbo module definition file.
  */
 
-import {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModule, RootTag} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
-import {Int32, Float, Double, RootTag} from 'react-native/Libraries/Types/CodegenTypes';
+import {Int32, Float, Double} from 'react-native/Libraries/Types/CodegenTypes';
 'use strict';
 
 ::_MODULE_ALIASED_STRUCTS_::
@@ -161,7 +161,9 @@ export function createTypeScriptGenerator() {
 
         const constantType = tryGetConstantType(nativeModule);
         const constantCode =
-          constantType === undefined ? '' : `  getConstants(): ${constantType}`;
+          constantType === undefined
+            ? ''
+            : `  getConstants(): ${translateType(constantType)}`;
 
         const membersCode = '';
 

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -35,7 +35,6 @@ import {TurboModule, RootTag} from 'react-native/Libraries/TurboModule/RCTExport
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 import {Int32, Float, Double} from 'react-native/Libraries/Types/CodegenTypes';
 'use strict';
-
 ::_MODULE_ALIASED_STRUCTS_::
 export interface Spec extends TurboModule {
 ::_MODULE_MEMBERS_::
@@ -122,7 +121,8 @@ function translateAlias(
   name: string,
   type: NativeModuleObjectTypeAnnotation,
 ): string {
-  return `interface ${name} {
+  return `
+export interface ${name} {
 ${type.properties
   .map((prop: ObjectProp) => {
     return `  ${prop.name}${optionalSign(prop)}: ${translateType(
@@ -130,7 +130,8 @@ ${type.properties
     )};`;
   })
   .join('\n')}
-}`;
+}
+`;
 }
 
 function tryGetConstantType(
@@ -205,7 +206,7 @@ export function generateTypeScript(
 
       const aliasCode = Object.keys(nativeModule.aliases)
         .map((name) => translateAlias(name, nativeModule.aliases[name]))
-        .join('\n\n');
+        .join('');
 
       const constantType = tryGetConstantType(nativeModule);
       const constantCode =

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+import {SchemaType} from 'react-native-tscodegen';
+
+type FilesOutput = Map<string, string>;
+
+const moduleTemplate = `
+/*
+ * This file is auto-generated from a NativeModule spec file in js.
+ *
+ * This is a TypeScript turbo module definition file.
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+'use strict';
+
+export interface Spec extends TurboModule {
+::_MODULE_MEMBERS_::
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('::_MODULE_NAME_::');
+`;
+
+export function createTypeScriptGenerator() {
+  return (
+    _libraryName: string,
+    schema: SchemaType,
+    _moduleSpecName: string,
+  ): FilesOutput => {
+    const files = new Map<string, string>();
+
+    for (const moduleName of Object.keys(schema.modules)) {
+      const nativeModule = schema.modules[moduleName];
+      // from 0.65 facebook's react-native-codegen
+      // the module name has the Native prefix comparing to 0.63
+      // when reading files we provided
+      const preferredModuleName = moduleName.startsWith('Native')
+        ? moduleName.substr(6)
+        : moduleName;
+
+      if (nativeModule.type === 'NativeModule') {
+        console.log(`Generating Native${preferredModuleName}Spec.g.ts`);
+
+        files.set(
+          `Native${preferredModuleName}Spec.g.ts`,
+          moduleTemplate
+            .replace(/::_MODULE_MEMBERS_::/g, '')
+            .replace(/::_MODULE_NAME_::/g, preferredModuleName),
+        );
+      }
+    }
+
+    return files;
+  };
+}

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -31,9 +31,8 @@ const moduleTemplate = `
  */
 
 // the following import statements are not actually working today
-import {TurboModule, RootTag} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
-import {Int32, Float, Double} from 'react-native/Libraries/Types/CodegenTypes';
 'use strict';
 ::_MODULE_ALIASED_STRUCTS_::
 export interface Spec extends TurboModule {
@@ -60,13 +59,10 @@ function translateType(
     case 'StringTypeAnnotation':
       return 'string';
     case 'NumberTypeAnnotation':
-      return 'number';
     case 'FloatTypeAnnotation':
-      return 'Float';
     case 'DoubleTypeAnnotation':
-      return 'Double';
     case 'Int32TypeAnnotation':
-      return 'Int32';
+      return 'number';
     case 'BooleanTypeAnnotation':
       return 'boolean';
     case 'ArrayTypeAnnotation':
@@ -94,7 +90,7 @@ function translateType(
         throw new Error(
           `Unknown reserved function: ${name} in translateReturnType`,
         );
-      return 'RootTag';
+      return 'number';
     }
     case 'TypeAliasTypeAnnotation':
       return type.name;

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -6,8 +6,16 @@
 
 'use strict';
 
-import {SchemaType} from 'react-native-tscodegen';
+import {
+  NamedShape,
+  NativeModuleBaseTypeAnnotation,
+  NativeModuleObjectTypeAnnotation,
+  NativeModuleSchema,
+  Nullable,
+  SchemaType,
+} from 'react-native-tscodegen';
 
+type ObjectProp = NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>;
 type FilesOutput = Map<string, string>;
 
 const moduleTemplate = `
@@ -17,16 +25,115 @@ const moduleTemplate = `
  * This is a TypeScript turbo module definition file.
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+import {Int32, Float, Double, RootTag} from 'react-native/Libraries/Types/CodegenTypes';
 'use strict';
 
+::_MODULE_ALIASED_STRUCTS_::
 export interface Spec extends TurboModule {
 ::_MODULE_MEMBERS_::
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('::_MODULE_NAME_::');
 `;
+
+function translateType(type: Nullable<NativeModuleBaseTypeAnnotation>): string {
+  // avoid: Property 'type' does not exist on type 'never'
+  const returnType = type.type;
+  switch (type.type) {
+    case 'StringTypeAnnotation':
+      return 'string';
+    case 'NumberTypeAnnotation':
+      return 'number';
+    case 'FloatTypeAnnotation':
+      return 'Float';
+    case 'DoubleTypeAnnotation':
+      return 'Double';
+    case 'Int32TypeAnnotation':
+      return 'Int32';
+    case 'BooleanTypeAnnotation':
+      return 'boolean';
+    case 'ArrayTypeAnnotation':
+      if (type.elementType) {
+        return `${translateType(type.elementType)}[]>`;
+      } else {
+        return `Array`;
+      }
+    case 'GenericObjectTypeAnnotation':
+      return 'object';
+    case 'ObjectTypeAnnotation':
+      return `{${type.properties
+        .map((prop: ObjectProp) => {
+          return `${prop.name}${prop.optional ? '?' : ''}: ${translateType(
+            prop.typeAnnotation,
+          )}`;
+        })
+        .join(', ')}}`;
+    case 'ReservedTypeAnnotation': {
+      // avoid: Property 'name' does not exist on type 'never'
+      const name = type.name;
+      // (#6597)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (name !== 'RootTag')
+        throw new Error(
+          `Unknown reserved function: ${name} in translateReturnType`,
+        );
+      return 'RootTag';
+    }
+    case 'TypeAliasTypeAnnotation':
+      return type.name;
+    case 'NullableTypeAnnotation':
+      return `(${translateType(type.typeAnnotation)} | null | undefined)`;
+    default:
+      throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
+  }
+}
+
+function translateAlias(
+  name: string,
+  type: NativeModuleObjectTypeAnnotation,
+): string {
+  return `interface ${name} {
+${type.properties
+  .map((prop: ObjectProp) => {
+    return `  ${prop.name}${prop.optional ? '?' : ''}: ${translateType(
+      prop.typeAnnotation,
+    )};`;
+  })
+  .join('\n')}
+}`;
+}
+
+export function tryGetConstantType(
+  nativeModule: NativeModuleSchema,
+): NativeModuleObjectTypeAnnotation | undefined {
+  const candidates = nativeModule.spec.properties.filter(
+    (prop) => prop.name === 'getConstants',
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const getConstant = candidates[0];
+  const funcType =
+    getConstant.typeAnnotation.type === 'NullableTypeAnnotation'
+      ? getConstant.typeAnnotation.typeAnnotation
+      : getConstant.typeAnnotation;
+  if (
+    funcType.params.length > 0 ||
+    funcType.returnTypeAnnotation.type !== 'ObjectTypeAnnotation'
+  ) {
+    return undefined;
+  }
+
+  const constantType = funcType.returnTypeAnnotation;
+  if (constantType.properties.length === 0) {
+    return undefined;
+  }
+
+  return constantType;
+}
 
 export function createTypeScriptGenerator() {
   return (
@@ -48,10 +155,21 @@ export function createTypeScriptGenerator() {
       if (nativeModule.type === 'NativeModule') {
         console.log(`Generating ${preferredModuleName}Spec.g.ts`);
 
+        const aliasCode = Object.keys(nativeModule.aliases)
+          .map((name) => translateAlias(name, nativeModule.aliases[name]))
+          .join('\n\n');
+
+        const constantType = tryGetConstantType(nativeModule);
+        const constantCode =
+          constantType === undefined ? '' : `  getConstants(): ${constantType}`;
+
+        const membersCode = '';
+
         files.set(
           `${preferredModuleName}Spec.g.ts`,
           moduleTemplate
-            .replace(/::_MODULE_MEMBERS_::/g, '')
+            .replace(/::_MODULE_ALIASED_STRUCTS_::/g, aliasCode)
+            .replace(/::_MODULE_MEMBERS_::/g, constantCode + membersCode)
             .replace(/::_MODULE_NAME_::/g, preferredModuleName),
         );
       }

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -183,52 +183,50 @@ function translateMethod(func: FunctionDecl): string {
   }`;
 }
 
-export function createTypeScriptGenerator() {
-  return (
-    _libraryName: string,
-    schema: SchemaType,
-    _moduleSpecName: string,
-  ): FilesOutput => {
-    const files = new Map<string, string>();
+export function generateTypeScript(
+  _libraryName: string,
+  schema: SchemaType,
+  _moduleSpecName: string,
+): FilesOutput {
+  const files = new Map<string, string>();
 
-    for (const moduleName of Object.keys(schema.modules)) {
-      const nativeModule = schema.modules[moduleName];
-      // from 0.65 facebook's react-native-codegen
-      // the module name has the Native prefix comparing to 0.63
-      // when reading files we provided
-      const nativePrefix = 'Native';
-      const preferredModuleName = moduleName.startsWith(nativePrefix)
-        ? moduleName.substr(nativePrefix.length)
-        : moduleName;
+  for (const moduleName of Object.keys(schema.modules)) {
+    const nativeModule = schema.modules[moduleName];
+    // from 0.65 facebook's react-native-codegen
+    // the module name has the Native prefix comparing to 0.63
+    // when reading files we provided
+    const nativePrefix = 'Native';
+    const preferredModuleName = moduleName.startsWith(nativePrefix)
+      ? moduleName.substr(nativePrefix.length)
+      : moduleName;
 
-      if (nativeModule.type === 'NativeModule') {
-        console.log(`Generating ${preferredModuleName}Spec.g.ts`);
+    if (nativeModule.type === 'NativeModule') {
+      console.log(`Generating ${preferredModuleName}Spec.g.ts`);
 
-        const aliasCode = Object.keys(nativeModule.aliases)
-          .map((name) => translateAlias(name, nativeModule.aliases[name]))
-          .join('\n\n');
+      const aliasCode = Object.keys(nativeModule.aliases)
+        .map((name) => translateAlias(name, nativeModule.aliases[name]))
+        .join('\n\n');
 
-        const constantType = tryGetConstantType(nativeModule);
-        const constantCode =
-          constantType === undefined
-            ? ''
-            : `  getConstants(): ${translateType(constantType)}`;
+      const constantType = tryGetConstantType(nativeModule);
+      const constantCode =
+        constantType === undefined
+          ? ''
+          : `  getConstants(): ${translateType(constantType)}`;
 
-        const methods = nativeModule.spec.properties.filter(
-          (prop) => prop.name !== 'getConstants',
-        );
-        const membersCode = methods.map(translateMethod).join('');
+      const methods = nativeModule.spec.properties.filter(
+        (prop) => prop.name !== 'getConstants',
+      );
+      const membersCode = methods.map(translateMethod).join('');
 
-        files.set(
-          `${preferredModuleName}Spec.g.ts`,
-          moduleTemplate
-            .replace(/::_MODULE_ALIASED_STRUCTS_::/g, aliasCode)
-            .replace(/::_MODULE_MEMBERS_::/g, constantCode + membersCode)
-            .replace(/::_MODULE_NAME_::/g, preferredModuleName),
-        );
-      }
+      files.set(
+        `${preferredModuleName}Spec.g.ts`,
+        moduleTemplate
+          .replace(/::_MODULE_ALIASED_STRUCTS_::/g, aliasCode)
+          .replace(/::_MODULE_MEMBERS_::/g, constantCode + membersCode)
+          .replace(/::_MODULE_NAME_::/g, preferredModuleName),
+      );
     }
+  }
 
-    return files;
-  };
+  return files;
 }

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -102,11 +102,13 @@ function translateType(
     case 'PromiseTypeAnnotation':
       return `Promise`;
     case `FunctionTypeAnnotation`:
-      return `((${type.params.map((param: FunctionParam) => {
-        return `${param.name}${param.optional ? '?' : ''}: ${translateType(
-          param.typeAnnotation,
-        )},`;
-      })}) => ${translateType(type.returnTypeAnnotation)})`;
+      return `((${type.params
+        .map((param: FunctionParam) => {
+          return `${param.name}${param.optional ? '?' : ''}: ${translateType(
+            param.typeAnnotation,
+          )}`;
+        })
+        .join(', ')}) => ${translateType(type.returnTypeAnnotation)})`;
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }
@@ -164,11 +166,13 @@ function translateMethod(func: FunctionDecl): string {
       : func.typeAnnotation;
 
   return `
-  ${func.name}(${funcType.params.map((param: FunctionParam) => {
-    return `${param.name}${param.optional ? '?' : ''}: ${translateType(
-      param.typeAnnotation,
-    )},`;
-  })})${func.optional ? '?' : ''}: ${translateType(
+  ${func.name}(${funcType.params
+    .map((param: FunctionParam) => {
+      return `${param.name}${param.optional ? '?' : ''}: ${translateType(
+        param.typeAnnotation,
+      )}`;
+    })
+    .join(', ')})${func.optional ? '?' : ''}: ${translateType(
     funcType.returnTypeAnnotation,
   )}${
     funcType.returnTypeAnnotation.type === 'ObjectTypeAnnotation' ? '' : ';'

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -170,7 +170,9 @@ function translateMethod(func: FunctionDecl): string {
     )},`;
   })})${func.optional ? '?' : ''}: ${translateType(
     funcType.returnTypeAnnotation,
-  )};`;
+  )}${
+    funcType.returnTypeAnnotation.type === 'ObjectTypeAnnotation' ? '' : ';'
+  }`;
 }
 
 export function createTypeScriptGenerator() {
@@ -206,7 +208,7 @@ export function createTypeScriptGenerator() {
         const methods = nativeModule.spec.properties.filter(
           (prop) => prop.name !== 'getConstants',
         );
-        const membersCode = methods.map(translateMethod);
+        const membersCode = methods.map(translateMethod).join('');
 
         files.set(
           `${preferredModuleName}Spec.g.ts`,

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -97,6 +97,16 @@ function translateType(
       return type.name;
     case 'NullableTypeAnnotation':
       return `(${translateType(type.typeAnnotation)} | null | undefined)`;
+    case 'VoidTypeAnnotation':
+      return `void`;
+    case 'PromiseTypeAnnotation':
+      return `Promise`;
+    case `FunctionTypeAnnotation`:
+      return `((${type.params.map((param: FunctionParam) => {
+        return `${param.name}${param.optional ? '?' : ''}: ${translateType(
+          param.typeAnnotation,
+        )},`;
+      })}) => ${translateType(type.returnTypeAnnotation)})`;
     default:
       throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
   }


### PR DESCRIPTION
## Description
Add TypeScript turbo module definition as new codegen target.
It is not triggered in `yarn build` in this repo.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The final goal is to bring type safety to `ISS/Rex.ts`. and `ISS/Rex.cpp` This would done in multiple changing to both repos.

### What
New features are added to `@react-native-windows/codegen`:
- `--ts`: Print TypeScript turbo module definition from flow, default to `false` for backward compabitility
- `--outdir`: Change the output directory, default to `codegen` for backward compatibility

### Known Issue
Facebook's turbo module codegen front-end doesn't support `Int64`, which could create problems as we need it. As JavaScript cannot actually store an `Int64`, maybe the native module should be changed to use string instead.

Import statements in generated TypeScript spec file are not working today.

## Testing
The following files **are not included** in this PR, they are created to show how it is going to work for `ISS/Rex.ts`:
- [Rex.js](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/src/Libraries/Utilities/Rex.js): define `Rex` native module in flow as a turbo module, it should be fine because turbo module and native module are compatible to each other.
- [NativeRexSpec.g.h](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/codegen-rex/NativeRexSpec.g.h): C++ spec output, to create a type check for the native module defined in `ISS/Rex.cpp` (line:167).
- [RexSpec.g.ts](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/codegen-rex/RexSpec.g.ts): TypeScript spec output, to create a strong-typed replacement for `NativeModule.Rex` in `ISS/Rex.ts`.

At this moment I have not finished testing ISS against the generated code yet, it will be done soon.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9588)