### PR TITLE
[0.66] MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early

### DIFF
--- a/change/react-native-windows-8a5e8b21-c7ab-4640-badb-cd9cabcd2ad7.json
+++ b/change/react-native-windows-8a5e8b21-c7ab-4640-badb-cd9cabcd2ad7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early (#9609)",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-8c4bdb9b-4524-4bef-8b96-75ec3f73f6f9.json
+++ b/change/react-native-windows-8c4bdb9b-4524-4bef-8b96-75ec3f73f6f9.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early (#9562)",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-8c4bdb9b-4524-4bef-8b96-75ec3f73f6f9.json
+++ b/change/react-native-windows-8c4bdb9b-4524-4bef-8b96-75ec3f73f6f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "MustBeNoExceptVoidFunctor should depend on the template type parameter to avoid being evaluated too early (#9562)",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/dispatchQueue/dispatchQueue.h
+++ b/vnext/Mso/dispatchQueue/dispatchQueue.h
@@ -723,9 +723,14 @@ inline DispatchTaskImpl<TInvoke, TOnCancel>::~DispatchTaskImpl() noexcept {
   }
 }
 
+namespace details {
+template <typename>
+constexpr bool always_false = false;
+}
+
 template <typename T>
 inline void MustBeNoExceptVoidFunctor() {
-  static_assert(false, __FUNCTION__ ": not a noexcept callable functor returning void");
+  static_assert(details::always_false<T>, __FUNCTION__ ": not a noexcept callable functor returning void");
 }
 
 template <typename TInvoke, typename TOnCancel>


### PR DESCRIPTION
## Description
Port #9562 to 0.66

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9749)