### PR TITLE
Implement crash management

### DIFF
--- a/change/react-native-windows-202e71fb-d2d3-431c-a1bd-53c82a6e6037.json
+++ b/change/react-native-windows-202e71fb-d2d3-431c-a1bd-53c82a6e6037.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement crash management for optional collection of Hermes JS callstack and heap addresses with Windows Error Reporting",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="..\Microsoft.ReactNative\Modules\DevSettingsModule.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\NativeModulesProvider.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\AsyncActionQueue.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\ReactHost\CrashManager.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSBundle_Win32.cpp" />
     <ClCompile Include="..\Microsoft.ReactNative\ReactHost\JSCallInvokerScheduler.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -281,6 +281,7 @@
     <ClInclude Include="ReactHost\ReactErrorProvider.h" />
     <ClInclude Include="ReactHost\ReactHost.h" />
     <ClInclude Include="ReactHost\ReactInstanceWin.h" />
+    <ClInclude Include="ReactHost\CrashManager.h" />
     <ClInclude Include="ReactHost\ReactNativeHeaders.h" />
     <ClInclude Include="ReactHost\React_Win.h" />
     <ClInclude Include="ReactCoreInjection.h">
@@ -621,6 +622,7 @@
     <ClCompile Include="ReactHost\ReactErrorProvider.cpp" />
     <ClCompile Include="ReactHost\ReactHost.cpp" />
     <ClCompile Include="ReactHost\ReactInstanceWin.cpp" />
+    <ClCompile Include="ReactHost\CrashManager.cpp" />
     <ClCompile Include="ReactCoreInjection.cpp">
       <DependentUpon>ReactCoreInjection.idl</DependentUpon>
       <SubType>Code</SubType>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -40,6 +40,9 @@
     <ClCompile Include="ReactHost\ReactInstanceWin.cpp">
       <Filter>ReactHost</Filter>
     </ClCompile>
+    <ClCompile Include="ReactHost\CrashManager.cpp">
+      <Filter>ReactHost</Filter>
+    </ClCompile>
     <ClCompile Include="ReactSupport.cpp" />
     <ClCompile Include="RedBox.cpp" />
     <ClCompile Include="TestHook.cpp" />
@@ -386,6 +389,9 @@
       <Filter>ReactHost</Filter>
     </ClInclude>
     <ClInclude Include="ReactHost\ReactInstanceWin.h">
+      <Filter>ReactHost</Filter>
+    </ClInclude>
+    <ClInclude Include="ReactHost\CrashManager.h">
       <Filter>ReactHost</Filter>
     </ClInclude>
     <ClInclude Include="ReactHost\ReactNativeHeaders.h">

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -6,6 +6,7 @@
 #include "ReactApplication.g.cpp"
 #include "winrt/Microsoft.ReactNative.h"
 
+#include "CrashManager.h"
 #include "IReactDispatcher.h"
 #include "Modules/LinkingManagerModule.h"
 #include "ReactNativeHost.h"
@@ -40,12 +41,15 @@ ReactApplication::ReactApplication(IInspectable const &outer) noexcept : ReactAp
 #ifndef USE_WINUI3
   Suspending({this, &ReactApplication::OnSuspending});
 
-#if defined _DEBUG && !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
+#if !defined DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION
   UnhandledException([this](IInspectable const &, UnhandledExceptionEventArgs const &e) {
+#if defined _DEBUG
     if (IsDebuggerPresent()) {
       auto errorMessage = e.Message();
       __debugbreak();
-    }
+    } else
+#endif
+      Mso::React::CrashManager::OnUnhandledException();
   });
 #endif
 #endif

--- a/vnext/Microsoft.ReactNative/ReactHost/CrashManager.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/CrashManager.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "CrashManager.h"
+#include "ReactInstanceWin.h"
+
+#include <winrt/Windows.Storage.h>
+
+#include <WerApi.h>
+
+namespace Mso::React {
+
+// When calling SetUnhandledExceptionFilter the previous filter is returned.
+// That should be saved so that if needed it can be called after the new unhandled exception has finished executing.
+// This allows the Windows Error Reporting system to process the error and upload the data for processing.
+static LPTOP_LEVEL_EXCEPTION_FILTER g_previousExceptionFilter = nullptr;
+
+static std::wstring g_logFileName;
+static bool g_WERExceptionFilterWasCalled{false}; // Prevent recursion in the custom handler
+
+/*static*/ std::atomic_uint CrashManager::_regCount{0};
+
+extern "C" LONG WINAPI CustomWERExceptionFilter(LPEXCEPTION_POINTERS const exceptionPointers) {
+  if (g_WERExceptionFilterWasCalled) {
+    return EXCEPTION_EXECUTE_HANDLER;
+  }
+
+  g_WERExceptionFilterWasCalled = true;
+
+  CrashManager::OnUnhandledException();
+
+  return g_previousExceptionFilter(exceptionPointers);
+}
+
+void InternalRegisterCustomHandler() noexcept {
+  // Do this now because by the time we catch the exception we may be in OOM
+#ifndef CORE_ABI // win32 vs uwp file permissions
+  wchar_t currentDirectory[MAX_PATH];
+  GetTempPath(MAX_PATH, currentDirectory);
+  g_logFileName = currentDirectory;
+#else
+  g_logFileName = winrt::Windows::Storage::ApplicationData::Current().LocalFolder().Path() + L"\\";
+#endif
+
+  g_logFileName += L"ReactNativeCrashDetails.txt";
+
+  ::WerRegisterFile(g_logFileName.c_str(), WerRegFileTypeOther, WER_FILE_ANONYMOUS_DATA);
+
+  g_previousExceptionFilter = ::SetUnhandledExceptionFilter(CustomWERExceptionFilter);
+}
+
+void InternalUnregisterCustomHandler() noexcept {
+  ::WerUnregisterFile(g_logFileName.c_str());
+
+  if (g_previousExceptionFilter) {
+    ::SetUnhandledExceptionFilter(g_previousExceptionFilter);
+    g_previousExceptionFilter = nullptr;
+  }
+}
+
+/*static*/ void CrashManager::OnUnhandledException() noexcept {
+  FILE *f{nullptr};
+  auto err = _wfopen_s(&f, g_logFileName.c_str(), L"w");
+  if (err == 0) {
+    CrashHandler(_fileno(f));
+    fclose(f);
+  }
+}
+
+/*static*/ void CrashManager::CrashHandler(int fileDescriptor) noexcept {
+  ReactInstanceWin::CrashHandler(fileDescriptor);
+
+  // call any other component's static crash handlers here
+}
+
+/*static*/ void CrashManager::RegisterCustomHandler() noexcept {
+  if (_regCount++ == 0) {
+    InternalRegisterCustomHandler();
+  }
+}
+
+/*static*/ void CrashManager::UnregisterCustomHandler() noexcept {
+  if (--_regCount == 0) {
+    InternalUnregisterCustomHandler();
+  }
+}
+
+#if defined(DEBUG)
+/*static*/ std::string CrashManager::TestCollectCrashData() {
+  FILE *f{nullptr};
+  if (tmpfile_s(&f) != 0) {
+    return std::string{};
+  }
+
+  CrashHandler(_fileno(f));
+  const auto sz = (size_t)ftell(f);
+  rewind(f);
+
+  std::string out;
+  out.resize(sz);
+  const auto readsz = fread(&out[0], 1, sz, f);
+  assert(readsz == sz);
+  fclose(f);
+
+  return out;
+}
+#endif
+
+} // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/CrashManager.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/CrashManager.cpp
@@ -35,7 +35,7 @@ extern "C" LONG WINAPI CustomWERExceptionFilter(LPEXCEPTION_POINTERS const excep
 void InternalRegisterCustomHandler() noexcept {
   // Do this now because by the time we catch the exception we may be in OOM
 #ifndef CORE_ABI // win32 vs uwp file permissions
-  wchar_t currentDirectory[MAX_PATH] {};
+  wchar_t currentDirectory[MAX_PATH]{};
   VerifyElseCrash(!!GetTempPath(MAX_PATH, currentDirectory));
   g_logFileName = currentDirectory;
 #else

--- a/vnext/Microsoft.ReactNative/ReactHost/CrashManager.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/CrashManager.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <atomic>
+
+namespace Mso::React {
+
+class CrashManager final {
+ public:
+  static void RegisterCustomHandler() noexcept;
+  static void UnregisterCustomHandler() noexcept;
+  static void OnUnhandledException() noexcept;
+
+#if defined(DEBUG)
+  static std::string TestCollectCrashData();
+#endif
+
+ private:
+  static void CrashHandler(int fileDescriptor) noexcept;
+  static std::atomic_uint _regCount;
+};
+
+} // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -307,6 +307,14 @@ struct ReactOptions {
       bool value) noexcept;
   static bool UseDirectDebugger(winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept;
 
+  //! Enables the default unhandled exception handler
+  void SetEnableDefaultCrashHandler(bool enable) noexcept;
+  bool EnableDefaultCrashHandler() const noexcept;
+  static void SetEnableDefaultCrashHandler(
+      winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
+      bool value) noexcept;
+  static bool EnableDefaultCrashHandler(winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept;
+
   //! Adds registered JS bundle to JSBundles.
   LIBLET_PUBLICAPI ReactOptions &AddRegisteredJSBundle(std::string_view jsBundleId) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactHost.cpp
@@ -75,6 +75,14 @@ winrt::Microsoft::ReactNative::IReactPropertyName EnableFabricProperty() noexcep
   return propName;
 }
 
+winrt::Microsoft::ReactNative::IReactPropertyName EnableDefaultCrashHandlerProperty() noexcept {
+  static winrt::Microsoft::ReactNative::IReactPropertyName propName =
+      winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetName(
+          winrt::Microsoft::ReactNative::ReactPropertyBagHelper::GetNamespace(L"ReactNative.ReactOptions"),
+          L"EnableDefaultCrashHandler");
+  return propName;
+}
+
 //=============================================================================================
 // ReactOptions implementation
 //=============================================================================================
@@ -232,6 +240,25 @@ bool ReactOptions::UseDirectDebugger() const noexcept {
 /*static*/ bool ReactOptions::UseDirectDebugger(
     winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept {
   return winrt::unbox_value_or<bool>(properties.Get(UseDirectDebuggerProperty()), false);
+}
+
+void ReactOptions::SetEnableDefaultCrashHandler(bool enabled) noexcept {
+  Properties.Set(EnableDefaultCrashHandlerProperty(), winrt::box_value(enabled));
+}
+
+bool ReactOptions::EnableDefaultCrashHandler() const noexcept {
+  return EnableDefaultCrashHandler(Properties);
+}
+
+/*static*/ void ReactOptions::SetEnableDefaultCrashHandler(
+    winrt::Microsoft::ReactNative::IReactPropertyBag const &properties,
+    bool value) noexcept {
+  properties.Set(EnableDefaultCrashHandlerProperty(), winrt::box_value(value));
+}
+
+/*static*/ bool ReactOptions::EnableDefaultCrashHandler(
+    winrt::Microsoft::ReactNative::IReactPropertyBag const &properties) noexcept {
+  return winrt::unbox_value_or<bool>(properties.Get(EnableDefaultCrashHandlerProperty()), false);
 }
 
 //=============================================================================================

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -82,6 +82,8 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   bool UseDeveloperSupport() const noexcept;
   JSIEngine JsiEngine() const noexcept;
 
+  static void CrashHandler(int fileDescriptor) noexcept;
+
  private:
   friend MakePolicy;
   ReactInstanceWin(
@@ -123,6 +125,8 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
 
   void DrainJSCallQueue() noexcept;
   void AbandonJSCallQueue() noexcept;
+
+  void InstanceCrashHandler(int fileDescriptor) noexcept;
 
   struct JSCallEntry {
     std::string ModuleName;
@@ -185,6 +189,9 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
 
   std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> m_jsiRuntimeHolder;
   winrt::Microsoft::ReactNative::JsiRuntime m_jsiRuntime{nullptr};
+
+  static std::mutex s_registryMutex; // protects access to s_instanceRegistry
+  static std::vector<ReactInstanceWin *> s_instanceRegistry;
 };
 
 } // namespace Mso::React

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -99,6 +99,14 @@ void ReactInstanceSettings::DebuggerBreakOnNextLine(bool value) noexcept {
   Mso::React::ReactOptions::SetDebuggerBreakOnNextLine(m_properties, value);
 }
 
+bool ReactInstanceSettings::EnableDefaultCrashHandler() noexcept {
+  return Mso::React::ReactOptions::EnableDefaultCrashHandler(m_properties);
+}
+
+void ReactInstanceSettings::EnableDefaultCrashHandler(bool value) noexcept {
+  Mso::React::ReactOptions::SetEnableDefaultCrashHandler(m_properties, value);
+}
+
 bool ReactInstanceSettings::EnableDeveloperMenu() noexcept {
   return UseDeveloperSupport();
 }

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -96,6 +96,9 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   bool EnableByteCodeCaching() noexcept;
   void EnableByteCodeCaching(bool value) noexcept;
 
+  bool EnableDefaultCrashHandler() noexcept;
+  void EnableDefaultCrashHandler(bool value) noexcept;
+
   //! Same as UseDeveloperSupport
   bool EnableDeveloperMenu() noexcept;
   void EnableDeveloperMenu(bool value) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -151,6 +151,11 @@ namespace Microsoft.ReactNative
     DOC_DEFAULT("false")
     Boolean EnableByteCodeCaching { get; set; };
 
+    DOC_STRING(
+      "Opt in to using the default unhandled exception handler that logs additional information into a text file for WER.")
+    DOC_DEFAULT("false")
+    Boolean EnableDefaultCrashHandler { get; set; };
+
     // Deprecated
     [deprecated(
       "This property has been replaced by @.UseDeveloperSupport. "

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -152,7 +152,7 @@ namespace Microsoft.ReactNative
     Boolean EnableByteCodeCaching { get; set; };
 
     DOC_STRING(
-      "Opt in to using the default unhandled exception handler that logs additional information into a text file for WER.")
+      "Enables the default unhandled exception handler that logs additional information into a text file for [Windows Error Reporting](https://docs.microsoft.com/windows/win32/wer/windows-error-reporting).")
     DOC_DEFAULT("false")
     Boolean EnableDefaultCrashHandler { get; set; };
 

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -136,6 +136,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 
   reactOptions.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
   reactOptions.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();
+  reactOptions.SetEnableDefaultCrashHandler(m_instanceSettings.EnableDefaultCrashHandler());
   reactOptions.SetJsiEngine(static_cast<Mso::React::JSIEngine>(m_instanceSettings.JSIEngineOverride()));
 
   reactOptions.ModuleProvider = modulesProvider;

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -89,6 +89,8 @@ struct DevSettings {
   std::function<void()> showDevMenuCallback;
 
   bool inlineSourceMap{true};
+
+  bool enableDefaultCrashHandler{false};
 };
 
 } // namespace react

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -17,6 +17,8 @@ class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
   facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
 
+  void crashHandler(int fileDescriptor) noexcept override;
+
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;

--- a/vnext/Shared/HermesShim.cpp
+++ b/vnext/Shared/HermesShim.cpp
@@ -11,6 +11,8 @@ static decltype(&facebook::hermes::makeHermesRuntime) s_makeHermesRuntime{nullpt
 static decltype(&facebook::hermes::HermesRuntime::enableSamplingProfiler) s_enableSamplingProfiler{nullptr};
 static decltype(&facebook::hermes::HermesRuntime::disableSamplingProfiler) s_disableSamplingProfiler{nullptr};
 static decltype(&facebook::hermes::HermesRuntime::dumpSampledTraceToFile) s_dumpSampledTraceToFile{nullptr};
+static decltype(&facebook::hermes::makeHermesRuntimeWithWER) s_makeHermesRuntimeWithWER{nullptr};
+static decltype(&facebook::hermes::hermesCrashHandler) s_hermesCrashHandler{nullptr};
 
 #if _M_X64
 constexpr const char *makeHermesRuntimeSymbol =
@@ -19,6 +21,9 @@ constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@Her
 constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
 constexpr const char *dumpSampledTraceToFileSymbol =
     "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
+constexpr const char *makeHermesRuntimeWithWERSymbol =
+    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
+constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAEAVHermesRuntime@12@H@Z";
 #endif
 
 #if _M_ARM64
@@ -28,6 +33,9 @@ constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@Her
 constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
 constexpr const char *dumpSampledTraceToFileSymbol =
     "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
+constexpr const char *makeHermesRuntimeWithWERSymbol =
+    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
+constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAEAVHermesRuntime@12@H@Z";
 #endif
 
 #if _M_IX86
@@ -37,6 +45,9 @@ constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@Her
 constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
 constexpr const char *dumpSampledTraceToFileSymbol =
     "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
+constexpr const char *makeHermesRuntimeWithWERSymbol =
+    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
+constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAAVHermesRuntime@12@H@Z";
 #endif
 
 static void EnsureHermesLoaded() noexcept {
@@ -59,6 +70,14 @@ static void EnsureHermesLoaded() noexcept {
     s_dumpSampledTraceToFile = reinterpret_cast<decltype(s_dumpSampledTraceToFile)>(
         GetProcAddress(s_hermesModule, dumpSampledTraceToFileSymbol));
     VerifyElseCrash(s_dumpSampledTraceToFile);
+
+    s_makeHermesRuntimeWithWER = reinterpret_cast<decltype(s_makeHermesRuntimeWithWER)>(
+        GetProcAddress(s_hermesModule, makeHermesRuntimeWithWERSymbol));
+    VerifyElseCrash(s_makeHermesRuntimeWithWER);
+
+    s_hermesCrashHandler =
+        reinterpret_cast<decltype(s_hermesCrashHandler)>(GetProcAddress(s_hermesModule, hermesCrashHandlerSymbol));
+    VerifyElseCrash(s_hermesCrashHandler);
   }
 }
 
@@ -80,6 +99,16 @@ void disableSamplingProfiler() {
 void dumpSampledTraceToFile(const std::string &fileName) {
   EnsureHermesLoaded();
   s_dumpSampledTraceToFile(fileName);
+}
+
+std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeWithWER() {
+  EnsureHermesLoaded();
+  return s_makeHermesRuntimeWithWER();
+}
+
+void hermesCrashHandler(facebook::hermes::HermesRuntime &runtime, int fileDescriptor) {
+  EnsureHermesLoaded();
+  s_hermesCrashHandler(runtime, fileDescriptor);
 }
 
 } // namespace Microsoft::ReactNative::HermesShim

--- a/vnext/Shared/HermesShim.h
+++ b/vnext/Shared/HermesShim.h
@@ -15,5 +15,7 @@ std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes:
 void enableSamplingProfiler();
 void disableSamplingProfiler();
 void dumpSampledTraceToFile(const std::string &fileName);
+std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeWithWER();
+void hermesCrashHandler(facebook::hermes::HermesRuntime &runtime, int fileDescriptor);
 
 } // namespace Microsoft::ReactNative::HermesShim

--- a/vnext/Shared/JSI/RuntimeHolder.h
+++ b/vnext/Shared/JSI/RuntimeHolder.h
@@ -17,6 +17,10 @@ namespace Microsoft::JSI {
 struct RuntimeHolderLazyInit {
   virtual std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept = 0;
   virtual facebook::react::JSIEngineOverride getRuntimeType() noexcept = 0;
+
+  // You can call this when a crash happens to attempt recording additional data
+  // The fd supplied is a raw file stream an implementation might write JSON to
+  virtual void crashHandler(int fileDescriptor) noexcept {};
 };
 
 } // namespace Microsoft::JSI


### PR DESCRIPTION
Note: this is being resubmitted since the [original PR](https://github.com/microsoft/react-native-windows/pull/9150) was lost due to accidental fork cleanup.

## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
We want to make runtime crashes more actionable by recording additional data with Windows Error Reporting which can be requested along crash reports and dumps for analysis.

### What / Why
* Add a CrashManager that calls into crashHandler functions exposed by the ReactInstances. Implement crashHandler for ReactInstance that forwards to JSIRuntimeHolder; the Hermes JSIRuntimeHolder calls into the Hermes VM crashHandler to record some additional details at the time of the crash (such as callstack and addresses of heaps)
* Replaced the Hermes runtime with one that registers additional details (memory blocks, metadata) with Windows Error Reporting to have them available in case of a crash
* Add a EnableDefaultCrashHandler property on the instance settings (default false) which -when enabled- registers a default unhandled exception handler which calls into the CrashManager to register a `CrashDetails.txt` file for WER (this is only uploaded by "requesting additional data" for the bucket in Windows Dev Center / Watson)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9642)