### PR TITLE
[0.68] Update WebView2 Package Import Following PkgRef Support

### DIFF
--- a/change/react-native-windows-2bf487b3-ad01-47f4-a8ca-d446525207d1.json
+++ b/change/react-native-windows-2bf487b3-ad01-47f4-a8ca-d446525207d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update WebView Pkg Dep Following Pkg Ref",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -24,7 +24,6 @@
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\Generated\PackageVersion.g.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\PackageVersionDefinitions.props" />
-  <Import Project="$(SolutionDir)packages\Microsoft.Web.WebView2.$(WebView2Version)\build\native\Microsoft.Web.WebView2.props" Condition="'$(WebView2Version)'!='' And Exists('$(SolutionDir)packages\Microsoft.Web.WebView2.$(WebView2Version)\build\native\Microsoft.Web.WebView2.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
       <Configuration>Debug</Configuration>
@@ -829,13 +828,6 @@
     <When Condition="'$(UseV8)' == 'true'">
       <ItemGroup>
         <PackageReference Include="ReactNative.V8Jsi.Windows.UWP" Version="$(V8Version)" />
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="'$(WebView2Version)'!=''">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.Web.WebView2" Version="$(WebView2Version)" />
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
* Update WebView Pkg Dep Following Pkg Ref

* Change files

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Now that PackageReference is being used WebView2 package version specification and reference is needed. This is implicitly done by importing the WinUI package via PackageReference.

Remove lingering import of WebView2.props.

Note: Apps using community modules, or apps created prior to v0.68 may still need the WebView2 package specified in their packages.config file.

Resolves https://github.com/microsoft/react-native-windows/issues/9618

### What
Remove explicit references/import of WebView2 package.

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

Backport #9706 to 0.68.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9708)