### PR TITLE
[0.66] Crash when getting Platform.osVersion on Windows 8.1

### DIFF
--- a/change/react-native-windows-daade875-fb12-466a-977d-34ee3c6b8f76.json
+++ b/change/react-native-windows-daade875-fb12-466a-977d-34ee3c6b8f76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Crash when getting Platform.osVersion on Windows 8.1",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/PlatformConstantsModule.cpp
+++ b/vnext/Shared/Modules/PlatformConstantsModule.cpp
@@ -60,6 +60,10 @@ std::map<std::string, folly::dynamic> PlatformConstantsModule::getConstants() {
 }
 
 /*static*/ int32_t PlatformConstantsModule::OsVersion() noexcept {
+  if (!IsWindows10OrGreater()) {
+    return -1;
+  }
+
   for (uint16_t i = 1;; ++i) {
     if (!ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", i)) {
       return i - 1;


### PR DESCRIPTION
Port #9567 to 0.66

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9596)