### PR TITLE
Set ResolveNuGetPackages in external props

### DIFF
--- a/change/react-native-windows-fe9965b7-8e26-4928-b2d8-7453a5738923.json
+++ b/change/react-native-windows-fe9965b7-8e26-4928-b2d8-7453a5738923.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set ResolveNuGetPackages in external props",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
@@ -41,6 +41,9 @@
   <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
     <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
     <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</RestoreUseStaticGraphEvaluation>
+
+    <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
   </PropertyGroup>
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Generated\PackageVersion.g.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
@@ -16,12 +16,6 @@
     <SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>true</SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>
     <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
-
-  <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
-  <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-  </PropertyGroup>
-
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -16,6 +16,12 @@
     <SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>true</SkipAddPriPayloadFilesToCopyToOutputDirectoryItems>
     <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
+
+  <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
+  <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />


### PR DESCRIPTION
## Description
Set MSBuild property `ResolveNuGetPackages` to `false` for projects consuming MSRN.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
External projects will fail to build due to `PackageReference` on C++ not being compatible with property `ResolveNuGetPackages`.

Resolves #9512

### What
Sets MSBuild property `ResolveNuGetPackages` to `false`. See `vnext\PropertySheets\External\Microsoft.ReactNative.Common.props`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9628)