### PR TITLE
Fix tag handling for foreign UI elements

### DIFF
--- a/change/react-native-windows-0b30a99b-f579-48be-9dd3-fcbae6d5bd54.json
+++ b/change/react-native-windows-0b30a99b-f579-48be-9dd3-fcbae6d5bd54.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix tag handling to allow non-RNW elements in the scene (e.g. AdaptiveCards)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentViewRegistry.cpp
@@ -60,7 +60,7 @@ ComponentViewDescriptor const &ComponentViewRegistry::dequeueComponentViewWithCo
     view = std::make_shared<ViewComponentView>();
   }
 
-  view->Element().Tag(winrt::box_value(tag));
+  SetTag(view->Element(), tag);
   auto it = m_registry.insert({tag, ComponentViewDescriptor{view}});
   return it.first->second;
 }
@@ -79,6 +79,6 @@ void ComponentViewRegistry::enqueueComponentViewWithComponentHandle(
   assert(m_registry.find(tag) != m_registry.end());
 
   m_registry.erase(tag);
-  static_cast<ViewComponentView &>(*componentViewDescriptor.view).Element().Tag(nullptr);
+  SetTag(static_cast<ViewComponentView &>(*componentViewDescriptor.view).Element(), nullptr);
 }
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentViewRegistry.cpp
@@ -25,6 +25,7 @@
 #include "ScrollViewComponentView.h"
 #include "TextComponentView.h"
 #include "ViewComponentView.h"
+#include "XamlView.h"
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -236,7 +236,7 @@ void NativeUIManager::AddRootView(ShadowNode &shadowNode, facebook::react::IReac
   m_tagsToYogaNodes.emplace(shadowNode.m_tag, make_yoga_node(m_yogaConfig));
 
   auto element = view.as<xaml::FrameworkElement>();
-  element.Tag(winrt::PropertyValue::CreateInt64(shadowNode.m_tag));
+  Microsoft::ReactNative::SetTag(element, shadowNode.m_tag);
 
   // Add listener to size change so we can redo the layout when that happens
   m_sizeChangedVector.push_back(
@@ -980,7 +980,7 @@ void NativeUIManager::measure(
   int64_t childTag = rootTag;
   while (true) {
     auto &currNode = m_host->GetShadowNodeForTag(rootTag);
-    if (currNode.m_parent == -1)
+    if (currNode.m_parent == InvalidTag)
       break;
     ShadowNodeBase &rootNode = static_cast<ShadowNodeBase &>(currNode);
     if (rootNode.IsWindowed()) {
@@ -1094,9 +1094,9 @@ void NativeUIManager::findSubviewIn(
 
   for (const auto &elem : hitTestElements) {
     if (foundElement = elem.try_as<xaml::FrameworkElement>()) {
-      auto tag = foundElement.Tag();
-      if (tag != nullptr) {
-        foundTag = tag.as<winrt::IPropertyValue>().GetInt64();
+      auto tag = GetTag(foundElement);
+      if (tag != InvalidTag) {
+        foundTag = tag;
         break;
       }
     }

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -167,7 +167,7 @@ bool ImageViewManager::UpdateProperty(
 }
 
 void ImageViewManager::EmitImageEvent(winrt::Grid grid, const char *eventName, ReactImageSource &source) {
-  int64_t tag = grid.Tag().as<winrt::IPropertyValue>().GetInt64();
+  int64_t tag = GetTag(grid);
   folly::dynamic imageSource =
       folly::dynamic::object()("uri", source.uri)("width", source.width)("height", source.height);
 

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -411,7 +411,7 @@ facebook::react::SharedEventEmitter EventEmitterForElement(
     if (element = parent.try_as<xaml::FrameworkElement>()) {
       auto elementTag = GetTag(element);
       if (elementTag != InvalidTag) {
-        if (tag = static_cast<facebook::react::Tag>(elementTag))
+        if ((tag = static_cast<facebook::react::Tag>(elementTag)) != InvalidTag)
           return EventEmitterForElement(uimanager, tag);
       }
     }

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -329,7 +329,7 @@ void TouchEventHandler::UpdatePointersInViews(
     } else {
       // newViews is empty when UpdatePointersInViews is called from outside
       // the root view, in this case use -1 for the JS event pointer target
-      const auto tag = !newViews.empty() ? newViews.front() : -1;
+      const auto tag = !newViews.empty() ? newViews.front() : InvalidTag;
       pointer = CreateReactPointer(args, tag, sourceElement);
     }
 
@@ -409,9 +409,9 @@ facebook::react::SharedEventEmitter EventEmitterForElement(
   auto element = view->Element();
   while (auto parent = element.Parent()) {
     if (element = parent.try_as<xaml::FrameworkElement>()) {
-      auto boxedTag = element.Tag();
-      if (boxedTag) {
-        if (tag = winrt::unbox_value<facebook::react::Tag>(element.Tag()))
+      auto elementTag = GetTag(element);
+      if (elementTag != InvalidTag) {
+        if (tag = static_cast<facebook::react::Tag>(elementTag))
           return EventEmitterForElement(uimanager, tag);
       }
     }
@@ -806,7 +806,7 @@ std::vector<int64_t> GetTagsForBranch(INativeUIManagerHost *host, int64_t tag, i
   std::vector<int64_t> tags;
 
   auto *shadowNode = host->FindShadowNodeForTag(tag);
-  while (shadowNode != nullptr && tag != -1) {
+  while (shadowNode != nullptr && tag != InvalidTag) {
     if (tag == rootTag) {
       break;
     }

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -46,7 +46,7 @@ TouchEventHandler::~TouchEventHandler() {
 }
 
 void TouchEventHandler::AddTouchHandlers(XamlView xamlView, XamlView rootView, bool handledEventsToo) {
-  auto uiElement(xamlView.as<xaml::UIElement>());
+  auto uiElement(xamlView.try_as<xaml::UIElement>());
   if (uiElement == nullptr) {
     assert(false);
     return;

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -37,7 +37,7 @@ void XamlUIService::DispatchEvent(
     JSValueArgWriter const &eventDataArgWriter) noexcept {
   auto paramsWriter = winrt::make_self<DynamicWriter>();
   paramsWriter->WriteArrayBegin();
-  paramsWriter->WriteInt64(unbox_value<int64_t>(view.Tag()));
+  paramsWriter->WriteInt64(::Microsoft::ReactNative::GetTag(view));
   paramsWriter->WriteString(eventName);
   if (eventDataArgWriter) {
     eventDataArgWriter(*paramsWriter);

--- a/vnext/Microsoft.ReactNative/XamlView.h
+++ b/vnext/Microsoft.ReactNative/XamlView.h
@@ -8,14 +8,19 @@
 namespace Microsoft::ReactNative {
 
 using XamlView = xaml::DependencyObject;
+constexpr int64_t InvalidTag = -1;
 
 inline int64_t GetTag(XamlView view) {
   auto tagValue = view.ReadLocalValue(xaml::FrameworkElement::TagProperty());
   if (tagValue != xaml::DependencyProperty::UnsetValue()) {
-    return tagValue.as<winrt::IPropertyValue>().GetInt64();
-  } else {
-    return -1;
+    if (auto tagValueInt = tagValue.try_as<winrt::IPropertyValue>()) {
+      if (tagValueInt.Type() == winrt::PropertyType::Int64) {
+        return tagValueInt.GetInt64();
+      }
+    }
   }
+
+  return InvalidTag;
 }
 
 inline void SetTag(XamlView view, int64_t tag) {


### PR DESCRIPTION
## Description
We are making some incorrect assumptions about where UI elements come from (we expect RNW to be responsible for all of the XAML UI in a scene). Therefore we expect that the `Tag` will be set, and not only that, that it will be an int, and that it will represent a react tag.

This works fine for a pure RNW app. When hosting non-RNW content, e.g. when adding AdaptiveCards, this assumption breaks down, as AC will set its own WinRT object as the XAML element's Tag.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

Resolves #9560 

### What
Centralize getting/setting the tag to one single place. 
In the future we can change this logic to make the assumption less flimsy. For example, we still assume that if it is an int, it will be a react tag. We could do the same as what AC does and set the tag to be a strongly typed object that we can key off of to identify a UI element created by RNW.

## Testing
Ran the app provided by HP that illustrates the repro, verified it doesn't crash anymore.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9593)