### PR TITLE
Adding to Contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Here's what the contribution process looks like:
 > ⚛️ For RNW-specific walkthrough on setting up your branch, see the [Setup page](https://github.com/microsoft/react-native-windows/wiki/Setup) in our Wiki. 
 
 ### 🔙 **Backporting**
-There are cases when we'll want to port a fix back into one or more of the previous stable releases. If you are working on backporting a fix, your development process will look similar to what's described above, main difference being that your feature branch will need to build off of one of the n-stable branch as the base, instead of main. For example, if you were backporting a change to 0.67-stable you would run the following commands to get your branch set up:
+There are cases when we'll want to port a fix back into one or more of the previous stable releases. If you are working on backporting a fix, your development process will look similar to what's described above, main difference being that your feature branch will need to build off of one of the n-stable branches as the base, instead of main. For example, if you were backporting a change to 0.67-stable you would run the following commands to get your branch set up:
 
 ```
 > git fetch upstream

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ There are cases when we'll want to port a fix back into one or more of the previ
 
 Then once you've added and tested the desired changes, you'll have to make sure to specify the target stable branch, instead of main, as the base branch when creating your PR.
 
-> Note that in order to preserve stability and compatibility we don't backport all fixes, and all backport changes will go through additional triage to get approved.
+> Note that in order to preserve stability and compatibility we don't backport all fixes, and all backport changes beyond a certain release (currently 0.66-stable) will go through additional triage to get approved.
 ### 🧪 Testing
 
 Build and see if your solution works. Consult [Building React-Native-Windows](https://github.com/microsoft/react-native-windows/blob/main/docs/building-rnw.md) if you have problems.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,8 @@ There are cases when we'll want to port a fix back into one or more of the previ
 Then once you've added and tested the desired changes, you'll have to make sure to specify the target stable branch, instead of main, as the base branch when creating your PR.
 
 > Note that in order to preserve stability and compatibility we don't backport all fixes, and all backport changes beyond a certain release (currently 0.66-stable) will go through additional triage to get approved.
+
+For more information, see our [Wiki page on Backporting](https://github.com/microsoft/react-native-windows/wiki/Backporting-a-Change). 
 ### 🧪 Testing
 
 Build and see if your solution works. Consult [Building React-Native-Windows](https://github.com/microsoft/react-native-windows/blob/main/docs/building-rnw.md) if you have problems.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,19 @@ Here's what the contribution process looks like:
 
 > ⚛️ For RNW-specific walkthrough on setting up your branch, see the [Setup page](https://github.com/microsoft/react-native-windows/wiki/Setup) in our Wiki. 
 
+### 🔙 **Backporting**
+There are cases when we'll want to port a fix back into one or more of the previous stable releases. If you are working on backporting a fix, your development process will look similar to what's described above, main difference being that your feature branch will need to build off of one of the n-stable branch as the base, instead of main. For example, if you were backporting a change to 0.67-stable you would run the following commands to get your branch set up:
+
+```
+> git fetch upstream
+> git checkout 0.67-stable
+> git pull upstream 0.67-stable
+> git checkout -b backport_branch_name
+```
+
+Then once you've added and tested the desired changes, you'll have to make sure to specify the target stable branch, instead of main, as the base branch when creating your PR.
+
+> Note that in order to preserve stability and compatibility we don't backport all fixes, and all backport changes will go through additional triage to get approved.
 ### 🧪 Testing
 
 Build and see if your solution works. Consult [Building React-Native-Windows](https://github.com/microsoft/react-native-windows/blob/main/docs/building-rnw.md) if you have problems.


### PR DESCRIPTION
Adding a quick overview of how backporting works to CONTRIBUTING.md, so we can tag issues such as https://github.com/microsoft/react-native-windows/issues/9155 with `help wanted` or `good first issue` and have some guidance to reference on how to get that done. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9643)