### PR TITLE
Use Canvas.Top and Left instead of custom DependencyProperties

### DIFF
--- a/change/react-native-windows-1de81d27-2dc7-4a31-914e-572cdf8c1945.json
+++ b/change/react-native-windows-1de81d27-2dc7-4a31-914e-572cdf8c1945.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use Canvas dependency properties for Top/Left instead of custom DPs",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
@@ -7,6 +7,7 @@
 #include <UI.Xaml.Controls.h>
 #include "DynamicAutomationProperties.h"
 #include "FrameworkElementTransferProperties.h"
+#include "ViewPanel.h"
 
 namespace Microsoft::ReactNative {
 
@@ -45,8 +46,18 @@ void TransferFrameworkElementProperties(const xaml::DependencyObject &oldView, c
   TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
   TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
   TransferProperty(oldView, newView, xaml::Controls::Canvas::ZIndexProperty());
-  TransferProperty(oldView, newView, winrt::Microsoft::ReactNative::ViewPanel::LeftProperty());
-  TransferProperty(oldView, newView, winrt::Microsoft::ReactNative::ViewPanel::TopProperty());
+
+  const auto oldUI = oldView.as<xaml::UIElement>();
+  const auto left = winrt::Microsoft::ReactNative::ViewPanel::GetLeft(oldUI);
+  const auto top = winrt::Microsoft::ReactNative::ViewPanel::GetTop(oldUI);
+  oldUI.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::LeftProperty());
+  oldUI.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::TopProperty());
+  winrt::Microsoft::ReactNative::implementation::ViewPanel::InvalidateForArrange(oldView);
+
+  const auto newUI = newView.as<xaml::UIElement>();
+  winrt::Microsoft::ReactNative::ViewPanel::SetLeft(newUI, left);
+  winrt::Microsoft::ReactNative::ViewPanel::SetTop(newUI, top);
+  // ViewPanel::SetLeft and SetTop already invalidate for arrange
 
   // Accessibility Properties
   TransferProperty(oldView, newView, xaml::Automation::AutomationProperties::AutomationIdProperty());

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -115,7 +115,7 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   InvalidateForArrange(element);
 }
 
-void ViewPanel::InvalidateForArrange(const xaml::DependencyObject& element) {
+void ViewPanel::InvalidateForArrange(const xaml::DependencyObject &element) {
   // If the element's position has changed, we must invalidate the parent for arrange,
   // as it's the parent's responsibility to arrange its children.
   if (auto parent = VisualTreeHelper::GetParent(element)) {

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -47,14 +47,6 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
     panel->m_propertiesChanged = true;
 }
 
-/*static*/ void ViewPanel::PositionPropertyChanged(
-    xaml::DependencyObject sender,
-    xaml::DependencyPropertyChangedEventArgs e) {
-  auto element{sender.as<xaml::UIElement>()};
-  if (element != nullptr)
-    InvalidateForArrange(element);
-}
-
 /*static*/ xaml::DependencyProperty ViewPanel::ViewBackgroundProperty() {
   static xaml::DependencyProperty s_viewBackgroundProperty = xaml::DependencyProperty::Register(
       L"ViewBackground",
@@ -96,23 +88,11 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
 }
 
 /*static*/ xaml::DependencyProperty ViewPanel::TopProperty() {
-  static xaml::DependencyProperty s_topProperty = xaml::DependencyProperty::RegisterAttached(
-      L"Top",
-      winrt::xaml_typename<double>(),
-      viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::box_value((double)0), ViewPanel::PositionPropertyChanged));
-
-  return s_topProperty;
+  return xaml::Controls::Canvas::TopProperty();
 }
 
 /*static*/ xaml::DependencyProperty ViewPanel::LeftProperty() {
-  static xaml::DependencyProperty s_LeftProperty = xaml::DependencyProperty::RegisterAttached(
-      L"Left",
-      winrt::xaml_typename<double>(),
-      viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::box_value((double)0), ViewPanel::PositionPropertyChanged));
-
-  return s_LeftProperty;
+  return xaml::Controls::Canvas::LeftProperty();
 }
 
 /*static*/ xaml::DependencyProperty ViewPanel::ClipChildrenProperty() {
@@ -135,7 +115,7 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   InvalidateForArrange(element);
 }
 
-void ViewPanel::InvalidateForArrange(xaml::UIElement element) {
+void ViewPanel::InvalidateForArrange(const xaml::DependencyObject& element) {
   // If the element's position has changed, we must invalidate the parent for arrange,
   // as it's the parent's responsibility to arrange its children.
   if (auto parent = VisualTreeHelper::GetParent(element)) {

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -77,13 +77,12 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
     return winrt::unbox_value<double>(element.GetValue(LeftProperty()));
   }
 
- static void InvalidateForArrange(const xaml::DependencyObject& element);
+  static void InvalidateForArrange(const xaml::DependencyObject &element);
 
  private:
   void Remove(xaml::UIElement element) const;
 
   void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
-
 
  private:
   bool m_propertiesChanged{false};

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -77,12 +77,13 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
     return winrt::unbox_value<double>(element.GetValue(LeftProperty()));
   }
 
+ static void InvalidateForArrange(const xaml::DependencyObject& element);
+
  private:
   void Remove(xaml::UIElement element) const;
 
   void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
 
-  static void InvalidateForArrange(xaml::UIElement element);
 
  private:
   bool m_propertiesChanged{false};
@@ -93,7 +94,6 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
 
  private:
   static void VisualPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);
-  static void PositionPropertyChanged(xaml::DependencyObject sender, xaml::DependencyPropertyChangedEventArgs e);
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
## Description
This switches the existing ViewPanel custom DependencyProperties for Top/Left with Canvas's own.
This is part 1 of 3 of getting us off of a custom panel. There should be a small (negligible?) perf improvement from this.

Resolves #9632 

## Testing
Ran RNTester, no changes observed, as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9648)