### PR TITLE
Stop Telemetry background threads running after test completion

### DIFF
--- a/change/@react-native-windows-telemetry-b9507482-ef51-4a3c-b217-6a53d40e0bb4.json
+++ b/change/@react-native-windows-telemetry-b9507482-ef51-4a3c-b217-6a53d40e0bb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Stop Telemetry background threads running after test completion",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@react-native-windows/fs": "^0.0.0-canary.1",
     "@xmldom/xmldom": "^0.7.5",
-    "applicationinsights": "^2.1.5",
+    "applicationinsights": "^2.3.1",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",
     "lodash": "^4.17.21",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -14,7 +14,7 @@
     "clean": "rnw-scripts clean",
     "lint": "rnw-scripts lint",
     "lint:fix": "rnw-scripts lint:fix",
-    "test": "set RNW_CLI_TEST=true&& rnw-scripts test",
+    "test": "set RNW_CLI_TEST=true&&set APPLICATION_INSIGHTS_NO_STATSBEAT=true&& rnw-scripts test",
     "watch": "rnw-scripts watch"
   },
   "dependencies": {

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -145,10 +145,7 @@ export class Telemetry {
 
   /** Sets up Telemetry.client. */
   private static setupClient() {
-    appInsights.Configuration.setInternalLogging(
-      Telemetry.isTest,
-      Telemetry.isTest,
-    );
+    appInsights.Configuration.setInternalLogging(false, false);
 
     Telemetry.client = new appInsights.TelemetryClient(
       Telemetry.options.setupString,
@@ -162,6 +159,8 @@ export class Telemetry {
     }
 
     Telemetry.client.config.disableAppInsights = Telemetry.isTest;
+    Telemetry.client.config.disableStatsbeat = true;
+    Telemetry.client.getStatsbeat()?.enable(false);
     Telemetry.client.channel.setUseDiskRetryCaching(!Telemetry.isTest);
   }
 

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -160,7 +160,12 @@ export class Telemetry {
 
     Telemetry.client.config.disableAppInsights = Telemetry.isTest;
     Telemetry.client.config.disableStatsbeat = true;
-    Telemetry.client.getStatsbeat().enable(false);
+
+    // Despite trying to disable the statsbeat, it might still be running: https://github.com/microsoft/ApplicationInsights-node.js/issues/943
+    // So we want to disable it, and despite the method's typing, getStatsbeat() _can_ return undefined
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    Telemetry.client.getStatsbeat()?.enable(false);
+
     Telemetry.client.channel.setUseDiskRetryCaching(!Telemetry.isTest);
   }
 

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -160,7 +160,7 @@ export class Telemetry {
 
     Telemetry.client.config.disableAppInsights = Telemetry.isTest;
     Telemetry.client.config.disableStatsbeat = true;
-    Telemetry.client.getStatsbeat()?.enable(false);
+    Telemetry.client.getStatsbeat().enable(false);
     Telemetry.client.channel.setUseDiskRetryCaching(!Telemetry.isTest);
   }
 

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -6,7 +6,6 @@
  */
 
 import * as appInsights from 'applicationinsights';
-import CorrelationIdManager from 'applicationinsights/out/Library/CorrelationIdManager';
 import * as path from 'path';
 
 import {
@@ -40,13 +39,6 @@ export class TelemetryTest extends Telemetry {
     Telemetry.isTest = true;
 
     await Telemetry.setup({preserveErrorMessages: true});
-
-    // Workaround for https://github.com/microsoft/ApplicationInsights-node.js/issues/833
-    Telemetry.client!.config.correlationIdRetryIntervalMs = 500;
-    CorrelationIdManager.cancelCorrelationIdQuery(
-      Telemetry.client!.config,
-      () => {},
-    );
   }
 
   /** Run at the end of each test where telemetry was fired. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2898,7 +2898,7 @@ appdirsjs@^1.2.4:
   resolved "https://registry.yarnpkg.com/appdirsjs/-/appdirsjs-1.2.4.tgz#3ab582acc9fdfaaa0c1f81b3a25422ad4d95f9d4"
   integrity sha512-WO5StDORR6JF/xYnXk/Fm0yu+iULaV5ULKuUw0Tu+jbgiTlSquaWBCgbpnsHLMXldf+fM3Gxn5p7vjond7He6w==
 
-applicationinsights@^2.1.5:
+applicationinsights@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.3.1.tgz#b6908ea2da67bf3dc781da9b0994e1e042ca8b91"
   integrity sha512-lhKd8EgmLKdDDhzB0jx8lcnbTAzedT63AH5DosnK4GQO3HgjRCC7AlUr86+aEwJEWfmfg0CxEdXDb9Rug/5XpQ==


### PR DESCRIPTION
This PR disables the ApplicationInsights (AI) internal logging. We used to enable it during our tests to get more info, but all this logging happens on a background thread which interferes with the tests exiting cleanly and clutters up the test output.

This PR also removes the CorrelationIDManager workaround (to kill its background thread) since issue https://github.com/microsoft/ApplicationInsights-node.js/issues/833 was fixed and it no longer runs indefinitely.

This PR also disables AI's StatsBeat - yet another source of unnecessary background threads which interfere with our tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9801)