### PR TITLE
Fix turbo module codegen to generate correct import statement and registration

### DIFF
--- a/change/@office-iss-react-native-win32-456d474d-1335-4afa-b705-2469b8b42cd5.json
+++ b/change/@office-iss-react-native-win32-456d474d-1335-4afa-b705-2469b8b42cd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade @types/react-native",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-2bef1ea6-91e9-49fa-a257-8ecd899309a9.json
+++ b/change/@react-native-windows-codegen-2bef1ea6-91e9-49fa-a257-8ecd899309a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix turbo module codegen to generate correct import statement and registration",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-b4b1577a-81c5-4a47-88ae-181bc9bf38e2.json
+++ b/change/react-native-windows-b4b1577a-81c5-4a47-88ae-181bc9bf38e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade @types/react-native",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -64,7 +64,7 @@
     "@types/node": "^14.14.22",
     "@types/prop-types": "15.7.1",
     "@types/react": "^17.0.21",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.32.0",
     "flow-bin": "^0.171.0",

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -177,15 +177,18 @@ function writeMapToFiles(map: Map<string, string>, outputDir: string) {
 function parseFlowFile(filename: string): SchemaType {
   try {
     const schema = parseFile(filename);
-    const contents = fs.readFileSync(filename, 'utf8');
-    if (contents) {
-      if (contents.includes('TurboModuleRegistry.get<')) {
-        for (const spec of schema.modules) {
-          setOptionalTurboModule(spec, false);
-        }
-      } else if (contents.includes('TurboModuleRegistry.getEnforcing<')) {
-        for (const spec of schema.modules) {
-          setOptionalTurboModule(spec, true);
+    // there will be at most one turbo module per file
+    const moduleName = Object.keys(schema.modules)[0];
+    if (moduleName) {
+      const spec = schema.modules[moduleName];
+      if (spec.type === 'NativeModule') {
+        const contents = fs.readFileSync(filename, 'utf8');
+        if (contents) {
+          if (contents.includes('TurboModuleRegistry.get<')) {
+            setOptionalTurboModule(spec, false);
+          } else if (contents.includes('TurboModuleRegistry.getEnforcing<')) {
+            setOptionalTurboModule(spec, true);
+          }
         }
       }
     }

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -184,6 +184,7 @@ function parseFlowFile(filename: string): SchemaType {
       if (spec.type === 'NativeModule') {
         const contents = fs.readFileSync(filename, 'utf8');
         if (contents) {
+          // This is a temporary implementation until such information is added to the schema in facebook/react-native
           if (contents.includes('TurboModuleRegistry.get<')) {
             setOptionalTurboModule(spec, true);
           } else if (contents.includes('TurboModuleRegistry.getEnforcing<')) {

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -185,9 +185,9 @@ function parseFlowFile(filename: string): SchemaType {
         const contents = fs.readFileSync(filename, 'utf8');
         if (contents) {
           if (contents.includes('TurboModuleRegistry.get<')) {
-            setOptionalTurboModule(spec, false);
-          } else if (contents.includes('TurboModuleRegistry.getEnforcing<')) {
             setOptionalTurboModule(spec, true);
+          } else if (contents.includes('TurboModuleRegistry.getEnforcing<')) {
+            setOptionalTurboModule(spec, false);
           }
         }
       }

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -30,9 +30,7 @@ const moduleTemplate = `
  * This is a TypeScript turbo module definition file.
  */
 
-// the following import statements are not actually working today
-import {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
-import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+import {TurboModule, TurboModuleRegistry} from 'react-native';
 'use strict';
 ::_MODULE_ALIASED_STRUCTS_::
 export interface Spec extends TurboModule {

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -18,6 +18,22 @@ import {
   SchemaType,
 } from 'react-native-tscodegen';
 
+interface CodegenNativeModuleSchema extends NativeModuleSchema {
+  optionalTurboModule?: boolean;
+}
+
+export function setOptionalTurboModule(
+  schema: NativeModuleSchema,
+  optional: boolean,
+): void {
+  const cs = <CodegenNativeModuleSchema>schema;
+  cs.optionalTurboModule = optional;
+}
+
+export function getOptionalTurboModule(schema: NativeModuleSchema): boolean {
+  return (<CodegenNativeModuleSchema>schema).optionalTurboModule ?? false;
+}
+
 type ObjectProp = NamedShape<Nullable<NativeModuleBaseTypeAnnotation>>;
 type FunctionParam = NamedShape<Nullable<NativeModuleParamTypeAnnotation>>;
 type FunctionDecl = NamedShape<Nullable<NativeModuleFunctionTypeAnnotation>>;
@@ -37,7 +53,7 @@ export interface Spec extends TurboModule {
 ::_MODULE_MEMBERS_::
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('::_MODULE_NAME_::');
+export default TurboModuleRegistry.::_MODULE_GETTER_::<Spec>('::_MODULE_NAME_::');
 `;
 
 function optionalSign<T>(obj: NamedShape<T>): string {
@@ -218,7 +234,11 @@ export function generateTypeScript(
         moduleTemplate
           .replace(/::_MODULE_ALIASED_STRUCTS_::/g, aliasCode)
           .replace(/::_MODULE_MEMBERS_::/g, constantCode + membersCode)
-          .replace(/::_MODULE_NAME_::/g, preferredModuleName),
+          .replace(/::_MODULE_NAME_::/g, preferredModuleName)
+          .replace(
+            /::_MODULE_GETTER_::/g,
+            getOptionalTurboModule(nativeModule) ? 'get' : 'getEnforcing',
+          ),
       );
     }
   }

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.21",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "babel-jest": "^26.3.0",
     "eslint": "^7.32.0",
     "jest": "^26.6.3",

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/ora": "^3.2.0",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "@types/ws": "^7.4.0",
     "babel-jest": "^26.3.0",
     "eslint": "^7.32.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -26,7 +26,7 @@
     "@rnw-scripts/ts-config": "2.0.2",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.21",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "eslint": "^7.32.0",
     "just-scripts": "^1.3.3",
     "metro-config": "^0.67.0",

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -25,7 +25,7 @@
     "@rnw-scripts/metro-dev-config": "0.0.0",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.21",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "eslint": "^7.32.0",
     "just-scripts": "^1.3.3",
     "metro-config": "^0.67.0",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -65,7 +65,7 @@
     "@rnx-kit/jest-preset": "^0.1.0",
     "@types/node": "^14.14.22",
     "@types/react": "^17.0.21",
-    "@types/react-native": "^0.66.0",
+    "@types/react-native": "^0.66.17",
     "eslint": "^7.32.0",
     "eslint-plugin-prettier": "^4.0.0",
     "flow-bin": "^0.171.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2329,7 +2329,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/react-native@*", "@types/react-native@^0.66.0":
+"@types/react-native@*", "@types/react-native@^0.66.17":
   version "0.66.17"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.66.17.tgz#7a137f84be9b1b12074361fe58a081f93419d612"
   integrity sha512-Q3S+NhPvA1C35L9oLj8hgJj3QXmEC07Kd54o40ngUNQ2jdtAGc+7AKu2RZ3sPcIHpUBWN+WyHkCuPPQHoiDxQg==


### PR DESCRIPTION
`TurboModule` and `TurboModuleRegistry` has been added to `@types/react-native` 0.66.17, fix codegen accordingly.

1. Generate TypeScript code that imports `TurboModule` and `TurboModuleRegistry` directly from react-native.
2. If the input flow spec uses `TurboModuleRegistry.get<Spec>` instead of `getEnforcing`, the generated code does that too.
    1. This is a temporary implementation until such information is added to the schema in facebook/react-native

Here are test cases that **are not included in this PR**
1. [Rex.js](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/src/Libraries/Utilities/Rex.js) -> [RexSpec.g.ts](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/codegen-rex/RexSpec.g.ts)
2. [RexOptional.js](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/src/Libraries/Utilities/RexOptional.js) -> [RexOptionalSpec.g.ts](https://github.com/ZihanChen-MSFT/react-native-windows/blob/tm-rex-sample/vnext/codegen-rex/RexOptionalSpec.g.ts)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9659)