### PR TITLE
[0.68] Fix Sample Apps crash when loading the bundle

### DIFF
--- a/packages/sample-apps/windows/SampleAppCPP/App.xaml
+++ b/packages/sample-apps/windows/SampleAppCPP/App.xaml
@@ -6,5 +6,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:SampleAppCpp"
     xmlns:react="using:Microsoft.ReactNative">
-
+    <Application.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </Application.Resources>
 </react:ReactApplication>

--- a/packages/sample-apps/windows/SampleAppCS/App.xaml
+++ b/packages/sample-apps/windows/SampleAppCS/App.xaml
@@ -6,5 +6,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:SampleAppCS"
     xmlns:react="using:Microsoft.ReactNative">
-
+    <Application.Resources>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+    </Application.Resources>
 </react:ReactApplication>


### PR DESCRIPTION
This PR backports #9676 to 0.68.

Starting in RNW 0.66 (#8245) we changed from using a WUX::ProgressRing to a MUX::ProgressRing that we load into the UI when a bundle is being loaded from metro. This requries that the MUX resources are loaded in the App.xaml. This change was made for Playground, and always been present in the template for new apps, but was never made for the sample apps under `packages/sample-apps`.

Closes #9671

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9677)