### PR TITLE
Dependencies script checks for multiple VS installs

### DIFF
--- a/change/react-native-windows-ce41eed2-2de5-43a0-9d29-b100a2d39d30.json
+++ b/change/react-native-windows-ce41eed2-2de5-43a0-9d29-b100a2d39d30.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "rnw-deps - try prerelease, guard against multiple VS installs",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -72,6 +72,8 @@ $vsWorkloads = @('Microsoft.VisualStudio.Workload.ManagedDesktop',
     'Microsoft.VisualStudio.Workload.NativeDesktop',
     'Microsoft.VisualStudio.Workload.Universal');
 
+$vsver = "16.5"
+
 $v = [System.Environment]::OSVersion.Version;
 if ($env:Agent_BuildDirectory) {
     $drive = (Resolve-Path $env:Agent_BuildDirectory).Drive
@@ -88,17 +90,25 @@ function CheckVS {
     if (!(Test-Path $vsWhere)) {
         return $false;
     }
-    $output = & $vsWhere -version 16.5 -requires $vsComponents -property productPath
 
-    return ($output -ne $null) -and (Test-Path $output);
+    [String[]]$output = & $vsWhere -version $vsver -requires $vsComponents -property productPath
+
+    if (($output.Count -eq 0) -or (!(Test-Path $output[0]))) {
+        Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+        [String[]]$output = & $vsWhere -version $vsver -requires $vsComponents -property productPath -prerelease
+    }
+    if ($output.Count -gt 1) {
+        Write-Debug "More than one version of Visual Studio found, using the first one at $($output[0])"
+    }
+    return ($output.Count -ne 0) -and (Test-Path $output[0]);
 }
 
 function InstallVS {
     $installerPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer";
     $vsWhere = "$installerPath\vswhere.exe"
     if (Test-Path $vsWhere) {
-        $channelId = & $vsWhere -version 16.5 -property channelId
-        $productId = & $vsWhere -version 16.5 -property productId
+        $channelId = & $vsWhere -version $vsver -property channelId
+        $productId = & $vsWhere -version $vsver -property productId
     }
 
     if (!(Test-Path $vsWhere) -or ($channelId -eq $null) -or ($productId -eq $null)) {
@@ -109,8 +119,8 @@ function InstallVS {
         } else {
             & choco install -y visualstudio2019community
         }
-        $channelId = & $vsWhere -version 16.5 -property channelId
-        $productId = & $vsWhere -version 16.5 -property productId
+        $channelId = & $vsWhere -version $vsver -property channelId
+        $productId = & $vsWhere -version $vsver -property productId
     }
 
     $vsInstaller = "$installerPath\vs_installer.exe"
@@ -170,8 +180,17 @@ function CheckCppWinRT_VSIX {
         if (!(Test-Path $vsWhere)) {
             return $false;
         }
-        $vsPath = & $vsWhere -version 16.5 -property installationPath;
-        $natvis = Get-ChildItem "$vsPath\Common7\IDE\Extensions\cppwinrt.natvis" -Recurse;
+        [String[]]$vsPath = & $vsWhere -version $vsver -property installationPath;
+
+        if (($vsPath.Count -eq 0) -or (!(Test-Path $vsPath[0]))) {
+            Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+            [String[]]$vsPath = & $vsWhere -version $vsver -property installationPath -prerelease
+        }
+
+        if ($vsPath.Count -gt 1) {
+            Write-Debug "More than one version of Visual Studio found, using the first one at $($vsPath[0])"
+        }
+        $natvis = Get-ChildItem "$($vsPath[0])\Common7\IDE\Extensions\cppwinrt.natvis" -Recurse;
         return $null -ne $natvis;
     } catch { return $false };
 }
@@ -185,8 +204,19 @@ function InstallCppWinRT_VSIX {
     if (!(Test-Path $vsWhere)) {
         return $false;
     }
-    $productPath = & $vsWhere -version 16.5 -property productPath
-    $VSIXInstaller_exe = Join-Path (Split-Path $productPath) "VSIXInstaller.exe"
+    [String[]]$productPath = & $vsWhere -version $vsver -property productPath
+
+    if (($productPath.Count -eq 0) -or (!(Test-Path $productPath[0]))) {
+        Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+        [String[]]$productPath = & $vsWhere -version $vsver -property productPath -prerelease
+    }
+
+    if ($productPath.Count -gt 1) {
+        Write-Debug "More than one version of Visual Studio found, using the first one at $($productPath[0])"
+    }
+
+
+    $VSIXInstaller_exe = Join-Path (Split-Path $productPath[0]) "VSIXInstaller.exe"
     $process = Start-Process $VSIXInstaller_exe -PassThru -Wait -ArgumentList "/a /q $env:TEMP\Microsoft.Windows.CppWinRT.vsix"
     $process.WaitForExit();
 }

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -72,6 +72,7 @@ $vsWorkloads = @('Microsoft.VisualStudio.Workload.ManagedDesktop',
     'Microsoft.VisualStudio.Workload.NativeDesktop',
     'Microsoft.VisualStudio.Workload.Universal');
 
+# The minimum VS version to check for
 $vsver = "16.5"
 
 $v = [System.Environment]::OSVersion.Version;


### PR DESCRIPTION
## Description
The rnw-dependencies script doesn't currently handle multiple side-by-side VS installs, nor does it check prerelease as a fallback.

### Type of Change
- New feature (non-breaking change which adds functionality)

Resolves #9260 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9629)