### PR TITLE
Remove prettier extension reccomendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "xaver.clang-format",
-    "esbenp.prettier-vscode",
     "dbaeumer.vscode-eslint",
     "orta.vscode-jest",
     "ms-azure-devops.azure-pipelines",


### PR DESCRIPTION
We run prettier through ESLint. Remove the reccomendation to install the prettier plugin for gthe repo

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9653)