### PR TITLE
Add wrap-reverse to flex wrap options

### DIFF
--- a/change/react-native-windows-2345d670-7aa7-4de1-91e0-692025d93223.json
+++ b/change/react-native-windows-2345d670-7aa7-4de1-91e0-692025d93223.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add wrap-reverse to flex wrap options",
+  "packageName": "react-native-windows",
+  "email": "axelfratoni@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -456,6 +456,8 @@ static void StyleYogaNode(
         wrap = YGWrapNoWrap;
       else if (value == "wrap")
         wrap = YGWrapWrap;
+      else if (value == "wrap-reverse")
+        wrap = YGWrapWrapReverse;
       else
         assert(false);
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
`flexWrap: "wrap-reverse"` style property makes react-native-windows apps crash.

Resolves [#9569: Using flexWrap: "wrap-reverse" on a View component makes the app crash](https://github.com/microsoft/react-native-windows/issues/9569)

### What
Add `wrap-reverse` value to `NativeUIManager`.

## Testing
After adding this value, I verified that the `wrap-reverse` behavior worked properly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9589)