### PR TITLE
[0.66] Enable TurboModule Promise completion from any thread (#9595)

### DIFF
--- a/change/react-native-windows-b38f3f2f-4014-40fd-8c40-6134c3630c30.json
+++ b/change/react-native-windows-b38f3f2f-4014-40fd-8c40-6134c3630c30.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable TurboModule Promise completion from any thread (#9595)",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -200,6 +200,9 @@
     <ClCompile Include="..\Microsoft.ReactNative\JsiWriter.cpp">
       <DependentUpon>..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="..\Microsoft.ReactNative\JSDispatcherWriter.cpp">
+      <DependentUpon>..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="..\Microsoft.ReactNative\Modules\DevSettingsModule.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />
@@ -275,6 +278,9 @@
       <DependentUpon>..\Microsoft.ReactNative\IJSValueReader.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="..\Microsoft.ReactNative\JsiWriter.h">
+      <DependentUpon>..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="..\Microsoft.ReactNative\JSDispatcherWriter.h">
       <DependentUpon>..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="..\Microsoft.ReactNative\ReactInstanceSettings.h">

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.cpp
@@ -39,14 +39,19 @@ using namespace std::literals::chrono_literals;
       auto const &expectedEvent = expectedEvents[observeEventIndex];
       TestCheckEqual(expectedEvent.EventName, loggedEvent.EventName);
       if (expectedEvent.EventName != loggedEvent.EventName) {
-        break; // Dont hang waiting for more data
+        std::stringstream os;
+        os << "Values:" << '\n'
+           << "Expected: " << expectedEvent.Value.ToString() << '\n'
+           << "Actual: " << loggedEvent.Value.ToString();
+        TestCheckFail("%s", os.str().c_str());
+        break; // Don't hang waiting for more data
       }
       if (auto d1 = expectedEvent.Value.TryGetDouble(), d2 = loggedEvent.Value.TryGetDouble(); d1 && d2) {
         // Comparison of doubles has special logic because NaN != NaN.
         if (!isnan(*d1) && !isnan(*d2)) {
           TestCheckEqual(*d1, *d2);
           if (*d1 != *d2) {
-            break; // Dont hang waiting for more data
+            break; // Don't hang waiting for more data
           }
         }
       } else if (expectedEvent.Value != loggedEvent.Value) { // Use JSValue strict compare
@@ -55,7 +60,7 @@ using namespace std::literals::chrono_literals;
            << "Expected: " << expectedEvent.Value.ToString() << '\n'
            << "Actual: " << loggedEvent.Value.ToString();
         TestCheckFail("%s", os.str().c_str());
-        break; // Dont hang waiting for more data
+        break; // Don't hang waiting for more data
       }
 
       ++observeEventIndex;

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -3,28 +3,156 @@
 
 #include "pch.h"
 #include <NativeModules.h>
+#include <ReactCommon/TurboModule.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <TurboModuleProvider.h> // It is RNW specific
+#include <dispatchQueue/dispatchQueue.h>
+#include <future/future.h>
 #include <sstream>
 #include <string>
 #include "TestEventService.h"
 #include "TestReactNativeHostHolder.h"
 
 using namespace winrt;
+using namespace facebook;
 using namespace Microsoft::ReactNative;
 
 namespace ReactNativeIntegrationTests {
-
+// Use anonymous namespace to avoid any linking conflicts
 namespace {
 
-REACT_MODULE(SampleTurboModule)
-struct SampleTurboModule {
+REACT_STRUCT(Point)
+struct Point {
+  REACT_FIELD(X, L"x")
+  int X;
+  REACT_FIELD(Y, L"y")
+  int Y;
+};
+
+#define INDEX(counterBase) (__COUNTER__ - counterBase)
+
+struct CppTurboModuleSpec : TurboModuleSpec {
+  static constexpr int c2 = __COUNTER__ + 1; // +1 to start INDEX() with zero
+  static constexpr auto methods = std::tuple{
+      SyncMethod<int(std::string, React::JSValue) noexcept>{INDEX(c2), L"logAction"},
+
+      Method<void(int, int, Callback<int>) noexcept>{INDEX(c2), L"add"},
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negate"},
+      Method<void(Callback<std::string>) noexcept>{INDEX(c2), L"sayHello"},
+
+      Method<void() noexcept>{INDEX(c2), L"sayHello0"},
+      Method<void(Point) noexcept>{INDEX(c2), L"printPoint"},
+      Method<void(Point, Point) noexcept>{INDEX(c2), L"printLine"},
+
+      Method<void(int, int, Callback<int>) noexcept>{INDEX(c2), L"addCallback"},
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negateCallback"},
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negateAsyncCallback"},
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negateDispatchQueueCallback"},
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negateFutureCallback"},
+      Method<void(Callback<std::string const &>) noexcept>{INDEX(c2), L"sayHelloCallback"},
+
+      Method<void(Callback<>) noexcept>{INDEX(c2), L"callbackZeroArgs"},
+      Method<void(Callback<int, int>) noexcept>{INDEX(c2), L"callbackTwoArgs"},
+      Method<void(Callback<int, int, std::string const &>) noexcept>{INDEX(c2), L"callbackThreeArgs"},
+
+      Method<void(int, int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"divideCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{
+          INDEX(c2),
+          L"negateDispatchQueueCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateFutureCallbacks"},
+      Method<void(Callback<std::string const &>, Callback<std::string const &>) noexcept>{
+          INDEX(c2),
+          L"resolveSayHelloCallbacks"},
+      Method<void(Callback<std::string const &>, Callback<std::string const &>) noexcept>{
+          INDEX(c2),
+          L"rejectSayHelloCallbacks"},
+
+      Method<void(bool, Callback<>, Callback<>) noexcept>{INDEX(c2), L"twoCallbacksZeroArgs"},
+      Method<void(bool, Callback<int, int>, Callback<int, int>) noexcept>{INDEX(c2), L"twoCallbacksTwoArgs"},
+      Method<void(bool, Callback<int, int, std::string const &>, Callback<int, int, std::string const &>) noexcept>{
+          INDEX(c2),
+          L"twoCallbacksThreeArgs"},
+
+      Method<void(int, int, ReactPromise<int>) noexcept>{INDEX(c2), L"dividePromise"},
+      Method<void(int, ReactPromise<int>) noexcept>{INDEX(c2), L"negatePromise"},
+      Method<void(int, ReactPromise<int>) noexcept>{INDEX(c2), L"negateAsyncPromise"},
+      Method<void(int, ReactPromise<int>) noexcept>{INDEX(c2), L"negateDispatchQueuePromise"},
+      Method<void(int, ReactPromise<int>) noexcept>{INDEX(c2), L"negateFuturePromise"},
+      Method<void(int, ReactPromise<void>) noexcept>{INDEX(c2), L"voidPromise"},
+      Method<void(ReactPromise<std::string>) noexcept>{INDEX(c2), L"resolveSayHelloPromise"},
+      Method<void(ReactPromise<std::string>) noexcept>{INDEX(c2), L"rejectSayHelloPromise"},
+
+      SyncMethod<int(int, int) noexcept>{INDEX(c2), L"addSync"},
+      SyncMethod<int(int) noexcept>{INDEX(c2), L"negateSync"},
+      SyncMethod<std::string() noexcept>{INDEX(c2), L"sayHelloSync"},
+  };
+
+  template <class TModule>
+  static constexpr void ValidateModule() noexcept {
+    static constexpr int c3 = __COUNTER__ + 1; // +1 to start INDEX() with zero
+    constexpr auto methodCheckResults = CheckMethods<TModule, CppTurboModuleSpec>();
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "logAction", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "add", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negate", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "sayHello", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "sayHello0", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "printPoint", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "printLine", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "addCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateAsyncCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDispatchQueueCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateFutureCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "sayHelloCallback", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "callbackZeroArgs", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "callbackTwoArgs", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "callbackThreeArgs", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "divideCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateAsyncCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDispatchQueueCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateFutureCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "resolveSayHelloCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "rejectSayHelloCallbacks", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "twoCallbacksZeroArgs", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "twoCallbacksTwoArgs", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "twoCallbacksThreeArgs", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "dividePromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negatePromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateAsyncPromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDispatchQueuePromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateFuturePromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "voidPromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "resolveSayHelloPromise", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "rejectSayHelloPromise", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "addSync", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateSync", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "sayHelloSync", "Generated error message with signatures");
+  }
+};
+
+REACT_MODULE(CppTurboModule)
+struct CppTurboModule {
+  using ModuleSpec = CppTurboModuleSpec;
+
   REACT_INIT(Initialize)
   void Initialize(ReactContext const & /*reactContext*/) noexcept {}
 
-  REACT_CONSTANT(m_constantString, L"constantString")
-  const std::string m_constantString{"constantString"};
+  REACT_CONSTANT(ConstantString, L"constantString")
+  const std::string ConstantString{"myConstantString"};
 
-  REACT_CONSTANT(m_constantInt, L"constantInt")
-  const int m_constantInt{3};
+  REACT_CONSTANT(ConstantInt, L"constantInt")
+  const int ConstantInt{3};
 
   REACT_CONSTANT_PROVIDER(GetConstants)
   void GetConstants(React::ReactConstantProvider &provider) noexcept {
@@ -32,130 +160,307 @@ struct SampleTurboModule {
     provider.Add(L"constantInt2", 10);
   }
 
-  REACT_METHOD(Succeeded, L"succeeded")
-  void Succeeded() noexcept {
-    TestEventService::LogEvent("succeededSignal", true);
+  REACT_SYNC_METHOD(LogAction, L"logAction")
+  int LogAction(std::string actionName, React::JSValue value) noexcept {
+    TestEventService::LogEvent(actionName, std::move(value));
+    return 0;
   }
 
-  REACT_METHOD(OnError, L"onError")
-  void OnError(std::string errorMessage) noexcept {
-    // intended to keep the parameter name for debug purpose
-    TestEventService::LogEvent("succeededSignal", false);
+  REACT_METHOD(Add, L"add")
+  int Add(int x, int y) noexcept {
+    return x + y;
   }
 
-  REACT_METHOD(PromiseFunction, L"promiseFunction")
-  void PromiseFunction(std::string a, int b, bool c, ReactPromise<React::JSValue> result) noexcept {
-    auto resultString = (std::stringstream() << a << ", " << b << ", " << (c ? "true" : "false")).str();
-    result.Resolve({resultString});
-    // TODO:
-    // calling ".then" in the bundle fails, figure out why
-    // it could be an issue about environment setup
-    // since the issue doesn't happen in Playground.sln
-    PromiseFunctionResult(resultString);
+  REACT_METHOD(Negate, L"negate")
+  int Negate(int x) noexcept {
+    return -x;
   }
 
-  REACT_METHOD(PromiseFunctionResult, L"promiseFunctionResult")
-  void PromiseFunctionResult(std::string a) noexcept {
-    TestEventService::LogEvent("promiseFunctionSignal", std::move(a));
+  REACT_METHOD(SayHello, L"sayHello")
+  std::string SayHello() noexcept {
+    return "Hello";
   }
 
-  REACT_SYNC_METHOD(SyncFunction, L"syncFunction")
-  std::string SyncFunction(std::string a, int b, bool c) noexcept {
-    auto resultString = (std::stringstream() << a << ", " << b << ", " << (c ? "true" : "false")).str();
-    return resultString;
+  REACT_METHOD(SayHello0, L"sayHello0")
+  void SayHello0() noexcept {
+    TestEventService::LogEvent("sayHello0", "Hello");
   }
 
-  REACT_METHOD(SyncFunctionResult, L"syncFunctionResult")
-  void SyncFunctionResult(std::string a) noexcept {
-    TestEventService::LogEvent("syncFunctionSignal", std::move(a));
+  REACT_METHOD(PrintPoint, L"printPoint")
+  void PrintPoint(Point pt) noexcept {
+    std::stringstream ss;
+    ss << "Point: (" << pt.X << ", " << pt.Y << ")";
+    TestEventService::LogEvent("printPoint", ss.str());
   }
 
-  REACT_METHOD(Constants, L"constants")
-  void Constants(std::string a, int b, std::string c, int d) noexcept {
-    auto resultString = (std::stringstream() << a << ", " << b << ", " << c << ", " << d).str();
-    TestEventService::LogEvent("constantsSignal", std::move(resultString));
+  REACT_METHOD(PrintLine, L"printLine")
+  void PrintLine(Point start, Point end) noexcept {
+    std::stringstream ss;
+    ss << "Line: (" << start.X << ", " << start.Y << ")-(" << end.X << ", " << end.Y << ")";
+    TestEventService::LogEvent("printLine", ss.str());
   }
 
-  REACT_METHOD(OneCallback, L"oneCallback")
-  void OneCallback(int a, int b, const std::function<void(int)> &resolve) noexcept {
-    resolve(a + b);
+  REACT_METHOD(AddCallback, L"addCallback")
+  void AddCallback(int x, int y, std::function<void(int)> const &resolve) noexcept {
+    resolve(x + y);
   }
 
-  REACT_METHOD(OneCallbackResult, L"oneCallbackResult")
-  void OneCallbackResult(int r) noexcept {
-    TestEventService::LogEvent("oneCallbackSignal", r);
+  REACT_METHOD(NegateCallback, L"negateCallback")
+  void NegateCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    resolve(-x);
   }
 
-  REACT_METHOD(TwoCallbacks, L"twoCallbacks")
-  void TwoCallbacks(
-      bool succeeded,
-      int a,
-      std::string b,
-      const std::function<void(int)> &resolve,
-      const std::function<void(std::string)> &reject) noexcept {
-    if (succeeded) {
-      resolve(a);
+  REACT_METHOD(NegateAsyncCallback, L"negateAsyncCallback")
+  fire_and_forget NegateAsyncCallback(int x, std::function<void(int)> resolve) noexcept {
+    co_await winrt::resume_background();
+    resolve(-x);
+  }
+
+  REACT_METHOD(NegateDispatchQueueCallback, L"negateDispatchQueueCallback")
+  void NegateDispatchQueueCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve]() noexcept { resolve(-x); });
+  }
+
+  REACT_METHOD(NegateFutureCallback, L"negateFutureCallback")
+  void NegateFutureCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    Mso::PostFuture([x, resolve]() noexcept { resolve(-x); });
+  }
+
+  REACT_METHOD(SayHelloCallback, L"sayHelloCallback")
+  void SayHelloCallback(std::function<void(const std::string &)> const &resolve) noexcept {
+    resolve("Hello_2");
+  }
+
+  REACT_METHOD(CallbackZeroArgs, L"callbackZeroArgs")
+  void CallbackZeroArgs(std::function<void()> const &resolve) noexcept {
+    resolve();
+  }
+
+  REACT_METHOD(CallbackTwoArgs, L"callbackTwoArgs")
+  void CallbackTwoArgs(std::function<void(int, int)> const &resolve) noexcept {
+    resolve(1, 2);
+  }
+
+  REACT_METHOD(CallbackThreeArgs, L"callbackThreeArgs")
+  void CallbackThreeArgs(std::function<void(int, int, std::string const &)> const &resolve) noexcept {
+    resolve(1, 2, "Hello");
+  }
+
+  REACT_METHOD(DivideCallbacks, L"divideCallbacks")
+  void DivideCallbacks(
+      int x,
+      int y,
+      std::function<void(int)> const &resolve,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    if (y != 0) {
+      resolve(x / y);
     } else {
-      reject(b);
+      reject("Division by 0");
     }
   }
 
-  REACT_METHOD(TwoCallbacksResolved, L"twoCallbacksResolved")
-  void TwoCallbacksResolved(int r) noexcept {
-    TestEventService::LogEvent("twoCallbacksResolvedSignal", r);
+  REACT_METHOD(NegateCallbacks, L"negateCallbacks")
+  void NegateCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    if (x >= 0) {
+      resolve(-x);
+    } else {
+      reject("Already negative");
+    }
   }
 
-  REACT_METHOD(TwoCallbacksRejected, L"twoCallbacksRejected")
-  void TwoCallbacksRejected(std::string r) noexcept {
-    TestEventService::LogEvent("twoCallbacksResolvedSignal", std::move(r));
+  REACT_METHOD(NegateAsyncCallbacks, L"negateAsyncCallbacks")
+  fire_and_forget NegateAsyncCallbacks(
+      int x,
+      std::function<void(int)> resolve,
+      std::function<void(std::string const &)> reject) noexcept {
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      resolve(-x);
+    } else {
+      reject("Already negative");
+    }
+  }
+
+  REACT_METHOD(NegateDispatchQueueCallbacks, L"negateDispatchQueueCallbacks")
+  void NegateDispatchQueueCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, resolve, reject]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
+  }
+
+  REACT_METHOD(NegateFutureCallbacks, L"negateFutureCallbacks")
+  void NegateFutureCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    Mso::PostFuture([x, resolve, reject]() noexcept {
+      if (x >= 0) {
+        resolve(-x);
+      } else {
+        reject("Already negative");
+      }
+    });
+  }
+
+  REACT_METHOD(ResolveSayHelloCallbacks, L"resolveSayHelloCallbacks")
+  void ResolveSayHelloCallbacks(
+      std::function<void(std::string const &)> const &resolve,
+      std::function<void(std::string const &)> const & /*reject*/) noexcept {
+    resolve("Hello_3");
+  }
+
+  REACT_METHOD(RejectSayHelloCallbacks, L"rejectSayHelloCallbacks")
+  void RejectSayHelloCallbacks(
+      std::function<void(std::string const &)> const & /*resolve*/,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    reject("Goodbye");
+  }
+
+  REACT_METHOD(TwoCallbacksZeroArgs, L"twoCallbacksZeroArgs")
+  void TwoCallbacksZeroArgs(
+      bool useFirst,
+      std::function<void()> const &callback1,
+      std::function<void()> const &callback2) noexcept {
+    if (useFirst) {
+      callback1();
+    } else {
+      callback2();
+    }
+  }
+
+  REACT_METHOD(TwoCallbacksTwoArgs, L"twoCallbacksTwoArgs")
+  void TwoCallbacksTwoArgs(
+      bool useFirst,
+      std::function<void(int, int)> const &callback1,
+      std::function<void(int, int)> const &callback2) noexcept {
+    if (useFirst) {
+      callback1(1, 2);
+    } else {
+      callback2(3, 4);
+    }
+  }
+
+  REACT_METHOD(TwoCallbacksThreeArgs, L"twoCallbacksThreeArgs")
+  void TwoCallbacksThreeArgs(
+      bool useFirst,
+      std::function<void(int, int, std::string const &)> const &callback1,
+      std::function<void(int, int, std::string const &)> const &callback2) noexcept {
+    if (useFirst) {
+      callback1(1, 2, "Hello");
+    } else {
+      callback2(3, 4, "World");
+    }
+  }
+
+  REACT_METHOD(DividePromise, L"dividePromise")
+  void DividePromise(int x, int y, React::ReactPromise<int> const &result) noexcept {
+    if (y != 0) {
+      result.Resolve(x / y);
+    } else {
+      result.Reject("Division by 0");
+    }
+  }
+
+  REACT_METHOD(NegatePromise, L"negatePromise")
+  void NegatePromise(int x, React::ReactPromise<int> const &result) noexcept {
+    if (x >= 0) {
+      result.Resolve(-x);
+    } else {
+      React::ReactError error{};
+      error.Message = "Already negative";
+      result.Reject(std::move(error));
+    }
+  }
+
+  REACT_METHOD(NegateAsyncPromise, L"negateAsyncPromise")
+  fire_and_forget NegateAsyncPromise(int x, React::ReactPromise<int> result) noexcept {
+    co_await winrt::resume_background();
+    if (x >= 0) {
+      result.Resolve(-x);
+    } else {
+      React::ReactError error{};
+      error.Message = "Already negative";
+      result.Reject(std::move(error));
+    }
+  }
+
+  REACT_METHOD(NegateDispatchQueuePromise, L"negateDispatchQueuePromise")
+  void NegateDispatchQueuePromise(int x, React::ReactPromise<int> const &result) noexcept {
+    Mso::DispatchQueue::ConcurrentQueue().Post([x, result]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        React::ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
+  REACT_METHOD(NegateFuturePromise, L"negateFuturePromise")
+  void NegateFuturePromise(int x, React::ReactPromise<int> const &result) noexcept {
+    Mso::PostFuture([x, result]() noexcept {
+      if (x >= 0) {
+        result.Resolve(-x);
+      } else {
+        React::ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+    });
+  }
+
+  REACT_METHOD(VoidPromise, L"voidPromise")
+  void VoidPromise(int x, React::ReactPromise<void> const &result) noexcept {
+    if (x % 2 == 0) {
+      result.Resolve();
+    } else {
+      result.Reject("Odd unexpected");
+    }
+  }
+
+  REACT_METHOD(ResolveSayHelloPromise, L"resolveSayHelloPromise")
+  void ResolveSayHelloPromise(React::ReactPromise<std::string> const &result) noexcept {
+    result.Resolve("Hello_4");
+  }
+
+  REACT_METHOD(RejectSayHelloPromise, L"rejectSayHelloPromise")
+  void RejectSayHelloPromise(React::ReactPromise<std::string> const &result) noexcept {
+    React::ReactError error{};
+    error.Message = "Promise rejected";
+    result.Reject(std::move(error));
+  }
+
+  REACT_SYNC_METHOD(AddSync, L"addSync")
+  int AddSync(int x, int y) noexcept {
+    return x + y;
+  }
+
+  REACT_SYNC_METHOD(NegateSync, L"negateSync")
+  int NegateSync(int x) noexcept {
+    return -x;
+  }
+
+  REACT_SYNC_METHOD(SayHelloSync, L"sayHelloSync")
+  std::string SayHelloSync() noexcept {
+    return "Hello";
   }
 };
 
-struct SampleTurboModuleSpec : TurboModuleSpec {
-  static constexpr auto methods = std::tuple{
-      Method<void() noexcept>{0, L"succeeded"},
-      Method<void(std::string) noexcept>{1, L"onError"},
-      Method<void(std::string, int, bool, ReactPromise<React::JSValue>) noexcept>{2, L"promiseFunction"},
-      Method<void(std::string) noexcept>{3, L"promiseFunctionResult"},
-      SyncMethod<std::string(std::string, int, bool) noexcept>{4, L"syncFunction"},
-      Method<void(std::string) noexcept>{5, L"syncFunctionResult"},
-      Method<void(std::string, int, std::string, int) noexcept>{6, L"constants"},
-      Method<void(int, int, const std::function<void(int)> &) noexcept>{7, L"oneCallback"},
-      Method<void(int) noexcept>{8, L"oneCallbackResult"},
-      Method<void(
-          bool,
-          int,
-          std::string,
-          const std::function<void(int)> &,
-          const std::function<void(std::string)> &) noexcept>{9, L"twoCallbacks"},
-      Method<void(int) noexcept>{10, L"twoCallbacksResolved"},
-      Method<void(std::string) noexcept>{11, L"twoCallbacksRejected"},
-  };
-
-  template <class TModule>
-  static constexpr void ValidateModule() noexcept {
-    constexpr auto methodCheckResults = CheckMethods<TModule, SampleTurboModuleSpec>();
-
-    REACT_SHOW_METHOD_SPEC_ERRORS(0, "succeeded", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(1, "onError", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(2, "promiseFunction", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(3, "promiseFunctionResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(4, "syncFunction", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(5, "syncFunctionResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(6, "constants", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(7, "oneCallback", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(8, "oneCallbackResult", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(9, "twoCallbacks", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(10, "twoCallbacksResolved", "I don't care error message");
-    REACT_SHOW_METHOD_SPEC_ERRORS(11, "twoCallbacksRejected", "I don't care error message");
-  }
-};
-
-struct SampleTurboModulePackageProvider : winrt::implements<SampleTurboModulePackageProvider, IReactPackageProvider> {
+struct CppTurboModulePackageProvider : winrt::implements<CppTurboModulePackageProvider, IReactPackageProvider> {
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
     auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
-    experimental.AddTurboModule(
-        L"SampleTurboModule", MakeTurboModuleProvider<SampleTurboModule, SampleTurboModuleSpec>());
+    experimental.AddTurboModule(L"CppTurboModule", MakeTurboModuleProvider<CppTurboModule>());
   }
 };
 
@@ -166,18 +471,72 @@ TEST_CLASS (TurboModuleTests) {
     TestEventService::Initialize();
 
     auto reactNativeHost = TestReactNativeHostHolder(L"TurboModuleTests", [](ReactNativeHost const &host) noexcept {
-      host.PackageProviders().Append(winrt::make<SampleTurboModulePackageProvider>());
-      return true;
+      host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
     });
 
     TestEventService::ObserveEvents({
-        TestEvent{"promiseFunctionSignal", "something, 1, true"},
-        TestEvent{"oneCallbackSignal", 3},
-        TestEvent{"twoCallbacksResolvedSignal", 123},
-        TestEvent{"twoCallbacksResolvedSignal", "Failed"},
-        TestEvent{"syncFunctionSignal", "something, 2, false"},
-        TestEvent{"constantsSignal", "constantString, 3, Hello, 10"},
-        TestEvent{"succeededSignal", true},
+        TestEvent{"constantString", "myConstantString"},
+        TestEvent{"constantInt", 3},
+        TestEvent{"constantString2", "Hello"},
+        TestEvent{"constantInt2", 10},
+
+        TestEvent{"add", 10},
+        TestEvent{"negate", -10},
+        TestEvent{"sayHello", "Hello"},
+
+        TestEvent{"sayHello0", "Hello"},
+        TestEvent{"printPoint", "Point: (1, 2)"},
+        TestEvent{"printLine", "Line: (1, 2)-(3, 4)"},
+
+        TestEvent{"addCallback", 15},
+        TestEvent{"negateCallback", -15},
+        TestEvent{"negateAsyncCallback", -16},
+        TestEvent{"negateDispatchQueueCallback", -17},
+        TestEvent{"negateFutureCallback", -18},
+        TestEvent{"sayHelloCallback", "Hello_2"},
+
+        TestEvent{"callbackZeroArgs", nullptr},
+        TestEvent{"callbackTwoArgs", JSValueObject{{"x", 1}, {"y", 2}}},
+        TestEvent{"callbackThreeArgs", JSValueObject{{"x", 1}, {"y", 2}, {"msg", "Hello"}}},
+
+        TestEvent{"divideCallbacks", 2},
+        TestEvent{"divideCallbacks.error", "Division by 0"},
+        TestEvent{"negateCallbacks", -10},
+        TestEvent{"negateCallbacks.error", "Already negative"},
+        TestEvent{"negateAsyncCallbacks", -10},
+        TestEvent{"negateAsyncCallbacks.error", "Already negative"},
+        TestEvent{"negateDispatchQueueCallbacks", -10},
+        TestEvent{"negateDispatchQueueCallbacks.error", "Already negative"},
+        TestEvent{"negateFutureCallbacks", -10},
+        TestEvent{"negateFutureCallbacks.error", "Already negative"},
+        TestEvent{"resolveSayHelloCallbacks", "Hello_3"},
+        TestEvent{"rejectSayHelloCallbacks.error", "Goodbye"},
+
+        TestEvent{"twoCallbacksZeroArgs1", "success"},
+        TestEvent{"twoCallbacksZeroArgs2", "failure"},
+        TestEvent{"twoCallbacksTwoArgs1", JSValueObject{{"x", 1}, {"y", 2}}},
+        TestEvent{"twoCallbacksTwoArgs2", JSValueObject{{"x", 3}, {"y", 4}}},
+        TestEvent{"twoCallbacksThreeArgs1", JSValueObject{{"x", 1}, {"y", 2}, {"msg", "Hello"}}},
+        TestEvent{"twoCallbacksThreeArgs2", JSValueObject{{"x", 3}, {"y", 4}, {"msg", "World"}}},
+
+        TestEvent{"dividePromise", 5},
+        TestEvent{"dividePromise.error", "Division by 0"},
+        TestEvent{"negatePromise", -10},
+        TestEvent{"negatePromise.error", "Already negative"},
+        TestEvent{"negateAsyncPromise", -10},
+        TestEvent{"negateAsyncPromise.error", "Already negative"},
+        TestEvent{"negateDispatchQueuePromise", -10},
+        TestEvent{"negateDispatchQueuePromise.error", "Already negative"},
+        TestEvent{"negateFuturePromise", -10},
+        TestEvent{"negateFuturePromise.error", "Already negative"},
+        TestEvent{"voidPromise", "success"},
+        TestEvent{"voidPromise.error", "Odd unexpected"},
+        TestEvent{"resolveSayHelloPromise", "Hello_4"},
+        TestEvent{"rejectSayHelloPromise", "Promise rejected"},
+
+        TestEvent{"addSync", 42},
+        TestEvent{"negateSync", -12},
+        TestEvent{"sayHelloSync", "Hello"},
     });
   }
 };

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -460,7 +460,7 @@ struct CppTurboModule {
 struct CppTurboModulePackageProvider : winrt::implements<CppTurboModulePackageProvider, IReactPackageProvider> {
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
     auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
-    experimental.AddTurboModule(L"CppTurboModule", MakeTurboModuleProvider<CppTurboModule>());
+    experimental.AddTurboModule(L"CppTurboModule", MakeTurboModuleProvider<CppTurboModule, CppTurboModuleSpec>());
   }
 };
 
@@ -472,6 +472,7 @@ TEST_CLASS (TurboModuleTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"TurboModuleTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+      return true;
     });
 
     TestEventService::ObserveEvents({

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -1,54 +1,127 @@
 import * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegistry';
+const CppTurboModule = TurboModuleRegistry.getEnforcing('CppTurboModule');
 
-const sampleTurboModule = TurboModuleRegistry.getEnforcing('SampleTurboModule');
+// Convert function with one callback to Promise
+const promisify1 = fn =>
+  (...args) => new Promise(
+    res => fn(...args, result => res(result)));
 
-// function calls will be added to cover complete signatures
+// Convert function with two callbacks to Promise
+const promisify2 = fn =>
+  (...args) => new Promise(
+    res => fn(...args, result => res(result), result => res(result)));
 
-try {
-  sampleTurboModule
-    .promiseFunction('something', 1, true);
+(async function runTests() {
+  try {
+    const c = CppTurboModule.getConstants();
+    CppTurboModule.logAction("constantString", c.constantString);
+    CppTurboModule.logAction("constantInt", c.constantInt);
+    CppTurboModule.logAction("constantString2", c.constantString2);
+    CppTurboModule.logAction("constantInt2", c.constantInt2);
 
-  sampleTurboModule
-    .oneCallback(1, 2, function (r) {
-      sampleTurboModule
-        .oneCallbackResult(r);
-    });
+    let result;
+    result = await promisify1(CppTurboModule.add)(2, 8);
+    CppTurboModule.logAction("add", result);
+    result = await promisify1(CppTurboModule.negate)(10);
+    CppTurboModule.logAction("negate", result);
+    result = await promisify1(CppTurboModule.sayHello)();
+    CppTurboModule.logAction("sayHello", result);
 
-  sampleTurboModule
-    .twoCallbacks(true, 123, 'Failed', function (r) {
-      sampleTurboModule
-        .twoCallbacksResolved(r);
-    }, function (r) {
-      sampleTurboModule
-        .twoCallbacksRejected(r);
-    });
+    CppTurboModule.sayHello0();
+    CppTurboModule.printPoint({ x: 1, y: 2 });
+    CppTurboModule.printLine({ x: 1, y: 2 }, { x: 3, y: 4 });
 
-  sampleTurboModule
-    .twoCallbacks(false, 123, 'Failed', function (r) {
-      sampleTurboModule
-        .twoCallbacksResolved(r);
-    }, function (r) {
-      sampleTurboModule
-        .twoCallbacksRejected(r);
-    });
+    result = await promisify1(CppTurboModule.addCallback)(7, 8);
+    CppTurboModule.logAction("addCallback", result);
+    result = await promisify1(CppTurboModule.negateCallback)(15);
+    CppTurboModule.logAction("negateCallback", result);
+    result = await promisify1(CppTurboModule.negateAsyncCallback)(16);
+    CppTurboModule.logAction("negateAsyncCallback", result);
+    result = await promisify1(CppTurboModule.negateDispatchQueueCallback)(17);
+    CppTurboModule.logAction("negateDispatchQueueCallback", result);
+    result = await promisify1(CppTurboModule.negateFutureCallback)(18);
+    CppTurboModule.logAction("negateFutureCallback", result);
+    result = await promisify1(CppTurboModule.sayHelloCallback)();
+    CppTurboModule.logAction("sayHelloCallback", result);
 
-  sampleTurboModule
-    .syncFunctionResult(
-      sampleTurboModule
-        .syncFunction('something', 2, false)
-    );
+    CppTurboModule.callbackZeroArgs(() => CppTurboModule.logAction("callbackZeroArgs", null));
+    CppTurboModule.callbackTwoArgs((x, y) => CppTurboModule.logAction("callbackTwoArgs", { x, y }));
+    CppTurboModule.callbackThreeArgs((x, y, msg) => CppTurboModule.logAction("callbackThreeArgs", { x, y, msg }));
 
-  const c = sampleTurboModule.getConstants();
-  sampleTurboModule
-    .constants(
-      c.constantString,
-      c.constantInt,
-      c.constantString2,
-      c.constantInt2
-    );
+    result = await promisify2(CppTurboModule.divideCallbacks)(10, 5);
+    CppTurboModule.logAction("divideCallbacks", result);
+    result = await promisify2(CppTurboModule.divideCallbacks)(10, 0);
+    CppTurboModule.logAction("divideCallbacks.error", result);
+    result = await promisify2(CppTurboModule.negateCallbacks)(10);
+    CppTurboModule.logAction("negateCallbacks", result);
+    result = await promisify2(CppTurboModule.negateCallbacks)(-10);
+    CppTurboModule.logAction("negateCallbacks.error", result);
+    result = await promisify2(CppTurboModule.negateAsyncCallbacks)(10);
+    CppTurboModule.logAction("negateAsyncCallbacks", result);
+    result = await promisify2(CppTurboModule.negateAsyncCallbacks)(-10);
+    CppTurboModule.logAction("negateAsyncCallbacks.error", result);
+    result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(10);
+    CppTurboModule.logAction("negateDispatchQueueCallbacks", result);
+    result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(-10);
+    CppTurboModule.logAction("negateDispatchQueueCallbacks.error", result);
+    result = await promisify2(CppTurboModule.negateFutureCallbacks)(10);
+    CppTurboModule.logAction("negateFutureCallbacks", result);
+    result = await promisify2(CppTurboModule.negateFutureCallbacks)(-10);
+    CppTurboModule.logAction("negateFutureCallbacks.error", result);
+    result = await promisify2(CppTurboModule.resolveSayHelloCallbacks)();
+    CppTurboModule.logAction("resolveSayHelloCallbacks", result);
+    result = await promisify2(CppTurboModule.rejectSayHelloCallbacks)();
+    CppTurboModule.logAction("rejectSayHelloCallbacks.error", result);
 
-  sampleTurboModule
-    .succeeded();
-} catch (err) {
-  sampleTurboModule.onError(typeof err);
-}
+    const twoCallbacksZeroArgs = useFirst => CppTurboModule.twoCallbacksZeroArgs(useFirst,
+      () => CppTurboModule.logAction("twoCallbacksZeroArgs1", "success"),
+      () => CppTurboModule.logAction("twoCallbacksZeroArgs2", "failure"));
+    twoCallbacksZeroArgs(true);
+    twoCallbacksZeroArgs(false);
+    const twoCallbacksTwoArgs = useFirst => CppTurboModule.twoCallbacksTwoArgs(useFirst,
+      (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs1", { x, y }),
+      (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs2", { x, y }));
+    twoCallbacksTwoArgs(true);
+    twoCallbacksTwoArgs(false);
+    const twoCallbacksThreeArgs = useFirst => CppTurboModule.twoCallbacksThreeArgs(useFirst,
+      (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs1", { x, y, msg }),
+      (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs2", { x, y, msg }));
+    twoCallbacksThreeArgs(true);
+    twoCallbacksThreeArgs(false);
+
+    await CppTurboModule.dividePromise(10, 2)
+      .then(r => CppTurboModule.logAction("dividePromise", r));
+    await CppTurboModule.dividePromise(10, 0)
+      .catch(e => CppTurboModule.logAction("dividePromise.error", e.message));
+    await CppTurboModule.negatePromise(10)
+      .then(r => CppTurboModule.logAction("negatePromise", r));
+    await CppTurboModule.negatePromise(-10)
+      .catch(e => CppTurboModule.logAction("negatePromise.error", e.message));
+    await CppTurboModule.negateAsyncPromise(10)
+      .then(r => CppTurboModule.logAction("negateAsyncPromise", r));
+    await CppTurboModule.negateAsyncPromise(-10)
+      .catch(e => CppTurboModule.logAction("negateAsyncPromise.error", e.message));
+    await CppTurboModule.negateAsyncPromise(10)
+      .then(r => CppTurboModule.logAction("negateDispatchQueuePromise", r));
+    await CppTurboModule.negateAsyncPromise(-10)
+      .catch(e => CppTurboModule.logAction("negateDispatchQueuePromise.error", e.message));
+    await CppTurboModule.negateAsyncPromise(10)
+      .then(r => CppTurboModule.logAction("negateFuturePromise", r));
+    await CppTurboModule.negateAsyncPromise(-10)
+      .catch(e => CppTurboModule.logAction("negateFuturePromise.error", e.message));
+    await CppTurboModule.voidPromise(2)
+      .then(() => CppTurboModule.logAction("voidPromise", "success"));
+    await CppTurboModule.voidPromise(1)
+      .catch(e => CppTurboModule.logAction("voidPromise.error", e.message));
+    await CppTurboModule.resolveSayHelloPromise()
+      .then(r => CppTurboModule.logAction("resolveSayHelloPromise", r));
+    await CppTurboModule.rejectSayHelloPromise()
+      .catch(e => CppTurboModule.logAction("rejectSayHelloPromise", e.message));
+
+    CppTurboModule.logAction("addSync", CppTurboModule.addSync(40, 2));
+    CppTurboModule.logAction("negateSync", CppTurboModule.negateSync(12));
+    CppTurboModule.logAction("sayHelloSync", CppTurboModule.sayHelloSync());
+  } catch (err) {
+    CppTurboModule.logAction("Error", err.message);
+  }
+})();

--- a/vnext/Microsoft.ReactNative/JSDispatcherWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JSDispatcherWriter.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "JSDispatcherWriter.h"
+#include <JSI/JSIDynamic.h>
+#include <crash/verifyElseCrash.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+//===========================================================================
+// JSDispatcherWriter implementation
+//===========================================================================
+
+JSDispatcherWriter::JSDispatcherWriter(
+    IReactDispatcher const &jsDispatcher,
+    facebook::jsi::Runtime &jsiRuntime) noexcept
+    : m_jsDispatcher(jsDispatcher), m_jsiRuntime(jsiRuntime) {}
+
+void JSDispatcherWriter::WithResultArgs(
+    Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
+        handler) noexcept {
+  if (m_jsDispatcher.HasThreadAccess()) {
+    VerifyElseCrash(!m_dynamicWriter);
+    const facebook::jsi::Value *args{nullptr};
+    size_t argCount{0};
+    m_jsiWriter->AccessResultAsArgs(args, argCount);
+    handler(m_jsiRuntime, args, argCount);
+  } else {
+    VerifyElseCrash(!m_jsiWriter);
+    folly::dynamic dynValue = m_dynamicWriter->TakeValue();
+    m_jsDispatcher.Post([handler, dynValue, &runtime = m_jsiRuntime]() {
+      VerifyElseCrash(dynValue.isArray());
+      std::vector<facebook::jsi::Value> args;
+      args.reserve(dynValue.size());
+      for (auto const &item : dynValue) {
+        args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+      }
+      handler(runtime, args.data(), args.size());
+    });
+  }
+}
+
+void JSDispatcherWriter::WriteNull() noexcept {
+  GetWriter().WriteNull();
+}
+
+void JSDispatcherWriter::WriteBoolean(bool value) noexcept {
+  GetWriter().WriteBoolean(value);
+}
+
+void JSDispatcherWriter::WriteInt64(int64_t value) noexcept {
+  GetWriter().WriteInt64(value);
+}
+
+void JSDispatcherWriter::WriteDouble(double value) noexcept {
+  GetWriter().WriteDouble(value);
+}
+
+void JSDispatcherWriter::WriteString(const winrt::hstring &value) noexcept {
+  GetWriter().WriteString(value);
+}
+
+void JSDispatcherWriter::WriteObjectBegin() noexcept {
+  GetWriter().WriteObjectBegin();
+}
+
+void JSDispatcherWriter::WritePropertyName(const winrt::hstring &name) noexcept {
+  GetWriter().WritePropertyName(name);
+}
+
+void JSDispatcherWriter::WriteObjectEnd() noexcept {
+  GetWriter().WriteObjectEnd();
+}
+
+void JSDispatcherWriter::WriteArrayBegin() noexcept {
+  GetWriter().WriteArrayBegin();
+}
+
+void JSDispatcherWriter::WriteArrayEnd() noexcept {
+  GetWriter().WriteArrayEnd();
+}
+
+IJSValueWriter JSDispatcherWriter::GetWriter() noexcept {
+  if (m_jsDispatcher.HasThreadAccess()) {
+    VerifyElseCrash(!m_dynamicWriter);
+    if (!m_jsiWriter) {
+      m_jsiWriter = winrt::make_self<JsiWriter>(m_jsiRuntime);
+      m_writer = m_jsiWriter.as<IJSValueWriter>();
+    }
+  } else {
+    VerifyElseCrash(!m_jsiWriter);
+    if (!m_dynamicWriter) {
+      m_dynamicWriter = winrt::make_self<DynamicWriter>();
+      m_writer = m_dynamicWriter.as<IJSValueWriter>();
+    }
+  }
+  return m_writer;
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JSDispatcherWriter.h
+++ b/vnext/Microsoft.ReactNative/JSDispatcherWriter.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <functional/functor.h>
+#include "DynamicWriter.h"
+#include "JsiWriter.h"
+#include "folly/dynamic.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+// IJSValueWriter to ensure that JsiWriter is always used from JSDispatcher.
+// In case if writing is done outside of JSDispatcher, it uses DynamicWriter to create
+// folly::dynamic which then is written to JsiWriter in JSDispatcher.
+struct JSDispatcherWriter : winrt::implements<JSDispatcherWriter, IJSValueWriter> {
+  JSDispatcherWriter(IReactDispatcher const &jsDispatcher, facebook::jsi::Runtime &jsiRuntime) noexcept;
+  void WithResultArgs(Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
+                          handler) noexcept;
+
+ public: // IJSValueWriter
+  void WriteNull() noexcept;
+  void WriteBoolean(bool value) noexcept;
+  void WriteInt64(int64_t value) noexcept;
+  void WriteDouble(double value) noexcept;
+  void WriteString(const winrt::hstring &value) noexcept;
+  void WriteObjectBegin() noexcept;
+  void WritePropertyName(const winrt::hstring &name) noexcept;
+  void WriteObjectEnd() noexcept;
+  void WriteArrayBegin() noexcept;
+  void WriteArrayEnd() noexcept;
+
+ private:
+  IJSValueWriter GetWriter() noexcept;
+
+ private:
+  IReactDispatcher m_jsDispatcher;
+  facebook::jsi::Runtime &m_jsiRuntime;
+  winrt::com_ptr<DynamicWriter> m_dynamicWriter;
+  winrt::com_ptr<JsiWriter> m_jsiWriter;
+  IJSValueWriter m_writer;
+};
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JsiWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JsiWriter.cpp
@@ -61,7 +61,7 @@ void JsiWriter::WriteDouble(double value) noexcept {
 }
 
 void JsiWriter::WriteString(const winrt::hstring &value) noexcept {
-  WriteValue({m_runtime, facebook::jsi::String::createFromUtf8(m_runtime, winrt::to_string(value))});
+  WriteValue({facebook::jsi::String::createFromUtf8(m_runtime, winrt::to_string(value))});
 }
 
 void JsiWriter::WriteObjectBegin() noexcept {
@@ -161,18 +161,6 @@ JsiWriter::Container JsiWriter::Pop() noexcept {
 
 void JsiWriter::Push(Container &&container) noexcept {
   m_containers.push_back(std::move(container));
-}
-
-/*static*/ facebook::jsi::Value JsiWriter::ToJsiValue(
-    facebook::jsi::Runtime &runtime,
-    JSValueArgWriter const &argWriter) noexcept {
-  if (argWriter) {
-    IJSValueWriter jsiWriter = winrt::make<JsiWriter>(runtime);
-    argWriter(jsiWriter);
-    return jsiWriter.as<JsiWriter>()->MoveResult();
-  }
-
-  return {};
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JsiWriter.h
+++ b/vnext/Microsoft.ReactNative/JsiWriter.h
@@ -35,9 +35,6 @@ struct JsiWriter : winrt::implements<JsiWriter, IJSValueWriter> {
   void WriteArrayBegin() noexcept;
   void WriteArrayEnd() noexcept;
 
- public:
-  static facebook::jsi::Value ToJsiValue(facebook::jsi::Runtime &runtime, JSValueArgWriter const &argWriter) noexcept;
-
  private:
   enum class ContainerState {
     AcceptValueAndFinish,

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -192,6 +192,9 @@
     <ClInclude Include="DynamicWriter.h">
       <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClInclude>
+    <ClInclude Include="JSDispatcherWriter.h">
+      <DependentUpon>IJSValueWriter.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="GlyphViewManager.h" />
     <ClInclude Include="HResult.h" />
     <ClInclude Include="IReactDispatcher.h">
@@ -506,6 +509,9 @@
       <DependentUpon>IJSValueReader.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="DynamicWriter.cpp">
+      <DependentUpon>IJSValueWriter.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="JSDispatcherWriter.cpp">
       <DependentUpon>IJSValueWriter.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="GlyphViewManager.cpp" />

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -7,6 +7,7 @@
 #include "pch.h"
 #include "TurboModulesProvider.h"
 #include <ReactCommon/TurboModuleUtils.h>
+#include "JSDispatcherWriter.h"
 #include "JsiApi.h"
 #include "JsiReader.h"
 #include "JsiWriter.h"
@@ -58,7 +59,7 @@ struct TurboModuleBuilder : winrt::implements<TurboModuleBuilder, IReactModuleBu
   std::unordered_map<std::string, TurboModuleMethodInfo> m_methods;
   std::unordered_map<std::string, SyncMethodDelegate> m_syncMethods;
   std::vector<ConstantProviderDelegate> m_constantProviders;
-  bool m_constantsEvaluated = false;
+  bool m_constantsEvaluated{false};
 
  private:
   void EnsureMemberNotSet(const std::string &key, bool checkingMethod) noexcept {
@@ -82,11 +83,13 @@ class TurboModuleImpl : public facebook::react::TurboModule {
   TurboModuleImpl(
       const IReactContext &reactContext,
       const std::string &name,
-      std::shared_ptr<facebook::react::CallInvoker> jsInvoker,
-      ReactModuleProvider reactModuleProvider)
-      : facebook::react::TurboModule(name, jsInvoker), m_moduleBuilder(winrt::make<TurboModuleBuilder>(reactContext)) {
-    providedModule = reactModuleProvider(m_moduleBuilder);
-    if (auto hostObject = providedModule.try_as<IJsiHostObject>()) {
+      const std::shared_ptr<facebook::react::CallInvoker> &jsInvoker,
+      const ReactModuleProvider &reactModuleProvider)
+      : facebook::react::TurboModule(name, jsInvoker),
+        m_reactContext(reactContext),
+        m_moduleBuilder(winrt::make<TurboModuleBuilder>(reactContext)),
+        m_providedModule(reactModuleProvider(m_moduleBuilder)) {
+    if (auto hostObject = m_providedModule.try_as<IJsiHostObject>()) {
       m_hostObjectWrapper = std::make_shared<implementation::HostObjectWrapper>(hostObject);
     }
   }
@@ -96,12 +99,13 @@ class TurboModuleImpl : public facebook::react::TurboModule {
       return m_hostObjectWrapper->getPropertyNames(rt);
     }
 
-    std::vector<facebook::jsi::PropNameID> props;
-    auto tmb = m_moduleBuilder.as<TurboModuleBuilder>();
-    for (auto &it : tmb->m_methods) {
-      props.push_back(facebook::jsi::PropNameID::forAscii(rt, it.first));
+    auto turboModuleBuilder = m_moduleBuilder.as<TurboModuleBuilder>();
+    std::vector<facebook::jsi::PropNameID> propertyNames;
+    propertyNames.reserve(turboModuleBuilder->m_methods.size());
+    for (auto &methodInfo : turboModuleBuilder->m_methods) {
+      propertyNames.push_back(facebook::jsi::PropNameID::forAscii(rt, methodInfo.first));
     }
-    return props;
+    return propertyNames;
   };
 
   facebook::jsi::Value get(facebook::jsi::Runtime &runtime, const facebook::jsi::PropNameID &propName) override {
@@ -110,25 +114,25 @@ class TurboModuleImpl : public facebook::react::TurboModule {
     }
 
     // it is not safe to assume that "runtime" never changes, so members are not cached here
-    auto tmb = m_moduleBuilder.as<TurboModuleBuilder>();
-    auto key = propName.utf8(runtime);
+    auto moduleBuilder = m_moduleBuilder.as<TurboModuleBuilder>();
+    std::string key = propName.utf8(runtime);
 
-    if (key == "getConstants" && tmb->m_constantProviders.size() > 0) {
+    if (key == "getConstants" && !moduleBuilder->m_constantProviders.empty()) {
       // try to find getConstants if there is any constant
       return facebook::jsi::Function::createFromHostFunction(
           runtime,
           propName,
           0,
-          [&runtime, tmb](
+          [moduleBuilder](
               facebook::jsi::Runtime &rt,
               const facebook::jsi::Value &thisVal,
               const facebook::jsi::Value *args,
               size_t count) {
             // collect all constants to an object
-            auto writer = winrt::make<JsiWriter>(runtime);
+            auto writer = winrt::make<JsiWriter>(rt);
             writer.WriteObjectBegin();
-            for (auto cp : tmb->m_constantProviders) {
-              cp(writer);
+            for (auto constantProvider : moduleBuilder->m_constantProviders) {
+              constantProvider(writer);
             }
             writer.WriteObjectEnd();
             return writer.as<JsiWriter>()->MoveResult();
@@ -137,150 +141,134 @@ class TurboModuleImpl : public facebook::react::TurboModule {
 
     {
       // try to find a Method
-      auto it = tmb->m_methods.find(key);
-      if (it != tmb->m_methods.end()) {
-        return facebook::jsi::Function::createFromHostFunction(
-            runtime,
-            propName,
-            0,
-            [&runtime, method = it->second](
-                facebook::jsi::Runtime &rt,
-                const facebook::jsi::Value &thisVal,
-                const facebook::jsi::Value *args,
-                size_t count) {
-              // prepare input arguments
-              size_t serializableArgumentCount = count;
-              switch (method.ReturnType) {
-                case MethodReturnType::Callback:
-                  VerifyElseCrash(count >= 1);
-                  VerifyElseCrash(args[count - 1].isObject() && args[count - 1].asObject(runtime).isFunction(runtime));
-                  serializableArgumentCount -= 1;
-                  break;
-                case MethodReturnType::TwoCallbacks:
-                  VerifyElseCrash(count >= 2);
-                  VerifyElseCrash(args[count - 1].isObject() && args[count - 1].asObject(runtime).isFunction(runtime));
-                  VerifyElseCrash(args[count - 2].isObject() && args[count - 2].asObject(runtime).isFunction(runtime));
-                  serializableArgumentCount -= 2;
-                  break;
-                case MethodReturnType::Void:
-                case MethodReturnType::Promise:
-                  // handled below
-                  break;
-              }
-              auto argReader = winrt::make<JsiReader>(runtime, args, serializableArgumentCount);
-
-              // prepare output value
-              // TODO: it is no reason to pass a argWriter just to receive [undefined] for void, should be optimized
-              auto argWriter = winrt::make<JsiWriter>(runtime);
-
-              // call the function
-              switch (method.ReturnType) {
-                case MethodReturnType::Void: {
-                  method.Method(argReader, argWriter, nullptr, nullptr);
+      auto it = moduleBuilder->m_methods.find(key);
+      if (it != moduleBuilder->m_methods.end()) {
+        TurboModuleMethodInfo methodInfo = it->second;
+        switch (methodInfo.ReturnType) {
+          case MethodReturnType::Void:
+            return facebook::jsi::Function::createFromHostFunction(
+                runtime,
+                propName,
+                0,
+                [methodInfo](
+                    facebook::jsi::Runtime &rt,
+                    const facebook::jsi::Value & /*thisVal*/,
+                    const facebook::jsi::Value *args,
+                    size_t argCount) {
+                  methodInfo.Method(winrt::make<JsiReader>(rt, args, argCount), nullptr, nullptr, nullptr);
                   return facebook::jsi::Value::undefined();
-                }
-                case MethodReturnType::Promise: {
+                });
+          case MethodReturnType::Callback:
+            return facebook::jsi::Function::createFromHostFunction(
+                runtime,
+                propName,
+                0,
+                [jsDispatcher = m_reactContext.JSDispatcher(), methodInfo](
+                    facebook::jsi::Runtime &rt,
+                    const facebook::jsi::Value & /*thisVal*/,
+                    const facebook::jsi::Value *args,
+                    size_t argCount) {
+                  VerifyElseCrash(argCount > 0);
+                  methodInfo.Method(
+                      winrt::make<JsiReader>(rt, args, argCount - 1),
+                      winrt::make<JSDispatcherWriter>(jsDispatcher, rt),
+                      MakeCallback(rt, {rt, args[argCount - 1]}),
+                      nullptr);
+                  return facebook::jsi::Value::undefined();
+                });
+          case MethodReturnType::TwoCallbacks:
+            return facebook::jsi::Function::createFromHostFunction(
+                runtime,
+                propName,
+                0,
+                [jsDispatcher = m_reactContext.JSDispatcher(), methodInfo](
+                    facebook::jsi::Runtime &rt,
+                    const facebook::jsi::Value & /*thisVal*/,
+                    const facebook::jsi::Value *args,
+                    size_t argCount) {
+                  VerifyElseCrash(argCount > 1);
+                  methodInfo.Method(
+                      winrt::make<JsiReader>(rt, args, argCount - 2),
+                      winrt::make<JSDispatcherWriter>(jsDispatcher, rt),
+                      MakeCallback(rt, {rt, args[argCount - 2]}),
+                      MakeCallback(rt, {rt, args[argCount - 1]}));
+                  return facebook::jsi::Value::undefined();
+                });
+          case MethodReturnType::Promise:
+            return facebook::jsi::Function::createFromHostFunction(
+                runtime,
+                propName,
+                0,
+                [jsDispatcher = m_reactContext.JSDispatcher(), methodInfo](
+                    facebook::jsi::Runtime &rt,
+                    const facebook::jsi::Value & /*thisVal*/,
+                    const facebook::jsi::Value *args,
+                    size_t count) {
+                  auto argReader = winrt::make<JsiReader>(rt, args, count);
+                  auto argWriter = winrt::make<JSDispatcherWriter>(jsDispatcher, rt);
                   return facebook::react::createPromiseAsJSIValue(
-                      runtime, [=](facebook::jsi::Runtime &runtime, std::shared_ptr<facebook::react::Promise> promise) {
-                        method.Method(
+                      rt,
+                      [methodInfo, argReader, argWriter](
+                          facebook::jsi::Runtime &runtime, std::shared_ptr<facebook::react::Promise> promise) {
+                        methodInfo.Method(
                             argReader,
                             argWriter,
-                            [promise, &runtime](const IJSValueWriter &writer) {
-                              auto result = writer.as<JsiWriter>()->MoveResult();
-                              if (result.isObject()) {
-                                auto resultArrayObject = result.getObject(runtime);
-                                VerifyElseCrash(resultArrayObject.isArray(runtime));
-                                auto resultArray = resultArrayObject.getArray(runtime);
-                                VerifyElseCrash(resultArray.length(runtime) == 1);
-                                auto resultItem = resultArray.getValueAtIndex(runtime, 0);
-                                promise->resolve(resultItem);
-                              } else {
-                                VerifyElseCrash(false);
-                              }
+                            [promise](const IJSValueWriter &writer) {
+                              writer.as<JSDispatcherWriter>()->WithResultArgs([promise](
+                                                                                  facebook::jsi::Runtime &runtime,
+                                                                                  facebook::jsi::Value const *args,
+                                                                                  size_t argCount) {
+                                VerifyElseCrash(argCount == 1);
+                                promise->resolve(args[0]);
+                              });
                             },
-                            [promise, &runtime](const IJSValueWriter &writer) {
-                              auto result = writer.as<JsiWriter>()->MoveResult();
-                              if (result.isString()) {
-                                promise->reject(result.getString(runtime).utf8(runtime));
-                              } else if (result.isObject()) {
-                                auto errorArrayObject = result.getObject(runtime);
-                                VerifyElseCrash(errorArrayObject.isArray(runtime));
-                                auto errorArray = errorArrayObject.getArray(runtime);
-                                VerifyElseCrash(errorArray.length(runtime) == 1);
-                                auto errorObjectValue = errorArray.getValueAtIndex(runtime, 0);
-                                VerifyElseCrash(errorObjectValue.isObject());
-                                auto errorObject = errorObjectValue.getObject(runtime);
-                                VerifyElseCrash(errorObject.hasProperty(runtime, "message"));
-                                auto errorMessage = errorObject.getProperty(runtime, "message");
-                                VerifyElseCrash(errorMessage.isString());
-                                promise->reject(errorMessage.getString(runtime).utf8(runtime));
-                              } else {
-                                VerifyElseCrash(false);
-                              }
+                            [promise](const IJSValueWriter &writer) {
+                              writer.as<JSDispatcherWriter>()->WithResultArgs([promise](
+                                                                                  facebook::jsi::Runtime &runtime,
+                                                                                  facebook::jsi::Value const *args,
+                                                                                  size_t argCount) {
+                                VerifyElseCrash(argCount == 1);
+                                // To match the Android and iOS TurboModule behavior we create the Error object for
+                                // the Promise rejection the same way as in updateErrorWithErrorData method.
+                                // See react-native/Libraries/BatchedBridge/NativeModules.js for details.
+                                auto error = runtime.global()
+                                                 .getPropertyAsFunction(runtime, "Error")
+                                                 .callAsConstructor(runtime, {});
+                                auto &errorData = args[0];
+                                if (errorData.isObject()) {
+                                  runtime.global()
+                                      .getPropertyAsObject(runtime, "Object")
+                                      .getPropertyAsFunction(runtime, "assign")
+                                      .call(runtime, error, errorData.getObject(runtime));
+                                }
+                                promise->reject_.call(runtime, error);
+                              });
                             });
                       });
-                }
-                case MethodReturnType::Callback:
-                case MethodReturnType::TwoCallbacks: {
-                  facebook::jsi::Value resolveFunction;
-                  facebook::jsi::Value rejectFunction;
-                  if (method.ReturnType == MethodReturnType::Callback) {
-                    resolveFunction = {runtime, args[count - 1]};
-                  } else {
-                    resolveFunction = {runtime, args[count - 2]};
-                    rejectFunction = {runtime, args[count - 1]};
-                  }
-
-                  auto makeCallback =
-                      [&runtime](const facebook::jsi::Value &callbackValue) noexcept -> MethodResultCallback {
-                    // workaround: xcode doesn't accept a captured value with only rvalue copy constructor
-                    auto functionObject =
-                        std::make_shared<facebook::jsi::Function>(callbackValue.asObject(runtime).asFunction(runtime));
-                    return [&runtime, callbackFunction = functionObject](const IJSValueWriter &writer) noexcept {
-                      const facebook::jsi::Value *resultArgs = nullptr;
-                      size_t resultCount = 0;
-                      writer.as<JsiWriter>()->AccessResultAsArgs(resultArgs, resultCount);
-                      callbackFunction->call(runtime, resultArgs, resultCount);
-                    };
-                  };
-
-                  method.Method(
-                      argReader,
-                      argWriter,
-                      makeCallback(resolveFunction),
-                      (method.ReturnType == MethodReturnType::Callback ? nullptr : makeCallback(rejectFunction)));
-                  return facebook::jsi::Value::undefined();
-                }
-                default:
-                  VerifyElseCrash(false);
-              }
-            });
+                });
+          default:
+            VerifyElseCrash(false);
+        }
       }
     }
 
     {
       // try to find a SyncMethod
-      auto it = tmb->m_syncMethods.find(key);
-      if (it != tmb->m_syncMethods.end()) {
+      auto it = moduleBuilder->m_syncMethods.find(key);
+      if (it != moduleBuilder->m_syncMethods.end()) {
         return facebook::jsi::Function::createFromHostFunction(
             runtime,
             propName,
             0,
-            [&runtime, method = it->second](
+            [method = it->second](
                 facebook::jsi::Runtime &rt,
                 const facebook::jsi::Value &thisVal,
                 const facebook::jsi::Value *args,
                 size_t count) {
-              // prepare input arguments
-              auto argReader = winrt::make<JsiReader>(runtime, args, count);
-
-              // prepare output value
-              auto writer = winrt::make<JsiWriter>(runtime);
-
-              // call the function
-              method(argReader, writer);
-
-              return writer.as<JsiWriter>()->MoveResult();
+              auto argReader = winrt::make<JsiReader>(rt, args, count);
+              auto argWriter = winrt::make<JsiWriter>(rt);
+              method(argReader, argWriter);
+              return argWriter.as<JsiWriter>()->MoveResult();
             });
       }
     }
@@ -299,17 +287,30 @@ class TurboModuleImpl : public facebook::react::TurboModule {
   }
 
  private:
+  static MethodResultCallback MakeCallback(facebook::jsi::Runtime &runtime, facebook::jsi::Value callback) noexcept {
+    auto sharedCallback =
+        std::make_shared<facebook::jsi::Function>(std::move(callback).asObject(runtime).asFunction(runtime));
+    return [sharedCallback = std::move(sharedCallback)](const IJSValueWriter &writer) noexcept {
+      writer.as<JSDispatcherWriter>()->WithResultArgs(
+          [sharedCallback](facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t count) {
+            sharedCallback->call(rt, args, count);
+          });
+    };
+  }
+
+ private:
+  IReactContext m_reactContext;
   IReactModuleBuilder m_moduleBuilder;
-  IInspectable providedModule;
+  IInspectable m_providedModule;
   std::shared_ptr<implementation::HostObjectWrapper> m_hostObjectWrapper;
 };
 
 /*-------------------------------------------------------------------------------
   TurboModulesProvider
 -------------------------------------------------------------------------------*/
-TurboModulesProvider::TurboModulePtr TurboModulesProvider::getModule(
+std::shared_ptr<facebook::react::TurboModule> TurboModulesProvider::getModule(
     const std::string &moduleName,
-    const CallInvokerPtr &callInvoker) noexcept {
+    const std::shared_ptr<facebook::react::CallInvoker> &callInvoker) noexcept {
   // fail if the expected turbo module has not been registered
   auto it = m_moduleProviders.find(moduleName);
   if (it == m_moduleProviders.end()) {

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -13,16 +13,11 @@
 namespace winrt::Microsoft::ReactNative {
 
 class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
- private:
-  using TurboModule = facebook::react::TurboModule;
-  using CallInvoker = facebook::react::CallInvoker;
-
-  using TurboModulePtr = std::shared_ptr<TurboModule>;
-  using CallInvokerPtr = std::shared_ptr<CallInvoker>;
-
- public:
-  virtual TurboModulePtr getModule(const std::string &moduleName, const CallInvokerPtr &callInvoker) noexcept override;
-  virtual std::vector<std::string> getEagerInitModuleNames() noexcept override;
+ public: // TurboModuleRegistry implementation
+  std::shared_ptr<facebook::react::TurboModule> getModule(
+      const std::string &moduleName,
+      const std::shared_ptr<facebook::react::CallInvoker> &callInvoker) noexcept override;
+  std::vector<std::string> getEagerInitModuleNames() noexcept override;
 
  public:
   void SetReactContext(const IReactContext &reactContext) noexcept;

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -3,9 +3,7 @@
 
 #include "pch.h"
 
-#include <DynamicReader.h>
 #include <JSValueWriter.h>
-#include <JsiWriter.h>
 #include <Views/SIPEventHandler.h>
 #include <Views/ShadowNodeBase.h>
 #include "Impl/ScrollViewUWPImplementation.h"


### PR DESCRIPTION
## Description
Cherry pick PR #9595

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
In NativeModules 2.0 we can complete Promises in async methods from any thread.
They use `DynamicWriter` to serialize result value to `folly::dynamic` which then is serialized to a JSI value in JS dispatcher.
But the C++ TurboModules which are based on the NativeModules 2.0 cannot complete Promises from any thread because they use the `JsiWriter` that must be always invoked from the JS dispatcher.
In this PR we fix this issue to keep the TurboModules behavior consistent with the NativeModules 2.0 and to allow Promises to be completed from any thread.

### What
To address this issue, the new `JSDispatcherWriter` is added internally to the `Microsoft.ReactNative` project.
This class wraps both `JsiWriter` and the `DynamicWriter`:
- If the writer is used in JS dispatcher thread, then it uses the `JsiWriter` directly.
- Otherwise, if it is used from any other thread, then it uses the `DynamicWriter` to create a `folly::dynamic` first which is then serialized to JSI using the `JsiWriter` in the JS dispatcher.
- Note, that the `JsiWriter` vs `DynamicWriter` is chosen only at the first write. All the following writes must be done from the same thread. Otherwise, we crash the application because it is not a recoverable programming error.

This makes the TurboModule's Promises to behave the same way as the NativeModule's Promises.
It simplifies transition from the NativeModules to the TurboModules by just adding the spec to the existing NativeModules.

The change actually affects not only the Promises, but also the methods that use callbacks.
All callbacks can be invoked from any thread like in the NativeModules 2.0.

## Testing
The `TurboModuleTests.cpp` and `TurboModuleTests.js` were mostly rewritten to cover all possible use cases and the invocation of callbacks and Promises from background threads. All these new unit tests are passing.
Since the invocation could happen from any thread, the test JS code uses `await` keywords to ensure that next test is not started before the previous one is completed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9604)