### PR TITLE
Enable version checks in IDL files

### DIFF
--- a/change/react-native-windows-75461af6-8aa8-4ca9-8277-9e541ff6ffc3.json
+++ b/change/react-native-windows-75461af6-8aa8-4ca9-8277-9e541ff6ffc3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable version checks in IDL files",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/PackageVersionDefinitions.props
+++ b/vnext/PropertySheets/PackageVersionDefinitions.props
@@ -24,5 +24,21 @@
       </PreprocessorDefinitions>
 
     </ClCompile>
+    <Midl>
+
+      <PreprocessorDefinitions>
+        RNW_VERSION=$(ReactNativeWindowsVersion);
+        RNW_MAJOR=$(ReactNativeWindowsMajor);
+        RNW_MINOR=$(ReactNativeWindowsMinor);
+        RNW_PATCH=$(ReactNativeWindowsPatch);
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+
+      <PreprocessorDefinitions Condition="'$(ReactNativeWindowsCanary)' == 'true'">
+        RNW_CANARY;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+
+    </Midl>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
## Description
The version macros don't work in IDL files; this is because the preprocessor macros for MIDL and for the C++ compiler are defined separately.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Needed for doing version checks in modules like react-native-webview (when adding support for WebView2)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9728)