### PR TITLE
[0.66] Security: Update simple-git dependency to 3.3.0

### DIFF
--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -19,7 +19,7 @@
     "glob": "^7.1.6",
     "lodash": "^4.17.15",
     "semver": "^7.3.2",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "yargs": "^16.2.0"
   },

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -14,7 +14,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import semver from 'semver';
-import simplegit from 'simple-git/promise';
+import simplegit from 'simple-git';
 import util from 'util';
 import yargs from 'yargs';
 

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -16,7 +16,7 @@
     "@react-native-windows/find-repo-root": "0.66.1",
     "@react-native-windows/package-utils": "0.66.1",
     "chalk": "^4.1.0",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "yargs": "^16.2.0"
   },

--- a/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
+++ b/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
@@ -14,7 +14,7 @@
 
 import chalk from 'chalk';
 import child_process from 'child_process';
-import simplegit from 'simple-git/promise';
+import simplegit from 'simple-git';
 import yargs from 'yargs';
 
 import {
@@ -158,7 +158,7 @@ async function updateBeachballConfig(
  * Finds packages where we need to update version number + beachball config
  */
 async function enumeratePackagesToPromote(): Promise<WritableNpmPackage[]> {
-  return enumerateRepoPackages(async pkg => pkg.json.promoteRelease === true);
+  return enumerateRepoPackages(async (pkg) => pkg.json.promoteRelease === true);
 }
 
 /**
@@ -181,7 +181,7 @@ function distTag(release: ReleaseType, version: string): string {
  */
 async function updatePackageVersions(version: string) {
   const packagesToPromote = await enumeratePackagesToPromote();
-  const promotedPackages = packagesToPromote.map(p => p.json.name);
+  const promotedPackages = packagesToPromote.map((p) => p.json.name);
 
   for (const pkg of packagesToPromote) {
     await pkg.mergeProps({version});
@@ -218,7 +218,7 @@ async function updatePackageVersions(version: string) {
  */
 async function markMainBranchPackagesPrivate() {
   const mainBranchPublishedPackages = await enumerateRepoPackages(
-    async pkg => !pkg.json.promoteRelease && !pkg.json.private,
+    async (pkg) => !pkg.json.promoteRelease && !pkg.json.private,
   );
 
   for (const pkg of mainBranchPublishedPackages) {

--- a/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
+++ b/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
@@ -158,7 +158,7 @@ async function updateBeachballConfig(
  * Finds packages where we need to update version number + beachball config
  */
 async function enumeratePackagesToPromote(): Promise<WritableNpmPackage[]> {
-  return enumerateRepoPackages(async (pkg) => pkg.json.promoteRelease === true);
+  return enumerateRepoPackages(async pkg => pkg.json.promoteRelease === true);
 }
 
 /**
@@ -181,7 +181,7 @@ function distTag(release: ReleaseType, version: string): string {
  */
 async function updatePackageVersions(version: string) {
   const packagesToPromote = await enumeratePackagesToPromote();
-  const promotedPackages = packagesToPromote.map((p) => p.json.name);
+  const promotedPackages = packagesToPromote.map(p => p.json.name);
 
   for (const pkg of packagesToPromote) {
     await pkg.mergeProps({version});
@@ -218,7 +218,7 @@ async function updatePackageVersions(version: string) {
  */
 async function markMainBranchPackagesPrivate() {
   const mainBranchPublishedPackages = await enumerateRepoPackages(
-    async (pkg) => !pkg.json.promoteRelease && !pkg.json.private,
+    async pkg => !pkg.json.promoteRelease && !pkg.json.private,
   );
 
   for (const pkg of mainBranchPublishedPackages) {

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -34,7 +34,7 @@
     "node-fetch": "^2.6.0",
     "ora": "^3.4.0",
     "semver": "^7.3.2",
-    "simple-git": "^1.131.0",
+    "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "upath": "^1.2.0",
     "yargs": "^16.2.0"

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import semver from 'semver';
-import simplegit from 'simple-git/promise';
+import simplegit, {SimpleGit, ResetMode} from 'simple-git';
 
 import BatchingQueue from './BatchingQueue';
 import FileSystemRepository from './FileSystemRepository';
@@ -26,9 +26,10 @@ const RN_GITHUB_URL = 'https://github.com/facebook/react-native.git';
  * between getting file contents of different versions may be slow.
  */
 export default class GitReactFileRepository
-  implements VersionedReactFileRepository {
+  implements VersionedReactFileRepository
+{
   private readonly fileRepo: FileSystemRepository;
-  private readonly gitClient: simplegit.SimpleGit;
+  private readonly gitClient: SimpleGit;
   private checkedOutVersion?: string;
   private static githubToken?: string;
 
@@ -37,7 +38,7 @@ export default class GitReactFileRepository
   // ensure they are performed atomically.
   private readonly batchingQueue: BatchingQueue<string>;
 
-  private constructor(gitDirectory: string, gitClient: simplegit.SimpleGit) {
+  private constructor(gitDirectory: string, gitClient: SimpleGit) {
     this.batchingQueue = new BatchingQueue();
     this.fileRepo = new FileSystemRepository(gitDirectory);
     this.gitClient = gitClient;
@@ -54,7 +55,6 @@ export default class GitReactFileRepository
     await fs.promises.mkdir(dir, {recursive: true});
 
     const gitClient = simplegit(dir);
-    gitClient.silent(true);
 
     if (!(await gitClient.checkIsRepo())) {
       await gitClient.init();
@@ -126,7 +126,7 @@ export default class GitReactFileRepository
 
         return patch;
       } finally {
-        await this.gitClient.reset('hard');
+        await this.gitClient.reset(ResetMode.HARD);
       }
     });
   }
@@ -178,7 +178,7 @@ export default class GitReactFileRepository
 
         return {patchedFile, hasConflicts};
       } finally {
-        await this.gitClient.reset('hard');
+        await this.gitClient.reset(ResetMode.HARD);
       }
     });
   }

--- a/packages/react-native-platform-override/src/GitReactFileRepository.ts
+++ b/packages/react-native-platform-override/src/GitReactFileRepository.ts
@@ -26,8 +26,7 @@ const RN_GITHUB_URL = 'https://github.com/facebook/react-native.git';
  * between getting file contents of different versions may be slow.
  */
 export default class GitReactFileRepository
-  implements VersionedReactFileRepository
-{
+  implements VersionedReactFileRepository {
   private readonly fileRepo: FileSystemRepository;
   private readonly gitClient: SimpleGit;
   private checkedOutVersion?: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,18 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@microsoft/task-scheduler@^2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.7.0.tgz#ec08645bbf708299a2d13bfd56a1a928189cd33c"
@@ -4181,6 +4193,13 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.3:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -10074,12 +10093,14 @@ signedsource@^1.0.0:
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
 
-simple-git@^1.131.0:
-  version "1.132.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.132.0.tgz#53ac4c5ec9e74e37c2fd461e23309f22fcdf09b1"
-  integrity sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==
+simple-git@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-3.3.0.tgz#91692d576f851be691124781b79872b246d2f92c"
+  integrity sha512-K9qcbbZwPHhk7MLi0k0ekvSFXJIrRoXgHhqMXAFM75qS68vdHTcuzmul1ilKI02F/4lXshVgBoDll2t++JK0PQ==
   dependencies:
-    debug "^4.0.1"
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.3"
 
 simple-plist@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR backports #9709 to 0.66.

There is a CG alert for older versions of simple-git.

While there is not specific remediation at this time, we're very far
behind and the newest version has a fix, so presumably getting up to
date is in our best interest.

See: https://nvd.nist.gov/vuln/detail/CVE-2022-24433