### PR TITLE
[0.68] Fix Sequential Mso DispatchQueue deadlock on shutdown

### DIFF
--- a/change/react-native-windows-994ac337-c779-45ca-aea6-48c686f2e857.json
+++ b/change/react-native-windows-994ac337-c779-45ca-aea6-48c686f2e857.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Sequential DispatchQueue deadlock on shutdown",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -100,6 +100,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="activeObject\activeObjectTest.cpp" />
+    <ClCompile Include="dispatchQueue\dispatchQueueTest.cpp" />
     <ClCompile Include="errorCode\errorProviderTest.cpp" />
     <ClCompile Include="errorCode\maybeTest.cpp" />
     <ClCompile Include="eventWaitHandle\eventWaitHandleTest.cpp" />

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj.filters
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="pch">
       <UniqueIdentifier>{c1f49da1-d949-4a14-a312-36dd851d3f85}</UniqueIdentifier>
     </Filter>
+    <Filter Include="dispatchQueue">
+      <UniqueIdentifier>{f4486561-9d0c-45ec-a4a2-571345827d07}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="activeObject\activeObjectTest.cpp">
@@ -117,6 +120,9 @@
     </ClCompile>
     <ClCompile Include="pch.cpp">
       <Filter>pch</Filter>
+    </ClCompile>
+    <ClCompile Include="dispatchQueue\dispatchQueueTest.cpp">
+      <Filter>dispatchQueue</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Mso.UnitTests/dispatchQueue/dispatchQueueTest.cpp
+++ b/vnext/Mso.UnitTests/dispatchQueue/dispatchQueueTest.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "dispatchQueue/dispatchQueue.h"
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include "motifCpp/testCheck.h"
+
+namespace Mso {
+extern void Test_ThreadPoolSchedulerWin_EnableThreadPoolWorkTracking(bool enable) noexcept;
+extern void Test_ThreadPoolSchedulerWin_WaitForThreadPoolWorkCompletion() noexcept;
+} // namespace Mso
+
+namespace DispatchQueueTests {
+
+TEST_CLASS (DispatchQueueTest) {
+  TEST_METHOD(DispatchQueue_Shutdown) {
+    // Check that there is no dead lock if queue is released outside of task.
+    std::mutex mutex;
+    std::atomic<bool> taskStarted{false};
+    std::condition_variable whenTaskStarted;
+    int callCount = 0;
+    {
+      Mso::DispatchQueue queue = Mso::DispatchQueue::MakeSerialQueue();
+      queue.Post([&]() {
+        ++callCount;
+        taskStarted = true;
+        whenTaskStarted.notify_all();
+      });
+      std::unique_lock lock(mutex);
+      whenTaskStarted.wait(lock, [&]() { return taskStarted.load(); });
+    }
+    TestCheck(callCount == 1);
+  }
+
+  TEST_METHOD(DispatchQueue_ShutdownFromTask) {
+    // Check that there is no dead lock if queue is released form a task.
+    // Use shared_ptr for mutex because the test completes before the DispatchQueue task.
+    std::shared_ptr<std::mutex> mutex = std::make_shared<std::mutex>();
+    std::atomic<bool> taskStarted{false};
+    std::condition_variable whenTaskStarted;
+    std::atomic<bool> queueReleased{false};
+    std::condition_variable whenQueueReleased;
+    int callCount = 0;
+    Mso::Test_ThreadPoolSchedulerWin_EnableThreadPoolWorkTracking(true);
+    {
+      Mso::DispatchQueue queue = Mso::DispatchQueue::MakeSerialQueue();
+      queue.Post([&, mutex]() {
+        ++callCount;
+        std::unique_lock lock(*mutex);
+        taskStarted = true;
+        whenTaskStarted.notify_all();
+        // Wait until the queue is released outside of task.
+        whenQueueReleased.wait(lock, [&]() { return queueReleased.load(); });
+      });
+      std::unique_lock lock(*mutex);
+      whenTaskStarted.wait(lock, [&]() { return taskStarted.load(); });
+    }
+    {
+      std::unique_lock lock(*mutex);
+      queueReleased = true;
+      whenQueueReleased.notify_all();
+    }
+    TestCheck(callCount == 1);
+    Mso::Test_ThreadPoolSchedulerWin_WaitForThreadPoolWorkCompletion();
+    Mso::Test_ThreadPoolSchedulerWin_EnableThreadPoolWorkTracking(false);
+  }
+};
+
+} // namespace DispatchQueueTests


### PR DESCRIPTION
Cherry pick PR #9818
Original PR description:

## Description

Fix Sequential Mso DispatchQueue deadlock on shutdown

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

@acoates-ms has reported an issue that we have a deadlock when Mso sequential DispatchQueue based on thread pool is shutting down. The source of the issue is that the scheduler class waits for thread pool work to finish in the destructor, and if the dispatch queue or the scheduler class is being destroyed from the thread pool task itself, then we are getting a deadlock:
- the scheduler class destructor waits for thread pool task to finish;
- the thread pool task waits on the scheduler class to complete destruction.

### What

To fix the issue we are introducing `ThreadPoolSchedulerWinContext` class that tracks current `ThreadPoolSchedulerWin` instance used by current thread. The `ThreadPoolSchedulerWin::AwaitTermination()` method waits for tasks to finish only if `this` is not equal to `ThreadPoolSchedulerWinContext::CurrentScheduler()`.

## Testing

Two new DispatchQueue unit tests are added to verify two different shutdown scenarios for the sequential dispatch queue: when the queue is destroyed from outside and from inside of a thread pool task.
The `ThreadPoolSchedulerWin` class was extended with additional APIs to enable waiting for thread pool tasks.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9864)