### PR TITLE
Adds mouse-click events e2e tests

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseClickExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Mouse/MouseClickExample.windows.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+'use strict';
+
+const React = require('react');
+
+const {StyleSheet, View, Text, BackHandler, Button} = require('react-native');
+
+exports.displayName = 'MouseClickExample';
+exports.title = 'Mouse Click Events';
+exports.category = 'Basic';
+exports.description =
+  'Tests that mouse click events work on intended components';
+exports.examples = [
+  {
+    title: 'Mouse click events work on intended components\n',
+    render: function (): React.Node {
+      return <ExampleComponent />;
+    },
+  },
+];
+
+const styles = StyleSheet.create({
+  page: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+  },
+  mainContainer: {
+    width: 400,
+    height: 400,
+    backgroundColor: '#CCCCCC',
+  },
+  logBoxStyle: {
+    width: 250,
+    padding: 10,
+    marginBottom: 10,
+    backgroundColor: '#f9f9f9',
+  },
+  viewStyle: {
+    width: 100,
+    height: 100,
+    padding: 15,
+    margin: 10,
+    justifyContent: 'center',
+    backgroundColor: '#add8e6',
+    borderRadius: 50,
+  },
+});
+
+export default class ExampleComponent extends React.Component<
+  {},
+  {
+    primaryCount: number,
+    secondaryCount: number,
+    auxiliaryCount: number,
+  },
+> {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      primaryCount: 0,
+      secondaryCount: 0,
+      auxiliaryCount: 0,
+    };
+  }
+
+  componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.back);
+  }
+
+  render() {
+    const pageProps: any = {
+      style: styles.page,
+    };
+
+    const clear = () => {
+      this.setState({primaryCount: 0, auxiliaryCount: 0, secondaryCount: 0});
+    };
+
+    const incrementPrimary = () => {
+      this.setState({primaryCount: this.state.primaryCount + 1});
+    };
+
+    const increment = (event: PressEvent) => {
+      if (event.nativeEvent.button === 0) {
+        this.setState({primaryCount: this.state.primaryCount + 1});
+      } else if (event.nativeEvent.button === 1) {
+        this.setState({auxiliaryCount: this.state.auxiliaryCount + 1});
+      } else if (event.nativeEvent.button === 2) {
+        this.setState({secondaryCount: this.state.secondaryCount + 1});
+      }
+    };
+
+    return (
+      <View style={styles.page} {...pageProps}>
+        <View style={styles.logBoxStyle}>
+          <Text testID="press_console_primary">
+            Primary Pressed x{this.state.primaryCount}
+          </Text>
+          <Text testID="press_console_auxiliary">
+            Auxiliary Pressed x{this.state.auxiliaryCount}
+          </Text>
+          <Text testID="press_console_secondary">
+            Secondary Pressed x{this.state.secondaryCount}
+          </Text>
+        </View>
+        <Button
+          testID="clear_state_button"
+          title="Clear state"
+          onPress={clear}
+        />
+        <View style={styles.viewStyle} onStartShouldSetResponder={increment}>
+          <Text testID="view_click">I'm a view!</Text>
+        </View>
+        <Button
+          testID="button_click"
+          title="I'm a button!"
+          onPress={incrementPrimary}
+        />
+      </View>
+    );
+  }
+}

--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -275,6 +275,11 @@ const APIs: Array<RNTesterModuleInfo> = [
     module: require('../examples-win/Mouse/MouseExample'),
   },
   {
+    key: 'MouseClickExample',
+    category: 'Basic',
+    module: require('../examples-win/Mouse/MouseClickExample'),
+  },
+  {
     key: 'NativeAnimationsExample',
     category: 'UI',
     module: require('../examples/NativeAnimation/NativeAnimationsExample'),

--- a/packages/e2e-test-app/test/MouseClickTest.test.ts
+++ b/packages/e2e-test-app/test/MouseClickTest.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @format
+ */
+
+import {app} from '@react-native-windows/automation';
+import {goToApiExample} from './RNTesterNavigation';
+
+beforeAll(async () => {
+  await goToApiExample('Mouse Click Events');
+});
+
+describe('Mouse Click Events', () => {
+  beforeEach(async () => {
+    await clearState();
+  });
+
+  test('Primary-Click on View', async () => {
+    const view = await app.findElementByTestID('view_click');
+    await view.click();
+    void (await checkConsole(1, 0, 0));
+  });
+
+  test('Auxiliary-Click on View', async () => {
+    const view = await app.findElementByTestID('view_click');
+    await view.click({button: 1});
+    void (await checkConsole(0, 1, 0));
+  });
+
+  test('Secondary-Click on View', async () => {
+    const view = await app.findElementByTestID('view_click');
+    await view.click({button: 2});
+    void (await checkConsole(0, 0, 1));
+  });
+
+  test('Primary-Click on Button', async () => {
+    const button = await app.findElementByTestID('button_click');
+    await button.click();
+    void (await checkConsole(1, 0, 0));
+  });
+
+  test('Auxiliary-Click on Button should not work', async () => {
+    const button = await app.findElementByTestID('button_click');
+    await button.click({button: 1});
+    void (await checkConsole(0, 0, 0));
+  });
+
+  test('Secondary-Click on Button should not work', async () => {
+    const button = await app.findElementByTestID('button_click');
+    await button.click({button: 2});
+    void (await checkConsole(0, 0, 0));
+  });
+});
+
+async function clearState() {
+  const clearButton = await app.findElementByTestID('clear_state_button');
+  await clearButton.click();
+}
+
+async function checkConsole(
+  expectedPrimary: int,
+  expectedAuxiliary: int,
+  expectedSecondary: int,
+) {
+  const textPrimary = await app.findElementByTestID('press_console_primary');
+  const textAuxiliary = await app.findElementByTestID(
+    'press_console_auxiliary',
+  );
+  const textSecondary = await app.findElementByTestID(
+    'press_console_secondary',
+  );
+  expect(await textPrimary.getText()).toBe(
+    'Primary Pressed x' + expectedPrimary,
+  );
+  expect(await textAuxiliary.getText()).toBe(
+    'Auxiliary Pressed x' + expectedAuxiliary,
+  );
+  expect(await textSecondary.getText()).toBe(
+    'Secondary Pressed x' + expectedSecondary,
+  );
+}


### PR DESCRIPTION
## Description
Adds page to RN-testers to test basic mouse-click functionality on intended components. Tests that Primary, Auxiliary, and Secondary clicks work on a View but **only** primary clicks work on a button.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Currently we have no tests for Auxiliary or Secondary clicks.

### What
Added page to RN-tester so as click-events for windows grow and develop, so can the test page. 
## Screenshots
https://user-images.githubusercontent.com/42554868/159086657-0472a6fe-e9b5-4af3-85ac-63cbaddcea07.mp4

## Testing
Tested locally

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9719)