### PR TITLE
Add link to e2e-testing doc and small fix

### DIFF
--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -33,16 +33,22 @@ module.exports = {
 
 **Running all tests**
 
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn start`
+> 
 > C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest`
 
 
 **Running a specific test**
 
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn start`
+> 
 ⚠ Only the test filename (without the rest of the path) should be included.
 > C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest visitAllPages.test.ts`
 
 **Break on app start**
 
+> C:\repo\react-native-windows\packages\e2e-test-app> `yarn start`
+> 
 > C:\repo\react-native-windows\packages\e2e-test-app> `yarn e2etest:debug visitAllPages.test.ts`
 
 ## Debugging E2E Tests in CI
@@ -85,8 +91,8 @@ inspect and manipulate a test application, allowing clients to connect to it usi
 
 ### WebDriverIO
 
-WebDriverIO is a JavaScript library which connects to WinAppDriver using the WebDriver protocol. It provides global
-APIs for querying the application UI tree such as selectors (see below) and a global `browser` object to manipulate the
+WebDriverIO is a JavaScript library which connects to WinAppDriver using the WebDriver protocol. It provides [global
+APIs](https://webdriver.io/docs/api) for querying the application UI tree such as selectors (see below) and a global `browser` object to manipulate the
 test application.
 
 ### Jest


### PR DESCRIPTION
## Description
Add link to API documentation for WebDriverIO and specifies that "yarn start" is needed to run any e2e-test loc

### Why
While working through theses docs, I pulled up the wrong WebDriverIO documentation and it took a while to find the right one.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9720)