### PR TITLE
[Perf] Use compile-time string hashes when dispatching update properties

### DIFF
--- a/change/react-native-windows-4175c79f-54d0-4853-a98a-1a3046f925b1.json
+++ b/change/react-native-windows-4175c79f-54d0-4853-a98a-1a3046f925b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use compile-time string hash comparisons instead of runtime string comparisons",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -215,9 +215,6 @@
     <ClCompile Include="Views\RawTextViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
-    <ClCompile Include="Views\ReactRootControl.cpp">
-      <Filter>Views</Filter>
-    </ClCompile>
     <ClCompile Include="Views\RefreshControlManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
@@ -337,6 +334,8 @@
       <Filter>Views\Text</Filter>
     </ClCompile>
     <ClCompile Include="ReactPointerEventArgs.cpp" />
+    <ClCompile Include="Views\FrameworkElementTransferProperties.cpp" />
+    <ClCompile Include="Views\ReactViewInstance.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
@@ -575,9 +574,6 @@
     <ClInclude Include="Views\RawTextViewManager.h">
       <Filter>Views</Filter>
     </ClInclude>
-    <ClInclude Include="Views\ReactRootControl.h">
-      <Filter>Views</Filter>
-    </ClInclude>
     <ClInclude Include="Views\RefreshControlManager.h">
       <Filter>Views</Filter>
     </ClInclude>
@@ -734,6 +730,8 @@
       <Filter>Views\Text</Filter>
     </ClInclude>
     <ClInclude Include="ReactPointerEventArgs.h" />
+    <ClInclude Include="Views\FrameworkElementTransferProperties.h" />
+    <ClInclude Include="Views\ReactViewInstance.h" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />
@@ -772,6 +770,7 @@
     <Midl Include="DocString.idl" />
     <Midl Include="DesktopWindowMessage.idl" />
     <Midl Include="ReactPointerEventArgs.idl" />
+    <Midl Include="ReactCoreInjection.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -15,6 +15,7 @@
 #include "QuirkSettings.h"
 #include "ReactRootViewTagGenerator.h"
 #include "Unicode.h"
+#include "fixed_string.h"
 
 namespace winrt {
 using namespace Windows::Foundation;
@@ -407,362 +408,476 @@ static void SetYogaValueAutoHelper(
   }
 }
 
+
 static void StyleYogaNode(
     ShadowNodeBase &shadowNode,
     const YGNodeRef yogaNode,
     const winrt::Microsoft::ReactNative::JSValueObject &props) {
   for (const auto &pair : props) {
-    const std::string &key = pair.first;
+    const auto &key = pair.first;
+    const auto key_hash = details::hash(pair.first.c_str());
     const auto &value = pair.second;
+    const auto value_hash = value.Type() == winrt::Microsoft::ReactNative::JSValueType::String
+        ? details::hash(value.TryGetString()->c_str())
+        : 0ull;
 
-    if (key == "flexDirection") {
-      YGFlexDirection direction = YGFlexDirectionColumn;
+    switch (key_hash) {
+      case HASH_STRING("flexDirection"): {
+        YGFlexDirection direction = YGFlexDirectionColumn;
 
-      if (value == "column" || value.IsNull())
-        direction = YGFlexDirectionColumn;
-      else if (value == "row")
-        direction = YGFlexDirectionRow;
-      else if (value == "column-reverse")
-        direction = YGFlexDirectionColumnReverse;
-      else if (value == "row-reverse")
-        direction = YGFlexDirectionRowReverse;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("column") || value.IsNull())
+          direction = YGFlexDirectionColumn;
+        else if (value_hash == HASH_STRING("row"))
+          direction = YGFlexDirectionRow;
+        else if (value_hash == HASH_STRING("column-reverse"))
+          direction = YGFlexDirectionColumnReverse;
+        else if (value_hash == HASH_STRING("row-reverse"))
+          direction = YGFlexDirectionRowReverse;
+        else
+          assert(false);
 
-      YGNodeStyleSetFlexDirection(yogaNode, direction);
-    } else if (key == "justifyContent") {
-      YGJustify justify = YGJustifyFlexStart;
+        YGNodeStyleSetFlexDirection(yogaNode, direction);
+        break;
+      }
+      case HASH_STRING("justifyContent"): {
+        YGJustify justify = YGJustifyFlexStart;
 
-      if (value == "flex-start" || value.IsNull())
-        justify = YGJustifyFlexStart;
-      else if (value == "flex-end")
-        justify = YGJustifyFlexEnd;
-      else if (value == "center")
-        justify = YGJustifyCenter;
-      else if (value == "space-between")
-        justify = YGJustifySpaceBetween;
-      else if (value == "space-around")
-        justify = YGJustifySpaceAround;
-      else if (value == "space-evenly")
-        justify = YGJustifySpaceEvenly;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("flex-start") || value.IsNull())
+          justify = YGJustifyFlexStart;
+        else if (value_hash == HASH_STRING("flex-end"))
+          justify = YGJustifyFlexEnd;
+        else if (value_hash == HASH_STRING("center"))
+          justify = YGJustifyCenter;
+        else if (value_hash == HASH_STRING("space-between"))
+          justify = YGJustifySpaceBetween;
+        else if (value_hash == HASH_STRING("space-around"))
+          justify = YGJustifySpaceAround;
+        else if (value_hash == HASH_STRING("space-evenly"))
+          justify = YGJustifySpaceEvenly;
+        else
+          assert(false);
 
-      YGNodeStyleSetJustifyContent(yogaNode, justify);
-    } else if (key == "flexWrap") {
-      YGWrap wrap = YGWrapNoWrap;
+        YGNodeStyleSetJustifyContent(yogaNode, justify);
+        break;
+      }
+      case HASH_STRING("flexWrap"): {
+        YGWrap wrap = YGWrapNoWrap;
 
-      if (value == "nowrap" || value.IsNull())
-        wrap = YGWrapNoWrap;
-      else if (value == "wrap")
-        wrap = YGWrapWrap;
-      else if (value == "wrap-reverse")
-        wrap = YGWrapWrapReverse;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("nowrap") || value.IsNull())
+          wrap = YGWrapNoWrap;
+        else if (value_hash == HASH_STRING("wrap"))
+          wrap = YGWrapWrap;
+        else if (value_hash == HASH_STRING("wrap-reverse"))
+          wrap = YGWrapWrapReverse;
+        else
+          assert(false);
 
-      YGNodeStyleSetFlexWrap(yogaNode, wrap);
-    } else if (key == "alignItems") {
-      YGAlign align = YGAlignStretch;
+        YGNodeStyleSetFlexWrap(yogaNode, wrap);
+        break;
+      }
+      case HASH_STRING("alignItems"): {
+        YGAlign align = YGAlignStretch;
 
-      if (value == "stretch" || value.IsNull())
-        align = YGAlignStretch;
-      else if (value == "flex-start")
-        align = YGAlignFlexStart;
-      else if (value == "flex-end")
-        align = YGAlignFlexEnd;
-      else if (value == "center")
-        align = YGAlignCenter;
-      else if (value == "baseline")
-        align = YGAlignBaseline;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("stretch") || value.IsNull())
+          align = YGAlignStretch;
+        else if (value_hash == HASH_STRING("flex-start"))
+          align = YGAlignFlexStart;
+        else if (value_hash == HASH_STRING("flex-end"))
+          align = YGAlignFlexEnd;
+        else if (value_hash == HASH_STRING("center"))
+          align = YGAlignCenter;
+        else if (value_hash == HASH_STRING("baseline"))
+          align = YGAlignBaseline;
+        else
+          assert(false);
 
-      YGNodeStyleSetAlignItems(yogaNode, align);
-    } else if (key == "alignSelf") {
-      YGAlign align = YGAlignAuto;
+        YGNodeStyleSetAlignItems(yogaNode, align);
+        break;
+      }
+      case HASH_STRING("alignSelf"): {
+        YGAlign align = YGAlignAuto;
 
-      if (value == "auto" || value.IsNull())
-        align = YGAlignAuto;
-      else if (value == "stretch")
-        align = YGAlignStretch;
-      else if (value == "flex-start")
-        align = YGAlignFlexStart;
-      else if (value == "flex-end")
-        align = YGAlignFlexEnd;
-      else if (value == "center")
-        align = YGAlignCenter;
-      else if (value == "baseline")
-        align = YGAlignBaseline;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("auto") || value.IsNull())
+          align = YGAlignAuto;
+        else if (value_hash == HASH_STRING("stretch"))
+          align = YGAlignStretch;
+        else if (value_hash == HASH_STRING("flex-start"))
+          align = YGAlignFlexStart;
+        else if (value_hash == HASH_STRING("flex-end"))
+          align = YGAlignFlexEnd;
+        else if (value_hash == HASH_STRING("center"))
+          align = YGAlignCenter;
+        else if (value_hash == HASH_STRING("baseline"))
+          align = YGAlignBaseline;
+        else
+          assert(false);
 
-      YGNodeStyleSetAlignSelf(yogaNode, align);
-    } else if (key == "alignContent") {
-      YGAlign align = YGAlignFlexStart;
+        YGNodeStyleSetAlignSelf(yogaNode, align);
+        break;
+      }
+      case HASH_STRING("alignContent"): {
+        YGAlign align = YGAlignFlexStart;
 
-      if (value == "stretch")
-        align = YGAlignStretch;
-      else if (value == "flex-start" || value.IsNull())
-        align = YGAlignFlexStart;
-      else if (value == "flex-end")
-        align = YGAlignFlexEnd;
-      else if (value == "center")
-        align = YGAlignCenter;
-      else if (value == "space-between")
-        align = YGAlignSpaceBetween;
-      else if (value == "space-around")
-        align = YGAlignSpaceAround;
-      else
-        assert(false);
+        if (value_hash == HASH_STRING("stretch"))
+          align = YGAlignStretch;
+        else if (value_hash == HASH_STRING("flex-start") || value.IsNull())
+          align = YGAlignFlexStart;
+        else if (value_hash == HASH_STRING("flex-end"))
+          align = YGAlignFlexEnd;
+        else if (value_hash == HASH_STRING("center"))
+          align = YGAlignCenter;
+        else if (value_hash == HASH_STRING("space-between"))
+          align = YGAlignSpaceBetween;
+        else if (value_hash == HASH_STRING("space-around"))
+          align = YGAlignSpaceAround;
+        else
+          assert(false);
 
-      YGNodeStyleSetAlignContent(yogaNode, align);
-    } else if (key == "flex") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        YGNodeStyleSetAlignContent(yogaNode, align);
+        break;
+      }
+      case HASH_STRING("flex"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
 
-      YGNodeStyleSetFlex(yogaNode, result);
-    } else if (key == "flexGrow") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        YGNodeStyleSetFlex(yogaNode, result);
+        break;
+      }
+      case HASH_STRING("flexGrow"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
 
-      YGNodeStyleSetFlexGrow(yogaNode, result);
-    } else if (key == "flexShrink") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        YGNodeStyleSetFlexGrow(yogaNode, result);
+        break;
+      }
+      case HASH_STRING("flexShrink"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
 
-      YGNodeStyleSetFlexShrink(yogaNode, result);
-    } else if (key == "flexBasis") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueAutoHelper(
-          yogaNode, result, YGNodeStyleSetFlexBasis, YGNodeStyleSetFlexBasisPercent, YGNodeStyleSetFlexBasisAuto);
-    } else if (key == "position") {
-      YGPositionType position = YGPositionTypeRelative;
-
-      if (value == "relative" || value.IsNull())
-        position = YGPositionTypeRelative;
-      else if (value == "absolute")
-        position = YGPositionTypeAbsolute;
-      else if (value == "static")
-        position = YGPositionTypeStatic;
-      else
-        assert(false);
-
-      YGNodeStyleSetPositionType(yogaNode, position);
-    } else if (key == "overflow") {
-      YGOverflow overflow = YGOverflowVisible;
-      if (value == "visible" || value.IsNull())
-        overflow = YGOverflowVisible;
-      else if (value == "hidden")
-        overflow = YGOverflowHidden;
-      else if (value == "scroll")
-        overflow = YGOverflowScroll;
-
-      YGNodeStyleSetOverflow(yogaNode, overflow);
-    } else if (key == "display") {
-      YGDisplay display = YGDisplayFlex;
-      if (value == "flex" || value.IsNull())
-        display = YGDisplayFlex;
-      else if (value == "none")
-        display = YGDisplayNone;
-
-      YGNodeStyleSetDisplay(yogaNode, display);
-    } else if (key == "direction") {
-      // https://github.com/microsoft/react-native-windows/issues/4668
-      // In order to support the direction property, we tell yoga to always layout
-      // in LTR direction, then push the appropriate FlowDirection into XAML.
-      // This way XAML handles flipping in RTL mode, which works both for RN components
-      // as well as native components that have purely XAML sub-trees (eg ComboBox).
-      YGDirection direction = YGDirectionLTR;
-
-      YGNodeStyleSetDirection(yogaNode, direction);
-    } else if (key == "aspectRatio") {
-      float result = NumberOrDefault(value, 1.0f /*default*/);
-
-      YGNodeStyleSetAspectRatio(yogaNode, result);
-    } else if (key == "left") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeLeft, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "top") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeTop, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "right") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeRight, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "bottom") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeBottom, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "end") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeEnd, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "start") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeStart, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
-    } else if (key == "width") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueAutoHelper(
-          yogaNode, result, YGNodeStyleSetWidth, YGNodeStyleSetWidthPercent, YGNodeStyleSetWidthAuto);
-    } else if (key == "minWidth") {
-      YGValue result = YGValueOrDefault(value, YGValue{0.0f, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMinWidth, YGNodeStyleSetMinWidthPercent);
-    } else if (key == "maxWidth") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMaxWidth, YGNodeStyleSetMaxWidthPercent);
-    } else if (key == "height") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueAutoHelper(
-          yogaNode, result, YGNodeStyleSetHeight, YGNodeStyleSetHeightPercent, YGNodeStyleSetHeightAuto);
-    } else if (key == "minHeight") {
-      YGValue result = YGValueOrDefault(value, YGValue{0.0f, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMinHeight, YGNodeStyleSetMinHeightPercent);
-    } else if (key == "maxHeight") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMaxHeight, YGNodeStyleSetMaxHeightPercent);
-    } else if (key == "margin") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeAll, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginLeft") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeLeft, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginStart") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeStart, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginTop") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeTop, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginRight") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeRight, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginEnd") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeEnd, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginBottom") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode, YGEdgeBottom, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
-    } else if (key == "marginHorizontal") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode,
-          YGEdgeHorizontal,
-          result,
-          YGNodeStyleSetMargin,
-          YGNodeStyleSetMarginPercent,
-          YGNodeStyleSetMarginAuto);
-    } else if (key == "marginVertical") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueAutoHelper(
-          yogaNode,
-          YGEdgeVertical,
-          result,
-          YGNodeStyleSetMargin,
-          YGNodeStyleSetMarginPercent,
-          YGNodeStyleSetMarginAuto);
-    } else if (key == "padding") {
-      if (!shadowNode.ImplementsPadding()) {
+        YGNodeStyleSetFlexShrink(yogaNode, result);
+        break;
+      }
+      case HASH_STRING("flexBasis"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeAll, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaUnitValueAutoHelper(
+            yogaNode, result, YGNodeStyleSetFlexBasis, YGNodeStyleSetFlexBasisPercent, YGNodeStyleSetFlexBasisAuto);
+        break;
       }
-    } else if (key == "paddingLeft") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("position"): {
+        YGPositionType position = YGPositionTypeRelative;
+
+        if (value_hash == HASH_STRING("relative") || value.IsNull())
+          position = YGPositionTypeRelative;
+        else if (value_hash == HASH_STRING("absolute"))
+          position = YGPositionTypeAbsolute;
+        else if (value_hash == HASH_STRING("static"))
+          position = YGPositionTypeStatic;
+        else
+          assert(false);
+
+        YGNodeStyleSetPositionType(yogaNode, position);
+        break;
+      }
+      case HASH_STRING("overflow"): {
+        YGOverflow overflow = YGOverflowVisible;
+        if (value_hash == HASH_STRING("visible") || value.IsNull())
+          overflow = YGOverflowVisible;
+        else if (value_hash == HASH_STRING("hidden"))
+          overflow = YGOverflowHidden;
+        else if (value_hash == HASH_STRING("scroll"))
+          overflow = YGOverflowScroll;
+
+        YGNodeStyleSetOverflow(yogaNode, overflow);
+        break;
+      }
+      case HASH_STRING("display"): {
+        YGDisplay display = YGDisplayFlex;
+        if (value_hash == HASH_STRING("flex") || value.IsNull())
+          display = YGDisplayFlex;
+        else if (value == "none")
+          display = YGDisplayNone;
+
+        YGNodeStyleSetDisplay(yogaNode, display);
+        break;
+      }
+      case HASH_STRING("direction"): {
+        // https://github.com/microsoft/react-native-windows/issues/4668
+        // In order to support the direction property, we tell yoga to always layout
+        // in LTR direction, then push the appropriate FlowDirection into XAML.
+        // This way XAML handles flipping in RTL mode, which works both for RN components
+        // as well as native components that have purely XAML sub-trees (eg ComboBox).
+        YGDirection direction = YGDirectionLTR;
+
+        YGNodeStyleSetDirection(yogaNode, direction);
+        break;
+      }
+      case HASH_STRING("aspectRatio"): {
+        float result = NumberOrDefault(value, 1.0f /*default*/);
+
+        YGNodeStyleSetAspectRatio(yogaNode, result);
+        break;
+      }
+      case HASH_STRING("left"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeLeft, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeLeft, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingStart") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("top"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeStart, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeTop, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingTop") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("right"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeTop, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeRight, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingRight") {
-      YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
-
-      SetYogaValueHelper(yogaNode, YGEdgeRight, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
-    } else if (key == "paddingEnd") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("bottom"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeEnd, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeBottom, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingBottom") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("end"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeBottom, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeEnd, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingHorizontal") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("start"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeHorizontal, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaValueHelper(yogaNode, YGEdgeStart, result, YGNodeStyleSetPosition, YGNodeStyleSetPositionPercent);
+        break;
       }
-    } else if (key == "paddingVertical") {
-      if (!shadowNode.ImplementsPadding()) {
+      case HASH_STRING("width"): {
         YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-        SetYogaValueHelper(yogaNode, YGEdgeVertical, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        SetYogaUnitValueAutoHelper(
+            yogaNode, result, YGNodeStyleSetWidth, YGNodeStyleSetWidthPercent, YGNodeStyleSetWidthAuto);
+        break;
       }
-    } else if (key == "borderWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+      case HASH_STRING("minWidth"): {
+        YGValue result = YGValueOrDefault(value, YGValue{0.0f, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeAll, result);
-    } else if (key == "borderLeftWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMinWidth, YGNodeStyleSetMinWidthPercent);
+        break;
+      }
+      case HASH_STRING("maxWidth"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeLeft, result);
-    } else if (key == "borderStartWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMaxWidth, YGNodeStyleSetMaxWidthPercent);
+        break;
+      }
+      case HASH_STRING("height"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeStart, result);
-    } else if (key == "borderTopWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaUnitValueAutoHelper(
+            yogaNode, result, YGNodeStyleSetHeight, YGNodeStyleSetHeightPercent, YGNodeStyleSetHeightAuto);
+        break;
+      }
+      case HASH_STRING("minHeight"): {
+        YGValue result = YGValueOrDefault(value, YGValue{0.0f, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeTop, result);
-    } else if (key == "borderRightWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMinHeight, YGNodeStyleSetMinHeightPercent);
+        break;
+      }
+      case HASH_STRING("maxHeight"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeRight, result);
-    } else if (key == "borderEndWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaUnitValueHelper(yogaNode, result, YGNodeStyleSetMaxHeight, YGNodeStyleSetMaxHeightPercent);
+        break;
+      }
+      case HASH_STRING("margin"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeEnd, result);
-    } else if (key == "borderBottomWidth") {
-      float result = NumberOrDefault(value, 0.0f /*default*/);
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeAll, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginLeft"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
 
-      YGNodeStyleSetBorder(yogaNode, YGEdgeBottom, result);
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeLeft, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginStart"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeStart, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginTop"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeTop, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginRight"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeRight, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginEnd"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode, YGEdgeEnd, result, YGNodeStyleSetMargin, YGNodeStyleSetMarginPercent, YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginBottom"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode,
+            YGEdgeBottom,
+            result,
+            YGNodeStyleSetMargin,
+            YGNodeStyleSetMarginPercent,
+            YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginHorizontal"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode,
+            YGEdgeHorizontal,
+            result,
+            YGNodeStyleSetMargin,
+            YGNodeStyleSetMarginPercent,
+            YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("marginVertical"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueAutoHelper(
+            yogaNode,
+            YGEdgeVertical,
+            result,
+            YGNodeStyleSetMargin,
+            YGNodeStyleSetMarginPercent,
+            YGNodeStyleSetMarginAuto);
+        break;
+      }
+      case HASH_STRING("padding"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeAll, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingLeft"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeLeft, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingStart"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeStart, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingTop"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeTop, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingRight"): {
+        YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+        SetYogaValueHelper(yogaNode, YGEdgeRight, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        break;
+      }
+      case HASH_STRING("paddingEnd"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeEnd, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingBottom"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeBottom, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingHorizontal"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeHorizontal, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("paddingVertical"): {
+        if (!shadowNode.ImplementsPadding()) {
+          YGValue result = YGValueOrDefault(value, YGValue{YGUndefined, YGUnitPoint} /*default*/, shadowNode, key);
+
+          SetYogaValueHelper(yogaNode, YGEdgeVertical, result, YGNodeStyleSetPadding, YGNodeStyleSetPaddingPercent);
+        }
+        break;
+      }
+      case HASH_STRING("borderWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeAll, result);
+        break;
+      }
+      case HASH_STRING("borderLeftWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeLeft, result);
+        break;
+      }
+      case HASH_STRING("borderStartWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeStart, result);
+        break;
+      }
+      case HASH_STRING("borderTopWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeTop, result);
+        break;
+      }
+      case HASH_STRING("borderRightWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeRight, result);
+        break;
+      }
+      case HASH_STRING("borderEndWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeEnd, result);
+        break;
+      }
+      case HASH_STRING("borderBottomWidth"): {
+        float result = NumberOrDefault(value, 0.0f /*default*/);
+
+        YGNodeStyleSetBorder(yogaNode, YGEdgeBottom, result);
+      }
     }
   }
 }

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -408,7 +408,6 @@ static void SetYogaValueAutoHelper(
   }
 }
 
-
 static void StyleYogaNode(
     ShadowNodeBase &shadowNode,
     const YGNodeRef yogaNode,
@@ -423,116 +422,165 @@ static void StyleYogaNode(
 
     switch (key_hash) {
       case HASH_STRING("flexDirection"): {
-        YGFlexDirection direction = YGFlexDirectionColumn;
+        YGFlexDirection direction;
 
-        if (value_hash == HASH_STRING("column") || value.IsNull())
-          direction = YGFlexDirectionColumn;
-        else if (value_hash == HASH_STRING("row"))
-          direction = YGFlexDirectionRow;
-        else if (value_hash == HASH_STRING("column-reverse"))
-          direction = YGFlexDirectionColumnReverse;
-        else if (value_hash == HASH_STRING("row-reverse"))
-          direction = YGFlexDirectionRowReverse;
-        else
-          assert(false);
-
+        switch (value_hash) {
+          case HASH_STRING("column"):
+            direction = YGFlexDirectionColumn;
+            break;
+          case HASH_STRING("row"):
+            direction = YGFlexDirectionRow;
+            break;
+          case HASH_STRING("column-reverse"):
+            direction = YGFlexDirectionColumnReverse;
+            break;
+          case HASH_STRING("row-reverse"):
+            direction = YGFlexDirectionRowReverse;
+            break;
+          default:
+            direction = YGFlexDirectionColumn;
+            assert(value.IsNull());
+        }
         YGNodeStyleSetFlexDirection(yogaNode, direction);
         break;
       }
       case HASH_STRING("justifyContent"): {
-        YGJustify justify = YGJustifyFlexStart;
+        YGJustify justify;
 
-        if (value_hash == HASH_STRING("flex-start") || value.IsNull())
-          justify = YGJustifyFlexStart;
-        else if (value_hash == HASH_STRING("flex-end"))
-          justify = YGJustifyFlexEnd;
-        else if (value_hash == HASH_STRING("center"))
-          justify = YGJustifyCenter;
-        else if (value_hash == HASH_STRING("space-between"))
-          justify = YGJustifySpaceBetween;
-        else if (value_hash == HASH_STRING("space-around"))
-          justify = YGJustifySpaceAround;
-        else if (value_hash == HASH_STRING("space-evenly"))
-          justify = YGJustifySpaceEvenly;
-        else
-          assert(false);
-
+        switch (value_hash) {
+          case HASH_STRING("flex-start"):
+            justify = YGJustifyFlexStart;
+            break;
+          case HASH_STRING("flex-end"):
+            justify = YGJustifyFlexEnd;
+            break;
+          case HASH_STRING("center"):
+            justify = YGJustifyCenter;
+            break;
+          case HASH_STRING("space-between"):
+            justify = YGJustifySpaceBetween;
+            break;
+          case HASH_STRING("space-around"):
+            justify = YGJustifySpaceAround;
+            break;
+          case HASH_STRING("space-evenly"):
+            justify = YGJustifySpaceEvenly;
+            break;
+          default:
+            justify = YGJustifyFlexStart;
+            assert(value.IsNull());
+        }
         YGNodeStyleSetJustifyContent(yogaNode, justify);
         break;
       }
       case HASH_STRING("flexWrap"): {
-        YGWrap wrap = YGWrapNoWrap;
+        YGWrap wrap;
 
-        if (value_hash == HASH_STRING("nowrap") || value.IsNull())
-          wrap = YGWrapNoWrap;
-        else if (value_hash == HASH_STRING("wrap"))
-          wrap = YGWrapWrap;
-        else if (value_hash == HASH_STRING("wrap-reverse"))
-          wrap = YGWrapWrapReverse;
-        else
-          assert(false);
+        switch (value_hash) {
+          case HASH_STRING("nowrap"):
+            wrap = YGWrapNoWrap;
+            break;
+          case HASH_STRING("wrap"):
+            wrap = YGWrapWrap;
+            break;
+          case HASH_STRING("wrap-reverse"):
+            wrap = YGWrapWrapReverse;
+            break;
+          default:
+            wrap = YGWrapNoWrap;
+            assert(value.IsNull());
 
+            break;
+        }
         YGNodeStyleSetFlexWrap(yogaNode, wrap);
         break;
       }
       case HASH_STRING("alignItems"): {
-        YGAlign align = YGAlignStretch;
+        YGAlign align;
 
-        if (value_hash == HASH_STRING("stretch") || value.IsNull())
-          align = YGAlignStretch;
-        else if (value_hash == HASH_STRING("flex-start"))
-          align = YGAlignFlexStart;
-        else if (value_hash == HASH_STRING("flex-end"))
-          align = YGAlignFlexEnd;
-        else if (value_hash == HASH_STRING("center"))
-          align = YGAlignCenter;
-        else if (value_hash == HASH_STRING("baseline"))
-          align = YGAlignBaseline;
-        else
-          assert(false);
-
+        switch (value_hash) {
+          case HASH_STRING("stretch"):
+            align = YGAlignStretch;
+            break;
+          case HASH_STRING("flex-start"):
+            align = YGAlignFlexStart;
+            break;
+          case HASH_STRING("flex-end"):
+            align = YGAlignFlexEnd;
+            break;
+          case HASH_STRING("center"):
+            align = YGAlignCenter;
+            break;
+          case HASH_STRING("baseline"):
+            align = YGAlignBaseline;
+            break;
+          default:
+            align = YGAlignStretch;
+            assert(value.IsNull());
+            break;
+        }
         YGNodeStyleSetAlignItems(yogaNode, align);
         break;
       }
       case HASH_STRING("alignSelf"): {
-        YGAlign align = YGAlignAuto;
+        YGAlign align;
 
-        if (value_hash == HASH_STRING("auto") || value.IsNull())
-          align = YGAlignAuto;
-        else if (value_hash == HASH_STRING("stretch"))
-          align = YGAlignStretch;
-        else if (value_hash == HASH_STRING("flex-start"))
-          align = YGAlignFlexStart;
-        else if (value_hash == HASH_STRING("flex-end"))
-          align = YGAlignFlexEnd;
-        else if (value_hash == HASH_STRING("center"))
-          align = YGAlignCenter;
-        else if (value_hash == HASH_STRING("baseline"))
-          align = YGAlignBaseline;
-        else
-          assert(false);
+        switch (value_hash) {
+          case HASH_STRING("auto"):
+            align = YGAlignAuto;
+            break;
+          case HASH_STRING("stretch"):
+            align = YGAlignStretch;
+            break;
+          case HASH_STRING("flex-start"):
+            align = YGAlignFlexStart;
+            break;
+          case HASH_STRING("flex-end"):
+            align = YGAlignFlexEnd;
+            break;
+          case HASH_STRING("center"):
+            align = YGAlignCenter;
+            break;
+          case HASH_STRING("baseline"):
+            align = YGAlignBaseline;
+            break;
+          default:
+            align = YGAlignAuto;
+            assert(value.IsNull());
+
+            break;
+        }
 
         YGNodeStyleSetAlignSelf(yogaNode, align);
         break;
       }
       case HASH_STRING("alignContent"): {
-        YGAlign align = YGAlignFlexStart;
+        YGAlign align;
 
-        if (value_hash == HASH_STRING("stretch"))
-          align = YGAlignStretch;
-        else if (value_hash == HASH_STRING("flex-start") || value.IsNull())
-          align = YGAlignFlexStart;
-        else if (value_hash == HASH_STRING("flex-end"))
-          align = YGAlignFlexEnd;
-        else if (value_hash == HASH_STRING("center"))
-          align = YGAlignCenter;
-        else if (value_hash == HASH_STRING("space-between"))
-          align = YGAlignSpaceBetween;
-        else if (value_hash == HASH_STRING("space-around"))
-          align = YGAlignSpaceAround;
-        else
-          assert(false);
-
+        switch (value_hash) {
+          case HASH_STRING("stretch"):
+            align = YGAlignStretch;
+            break;
+          case HASH_STRING("flex-start"):
+            align = YGAlignFlexStart;
+            break;
+          case HASH_STRING("flex-end"):
+            align = YGAlignFlexEnd;
+            break;
+          case HASH_STRING("center"):
+            align = YGAlignCenter;
+            break;
+          case HASH_STRING("space-between"):
+            align = YGAlignSpaceBetween;
+            break;
+          case HASH_STRING("space-around"):
+            align = YGAlignSpaceAround;
+            break;
+          default:
+            align = YGAlignFlexStart;
+            assert(value.IsNull());
+            break;
+        }
         YGNodeStyleSetAlignContent(yogaNode, align);
         break;
       }
@@ -562,38 +610,60 @@ static void StyleYogaNode(
         break;
       }
       case HASH_STRING("position"): {
-        YGPositionType position = YGPositionTypeRelative;
+        YGPositionType position;
 
-        if (value_hash == HASH_STRING("relative") || value.IsNull())
-          position = YGPositionTypeRelative;
-        else if (value_hash == HASH_STRING("absolute"))
-          position = YGPositionTypeAbsolute;
-        else if (value_hash == HASH_STRING("static"))
-          position = YGPositionTypeStatic;
-        else
-          assert(false);
-
+        switch (value_hash) {
+          case HASH_STRING("relative"):
+            position = YGPositionTypeRelative;
+            break;
+          case HASH_STRING("absolute"):
+            position = YGPositionTypeAbsolute;
+            break;
+          case HASH_STRING("static"):
+            position = YGPositionTypeStatic;
+            break;
+          default:
+            position = YGPositionTypeRelative;
+            assert(value.IsNull());
+            break;
+        }
         YGNodeStyleSetPositionType(yogaNode, position);
         break;
       }
       case HASH_STRING("overflow"): {
-        YGOverflow overflow = YGOverflowVisible;
-        if (value_hash == HASH_STRING("visible") || value.IsNull())
-          overflow = YGOverflowVisible;
-        else if (value_hash == HASH_STRING("hidden"))
-          overflow = YGOverflowHidden;
-        else if (value_hash == HASH_STRING("scroll"))
-          overflow = YGOverflowScroll;
-
+        YGOverflow overflow;
+        switch (value_hash) {
+          case HASH_STRING("visible"):
+            overflow = YGOverflowVisible;
+            break;
+          case HASH_STRING("hidden"):
+            overflow = YGOverflowHidden;
+            break;
+          case HASH_STRING("scroll"):
+            overflow = YGOverflowScroll;
+            break;
+          default:
+            overflow = YGOverflowVisible;
+            assert(value.IsNull());
+            break;
+        }
         YGNodeStyleSetOverflow(yogaNode, overflow);
         break;
       }
       case HASH_STRING("display"): {
-        YGDisplay display = YGDisplayFlex;
-        if (value_hash == HASH_STRING("flex") || value.IsNull())
-          display = YGDisplayFlex;
-        else if (value == "none")
-          display = YGDisplayNone;
+        YGDisplay display;
+        switch (value_hash) {
+          case HASH_STRING("flex"):
+            display = YGDisplayFlex;
+            break;
+          case HASH_STRING("none"):
+            display = YGDisplayNone;
+            break;
+          default:
+            display = YGDisplayFlex;
+            assert(value.IsNull());
+            break;
+        }
 
         YGNodeStyleSetDisplay(yogaNode, display);
         break;

--- a/vnext/include/Shared/fixed_string.h
+++ b/vnext/include/Shared/fixed_string.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#if (_MSVC_LANG >= 202002L)
+#define CONSTEVAL consteval
+#else
+#define CONSTEVAL constexpr
+#endif
+namespace details {
+
+#if defined(_WIN64)
+inline constexpr size_t FNV_offset_basis = 14695981039346656037ULL;
+inline constexpr size_t FNV_prime = 1099511628211ULL;
+#else // defined(_WIN64)
+inline constexpr size_t FNV_offset_basis = 2166136261U;
+inline constexpr size_t FNV_prime = 16777619U;
+#endif // defined(_WIN64)
+
+[[nodiscard]] inline CONSTEVAL size_t Fnv1a_append_bytes(
+    size_t _Val,
+    const char *_First,
+    const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val
+  for (size_t _Idx = 0; _Idx < _Count; ++_Idx) {
+    _Val ^= static_cast<size_t>(_First[_Idx]);
+    _Val *= FNV_prime;
+  }
+
+  return _Val;
+}
+
+_NODISCARD inline constexpr size_t Fnv1a_append_bytes_constexpr(
+    size_t _Val,
+    const char *_First,
+    const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val
+  for (size_t _Idx = 0; _Idx < _Count; ++_Idx) {
+    _Val ^= static_cast<size_t>(_First[_Idx]);
+    _Val *= FNV_prime;
+  }
+
+  return _Val;
+}
+
+inline size_t hash(const char *str) noexcept {
+  return Fnv1a_append_bytes_constexpr(FNV_offset_basis, str, strlen(str));
+}
+
+template <size_t N>
+struct fixed_string {
+  char val[N]{};
+  CONSTEVAL fixed_string(const char (&v)[N + 1]) noexcept {
+    for (size_t i = 0; i < N; i++) {
+      val[i] = v[i];
+    }
+  }
+  CONSTEVAL size_t length() const noexcept {
+    return N;
+  }
+
+  CONSTEVAL operator const char *() const noexcept {
+    return val;
+  }
+  CONSTEVAL const char &operator[](size_t pos) const {
+    return val[pos];
+  }
+  constexpr bool operator==(const char *v) const noexcept {
+    return strcmp(val, v) == 0;
+  }
+
+  CONSTEVAL size_t hash() const noexcept {
+    return Fnv1a_append_bytes(FNV_offset_basis, val, N);
+  }
+};
+template <size_t N>
+fixed_string(char const (&)[N]) -> fixed_string<N - 1>;
+
+} // namespace details
+
+#define HASH_STRING(STR) details::fixed_string{STR}.hash()

--- a/vnext/include/Shared/fixed_string.h
+++ b/vnext/include/Shared/fixed_string.h
@@ -8,16 +8,16 @@
 namespace details {
 
 #ifdef FNV_HASH_WIDTH_64
-  using hash_t = uint64_t;
-  inline constexpr size_t FNV_offset_basis = 14695981039346656037ULL;
-  inline constexpr size_t FNV_prime = 1099511628211ULL;
+using hash_t = uint64_t;
+inline constexpr size_t FNV_offset_basis = 14695981039346656037ULL;
+inline constexpr size_t FNV_prime = 1099511628211ULL;
 #else
-  using hash_t = uint32_t;
-  inline constexpr hash_t FNV_offset_basis = 2166136261U;
-  inline constexpr hash_t FNV_prime = 16777619U;
+using hash_t = uint32_t;
+inline constexpr hash_t FNV_offset_basis = 2166136261U;
+inline constexpr hash_t FNV_prime = 16777619U;
 #endif
 
-  [[nodiscard]] inline CONSTEVAL hash_t Fnv1a_append_bytes(
+[[nodiscard]] inline CONSTEVAL hash_t Fnv1a_append_bytes(
     hash_t _Val,
     const char *_First,
     const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val

--- a/vnext/include/Shared/fixed_string.h
+++ b/vnext/include/Shared/fixed_string.h
@@ -7,39 +7,41 @@
 #endif
 namespace details {
 
-#if defined(_WIN64)
-inline constexpr size_t FNV_offset_basis = 14695981039346656037ULL;
-inline constexpr size_t FNV_prime = 1099511628211ULL;
-#else // defined(_WIN64)
-inline constexpr size_t FNV_offset_basis = 2166136261U;
-inline constexpr size_t FNV_prime = 16777619U;
-#endif // defined(_WIN64)
+#ifdef FNV_HASH_WIDTH_64
+  using hash_t = uint64_t;
+  inline constexpr size_t FNV_offset_basis = 14695981039346656037ULL;
+  inline constexpr size_t FNV_prime = 1099511628211ULL;
+#else
+  using hash_t = uint32_t;
+  inline constexpr hash_t FNV_offset_basis = 2166136261U;
+  inline constexpr hash_t FNV_prime = 16777619U;
+#endif
 
-[[nodiscard]] inline CONSTEVAL size_t Fnv1a_append_bytes(
-    size_t _Val,
+  [[nodiscard]] inline CONSTEVAL hash_t Fnv1a_append_bytes(
+    hash_t _Val,
     const char *_First,
     const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val
   for (size_t _Idx = 0; _Idx < _Count; ++_Idx) {
-    _Val ^= static_cast<size_t>(_First[_Idx]);
+    _Val ^= static_cast<hash_t>(_First[_Idx]);
     _Val *= FNV_prime;
   }
 
   return _Val;
 }
 
-_NODISCARD inline constexpr size_t Fnv1a_append_bytes_constexpr(
-    size_t _Val,
+_NODISCARD inline constexpr hash_t Fnv1a_append_bytes_constexpr(
+    hash_t _Val,
     const char *_First,
     const size_t _Count) noexcept { // accumulate range [_First, _First + _Count) into partial FNV-1a hash _Val
   for (size_t _Idx = 0; _Idx < _Count; ++_Idx) {
-    _Val ^= static_cast<size_t>(_First[_Idx]);
+    _Val ^= static_cast<hash_t>(_First[_Idx]);
     _Val *= FNV_prime;
   }
 
   return _Val;
 }
 
-inline size_t hash(const char *str) noexcept {
+inline hash_t hash(const char *str) noexcept {
   return Fnv1a_append_bytes_constexpr(FNV_offset_basis, str, strlen(str));
 }
 
@@ -65,7 +67,7 @@ struct fixed_string {
     return strcmp(val, v) == 0;
   }
 
-  CONSTEVAL size_t hash() const noexcept {
+  CONSTEVAL hash_t hash() const noexcept {
     return Fnv1a_append_bytes(FNV_offset_basis, val, N);
   }
 };


### PR DESCRIPTION
## Description
We currently implement a lot of our update logic and mapping property names to values by using string comparisons.
We can shrink the size on disk and speed things up by instead computing a hash of the property names and comparing the resulting hashes.
What's more, the hashes for the values we compare against, can be computed at compile time.

### Type of Change
- New feature (non-breaking change which adds functionality)

### What
In this PR I am starting with creating the mechanism to do compile-time string hashes, and applying it to one function (`StyleYogaNode`). We can then start opting in more and more functions (esp. UpdateProperties and its friends).

### Results: 
✅ Code size for the `StyleYogaNode` function went down by **16%** when I converted the outer comparisons (the property name). 

✅It went further down when I also converted the property value comparisons, by a total of **47%**.

| | |
|--|--|
| Baseline | 6.8 kB |
| 64-bit FNV hash | 6.3 kB |
| 32-bit FNV hash | 5.7 kB |
| 32-bit FNV hash with inner value compares | 3.6 kB |

Speed-wise, I ran some micro benchmarkings (with a reduced version of StyleYogaNode) and saw average time per call go from 52 ns to 42 ns, about **20% faster** (caveat, the benchmark is a little flimsy so take this number as anecdotal for now...)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9841)