### PR TITLE
Fix error output in rnw-dependencies.ps1

### DIFF
--- a/change/react-native-windows-c6313129-5ecd-4713-a7e6-f1a0996e742e.json
+++ b/change/react-native-windows-c6313129-5ecd-4713-a7e6-f1a0996e742e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix deps script",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -95,7 +95,7 @@ function CheckVS {
     [String[]]$output = & $vsWhere -version $vsver -requires $vsComponents -property productPath
 
     if (($output.Count -eq 0) -or (!(Test-Path $output[0]))) {
-        Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+        Write-Debug "No Retail versions of Visual Studio found, trying pre-release..."
         [String[]]$output = & $vsWhere -version $vsver -requires $vsComponents -property productPath -prerelease
     }
     if ($output.Count -gt 1) {
@@ -184,7 +184,7 @@ function CheckCppWinRT_VSIX {
         [String[]]$vsPath = & $vsWhere -version $vsver -property installationPath;
 
         if (($vsPath.Count -eq 0) -or (!(Test-Path $vsPath[0]))) {
-            Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+            Write-Debug "No Retail versions of Visual Studio found, trying pre-release..."
             [String[]]$vsPath = & $vsWhere -version $vsver -property installationPath -prerelease
         }
 
@@ -208,7 +208,7 @@ function InstallCppWinRT_VSIX {
     [String[]]$productPath = & $vsWhere -version $vsver -property productPath
 
     if (($productPath.Count -eq 0) -or (!(Test-Path $productPath[0]))) {
-        Write-Debug No Retail versions of Visual Studio found, trying pre-release...
+        Write-Debug "No Retail versions of Visual Studio found, trying pre-release..."
         [String[]]$productPath = & $vsWhere -version $vsver -property productPath -prerelease
     }
 


### PR DESCRIPTION
## Description
Fixes #9807 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
When hitting some recoverable error conditions (e.g. no retail VS found), we error out because of missing a set of quotes around a string output.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9809)