### PR TITLE
Keep debugger connection across Hermes reloads, prevent memory leaks

### DIFF
--- a/change/react-native-windows-e4a169a0-4037-4919-a48d-70460a7a3a0f.json
+++ b/change/react-native-windows-e4a169a0-4037-4919-a48d-70460a7a3a0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "re-use InspectorPackagerConnection across reloads, prevent circular reference between DevSettings and HermesRuntimeHolder",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -265,7 +265,7 @@ void DevSupportManager::EnsureHermesInspector(
         m_BundleStatusProvider);
     m_inspectorPackagerConnection->connectAsync();
   });
-  
+
 #endif
 }
 

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -50,8 +50,7 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
       std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
 
-  virtual void StartInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept override;
-  virtual void StopInspector() noexcept override;
+  virtual void EnsureHermesInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept override;
   virtual void UpdateBundleStatus(bool isLastDownloadSucess, int64_t updateTimestamp) noexcept override;
 
  private:

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -74,7 +74,16 @@ class HermesExecutorRuntimeAdapter final : public facebook::hermes::inspector::R
 } // namespace
 
 void HermesRuntimeHolder::crashHandler(int fileDescriptor) noexcept {
-  HermesShim::hermesCrashHandler(static_cast<facebook::hermes::HermesRuntime &>(*m_runtime), fileDescriptor);
+  HermesShim::hermesCrashHandler(*m_hermesRuntime, fileDescriptor);
+}
+
+void HermesRuntimeHolder::teardown() noexcept
+{
+#ifdef HERMES_ENABLE_DEBUGGER
+  if (auto devSettings = m_weakDevSettings.lock(); devSettings && devSettings->useDirectDebugger) {
+    facebook::hermes::inspector::chrome::disableDebugging(*m_hermesRuntime);
+  }
+#endif
 }
 
 facebook::react::JSIEngineOverride HermesRuntimeHolder::getRuntimeType() noexcept {
@@ -84,43 +93,42 @@ facebook::react::JSIEngineOverride HermesRuntimeHolder::getRuntimeType() noexcep
 std::shared_ptr<jsi::Runtime> HermesRuntimeHolder::getRuntime() noexcept {
   std::call_once(m_once_flag, [this]() { initRuntime(); });
 
-  if (!m_runtime)
+  if (!m_hermesRuntime)
     std::terminate();
 
   // Make sure that the runtime instance is not consumed from multiple threads.
   if (m_own_thread_id != std::this_thread::get_id())
     std::terminate();
 
-  return m_runtime;
+  return m_hermesRuntime;
 }
 
 HermesRuntimeHolder::HermesRuntimeHolder(
     std::shared_ptr<facebook::react::DevSettings> devSettings,
     std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept
-    : m_devSettings(std::move(devSettings)), m_jsQueue(std::move(jsQueue)) {}
+    : m_weakDevSettings(devSettings), m_jsQueue(std::move(jsQueue)) {}
 
 void HermesRuntimeHolder::initRuntime() noexcept {
-  auto hermesRuntime = makeHermesRuntimeSystraced(m_devSettings->enableDefaultCrashHandler);
+  auto devSettings = m_weakDevSettings.lock();
+  if (!devSettings) std::terminate();
 
-  facebook::hermes::HermesRuntime &hermesRuntimeRef = *hermesRuntime;
-
-  m_runtime = std::move(hermesRuntime);
+  m_hermesRuntime = makeHermesRuntimeSystraced(devSettings->enableDefaultCrashHandler);
   m_own_thread_id = std::this_thread::get_id();
 
 #ifdef HERMES_ENABLE_DEBUGGER
-  if (m_devSettings->useDirectDebugger) {
-    auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(m_runtime, hermesRuntimeRef, m_jsQueue);
+  if (devSettings->useDirectDebugger) {
+    auto adapter = std::make_unique<HermesExecutorRuntimeAdapter>(m_hermesRuntime, *m_hermesRuntime, m_jsQueue);
     facebook::hermes::inspector::chrome::enableDebugging(
         std::move(adapter),
-        m_devSettings->debuggerRuntimeName.empty() ? "Hermes React Native" : m_devSettings->debuggerRuntimeName);
+        devSettings->debuggerRuntimeName.empty() ? "Hermes React Native" : devSettings->debuggerRuntimeName);
   }
 #endif
 
   // Add js engine information to Error.prototype so in error reporting we
   // can send this information.
   auto errorPrototype =
-      m_runtime->global().getPropertyAsObject(*m_runtime, "Error").getPropertyAsObject(*m_runtime, "prototype");
-  errorPrototype.setProperty(*m_runtime, "jsEngine", "hermes");
+      m_hermesRuntime->global().getPropertyAsObject(*m_hermesRuntime, "Error").getPropertyAsObject(*m_hermesRuntime, "prototype");
+  errorPrototype.setProperty(*m_hermesRuntime, "jsEngine", "hermes");
 }
 
 } // namespace react

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -77,8 +77,7 @@ void HermesRuntimeHolder::crashHandler(int fileDescriptor) noexcept {
   HermesShim::hermesCrashHandler(*m_hermesRuntime, fileDescriptor);
 }
 
-void HermesRuntimeHolder::teardown() noexcept
-{
+void HermesRuntimeHolder::teardown() noexcept {
 #ifdef HERMES_ENABLE_DEBUGGER
   if (auto devSettings = m_weakDevSettings.lock(); devSettings && devSettings->useDirectDebugger) {
     facebook::hermes::inspector::chrome::disableDebugging(*m_hermesRuntime);
@@ -110,7 +109,8 @@ HermesRuntimeHolder::HermesRuntimeHolder(
 
 void HermesRuntimeHolder::initRuntime() noexcept {
   auto devSettings = m_weakDevSettings.lock();
-  if (!devSettings) std::terminate();
+  if (!devSettings)
+    std::terminate();
 
   m_hermesRuntime = makeHermesRuntimeSystraced(devSettings->enableDefaultCrashHandler);
   m_own_thread_id = std::this_thread::get_id();
@@ -126,8 +126,9 @@ void HermesRuntimeHolder::initRuntime() noexcept {
 
   // Add js engine information to Error.prototype so in error reporting we
   // can send this information.
-  auto errorPrototype =
-      m_hermesRuntime->global().getPropertyAsObject(*m_hermesRuntime, "Error").getPropertyAsObject(*m_hermesRuntime, "prototype");
+  auto errorPrototype = m_hermesRuntime->global()
+                            .getPropertyAsObject(*m_hermesRuntime, "Error")
+                            .getPropertyAsObject(*m_hermesRuntime, "prototype");
   errorPrototype.setProperty(*m_hermesRuntime, "jsEngine", "hermes");
 }
 

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -9,6 +9,10 @@
 
 #include <DevSettings.h>
 
+namespace facebook::hermes {
+class HermesRuntime;
+}
+
 namespace facebook {
 namespace react {
 
@@ -19,18 +23,20 @@ class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
 
   void crashHandler(int fileDescriptor) noexcept override;
 
+  void teardown() noexcept override;
+
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;
 
  private:
   void initRuntime() noexcept;
-  std::shared_ptr<facebook::jsi::Runtime> m_runtime;
+  std::shared_ptr<facebook::hermes::HermesRuntime> m_hermesRuntime;
 
   std::once_flag m_once_flag;
   std::thread::id m_own_thread_id;
 
-  std::shared_ptr<facebook::react::DevSettings> m_devSettings;
+  std::weak_ptr<facebook::react::DevSettings> m_weakDevSettings;
   std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
 };
 

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -22,8 +22,7 @@ struct IDevSupportManager {
       std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
 
-  virtual void StartInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept = 0;
-  virtual void StopInspector() noexcept = 0;
+  virtual void EnsureHermesInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept = 0;
   virtual void UpdateBundleStatus(bool isLastDownloadSucess, int64_t updateTimestamp) noexcept = 0;
 };
 

--- a/vnext/Shared/JSI/RuntimeHolder.h
+++ b/vnext/Shared/JSI/RuntimeHolder.h
@@ -18,6 +18,8 @@ struct RuntimeHolderLazyInit {
   virtual std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept = 0;
   virtual facebook::react::JSIEngineOverride getRuntimeType() noexcept = 0;
 
+  virtual void teardown() noexcept {};
+
   // You can call this when a crash happens to attempt recording additional data
   // The fd supplied is a raw file stream an implementation might write JSON to
   virtual void crashHandler(int fileDescriptor) noexcept {};

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -254,7 +254,7 @@ InstanceImpl::InstanceImpl(
 #endif
 
   if (shouldStartHermesInspector(*m_devSettings)) {
-    m_devManager->StartInspector(m_devSettings->sourceBundleHost, m_devSettings->sourceBundlePort);
+    m_devManager->EnsureHermesInspector(m_devSettings->sourceBundleHost, m_devSettings->sourceBundlePort);
   }
 
   // Default (common) NativeModules
@@ -532,8 +532,9 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 }
 
 InstanceImpl::~InstanceImpl() {
-  if (shouldStartHermesInspector(*m_devSettings)) {
-    m_devManager->StopInspector();
+  if (shouldStartHermesInspector(*m_devSettings) && m_devSettings->jsiRuntimeHolder) {
+    m_devSettings->jsiRuntimeHolder->teardown();
+    // m_devManager->StopInspector();
   }
   m_nativeQueue->quitSynchronous();
 }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -534,7 +534,6 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
 InstanceImpl::~InstanceImpl() {
   if (shouldStartHermesInspector(*m_devSettings) && m_devSettings->jsiRuntimeHolder) {
     m_devSettings->jsiRuntimeHolder->teardown();
-    // m_devManager->StopInspector();
   }
   m_nativeQueue->quitSynchronous();
 }


### PR DESCRIPTION
## Keep debugger connection across Hermes reloads, prevent memory leaks

### Type of Change
- Bug fix 

### Why
Prior to this change, debugger front ends (e.g. Flipper, Chrome Inspect) would loose the connection to the Hermes engine upon reload. Also, several object (DevSettings, HermesRuntimeHolder, HermesRuntimeImpl ...) would get leaked across reloads. 

Resolves
- https://github.com/microsoft/react-native-windows/issues/9181
- https://github.com/microsoft/react-native-windows/issues/9824

### What
- keep InspectorPackagerConnection instance across reloads
- break circular reference between DevSettings and HermesRuntimeHolder


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9827)