### PR TITLE
[Win32] Don't load XAML if we are checking if we are a XAML app

### DIFF
--- a/change/react-native-windows-a8ae532b-cf51-4163-9351-660a49956641.json
+++ b/change/react-native-windows-a8ae532b-cf51-4163-9351-660a49956641.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Don't load XAML just to check if we are a XAML app",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/XamlUtils.h
+++ b/vnext/Microsoft.ReactNative.Cxx/XamlUtils.h
@@ -8,16 +8,50 @@
 
 #include "CppWinRTIncludes.h"
 
+extern "C" {
+HMODULE
+WINAPI
+WINRT_IMPL_GetModuleHandleW(_In_opt_ LPCWSTR lpModuleName);
+}
+
+#ifndef WINRT_IMPL_LINK
+#ifdef _M_HYBRID
+#define WINRT_IMPL_LINK(function, count) \
+  __pragma(comment(linker, "/alternatename:#WINRT_IMPL_" #function "@" #count "=#" #function "@" #count))
+#elif _M_ARM64EC
+#define WINRT_IMPL_LINK(function, count) \
+  __pragma(comment(linker, "/alternatename:#WINRT_IMPL_" #function "=#" #function))
+#elif _M_IX86
+#define WINRT_IMPL_LINK(function, count) \
+  __pragma(comment(linker, "/alternatename:_WINRT_IMPL_" #function "@" #count "=_" #function "@" #count))
+#else
+#define WINRT_IMPL_LINK(function, count) __pragma(comment(linker, "/alternatename:WINRT_IMPL_" #function "=" #function))
+#endif
+#endif
+WINRT_IMPL_LINK(GetModuleHandleW, 4);
+#undef WINRT_IMPL_LINK
+
 namespace XAML_CPPWINRT_NAMESPACE {
 
 // Return Application::Current() when it is present or nullptr otherwise.
 // It does not throw exception as Application::Current() does.
 inline Application TryGetCurrentApplication() noexcept {
-  auto applicationStatics = get_activation_factory<IApplicationStatics>(name_of<Application>());
-  auto abiApplicationStatics = static_cast<impl::abi_t<IApplicationStatics> *>(get_abi(applicationStatics));
-  void *value{};
-  abiApplicationStatics->get_Current(&value);
-  return Application{value, take_ownership_from_abi};
+#ifndef USE_WINUI3
+  constexpr auto xamlDll = L"Windows.UI.Xaml.dll";
+#else
+  constexpr auto xamlDll = L"Microsoft.UI.Xaml.dll";
+#endif
+
+  if (auto xamlIsLoaded = WINRT_IMPL_GetModuleHandleW(xamlDll)) {
+    auto applicationStatics = get_activation_factory<IApplicationStatics>(name_of<Application>());
+    auto abiApplicationStatics = static_cast<impl::abi_t<IApplicationStatics> *>(get_abi(applicationStatics));
+    void *value{};
+    abiApplicationStatics->get_Current(&value);
+    return Application{value, take_ownership_from_abi};
+  } else {
+    // If we don't have XAML loaded, we are not a XAML app
+    return nullptr;
+  }
 }
 
 } // namespace XAML_CPPWINRT_NAMESPACE


### PR DESCRIPTION
## Description
This change prevents loading XAML just to check if we are running inside of a XAML app. Today this would be a tax on non-XAML endpoints (NetUI? and win32).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
This change shrinks the app's memory usage since loading XAML brings in a whole bunch of DLLs, allocates, etc.
Overall there's about a **6 MB private working set drop** 🥳.

### What
A XAML app requires XAML to have been loaded, so check if XAML has been loaded already before even querying whether the app is a xaml app.


Name | Working set (memory) | Memory (active private working set) | Memory (private working set) | Memory (shared working set)
-- | -- | -- | -- | --
Baseline | 139444 | 111536 | 111536 | 27908
With change | 139000 | 104980 | 104980 | 34020


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9799)