### PR TITLE
Scope down usage of PackageReference

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
-    <ProjectCapability Include="PackageReferences" />
+    <ProjectCapability Include="PackageReferences" Condition="@(PackageReference->Count()) &gt; 0" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -174,6 +174,7 @@
     <Message Text="%0A" />
     <Message Text="NuGet" />
     <Message Text="=> @(_VarsNuGet->PadRight(40)) [$(%(_VarsNuGet.Identity))]" />
+    <Message Text="=> PackageReference->Count                  [@(PackageReference->Count())]" />
 
     <Message Text="%0A" />
     <Message Text="WinUI" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -86,6 +86,8 @@
         VCTargetsPath;
         UserRootDir;
         ProjectHome;
+        IntermediateOutputPath;
+        OutputPath;
       " />
       <_VarsCustom Include="
         RootDir;
@@ -123,7 +125,6 @@
         NuGetPackagesDirectory;
         NuGetRuntimeIdentifier;
         ProjectLockFile;
-        IntermediateOutputPath;
         NuGetTargetMoniker;
         TargetFramework;
         TargetFrameworks;

--- a/change/react-native-windows-60d16274-555b-4c37-aaa3-738a6f44be49.json
+++ b/change/react-native-windows-60d16274-555b-4c37-aaa3-738a6f44be49.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Scope down usage of PackageReferences",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -37,6 +37,9 @@
 
     <PublishDir>$(OutDir)\Publish\</PublishDir>
     <GeneratedFilesDir>$(IntDir)Generated Files\</GeneratedFilesDir>
+
+    <IntermediateOutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntDir)</IntermediateOutputPath>
+    <OutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(OutDir)</OutputPath>
   </PropertyGroup>
 
   <!--

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -9,7 +9,7 @@
     <!--
       Ensure restoring of PackageReference dependencies.
     -->
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackageReference" Condition="@(PackageReference->Count()) &gt; 0" />
 
     <!--
       Ensure restoring of packages.config dependencies.


### PR DESCRIPTION
## Description

Scope down `PackageReference` usage to project that will actually need it.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Usage of `PackageReference` added some overhead to builds under Visual Studio due to its lack of official support.

Closes #9475.
Mitigates #9619.

### What
- Sets `PackageReference`-specific items (`ProjectCapability Include="PackageReferences"`) only when the C++ project actually declares package references.
- Runs de ad-hoc call to the `Restore` target only when `PackageReference` is present.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9647)