### PR TITLE
Enable loading the bundle from an embedded resource via resource://moduleName/resourceId

### DIFF
--- a/change/react-native-windows-73626f69-9b5c-4bcc-bf4a-2bffdfab80b6.json
+++ b/change/react-native-windows-73626f69-9b5c-4bcc-bf4a-2bffdfab80b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable loading the bundle from an embedded resource via resource://moduleName/resourceId",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -100,7 +100,8 @@ namespace Microsoft.ReactNative
 
     DOC_STRING(
       "The name of the JavaScript bundle file to load. This should be a relative path from @.BundleRootPath. "
-      "The `.bundle` extension will be appended to the end, when looking for the bundle file.")
+      "The `.bundle` extension will be appended to the end, when looking for the bundle file.\n"
+      "If using an embedded RCDATA resource, this identifies the resource ID that stores the bundle. See @.BundleRootPath.")
     DOC_DEFAULT("index.windows")
     String JavaScriptBundleFile { get; set; };
 
@@ -183,8 +184,8 @@ namespace Microsoft.ReactNative
       "Examples:\n\n"
       "- `ms-appx:///Bundle` - locates the bundle in the MSIX package. See [URI schemes](https://docs.microsoft.com/windows/uwp/app-resources/uri-schemes) for other UWP/MSIX valid URI formats."
       "- `C:\\foo\\bar` - locates the bundle in the local filesystem. Note [UWP app file access permissions](https://docs.microsoft.com/windows/uwp/files/file-access-permissions)."
-      "- `resource://moduleName/resourceID` - locates the bundle as an embedded RCDATA resource in moduleName."
-      "- `resource:///resourceID` - locates the bundle as an embedded RCDATA resource in the running process's module."
+      "- `resource://moduleName` - locates the bundle as an embedded RCDATA resource in moduleName. Specify the resource ID in @.JavaScriptBundleFile."
+      "- `resource://` - locates the bundle as an embedded RCDATA resource in the running process's module. Specify the resource ID in @.JavaScriptBundleFile."
     )
     DOC_DEFAULT("ms-appx:///Bundle/")
     String BundleRootPath { get; set; };

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -180,9 +180,12 @@ namespace Microsoft.ReactNative
       "Base path used for the location of the bundle. \n"
       "This can be an `ms-appx://` or `ms-appdata://` URI (if the app is UWP or packaged using MSIX), "
       "a filesystem path, or a URI pointing at an embedded resource.\n"
-      "To specify an embedded (`RCDATA`) resource, use the format `resource://moduleName` for @.BundleRootPath "
-      "and use the resource ID as the @.JavaScriptBundleFile. If `moduleName` is empty, the embedded bundle resource "
-      " will be searched for in the running process's module.")
+      "Examples:\n\n"
+      "- `ms-appx:///Bundle` - locates the bundle in the MSIX package. See [URI schemes](https://docs.microsoft.com/windows/uwp/app-resources/uri-schemes) for other UWP/MSIX valid URI formats."
+      "- `C:\\foo\\bar` - locates the bundle in the local filesystem. Note [UWP app file access permissions](https://docs.microsoft.com/windows/uwp/files/file-access-permissions)."
+      "- `resource://moduleName/resourceID` - locates the bundle as an embedded RCDATA resource in moduleName."
+      "- `resource:///resourceID` - locates the bundle as an embedded RCDATA resource in the running process's module."
+    )
     DOC_DEFAULT("ms-appx:///Bundle/")
     String BundleRootPath { get; set; };
 

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -176,7 +176,13 @@ namespace Microsoft.ReactNative
       "If this is not provided, the value of @.JavaScriptBundleFile is used.")
     String DebugBundlePath { get; set; };
 
-    DOC_STRING("Base path used for the location of the bundle.")
+    DOC_STRING(
+      "Base path used for the location of the bundle. \n"
+      "This can be an `ms-appx://` or `ms-appdata://` URI (if the app is UWP or packaged using MSIX), "
+      "a filesystem path, or a URI pointing at an embedded resource.\n"
+      "To specify an embedded (`RCDATA`) resource, use the format `resource://moduleName` for @.BundleRootPath "
+      "and use the resource ID as the @.JavaScriptBundleFile. If `moduleName` is empty, the embedded bundle resource "
+      " will be searched for in the running process's module.")
     DOC_DEFAULT("ms-appx:///Bundle/")
     String BundleRootPath { get; set; };
 

--- a/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
@@ -65,8 +65,7 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string &b
     winrt::Windows::Foundation::Uri uri(str);
     file = co_await winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
   } else if (bundleUri._Starts_with("resource://")) {
-    script = GetBundleFromEmbeddedResource(str);
-    co_return script;
+    co_return GetBundleFromEmbeddedResource(str);
   } else {
     file = co_await winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(str);
   }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -509,7 +509,13 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
       auto bundleString = FileMappingBigString::fromPath(bundlePath);
 #else
-      std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
+      std::string bundlePath;
+      if (m_devSettings->bundleRootPath._Starts_with("resource://")) {
+        bundlePath = fmt::format(R"({}/{}.bundle)", m_devSettings->bundleRootPath, jsBundleRelativePath);
+      } else {
+        bundlePath = fmt::format(R"({}\{}.bundle)", m_devSettings->bundleRootPath, jsBundleRelativePath);
+      }
+
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);
 #endif
       m_innerInstance->loadScriptFromString(std::move(bundleString), std::move(jsBundleRelativePath), synchronously);
@@ -517,11 +523,9 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
   } catch (const std::exception &e) {
     m_devSettings->errorCallback(e.what());
   } catch (const winrt::hresult_error &hrerr) {
-    std::stringstream ss;
-    ss << "[" << std::hex << std::showbase << std::setw(8) << static_cast<uint32_t>(hrerr.code()) << "] "
-       << winrt::to_string(hrerr.message());
+    auto ss = fmt::format("[0x{:0>8x}] {}", static_cast<uint32_t>(hrerr.code()), winrt::to_string(hrerr.message()));
 
-    m_devSettings->errorCallback(std::move(ss.str()));
+    m_devSettings->errorCallback(std::move(ss));
   }
 }
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -511,9 +511,11 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 #else
       std::string bundlePath;
       if (m_devSettings->bundleRootPath._Starts_with("resource://")) {
-        bundlePath = fmt::format(R"({}/{}.bundle)", m_devSettings->bundleRootPath, jsBundleRelativePath);
+        bundlePath = winrt::Windows::Foundation::Uri(
+                         winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath))
+                         .ToString();
       } else {
-        bundlePath = fmt::format(R"({}\{}.bundle)", m_devSettings->bundleRootPath, jsBundleRelativePath);
+        bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);
@@ -523,9 +525,9 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
   } catch (const std::exception &e) {
     m_devSettings->errorCallback(e.what());
   } catch (const winrt::hresult_error &hrerr) {
-    auto ss = fmt::format("[0x{:0>8x}] {}", static_cast<uint32_t>(hrerr.code()), winrt::to_string(hrerr.message()));
+    auto error = fmt::format("[0x{:0>8x}] {}", static_cast<uint32_t>(hrerr.code()), winrt::to_string(hrerr.message()));
 
-    m_devSettings->errorCallback(std::move(ss));
+    m_devSettings->errorCallback(std::move(error));
   }
 }
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -515,7 +515,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
             winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath));
         bundlePath = winrt::to_string(uri.ToString());
       } else {
-        bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
+        bundlePath = (fs::path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -511,9 +511,9 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 #else
       std::string bundlePath;
       if (m_devSettings->bundleRootPath._Starts_with("resource://")) {
-        bundlePath = winrt::Windows::Foundation::Uri(
-                         winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath))
-                         .ToString();
+        auto uri = winrt::Windows::Foundation::Uri(
+            winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath));
+        bundlePath = winrt::to_string(uri.ToString());
       } else {
         bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
       }


### PR DESCRIPTION
## Description
Enable loading the JS bundle from an embedded resource via a `resource://moduleName/resourceId` URI.
This is already something that the desktop DLL does albeit through a different codepath so I don't want to touch that for the time being. Once this change goes in, maybe Office can move to this as a standard approach so we don't have to have two copies of essentially the same code.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
With the emphasis in non-UWP / WinAppSDK apps moving forward, it will be necessary to be able to load the bundle in other ways that aren't necessarily MRT / MRTCore.

Fixes #9769

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9768)