### PR TITLE
[0.68] Update how RunWindows phases are reported

### DIFF
--- a/change/@react-native-windows-cli-5c176e39-baa5-4bfb-818a-da9b3c8d1720.json
+++ b/change/@react-native-windows-cli-5c176e39-baa5-4bfb-818a-da9b3c8d1720.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.68] Update how RunWindows phases are reported",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -88,9 +88,12 @@ async function getExtraProps(): Promise<Record<string, any>> {
  */
 type RunWindowsPhase =
   | 'None'
-  | 'AutoLink'
-  | 'FindBuildTools'
+  | 'Info'
   | 'FindSolution'
+  | 'FindBuildTools'
+  | 'Autolink'
+  | 'RestorePackagesConfig'
+  | 'Build'
   | 'Deploy';
 
 let runWindowsPhase: RunWindowsPhase = 'None';
@@ -133,6 +136,7 @@ async function runWindows(
 
   let runWindowsError: Error | undefined;
   if (options.info) {
+    runWindowsPhase = 'Info';
     try {
       const output = await info.getEnvironmentInfo();
       console.log(output.trimEnd());
@@ -200,6 +204,7 @@ async function runWindowsInternal(
 
   // Get the solution file
   let slnFile;
+  runWindowsPhase = 'FindSolution';
   try {
     slnFile = build.getAppSolutionFile(options, config);
   } catch (e) {
@@ -228,6 +233,7 @@ async function runWindowsInternal(
   }
 
   // Restore packages.config files for dependencies that don't support PackageReference.
+  runWindowsPhase = 'RestorePackagesConfig';
   try {
     await buildTools.restorePackageConfigs(slnFile);
   } catch (e) {
@@ -239,8 +245,9 @@ async function runWindowsInternal(
     throw e;
   }
 
-  try {
-    if (options.autolink) {
+  if (options.autolink) {
+    runWindowsPhase = 'Autolink';
+    try {
       const autolinkArgs: string[] = [];
       const autolinkConfig = config;
       const autoLinkOptions: AutoLinkOptions = {
@@ -250,22 +257,21 @@ async function runWindowsInternal(
         sln: options.sln,
         telemetry: options.telemetry,
       };
-      runWindowsPhase = 'AutoLink';
       await autolinkWindowsInternal(
         autolinkArgs,
         autolinkConfig,
         autoLinkOptions,
       );
-    } else {
-      newInfo('Autolink step is skipped');
+    } catch (e) {
+      newError(`Autolinking failed. ${(e as Error).message}`);
+      throw e;
     }
-  } catch (e) {
-    newError(`Autolinking failed. ${(e as Error).message}`);
-    throw e;
+  } else {
+    newInfo('Autolink step is skipped');
   }
 
   if (options.build) {
-    runWindowsPhase = 'FindSolution';
+    runWindowsPhase = 'Build';
     if (!slnFile) {
       newError(
         'Visual Studio Solution file not found. Maybe run "npx react-native-windows-init" first?',
@@ -281,7 +287,6 @@ async function runWindowsInternal(
     msBuildProps.RunAutolinkCheck = 'false';
 
     try {
-      runWindowsPhase = 'FindSolution';
       await build.buildSolution(
         buildTools,
         slnFile!,
@@ -313,7 +318,7 @@ async function runWindowsInternal(
   }
 
   if (options.deploy) {
-    runWindowsPhase = 'FindSolution';
+    runWindowsPhase = 'Deploy';
     if (!slnFile) {
       newError(
         'Visual Studio Solution file not found. Maybe run "npx react-native-windows-init" first?',
@@ -322,7 +327,6 @@ async function runWindowsInternal(
     }
 
     try {
-      runWindowsPhase = 'Deploy';
       if (options.device || options.emulator || options.target) {
         await deploy.deployToDevice(options, verbose, config);
       } else {


### PR DESCRIPTION
This PR backports #9630 to 0.68.

This PR creates some new RunWindows phases and updates when/how they're set.

The phases did not include Build which seems like a big hole, or the new RestorePackagesConfig step that was added. It also always changed the phase to FindSolution when no solution was found.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9639)