### PR TITLE
Disable unstable telemetry tests 

### DIFF
--- a/change/@react-native-windows-telemetry-32822618-c317-4ef4-b236-2f800ce4fcee.json
+++ b/change/@react-native-windows-telemetry-32822618-c317-4ef4-b236-2f800ce4fcee.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disable unstable telemetry tests",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
@@ -7,6 +7,10 @@
 
 import * as basePropUtils from '../utils/basePropUtils';
 
+beforeAll(() => {
+  jest.setTimeout(10000); // These tests can run longer than the default 5000ms
+});
+
 test('deviceId() is valid', async () => {
   const value = await basePropUtils.deviceId();
   expect(value).toBeDefined();

--- a/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
@@ -7,10 +7,6 @@
 
 import * as basePropUtils from '../utils/basePropUtils';
 
-beforeAll(() => {
-  jest.setTimeout(10000); // These tests can run longer than the default 5000ms
-});
-
 test('deviceId() is valid', async () => {
   const value = await basePropUtils.deviceId();
   expect(value).toBeDefined();

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -402,7 +402,7 @@ function verifyTestCommandTelemetryProcessor(
   };
 }
 
-test('Telemetry run test command end to end, verify event fires', async done => {
+xtest('Telemetry run test command end to end, verify event fires', async done => {
   // AI eats errors thrown in telemetry processors
   const caughtErrors: Error[] = [];
   TelemetryTest.addTelemetryProcessor(
@@ -418,7 +418,7 @@ test('Telemetry run test command end to end, verify event fires', async done => 
   });
 });
 
-test('Telemetry run test command end to end with CodedError, verify events fire', async done => {
+xtest('Telemetry run test command end to end with CodedError, verify events fire', async done => {
   const expectedError = new errorUtils.CodedError('MSBuildError', 'test error');
 
   // AI eats errors thrown in telemetry processors
@@ -440,7 +440,7 @@ test('Telemetry run test command end to end with CodedError, verify events fire'
   });
 });
 
-test('Telemetry run test command end to end with CodedError (with error in message), verify events fire', async done => {
+xtest('Telemetry run test command end to end with CodedError (with error in message), verify events fire', async done => {
   const expectedError = new errorUtils.CodedError(
     'MSBuildError',
     'error FOO2020: test error',
@@ -465,7 +465,7 @@ test('Telemetry run test command end to end with CodedError (with error in messa
   });
 });
 
-test('Telemetry run test command end to end with CodedError (with data), verify events fire', async done => {
+xtest('Telemetry run test command end to end with CodedError (with data), verify events fire', async done => {
   const expectedError = new errorUtils.CodedError(
     'MSBuildError',
     'test error',
@@ -491,7 +491,7 @@ test('Telemetry run test command end to end with CodedError (with data), verify 
   });
 });
 
-test('Telemetry run test command end to end with Error, verify events fire', async done => {
+xtest('Telemetry run test command end to end with Error, verify events fire', async done => {
   const expectedError = new Error('error FOO2020: test error');
 
   // AI eats errors thrown in telemetry processors
@@ -509,7 +509,7 @@ test('Telemetry run test command end to end with Error, verify events fire', asy
   });
 });
 
-test('Telemetry run test command end to end with Error (no message), verify events fire', async done => {
+xtest('Telemetry run test command end to end with Error (no message), verify events fire', async done => {
   const expectedError = new Error();
 
   // AI eats errors thrown in telemetry processors

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -582,7 +582,7 @@ function getVerifyStackTelemetryProcessor(
   };
 }
 
-test('Telemetry run test command end to end with Error, verify sanitized message and stack', async done => {
+xtest('Telemetry run test command end to end with Error, verify sanitized message and stack', async done => {
   const expectedError = new Error('hello world');
 
   // AI eats errors thrown in telemetry processors
@@ -603,7 +603,7 @@ test('Telemetry run test command end to end with Error, verify sanitized message
   });
 });
 
-test('Telemetry run test command end to end with Error, verify sanitized message with path and stack', async done => {
+xtest('Telemetry run test command end to end with Error, verify sanitized message with path and stack', async done => {
   const expectedError = new Error(`hello ${process.cwd()}`);
 
   // AI eats errors thrown in telemetry processors

--- a/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
@@ -25,23 +25,19 @@ function expectValidVersion(version: string | null, expectSemVer: boolean) {
   }
 }
 
-beforeAll(() => {
-  jest.setTimeout(10000); // These tests can run longer than the default 5000ms
-});
-
 test('getNodeVersion() is valid', async () => {
   const version = await versionUtils.getNodeVersion();
   expectValidVersion(version, true);
 });
 
-test('getNpmVersion() is valid', async () => {
+xtest('getNpmVersion() is valid', async () => {
   const version = await versionUtils.getNpmVersion();
   if (version) {
     expectValidVersion(version, true);
   }
 });
 
-test('getYarnVersion() is valid', async () => {
+xtest('getYarnVersion() is valid', async () => {
   const version = await versionUtils.getYarnVersion();
   if (version) {
     expectValidVersion(version, true);

--- a/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
@@ -25,6 +25,10 @@ function expectValidVersion(version: string | null, expectSemVer: boolean) {
   }
 }
 
+beforeAll(() => {
+  jest.setTimeout(10000); // These tests can run longer than the default 5000ms
+});
+
 test('getNodeVersion() is valid', async () => {
   const version = await versionUtils.getNodeVersion();
   expectValidVersion(version, true);


### PR DESCRIPTION
This PR temporarily disables some of the telemetry tests as reported by https://github.com/microsoft/react-native-windows/issues/9820.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9823)