### PR TITLE
stop inspector when destructing instance

### DIFF
--- a/change/react-native-windows-687e3d6c-ef99-43b7-b957-b429aa764e9c.json
+++ b/change/react-native-windows-687e3d6c-ef99-43b7-b957-b429aa764e9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "stop inspector when destructing instance",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -526,7 +526,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 }
 
 InstanceImpl::~InstanceImpl() {
-  if (m_devSettings->jsiEngineOverride == JSIEngineOverride::Hermes) {
+  if (shouldStartHermesInspector(*m_devSettings)) {
     m_devManager->StopInspector();
   }
   m_nativeQueue->quitSynchronous();


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When creating new React instances using Hermes with the direct debugging option turned on, the inspector from the previous engine would not get shut down, leading to an accumulation of debug targets in debug clients (see Screenshots for an example).

### What
Change condition in InstanceImpl dtor to match the condition in InstanceImpl ctor.

## Screenshots
Accumulation of debug targets in Chrome Inspect window 
![MicrosoftTeams-image](https://user-images.githubusercontent.com/44379427/156842154-912ff9dc-87c8-444d-ae6c-412728caa1d2.png)


## Testing
Manually tested the change using RNW Playground app and Chrome Inspect page.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9645)