### PR TITLE
[0.67] Expose InlineSourceMap property

### DIFF
--- a/change/react-native-windows-d48d7a10-2970-40aa-9ee8-b874def5fff2.json
+++ b/change/react-native-windows-d48d7a10-2970-40aa-9ee8-b874def5fff2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose InlineSourceMap property",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d48d7a10-2970-40aa-9ee8-b874def5fff2.json
+++ b/change/react-native-windows-d48d7a10-2970-40aa-9ee8-b874def5fff2.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Expose InlineSourceMap property",
   "packageName": "react-native-windows",
   "email": "tudor.mihai@microsoft.com",

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -99,6 +99,10 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  bool RequestInlineSourceMap() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   hstring JavaScriptBundleFile() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -186,6 +186,10 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  bool RequestInlineSourceMap() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   hstring JavaScriptBundleFile() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -322,6 +322,8 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public string SourceBundleHost => throw new NotImplementedException();
 
     public ushort SourceBundlePort => throw new NotImplementedException();
+
+    public bool RequestInlineSourceMap => throw new NotImplementedException();
   }
 
   class ReactContextMock : IReactContext

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -53,6 +53,10 @@ uint16_t ReactSettingsSnapshot::SourceBundlePort() const noexcept {
   return m_settings->SourceBundlePort();
 }
 
+bool ReactSettingsSnapshot::RequestInlineSourceMap() const noexcept {
+  return m_settings->RequestInlineSourceMap();
+}
+
 hstring ReactSettingsSnapshot::JavaScriptBundleFile() const noexcept {
   return winrt::to_hstring(m_settings->JavaScriptBundleFile());
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -21,6 +21,7 @@ struct ReactSettingsSnapshot : winrt::implements<ReactSettingsSnapshot, IReactSe
   hstring BundleRootPath() const noexcept;
   hstring SourceBundleHost() const noexcept;
   uint16_t SourceBundlePort() const noexcept;
+  bool RequestInlineSourceMap() const noexcept;
   hstring JavaScriptBundleFile() const noexcept;
 
  public:
@@ -57,8 +58,8 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
       JSValueArgWriter const &paramsArgWriter) noexcept;
 
  public: // IReactContext
-  // Not part of the public ABI interface
-  // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods
+         // Not part of the public ABI interface
+         // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods
   Mso::React::IReactContext &GetInner() const noexcept;
 
  private:

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -85,6 +85,12 @@ namespace Microsoft.ReactNative
     UInt16 SourceBundlePort { get; };
 
     DOC_STRING(
+      "A read-only snapshot of the @ReactInstanceSettings.RequestInlineSourceMap property value "
+      "at the time when the React instance was created.\n"
+      "If set, the bundler will include the source maps inline (this will improve debugging experience, but for very large bundles it could have a significant performance hit)")
+    Boolean RequestInlineSourceMap { get; };
+
+    DOC_STRING(
       "A read-only snapshot of the @ReactInstanceSettings.JavaScriptBundleFile property value "
       "at the time when the React instance was created.\n"
       "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -102,6 +102,7 @@ struct IReactSettingsSnapshot : IUnknown {
   virtual std::string BundleRootPath() const noexcept = 0;
   virtual std::string SourceBundleHost() const noexcept = 0;
   virtual uint16_t SourceBundlePort() const noexcept = 0;
+  virtual bool RequestInlineSourceMap() const noexcept = 0;
   virtual std::string JavaScriptBundleFile() const noexcept = 0;
   virtual bool UseDeveloperSupport() const noexcept = 0;
   virtual JSIEngine JsiEngine() const noexcept = 0;
@@ -149,6 +150,7 @@ struct ReactDevOptions {
   //! Specify a value for a component, or leave empty to use the default.
   std::string SourceBundleHost; // Host domain (without port) for the bundler server. Default: "localhost".
   uint16_t SourceBundlePort{0}; // Host port for the bundler server. Default: "8081".
+  bool RequestInlineSourceMap{true}; // Request the source map inline
   std::string SourceBundleName; // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
   std::string SourceBundleExtension; // Bundle name extension. Default: ".bundle".
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.cpp
@@ -79,6 +79,13 @@ uint16_t ReactSettingsSnapshot::SourceBundlePort() const noexcept {
   return 0;
 }
 
+bool ReactSettingsSnapshot::RequestInlineSourceMap() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->RequestInlineSourceMap();
+  }
+  return false;
+}
+
 std::string ReactSettingsSnapshot::JavaScriptBundleFile() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->JavaScriptBundleFile();

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactContext.h
@@ -27,6 +27,7 @@ class ReactSettingsSnapshot final : public Mso::UnknownObject<IReactSettingsSnap
   std::string BundleRootPath() const noexcept override;
   std::string SourceBundleHost() const noexcept override;
   uint16_t SourceBundlePort() const noexcept override;
+  bool RequestInlineSourceMap() const noexcept override;
   std::string JavaScriptBundleFile() const noexcept override;
   bool UseDeveloperSupport() const noexcept override;
   JSIEngine JsiEngine() const noexcept override;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -383,6 +383,7 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->useJITCompilation = m_options.EnableJITCompilation;
           devSettings->sourceBundleHost = SourceBundleHost();
           devSettings->sourceBundlePort = SourceBundlePort();
+          devSettings->inlineSourceMap = RequestInlineSourceMap();
           devSettings->debugBundlePath = DebugBundlePath();
           devSettings->liveReloadCallback = GetLiveReloadCallback();
           devSettings->errorCallback = GetErrorCallback();
@@ -443,7 +444,6 @@ void ReactInstanceWin::Initialize() noexcept {
             case JSIEngine::Hermes:
               devSettings->jsiRuntimeHolder =
                   std::make_shared<facebook::react::HermesRuntimeHolder>(devSettings, m_jsMessageThread.Load());
-              devSettings->inlineSourceMap = false;
               break;
             case JSIEngine::V8:
 #if defined(USE_V8)
@@ -1059,6 +1059,10 @@ std::string ReactInstanceWin::SourceBundleHost() const noexcept {
 uint16_t ReactInstanceWin::SourceBundlePort() const noexcept {
   return m_options.DeveloperSettings.SourceBundlePort ? m_options.DeveloperSettings.SourceBundlePort
                                                       : facebook::react::DevServerHelper::DefaultPackagerPort;
+}
+
+bool ReactInstanceWin::RequestInlineSourceMap() const noexcept {
+  return m_options.DeveloperSettings.RequestInlineSourceMap;
 }
 
 JSIEngine ReactInstanceWin::JsiEngine() const noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -78,6 +78,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   std::string BundleRootPath() const noexcept;
   std::string SourceBundleHost() const noexcept;
   uint16_t SourceBundlePort() const noexcept;
+  bool RequestInlineSourceMap() const noexcept;
   std::string JavaScriptBundleFile() const noexcept;
   bool UseDeveloperSupport() const noexcept;
   JSIEngine JsiEngine() const noexcept;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -130,6 +130,9 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   uint16_t SourceBundlePort() noexcept;
   void SourceBundlePort(uint16_t value) noexcept;
 
+  bool RequestInlineSourceMap() noexcept;
+  void RequestInlineSourceMap(bool value) noexcept;
+
   JSIEngine JSIEngineOverride() noexcept;
   void JSIEngineOverride(JSIEngine value) noexcept;
 
@@ -174,6 +177,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   hstring m_sourceBundleHost{};
   hstring m_debuggerRuntimeName{};
   uint16_t m_sourceBundlePort{0};
+  bool m_requestInlineSourceMap{true};
   LogHandler m_nativeLogger{nullptr};
 
 #if USE_HERMES
@@ -306,6 +310,14 @@ inline uint16_t ReactInstanceSettings::SourceBundlePort() noexcept {
 
 inline void ReactInstanceSettings::SourceBundlePort(uint16_t value) noexcept {
   m_sourceBundlePort = value;
+}
+
+inline bool ReactInstanceSettings::RequestInlineSourceMap() noexcept {
+  return m_requestInlineSourceMap;
+}
+
+inline void ReactInstanceSettings::RequestInlineSourceMap(bool value) noexcept {
+  m_requestInlineSourceMap = value;
 }
 
 inline JSIEngine ReactInstanceSettings::JSIEngineOverride() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -204,16 +204,22 @@ namespace Microsoft.ReactNative
     IReactDispatcher UIDispatcher { get; set; };
 
     DOC_STRING(
-      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server hostname "
+      "When using @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server hostname "
       "that will be used to load the bundle from.")
     DOC_DEFAULT("localhost")
     String SourceBundleHost { get; set; };
 
     DOC_STRING(
-      "When using a @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server port "
+      "When using @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this is the server port "
       "that will be used to load the bundle from.")
     DOC_DEFAULT("8081")
     UInt16 SourceBundlePort { get; set; };
+
+    DOC_STRING(
+      "When using @.UseFastRefresh, @.UseLiveReload, or @.UseWebDebugger this controls whether the bundler should include inline source maps."
+      "If set, the bundler will include the source maps inline (this will improve debugging experience, but for very large bundles it could have a significant performance hit)")
+    DOC_DEFAULT("true")
+    Boolean RequestInlineSourceMap { get; set; };
 
     DOC_STRING(
       "The @JSIEngine override to be used with the React instance.\n"

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -132,6 +132,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   }
   reactOptions.DeveloperSettings.SourceBundleHost = to_string(m_instanceSettings.SourceBundleHost());
   reactOptions.DeveloperSettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
+  reactOptions.DeveloperSettings.RequestInlineSourceMap = m_instanceSettings.RequestInlineSourceMap();
 
   reactOptions.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
   reactOptions.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -372,7 +372,6 @@ InstanceImpl::InstanceImpl(
       switch (m_devSettings->jsiEngineOverride) {
         case JSIEngineOverride::Hermes:
           m_devSettings->jsiRuntimeHolder = std::make_shared<HermesRuntimeHolder>(m_devSettings, m_jsThread);
-          m_devSettings->inlineSourceMap = false;
           break;
         case JSIEngineOverride::V8: {
 #if defined(USE_V8)


### PR DESCRIPTION
## Description
Give applications the ability to control the InlineSourceMap property value.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We are currently hardcoding this to false for Hermes, because back in 2020 Hermes was choking with any inline source map larger than a few kilobytes. Things appear to work much better now, so the property will default to true, and -with this change- can be overridden by individual apps if needed.

Addresses the source map concern in #9407.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9592)