### PR TITLE
Automatically build on `yarn install`

### DIFF
--- a/.ado/templates/yarn-install.yml
+++ b/.ado/templates/yarn-install.yml
@@ -13,11 +13,11 @@ steps:
   # When using our own images, prefer the machine-installed version of
   # `midgard-yarn`.
   - ${{ if eq(parameters.agentImage, 'ManagedImage') }}:
-    - script: midgard-yarn --frozen-lockfile --cwd ${{ parameters.workingDirectory }}
+    - script: midgard-yarn --ignore-scripts --frozen-lockfile --cwd ${{ parameters.workingDirectory }}
       displayName: midgard-yarn (faster yarn install)
 
   # If using an image we don't control, acquire a fixed version of midgard-yarn
   # before install
   - ${{ else }}:
-    - script: npx --yes midgard-yarn@1.23.34 --frozen-lockfile --cwd ${{ parameters.workingDirectory }}
+    - script: npx --yes midgard-yarn@1.23.34 --ignore-scripts --frozen-lockfile --cwd ${{ parameters.workingDirectory }}
       displayName: midgard-yarn (faster yarn install)

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "doc": "doxysaurus --config vnext/doxysaurus.json",
     "format": "format-files -i -style=file -assume-filename=../.clang-format",
     "format:verify": "format-files -i -style=file -verify",
+    "postinstall": "yarn build",
     "test": "lage test --verbose",
     "validate-overrides": "react-native-platform-override validate"
   },


### PR DESCRIPTION
This triggers an incremental build when running `yarn` or `yarn install` from the repo root, to eliminate the need for an extra command. We have some optimizations in our pipelines to not do full builds, so we opt out of this behavior there and keep existing build logic.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9649)