### PR TITLE
Security: Update simple-git dependency to 3.3.0 

### DIFF
--- a/change/@rnw-scripts-create-github-releases-26cbc80f-b6d1-418f-90e2-87f1dda2cbb8.json
+++ b/change/@rnw-scripts-create-github-releases-26cbc80f-b6d1-418f-90e2-87f1dda2cbb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Security: Update simple-git dependency to 3.3.0",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-promote-release-b71596ae-578f-4c3c-a083-e8e3e9c658a9.json
+++ b/change/@rnw-scripts-promote-release-b71596ae-578f-4c3c-a083-e8e3e9c658a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Security: Update simple-git dependency to 3.3.0",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-b98b52ef-61a2-4f68-bd58-42f180e8d178.json
+++ b/change/react-native-platform-override-b98b52ef-61a2-4f68-bd58-42f180e8d178.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Security: Update simple-git dependency to 3.3.0",
+  "packageName": "react-native-platform-override",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -25,7 +25,7 @@
     "glob": "^7.1.6",
     "lodash": "^4.17.15",
     "semver": "^7.3.2",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "yargs": "^16.2.0"
   },

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -22,7 +22,7 @@
     "@react-native-windows/fs": "^1.0.2",
     "@react-native-windows/package-utils": "^0.0.0-canary.26",
     "chalk": "^4.1.0",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "yargs": "^16.2.0"
   },

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -35,7 +35,7 @@
     "node-fetch": "^2.6.7",
     "ora": "^3.4.0",
     "semver": "^7.3.2",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "upath": "^1.2.0",
     "yargs": "^16.2.0"

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -15,6 +15,7 @@ import FileSystemRepository from './FileSystemRepository';
 import {VersionedReactFileRepository} from './FileRepository';
 import {getNpmPackage} from './PackageUtils';
 import {fetchFullRef} from './refFromVersion';
+import {ResetMode} from 'simple-git';
 
 const RN_GITHUB_URL = 'https://github.com/facebook/react-native.git';
 
@@ -124,7 +125,7 @@ export default class GitReactFileRepository
 
         return patch;
       } finally {
-        await this.gitClient.reset('hard');
+        await this.gitClient.reset(ResetMode.HARD);
       }
     });
   }
@@ -178,7 +179,7 @@ export default class GitReactFileRepository
 
         return {patchedFile, hasConflicts};
       } finally {
-        await this.gitClient.reset('hard');
+        await this.gitClient.reset(ResetMode.HARD);
       }
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1467,6 +1467,18 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -4408,7 +4420,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
@@ -10359,12 +10371,14 @@ signedsource@^1.0.0:
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
 
-simple-git@^1.131.0:
-  version "1.132.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.132.0.tgz#53ac4c5ec9e74e37c2fd461e23309f22fcdf09b1"
-  integrity sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==
+simple-git@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.3.0.tgz#91692d576f851be691124781b79872b246d2f92c"
+  integrity sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==
   dependencies:
-    debug "^4.0.1"
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.3"
 
 simple-plist@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
There is a CG alert for older versions of simple-git.

While there is not specific remediation at this time, we're very far
behind and the newest version has a fix, so presumably getting up to
date is in our best interest.

See: https://nvd.nist.gov/vuln/detail/CVE-2022-24433