### PR TITLE
Render cached images synchronously

### DIFF
--- a/change/react-native-windows-874fd606-c45d-4d41-8a3b-676a6dbccbd0.json
+++ b/change/react-native-windows-874fd606-c45d-4d41-8a3b-676a6dbccbd0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[RN][Windows][Perf] Render cached images synchronously",
+  "packageName": "react-native-windows",
+  "email": "mowang@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ImageComponentView.cpp
@@ -20,7 +20,7 @@
 namespace Microsoft::ReactNative {
 
 ImageComponentView::ImageComponentView(winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : m_context(reactContext), m_element(ReactImage::Create()) {
+    : m_context(reactContext), m_element(ReactImage::Create(nullptr, nullptr)) {
   static auto const defaultProps = std::make_shared<facebook::react::ImageProps const>();
   m_props = defaultProps;
 

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -12,13 +12,11 @@
 
 namespace Microsoft::ReactNative {
 
-template <typename TKey, typename TValue>
+template <typename TKey, typename TValue, size_t size>
 class LRUCache {
  public:
   typedef typename std::pair<TKey, TValue> TKeyValuePair;
   typedef typename std::list<TKeyValuePair>::iterator TListIterator;
-
-  LRUCache(size_t maxSize) : m_maxSize(maxSize) {}
 
   void Put(const TKey &key, const TValue &value);
 
@@ -26,16 +24,13 @@ class LRUCache {
 
   bool Exists(const TKey &key) const;
 
-  size_t Size() const;
-
  private:
   std::list<TKeyValuePair> m_cacheItemsList;
   std::unordered_map<TKey, TListIterator> m_cacheItemsMap;
-  size_t m_maxSize;
 };
 
-template <typename TKey, typename TValue>
-void LRUCache<TKey, TValue>::Put(const TKey &key, const TValue &value) {
+template <typename TKey, typename TValue, size_t size>
+void LRUCache<TKey, TValue, size>::Put(const TKey &key, const TValue &value) {
   auto it = m_cacheItemsMap.find(key);
   m_cacheItemsList.push_front(TKeyValuePair(key, value));
   if (it != m_cacheItemsMap.end()) {
@@ -44,7 +39,7 @@ void LRUCache<TKey, TValue>::Put(const TKey &key, const TValue &value) {
   }
   m_cacheItemsMap[key] = m_cacheItemsList.begin();
 
-  if (m_cacheItemsMap.size() > m_maxSize) {
+  if (m_cacheItemsMap.size() > size) {
     auto last = m_cacheItemsList.end();
     last--;
     m_cacheItemsMap.erase(last->first);
@@ -52,8 +47,8 @@ void LRUCache<TKey, TValue>::Put(const TKey &key, const TValue &value) {
   }
 }
 
-template <typename TKey, typename TValue>
-const TValue &LRUCache<TKey, TValue>::Get(const TKey &key) {
+template <typename TKey, typename TValue, size_t size>
+const TValue &LRUCache<TKey, TValue, size>::Get(const TKey &key) {
   auto it = m_cacheItemsMap.find(key);
   if (it == m_cacheItemsMap.end()) {
     throw std::range_error("There is no such key in cache");
@@ -63,14 +58,9 @@ const TValue &LRUCache<TKey, TValue>::Get(const TKey &key) {
   }
 }
 
-template <typename TKey, typename TValue>
-bool LRUCache<TKey, TValue>::Exists(const TKey &key) const {
+template <typename TKey, typename TValue, size_t size>
+bool LRUCache<TKey, TValue, size>::Exists(const TKey &key) const {
   return m_cacheItemsMap.find(key) != m_cacheItemsMap.end();
-}
-
-template <typename TKey, typename TValue>
-size_t LRUCache<TKey, TValue>::Size() const {
-  return m_cacheItemsMap.size();
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -14,10 +14,10 @@ namespace Microsoft::ReactNative {
 
 template <typename TKey, typename TValue, size_t size>
 class LRUCache {
- public:
-  typedef typename std::pair<TKey, TValue> TKeyValuePair;
-  typedef typename std::list<TKeyValuePair>::iterator TListIterator;
+ using TKeyValuePair = typename std::pair<TKey, TValue>;
+ using TListIterator = typename std::list<TKeyValuePair>::iterator;
 
+ public:
   void Put(const TKey &key, const TValue &value);
 
   const TValue &Get(const TKey &key);

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <stdexcept>
 
-namespace react::uwp {
+namespace Microsoft::ReactNative {
 
 template<typename TKey, typename TValue>
 class LRUCache {

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -14,8 +14,8 @@ namespace Microsoft::ReactNative {
 
 template <typename TKey, typename TValue, size_t size>
 class LRUCache {
- using TKeyValuePair = typename std::pair<TKey, TValue>;
- using TListIterator = typename std::list<TKeyValuePair>::iterator;
+  using TKeyValuePair = typename std::pair<TKey, TValue>;
+  using TListIterator = typename std::list<TKeyValuePair>::iterator;
 
  public:
   void Put(const TKey &key, const TValue &value);

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -5,74 +5,72 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <list>
 #include <cstddef>
+#include <list>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace Microsoft::ReactNative {
 
-template<typename TKey, typename TValue>
+template <typename TKey, typename TValue>
 class LRUCache {
-public:
-	typedef typename std::pair<TKey, TValue> TKeyValuePair;
-	typedef typename std::list<TKeyValuePair>::iterator TListIterator;
+ public:
+  typedef typename std::pair<TKey, TValue> TKeyValuePair;
+  typedef typename std::list<TKeyValuePair>::iterator TListIterator;
 
-	LRUCache(size_t maxSize) :
-		m_maxSize(maxSize) {
-	}
+  LRUCache(size_t maxSize) : m_maxSize(maxSize) {}
 
-	void Put(const TKey& key, const TValue& value);
+  void Put(const TKey &key, const TValue &value);
 
-	const TValue& Get(const TKey& key);
+  const TValue &Get(const TKey &key);
 
-	bool Exists(const TKey& key) const;
+  bool Exists(const TKey &key) const;
 
-	size_t Size() const;
+  size_t Size() const;
 
-private:
-	std::list<TKeyValuePair> m_cacheItemsList;
-	std::unordered_map<TKey, TListIterator> m_cacheItemsMap;
-	size_t m_maxSize;
+ private:
+  std::list<TKeyValuePair> m_cacheItemsList;
+  std::unordered_map<TKey, TListIterator> m_cacheItemsMap;
+  size_t m_maxSize;
 };
 
-template<typename TKey, typename TValue>
-void LRUCache<TKey, TValue>::Put(const TKey& key, const TValue& value) {
-    auto it = m_cacheItemsMap.find(key);
-    m_cacheItemsList.push_front(TKeyValuePair(key, value));
-    if (it != m_cacheItemsMap.end()) {
-        m_cacheItemsList.erase(it->second);
-        m_cacheItemsMap.erase(it);
-    }
-    m_cacheItemsMap[key] = m_cacheItemsList.begin();
+template <typename TKey, typename TValue>
+void LRUCache<TKey, TValue>::Put(const TKey &key, const TValue &value) {
+  auto it = m_cacheItemsMap.find(key);
+  m_cacheItemsList.push_front(TKeyValuePair(key, value));
+  if (it != m_cacheItemsMap.end()) {
+    m_cacheItemsList.erase(it->second);
+    m_cacheItemsMap.erase(it);
+  }
+  m_cacheItemsMap[key] = m_cacheItemsList.begin();
 
-    if (m_cacheItemsMap.size() > m_maxSize) {
-        auto last = m_cacheItemsList.end();
-        last--;
-        m_cacheItemsMap.erase(last->first);
-        m_cacheItemsList.pop_back();
-    }
+  if (m_cacheItemsMap.size() > m_maxSize) {
+    auto last = m_cacheItemsList.end();
+    last--;
+    m_cacheItemsMap.erase(last->first);
+    m_cacheItemsList.pop_back();
+  }
 }
 
-template<typename TKey, typename TValue>
-const TValue& LRUCache<TKey, TValue>::Get(const TKey& key) {
-    auto it = m_cacheItemsMap.find(key);
-    if (it == m_cacheItemsMap.end()) {
-        throw std::range_error("There is no such key in cache");
-    } else {
-        m_cacheItemsList.splice(m_cacheItemsList.begin(), m_cacheItemsList, it->second);
-        return it->second->second;
-    }
+template <typename TKey, typename TValue>
+const TValue &LRUCache<TKey, TValue>::Get(const TKey &key) {
+  auto it = m_cacheItemsMap.find(key);
+  if (it == m_cacheItemsMap.end()) {
+    throw std::range_error("There is no such key in cache");
+  } else {
+    m_cacheItemsList.splice(m_cacheItemsList.begin(), m_cacheItemsList, it->second);
+    return it->second->second;
+  }
 }
 
-template<typename TKey, typename TValue>
-bool LRUCache<TKey, TValue>::Exists(const TKey& key) const {
-    return m_cacheItemsMap.find(key) != m_cacheItemsMap.end();
+template <typename TKey, typename TValue>
+bool LRUCache<TKey, TValue>::Exists(const TKey &key) const {
+  return m_cacheItemsMap.find(key) != m_cacheItemsMap.end();
 }
 
-template<typename TKey, typename TValue>
+template <typename TKey, typename TValue>
 size_t LRUCache<TKey, TValue>::Size() const {
-    return m_cacheItemsMap.size();
+  return m_cacheItemsMap.size();
 }
 
-}
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/LRUCache.h
+++ b/vnext/Microsoft.ReactNative/Utils/LRUCache.h
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// Credit: https://github.com/lamerman/cpp-lru-cache
+
+#pragma once
+
+#include <unordered_map>
+#include <list>
+#include <cstddef>
+#include <stdexcept>
+
+namespace react::uwp {
+
+template<typename TKey, typename TValue>
+class LRUCache {
+public:
+	typedef typename std::pair<TKey, TValue> TKeyValuePair;
+	typedef typename std::list<TKeyValuePair>::iterator TListIterator;
+
+	LRUCache(size_t maxSize) :
+		m_maxSize(maxSize) {
+	}
+
+	void Put(const TKey& key, const TValue& value);
+
+	const TValue& Get(const TKey& key);
+
+	bool Exists(const TKey& key) const;
+
+	size_t Size() const;
+
+private:
+	std::list<TKeyValuePair> m_cacheItemsList;
+	std::unordered_map<TKey, TListIterator> m_cacheItemsMap;
+	size_t m_maxSize;
+};
+
+template<typename TKey, typename TValue>
+void LRUCache<TKey, TValue>::Put(const TKey& key, const TValue& value) {
+    auto it = m_cacheItemsMap.find(key);
+    m_cacheItemsList.push_front(TKeyValuePair(key, value));
+    if (it != m_cacheItemsMap.end()) {
+        m_cacheItemsList.erase(it->second);
+        m_cacheItemsMap.erase(it);
+    }
+    m_cacheItemsMap[key] = m_cacheItemsList.begin();
+
+    if (m_cacheItemsMap.size() > m_maxSize) {
+        auto last = m_cacheItemsList.end();
+        last--;
+        m_cacheItemsMap.erase(last->first);
+        m_cacheItemsList.pop_back();
+    }
+}
+
+template<typename TKey, typename TValue>
+const TValue& LRUCache<TKey, TValue>::Get(const TKey& key) {
+    auto it = m_cacheItemsMap.find(key);
+    if (it == m_cacheItemsMap.end()) {
+        throw std::range_error("There is no such key in cache");
+    } else {
+        m_cacheItemsList.splice(m_cacheItemsList.begin(), m_cacheItemsList, it->second);
+        return it->second->second;
+    }
+}
+
+template<typename TKey, typename TValue>
+bool LRUCache<TKey, TValue>::Exists(const TKey& key) const {
+    return m_cacheItemsMap.find(key) != m_cacheItemsMap.end();
+}
+
+template<typename TKey, typename TValue>
+size_t LRUCache<TKey, TValue>::Size() const {
+    return m_cacheItemsMap.size();
+}
+
+}

--- a/vnext/Microsoft.ReactNative/Utils/cgmanifest.json
+++ b/vnext/Microsoft.ReactNative/Utils/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                    "RepositoryUrl": "https://github.com/lamerman/cpp-lru-cache",
+                    "CommitHash": "de1c4a03569bf3bd540e7f55ab5c2961411dbe22"
+                }
+            },
+            "DevelopmentDependency": false
+        }
+    ]
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -106,14 +106,17 @@ class ImageShadowNode : public ShadowNodeBase {
   winrt::event_token m_onLoadEndToken;
 };
 
-ImageViewManager::ImageViewManager(const Mso::React::IReactContext &context) : Super(context) {}
+ImageViewManager::ImageViewManager(const Mso::React::IReactContext &context) : Super(context) {
+  m_imageCache = std::make_shared<ImageCache>(100);
+  m_surfaceCache = std::make_shared<SurfaceCache>(100);
+}
 
 const wchar_t *ImageViewManager::GetName() const {
   return L"RCTImageView";
 }
 
 XamlView ImageViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microsoft::ReactNative::JSValueObject &) {
-  return ReactImage::Create().as<winrt::Grid>();
+  return ReactImage::Create(m_imageCache, m_surfaceCache).as<winrt::Grid>();
 }
 
 ShadowNode *ImageViewManager::createShadow() const {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -107,8 +107,8 @@ class ImageShadowNode : public ShadowNodeBase {
 };
 
 ImageViewManager::ImageViewManager(const Mso::React::IReactContext &context) : Super(context) {
-  m_imageCache = std::make_shared<ImageCache>(100);
-  m_surfaceCache = std::make_shared<SurfaceCache>(100);
+  m_imageCache = std::make_shared<ImageCache>();
+  m_surfaceCache = std::make_shared<SurfaceCache>();
 }
 
 const wchar_t *ImageViewManager::GetName() const {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
@@ -30,5 +30,7 @@ class ImageViewManager : public FrameworkElementViewManager {
 
  private:
   void setSource(xaml::Controls::Grid grid, const winrt::Microsoft::ReactNative::JSValue &sources);
+  std::shared_ptr<ImageCache> m_imageCache{nullptr};
+  std::shared_ptr<SurfaceCache> m_surfaceCache{nullptr};
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -33,7 +33,9 @@ using Microsoft::Common::Unicode::Utf8ToUtf16;
 
 namespace Microsoft::ReactNative {
 
-/*static*/ winrt::com_ptr<ReactImage> ReactImage::Create(std::shared_ptr<ImageCache> imageCache, std::shared_ptr<SurfaceCache> surfaceCache) {
+/*static*/ winrt::com_ptr<ReactImage> ReactImage::Create(
+    std::shared_ptr<ImageCache> imageCache,
+    std::shared_ptr<SurfaceCache> surfaceCache) {
   auto reactImage = winrt::make_self<ReactImage>(imageCache, surfaceCache);
   // Grid inheirts the layout direction from parent and mirrors the background image in RTL mode.
   // Forcing the container to LTR mode to avoid the unexpected mirroring behavior.
@@ -439,8 +441,10 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
         // Create a new bitmap image if
         // a.) there is no bitmap image from the image brush, or
-        // b.) the uri has changed, (Since the BitmapImage is mutable, to ensure the cache's integrity, a uri must pair with its own bitmap image)
-        if (!bitmapImage || !(uri && bitmapImage.UriSource() && uri.AbsoluteUri() == bitmapImage.UriSource().AbsoluteUri())) {
+        // b.) the uri has changed, (Since the BitmapImage is mutable, to ensure the cache's integrity, a uri must pair
+        // with its own bitmap image)
+        if (!bitmapImage ||
+            !(uri && bitmapImage.UriSource() && uri.AbsoluteUri() == bitmapImage.UriSource().AbsoluteUri())) {
           bitmapImage = winrt::BitmapImage{};
 
           strong_this->m_bitmapImageOpened = bitmapImage.ImageOpened(

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -226,7 +226,7 @@ bool ReactImage::TrySetBackgroundSync(bool fireLoadEndEvent) {
 
   bool shouldUseCache = false;
 
-  if (!m_useCompositionBrush && m_imageCache->Exists(source.uri)) {
+  if (!m_useCompositionBrush && (m_imageCache && m_imageCache->Exists(source.uri))) {
     shouldUseCache = true;
 
     winrt::ImageBrush imageBrush{Background().try_as<winrt::ImageBrush>()};
@@ -245,7 +245,7 @@ bool ReactImage::TrySetBackgroundSync(bool fireLoadEndEvent) {
     if (createImageBrush) {
       Background(imageBrush);
     }
-  } else if (m_useCompositionBrush && m_surfaceCache->Exists(source.uri)) {
+  } else if (m_useCompositionBrush && (m_surfaceCache && m_surfaceCache->Exists(source.uri))) {
     shouldUseCache = true;
 
     const auto compositionBrush{ReactImageBrush::Create()};
@@ -362,7 +362,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
 
                   strong_this->Background(compositionBrush.as<winrt::XamlCompositionBrushBase>());
 
-                  if (source.sourceType == ImageSourceType::Uri) {
+                  if (source.sourceType == ImageSourceType::Uri && strong_this->m_surfaceCache) {
                     strong_this->m_surfaceCache->Put(source.uri, surface);
                   }
 
@@ -454,7 +454,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
                     strong_this->m_imageSource.width = bitmap.PixelWidth();
                     imageBrush.Stretch(strong_this->ResizeModeToStretch());
 
-                    if (source.sourceType == ImageSourceType::Uri) {
+                    if (source.sourceType == ImageSourceType::Uri && strong_this->m_imageCache) {
                       strong_this->m_imageCache->Put(source.uri, bitmap);
                     }
                   }

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -77,7 +77,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
   GetImageMemoryStreamAsync(ReactImageSource source);
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
-  bool ReactImage::TrySetBackgroundSync(bool fireLoadEndEvent);
+  bool TrySetBackgroundSync(bool fireLoadEndEvent);
 
   bool m_useCompositionBrush{false};
   float m_blurRadius{0};

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -31,8 +31,8 @@ struct ReactImageSource {
   ImageSourceFormat sourceFormat = ImageSourceFormat::Bitmap;
 };
 
-typedef typename LRUCache<std::string, xaml::Media::Imaging::BitmapImage, 100> ImageCache;
-typedef typename LRUCache<std::string, xaml::Media::LoadedImageSurface, 100> SurfaceCache;
+using ImageCache = typename LRUCache<std::string, xaml::Media::Imaging::BitmapImage, 100>;
+using SurfaceCache = typename LRUCache<std::string, xaml::Media::LoadedImageSurface, 100>;
 
 struct ReactImage : xaml::Controls::GridT<ReactImage> {
   using Super = xaml::Controls::GridT<ReactImage>;

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -38,9 +38,12 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   using Super = xaml::Controls::GridT<ReactImage>;
 
  public:
-  static winrt::com_ptr<ReactImage> Create(std::shared_ptr<ImageCache> imageCache, std::shared_ptr<SurfaceCache> surfaceCache);
+  static winrt::com_ptr<ReactImage> Create(
+      std::shared_ptr<ImageCache> imageCache,
+      std::shared_ptr<SurfaceCache> surfaceCache);
 
-  ReactImage(std::shared_ptr<ImageCache> imageCache, std::shared_ptr<SurfaceCache> surfaceCache): m_imageCache{imageCache}, m_surfaceCache{surfaceCache} {};
+  ReactImage(std::shared_ptr<ImageCache> imageCache, std::shared_ptr<SurfaceCache> surfaceCache)
+      : m_imageCache{imageCache}, m_surfaceCache{surfaceCache} {};
 
   // Overrides
   winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size finalSize);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -31,8 +31,8 @@ struct ReactImageSource {
   ImageSourceFormat sourceFormat = ImageSourceFormat::Bitmap;
 };
 
-typedef typename LRUCache<std::string, xaml::Media::Imaging::BitmapImage> ImageCache;
-typedef typename LRUCache<std::string, xaml::Media::LoadedImageSurface> SurfaceCache;
+typedef typename LRUCache<std::string, xaml::Media::Imaging::BitmapImage, 100> ImageCache;
+typedef typename LRUCache<std::string, xaml::Media::LoadedImageSurface, 100> SurfaceCache;
 
 struct ReactImage : xaml::Controls::GridT<ReactImage> {
   using Super = xaml::Controls::GridT<ReactImage>;


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Previously the cached images still render asynchronously and therefore appear on the screen a few frames later than the adjacent UI, which results in flickers and flashes. The issue gets exacerbated on slower machines or when UI is busy.

### What
In this PR I added a LRU cache which stores the loaded BitmapImage so that the image can render synchronously from the cache next time.

## Screenshots
Below is the frame-by-frame playback for the before-and-after comparison.

Before: (Images appear after a few frames after the other UI has rendered)

https://user-images.githubusercontent.com/1132214/161341592-111b6412-07f0-44dc-8e86-5e876adcc401.mp4

After: (Images appear at the same time with the other UI)

https://user-images.githubusercontent.com/1132214/161341462-0bad8855-ffa0-4721-af6a-60fa61b069d2.mp4


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9766)