### PR TITLE
Re-enable telemetry tests

### DIFF
--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -31,5 +31,5 @@ jobs:
           inputs:
             versionSpec: '${{ nodeVersion }}.x'
 
-        - script: yarn test
-          displayName: yarn test --concurrency 1
+        - script: yarn test --concurrency 1
+          displayName: yarn test

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -32,4 +32,4 @@ jobs:
             versionSpec: '${{ nodeVersion }}.x'
 
         - script: yarn test
-          displayName: yarn test
+          displayName: yarn test --concurrency 1

--- a/change/@react-native-windows-telemetry-97ad5a9e-21cc-4617-8d2a-cee091607fd5.json
+++ b/change/@react-native-windows-telemetry-97ad5a9e-21cc-4617-8d2a-cee091607fd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reenable Telemetry tests",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -402,7 +402,7 @@ function verifyTestCommandTelemetryProcessor(
   };
 }
 
-xtest('Telemetry run test command end to end, verify event fires', async done => {
+test('Telemetry run test command end to end, verify event fires', async done => {
   // AI eats errors thrown in telemetry processors
   const caughtErrors: Error[] = [];
   TelemetryTest.addTelemetryProcessor(
@@ -418,7 +418,7 @@ xtest('Telemetry run test command end to end, verify event fires', async done =>
   });
 });
 
-xtest('Telemetry run test command end to end with CodedError, verify events fire', async done => {
+test('Telemetry run test command end to end with CodedError, verify events fire', async done => {
   const expectedError = new errorUtils.CodedError('MSBuildError', 'test error');
 
   // AI eats errors thrown in telemetry processors
@@ -440,7 +440,7 @@ xtest('Telemetry run test command end to end with CodedError, verify events fire
   });
 });
 
-xtest('Telemetry run test command end to end with CodedError (with error in message), verify events fire', async done => {
+test('Telemetry run test command end to end with CodedError (with error in message), verify events fire', async done => {
   const expectedError = new errorUtils.CodedError(
     'MSBuildError',
     'error FOO2020: test error',
@@ -465,7 +465,7 @@ xtest('Telemetry run test command end to end with CodedError (with error in mess
   });
 });
 
-xtest('Telemetry run test command end to end with CodedError (with data), verify events fire', async done => {
+test('Telemetry run test command end to end with CodedError (with data), verify events fire', async done => {
   const expectedError = new errorUtils.CodedError(
     'MSBuildError',
     'test error',
@@ -491,7 +491,7 @@ xtest('Telemetry run test command end to end with CodedError (with data), verify
   });
 });
 
-xtest('Telemetry run test command end to end with Error, verify events fire', async done => {
+test('Telemetry run test command end to end with Error, verify events fire', async done => {
   const expectedError = new Error('error FOO2020: test error');
 
   // AI eats errors thrown in telemetry processors
@@ -509,7 +509,7 @@ xtest('Telemetry run test command end to end with Error, verify events fire', as
   });
 });
 
-xtest('Telemetry run test command end to end with Error (no message), verify events fire', async done => {
+test('Telemetry run test command end to end with Error (no message), verify events fire', async done => {
   const expectedError = new Error();
 
   // AI eats errors thrown in telemetry processors
@@ -582,7 +582,7 @@ function getVerifyStackTelemetryProcessor(
   };
 }
 
-xtest('Telemetry run test command end to end with Error, verify sanitized message and stack', async done => {
+test('Telemetry run test command end to end with Error, verify sanitized message and stack', async done => {
   const expectedError = new Error('hello world');
 
   // AI eats errors thrown in telemetry processors
@@ -603,7 +603,7 @@ xtest('Telemetry run test command end to end with Error, verify sanitized messag
   });
 });
 
-xtest('Telemetry run test command end to end with Error, verify sanitized message with path and stack', async done => {
+test('Telemetry run test command end to end with Error, verify sanitized message with path and stack', async done => {
   const expectedError = new Error(`hello ${process.cwd()}`);
 
   // AI eats errors thrown in telemetry processors

--- a/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/versionUtils.test.ts
@@ -30,14 +30,14 @@ test('getNodeVersion() is valid', async () => {
   expectValidVersion(version, true);
 });
 
-xtest('getNpmVersion() is valid', async () => {
+test('getNpmVersion() is valid', async () => {
   const version = await versionUtils.getNpmVersion();
   if (version) {
     expectValidVersion(version, true);
   }
 });
 
-xtest('getYarnVersion() is valid', async () => {
+test('getYarnVersion() is valid', async () => {
   const version = await versionUtils.getYarnVersion();
   if (version) {
     expectValidVersion(version, true);


### PR DESCRIPTION
This PR re-enables the telemetry tests disabled by #9823, and setting the concurrency in ADO to 1.

The issue is that running our tests in parallel in ADO (via `lage`) causes too many tests to run at once, so the async tests sometimes get stuck when calling out to external tools.

This adds 1-2min to the node tests job, but it's not a bottleneck.

Closes #9820

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9825)