### PR TITLE
Move some libraries to delayload

### DIFF
--- a/change/react-native-windows-9233768b-4345-43af-8035-08c54dbaa6af.json
+++ b/change/react-native-windows-9233768b-4345-43af-8035-08c54dbaa6af.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "move some DLLs to delayload",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -138,7 +138,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>winsqlite3.lib;ChakraRT.lib;dxguid.lib;dloadhelper.lib;OneCoreUap_apiset.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>chakra.dll;winsqlite3.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>api-ms-win-core-file-l1-2-0.dll;ext-ms-win-uiacore-l1-1-1.dll;api-ms-win-core-windowserrorreporting-l1-1-0.dll;chakra.dll;winsqlite3.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>Microsoft.ReactNative.def</ModuleDefinitionFile>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -138,7 +138,14 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>winsqlite3.lib;ChakraRT.lib;dxguid.lib;dloadhelper.lib;OneCoreUap_apiset.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>api-ms-win-core-file-l1-2-0.dll;ext-ms-win-uiacore-l1-1-1.dll;api-ms-win-core-windowserrorreporting-l1-1-0.dll;chakra.dll;winsqlite3.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <DelayLoadDLLs>
+        api-ms-win-core-file-l1-2-0.dll;
+        api-ms-win-core-windowserrorreporting-l1-1-0.dll;
+        ext-ms-win-uiacore-l1-1-1.dll;
+        chakra.dll;
+        winsqlite3.dll;
+        %(DelayLoadDLLs)
+      </DelayLoadDLLs>
       <SubSystem>Console</SubSystem>
       <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
       <ModuleDefinitionFile>Microsoft.ReactNative.def</ModuleDefinitionFile>


### PR DESCRIPTION
## Description
@dmachaj  spotted this today and this seemed like low hanging fruit to go after (thanks David!!)
Moves some libraries like UIAutomationCore, the WER APIset and some file stuff out to delayload (only used by asyncstorage).
With this I saw a reduction of 1.3 MB in private working set in the example app in react-native-xaml

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Slightly improves memory usage for RNW Apps



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9710)