### PR TITLE
[0.66] Safe re-entrancy for EnsureHermesLoaded

### DIFF
--- a/change/react-native-windows-ab3ebecb-a61b-4e1f-abd4-379c7d6a81c8.json
+++ b/change/react-native-windows-ab3ebecb-a61b-4e1f-abd4-379c7d6a81c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Safe re-entrancy for EnsureHermesLoaded",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
If ReactNative / HermesRuntime is being initialized simultaneously from multiple threads, we can end up in EnsureHermesLoaded concurrently and use uninitialized function pointers.

Resolves (internal 37798610)

### What
Use std::call_once to ensure we can't call into the method concurrently from separate threads.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9689)