### PR TITLE
Eliminate a whole-bundle string copy

### DIFF
--- a/change/react-native-windows-4221e184-d6c7-49d8-9c92-8ce786a85e4c.json
+++ b/change/react-native-windows-4221e184-d6c7-49d8-9c92-8ce786a85e4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Perf] avoid copying the JS bundle string",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -71,7 +71,7 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
   if (FAILED(hr)) {
     std::string error;
     if (hr == WININET_E_CANNOT_CONNECT) {
-      error = fmt::format("A connection with the server {} could not be established\n\nIs the packager running?", url);
+      error = fmt::format("A connection with the server {} could not be established.\n\nIs the packager running?", url);
     } else {
       error = fmt::format("Error 0x{:x} downloading {}.", static_cast<int>(asyncRequest.ErrorCode()), url);
     }

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -73,7 +73,7 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
     if (hr == WININET_E_CANNOT_CONNECT) {
       error = fmt::format("A connection with the server {} could not be established\n\nIs the packager running?", url);
     } else {
-      error = fmt::format("Error 0x{:x} downloading {}", static_cast<int>(asyncRequest.ErrorCode()), url);
+      error = fmt::format("Error 0x{:x} downloading {}.", static_cast<int>(asyncRequest.ErrorCode()), url);
     }
     co_return std::make_pair(error, false);
   }

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -96,7 +96,7 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
     reader.ReadBytes(winrt::array_view(buf, buf + len));
     result = std::move(data);
   } else {
-    result = fmt::format("HTTP Error {} downloading {}", static_cast<int>(response.StatusCode()), url);
+    result = fmt::format("HTTP Error {} downloading {}.", static_cast<int>(response.StatusCode()), url);
   }
 
   co_return std::make_pair(std::move(result), response.IsSuccessStatusCode());

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -69,13 +69,13 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
 
   HRESULT hr = asyncRequest.ErrorCode();
   if (FAILED(hr)) {
-    std::ostringstream sstream;
+    std::string error;
     if (hr == WININET_E_CANNOT_CONNECT) {
-      sstream << "A connection with the server " << url << " could not be established\n\nIs the packager running?";
+      error = fmt::format("A connection with the server {} could not be established\n\nIs the packager running?", url);
     } else {
-      sstream << "Error " << std::hex << static_cast<int>(asyncRequest.ErrorCode()) << " downloading " << url;
+      error = fmt::format("Error 0x{:x} downloading {}", static_cast<int>(asyncRequest.ErrorCode()), url);
     }
-    co_return std::make_pair(sstream.str(), false);
+    co_return std::make_pair(error, false);
   }
 
   winrt::Windows::Web::Http::HttpResponseMessage response = asyncRequest.GetResults();
@@ -88,15 +88,14 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
   uint32_t len = reader.UnconsumedBufferLength();
   std::string result;
   if (len > 0 || response.IsSuccessStatusCode()) {
-    std::vector<uint8_t> data;
+    std::string data;
     data.resize(len);
-    reader.ReadBytes(winrt::array_view(data.data(), data.data() + len));
-    data.resize(len);
-    result = std::string(data.begin(), data.end());
+    auto buf = reinterpret_cast<uint8_t*>(data.data());
+    static_assert(sizeof(buf[0]) == sizeof(data[0]), "perf optimization relies on uint8_t and char being the same size");
+    reader.ReadBytes(winrt::array_view(buf, buf + len));
+    result = std::move(data);
   } else {
-    std::ostringstream sstream;
-    sstream << "HTTP Error " << static_cast<int>(response.StatusCode()) << " downloading " << url;
-    result = sstream.str();
+    result = fmt::format("HTTP Error {} downloading {}", static_cast<int>(response.StatusCode()), url);
   }
 
   co_return std::make_pair(std::move(result), response.IsSuccessStatusCode());

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -90,8 +90,9 @@ std::future<std::pair<std::string, bool>> GetJavaScriptFromServerAsync(const std
   if (len > 0 || response.IsSuccessStatusCode()) {
     std::string data;
     data.resize(len);
-    auto buf = reinterpret_cast<uint8_t*>(data.data());
-    static_assert(sizeof(buf[0]) == sizeof(data[0]), "perf optimization relies on uint8_t and char being the same size");
+    auto buf = reinterpret_cast<uint8_t *>(data.data());
+    static_assert(
+        sizeof(buf[0]) == sizeof(data[0]), "perf optimization relies on uint8_t and char being the same size");
     reader.ReadBytes(winrt::array_view(buf, buf + len));
     result = std::move(data);
   } else {


### PR DESCRIPTION
## Description
When reading the JS bundle from metro, we read the response as a `uint8_t` buffer, then copy it byte by byte to a std::string.
This gets expensive quickly. The stock hello world app's bundle is about 15.3 MB. On my PC, the string copy takes ~890ms.
Since uint8_t has the same size as char, we can cut some corners and avoid the copy altogether. This takes the copy from the buffer to 15 ms.

tl;dr: This shaves almost a second off of the boot path (in dev mode).

Also replacing some `stringstream` usage with `format` since the latter is slow.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9765)