### PR TITLE
Guard against crashes due to cancelations and other errors from BitmapSource/SvgImageSource SetSourceAsync

### DIFF
--- a/change/react-native-windows-c61cf00d-7e3b-4feb-86c3-41f2502f5435.json
+++ b/change/react-native-windows-c61cf00d-7e3b-4feb-86c3-41f2502f5435.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Guard against crashes due to cancelations and other errors from BitmapSource/SvgImageSource SetSourceAsync",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -184,7 +184,7 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> ReactImage::GetImageMe
 }
 template <typename TImage>
 std::wstring GetUriFromImage(const TImage &image) {
-  return image.UriSource().ToString().c_str();
+  return image.UriSource() ? image.UriSource().ToString().c_str() : L"<no Uri available>";
 }
 template <>
 std::wstring GetUriFromImage(const winrt::Uri &uri) {
@@ -193,7 +193,9 @@ std::wstring GetUriFromImage(const winrt::Uri &uri) {
 
 template <typename TImage>
 void ImageFailed(const TImage &image, const xaml::ExceptionRoutedEventArgs &args) {
+#ifdef DEBUG
   cdebug << L"Failed to load image " << GetUriFromImage(image) << L" (" << args.ErrorMessage().c_str() << L")\n";
+#endif
 }
 
 // TSourceFailedEventArgs can be either LoadedImageSourceLoadCompletedEventArgs or
@@ -203,10 +205,12 @@ void ImageFailed(const TImage &image, const xaml::ExceptionRoutedEventArgs &args
 template <typename TImage, typename TSourceFailedEventArgs>
 void ImageFailed(const TImage &image, const TSourceFailedEventArgs &args) {
   // https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.media.loadedimagesourceloadstatus
+#ifdef DEBUG
   constexpr std::wstring_view statusNames[] = {L"Success", L"NetworkError", L"InvalidFormat", L"Other"};
   const auto status = (int)args.Status();
   assert(0 <= status && status < ARRAYSIZE(statusNames));
   cdebug << L"Failed to load image " << GetUriFromImage(image) << L" (" << statusNames[status] << L")\n";
+#endif
 }
 
 winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -342,7 +342,20 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         }
 
         if (fromStream) {
-          co_await svgImageSource.SetSourceAsync(memoryStream);
+          try {
+            co_await svgImageSource.SetSourceAsync(memoryStream);
+          } catch (const winrt::hresult_error&) {
+            /*
+                winrt::hresult_canceled
+                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a SetSourceAsync
+                call is already in progress, the pending SetSourceAsync action will throw a TaskCanceledException and set the Status to Canceled.
+
+                WINCODEC_ERR_BADIMAGE
+                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be raised with the message 
+                "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception ordinarily indicates bad data, if your app is close 
+                to its memory limit then the cause of the exception is likely to be low memory. In that case, we recommend that you free memory and try again.            
+            */
+          }
         } else {
           svgImageSource.UriSource(uri);
         }
@@ -385,7 +398,20 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         }
 
         if (fromStream) {
-          co_await bitmapImage.SetSourceAsync(memoryStream);
+          try {
+            co_await bitmapImage.SetSourceAsync(memoryStream);
+          } catch (const winrt::hresult_error&) {
+            /*
+                winrt::hresult_canceled
+                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a SetSourceAsync
+                call is already in progress, the pending SetSourceAsync action will throw a TaskCanceledException and set the Status to Canceled.
+
+                WINCODEC_ERR_BADIMAGE
+                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be raised with the message 
+                "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception ordinarily indicates bad data, if your app is close 
+                to its memory limit then the cause of the exception is likely to be low memory. In that case, we recommend that you free memory and try again.            
+            */
+          }
         } else {
           bitmapImage.UriSource(uri);
 

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -348,16 +348,18 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         if (fromStream) {
           try {
             co_await svgImageSource.SetSourceAsync(memoryStream);
-          } catch (const winrt::hresult_error&) {
+          } catch (const winrt::hresult_error &) {
             /*
                 winrt::hresult_canceled
-                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a SetSourceAsync
-                call is already in progress, the pending SetSourceAsync action will throw a TaskCanceledException and set the Status to Canceled.
+                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a
+               SetSourceAsync call is already in progress, the pending SetSourceAsync action will throw a
+               TaskCanceledException and set the Status to Canceled.
 
                 WINCODEC_ERR_BADIMAGE
-                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be raised with the message 
-                "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception ordinarily indicates bad data, if your app is close 
-                to its memory limit then the cause of the exception is likely to be low memory. In that case, we recommend that you free memory and try again.            
+                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be
+               raised with the message "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception
+               ordinarily indicates bad data, if your app is close to its memory limit then the cause of the exception
+               is likely to be low memory. In that case, we recommend that you free memory and try again.
             */
           }
         } else {
@@ -404,16 +406,18 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
         if (fromStream) {
           try {
             co_await bitmapImage.SetSourceAsync(memoryStream);
-          } catch (const winrt::hresult_error&) {
+          } catch (const winrt::hresult_error &) {
             /*
                 winrt::hresult_canceled
-                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a SetSourceAsync
-                call is already in progress, the pending SetSourceAsync action will throw a TaskCanceledException and set the Status to Canceled.
+                If the app changes the image source again via SetSourceAsync, SetSource or UriSource while a
+               SetSourceAsync call is already in progress, the pending SetSourceAsync action will throw a
+               TaskCanceledException and set the Status to Canceled.
 
                 WINCODEC_ERR_BADIMAGE
-                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be raised with the message 
-                "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception ordinarily indicates bad data, if your app is close 
-                to its memory limit then the cause of the exception is likely to be low memory. In that case, we recommend that you free memory and try again.            
+                In low memory situations (most likely on lower-memory phones), it is possible for an exception to be
+               raised with the message "The image is unrecognized" and an HRESULT of 0x88982F60. While this exception
+               ordinarily indicates bad data, if your app is close to its memory limit then the cause of the exception
+               is likely to be low memory. In that case, we recommend that you free memory and try again.
             */
           }
         } else {


### PR DESCRIPTION
## Description
This guards against cancelations and "bad image" errors that can occur when trying to set an image's source

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
https://task.ms/38489209



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9735)