### PR TITLE
[0.65] CG: Update async to resolve CVE-2021-43138

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "set-value": "^4.0.1",
     "strip-ansi": "^6.0.1",
     "xmldom": "github:xmldom/xmldom#^0.7.5",
+    "**/clang-format/async": "^3.2.3",
+    "**/licenses/async": "^3.2.3",
     "**/@react-native/repo-config/jest-junit": "^13.0.0",
     "**/@react-native/repo-config/shelljs": "^0.8.5",
     "**/@react-native/repo-config/ws": "^6.2.2",

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -13,7 +13,7 @@
     "format-files": "./bin.js"
   },
   "dependencies": {
-    "async": "^3.2.0",
+    "async": "^3.2.3",
     "clang-format": "1.5.0",
     "source-map-support": "^0.5.19"
   },

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@react-native-windows/find-repo-root": "0.65.1",
     "@react-native-windows/package-utils": "0.65.1",
-    "async": "^3.2.0",
+    "async": "^3.2.3",
     "lodash": "^4.17.15",
     "ora": "^3.4.0",
     "react-native-platform-override": "^1.4.14",

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@react-native-windows/package-utils": "0.65.1",
-    "async": "^3.2.0",
+    "async": "^3.2.3",
     "chalk": "^4.1.0",
     "fp-ts": "^2.5.0",
     "globby": "^9.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3046,27 +3046,17 @@ async-settle@^1.0.0:
   dependencies:
     async-done "^1.2.2"
 
-async@0.6.x:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.6.2.tgz#41fd038a3812c0a8bc1842ecf08ba63eb0392bef"
-  integrity sha1-Qf0DijgSwKi8GELs8IumPrA5K+8=
-
-async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+async@0.6.x, async@^1.5.2, async@^3.2.0, async@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
+  integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
 
 async@^2.4.0:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
+  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
-
-async@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
-  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 asynckit@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR (partially) backports #9837 to 0.65.

This PR updates our dependencies on async to `async@^3.2.3` and/or `async@^2.6.4`.

A resolution is used for `**/clang-format/async` to get the new version of async without the new behavior changes by updating clang-format itself.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9848)