### PR TITLE
[0.67] Fix JSI implementation for Node-API and update v8jsi to 0.65.11 (#9867)

### DIFF
--- a/change/react-native-windows-5399ecee-0b0c-4061-ad9c-5308081e829d.json
+++ b/change/react-native-windows-5399ecee-0b0c-4061-ad9c-5308081e829d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix JSI for Node-API and update V8 to 0.65.11",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.5" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.11" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.5" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.11" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.cpp
@@ -190,7 +190,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   facebook::jsi::Function createFunctionFromHostFunction(
       const facebook::jsi::PropNameID &name,
       unsigned int paramCount,
-      facebook::jsi::HostFunctionType type) override;
+      facebook::jsi::HostFunctionType func) override;
   facebook::jsi::Value call(
       const facebook::jsi::Function &func,
       const facebook::jsi::Value &jsThis,
@@ -475,7 +475,7 @@ struct NapiJsiRuntime : facebook::jsi::Runtime {
   void SetProperty(napi_value object, napi_value propertyId, napi_value value, napi_property_attributes attrs) const;
   napi_value CreateArray(size_t length) const;
   void SetElement(napi_value array, uint32_t index, napi_value value) const;
-  static napi_value JsiHostFunctionCallback(napi_env env, napi_callback_info info) noexcept;
+  static napi_value __cdecl JsiHostFunctionCallback(napi_env env, napi_callback_info info) noexcept;
   napi_value CreateExternalFunction(napi_value name, int32_t paramCount, napi_callback callback, void *callbackData);
   napi_value CreateExternalObject(void *data, napi_finalize finalizeCallback) const;
   template <typename T>
@@ -1702,7 +1702,7 @@ void NapiJsiRuntime::SetElement(napi_value array, uint32_t index, napi_value val
 }
 
 // The NAPI external function callback used for the JSI host function implementation.
-/*static*/ napi_value NapiJsiRuntime::JsiHostFunctionCallback(napi_env env, napi_callback_info info) noexcept {
+/*static*/ napi_value __cdecl NapiJsiRuntime::JsiHostFunctionCallback(napi_env env, napi_callback_info info) noexcept {
   HostFunctionWrapper *hostFuncWrapper{};
   size_t argc{};
   CHECK_NAPI_ELSE_CRASH(
@@ -1750,15 +1750,11 @@ napi_value NapiJsiRuntime::CreateExternalObject(void *data, napi_finalize finali
 // Wraps up std::unique_ptr as an external object.
 template <typename T>
 napi_value NapiJsiRuntime::CreateExternalObject(unique_ptr<T> &&data) const {
-  napi_value object =
-      CreateExternalObject(data.get(), [](napi_env /*env*/, void *dataToDestroy, void * /*finalizerHint*/) {
-        // We wrap dataToDestroy in a unique_ptr to avoid calling delete explicitly.
-        if (std::is_array<T>::value) {
-          delete[] static_cast<T *>(dataToDestroy);
-        } else {
-          delete static_cast<T *>(dataToDestroy);
-        }
-      });
+  napi_finalize finalize = [](napi_env /*env*/, void *dataToDestroy, void * /*finalizerHint*/) {
+    // We wrap dataToDestroy in a unique_ptr to avoid calling delete explicitly.
+    unique_ptr<T> dataDeleter{static_cast<T *>(dataToDestroy)};
+  };
+  napi_value object = CreateExternalObject(data.get(), finalize);
 
   // We only call data.release() after the CreateExternalObject succeeds.
   // Otherwise, when CreateExternalObject fails and an exception is thrown,
@@ -1807,7 +1803,7 @@ napi_value NapiJsiRuntime::GetHostObjectProxyHandler() {
 // Sets Proxy trap method as a pointer to NapiJsiRuntime instance method.
 template <napi_value (NapiJsiRuntime::*trapMethod)(span<napi_value>), size_t argCount>
 void NapiJsiRuntime::SetProxyTrap(napi_value handler, napi_value propertyName) {
-  auto proxyTrap = [](napi_env env, napi_callback_info info) noexcept {
+  napi_callback proxyTrap = [](napi_env env, napi_callback_info info) noexcept {
     NapiJsiRuntime *runtime{};
     napi_value args[argCount]{};
     size_t actualArgCount{argCount};

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
+#ifndef MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME
+#define MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME
 
 // JSI
 #include <js_native_ext_api.h>
@@ -19,3 +21,5 @@ namespace Microsoft::JSI {
 std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNodeApiJsiRuntime(napi_env env) noexcept;
 
 } // namespace Microsoft::JSI
+
+#endif // MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.10.0-ms.1" targetFramework="native" />
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.5" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.11" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -16,7 +16,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.65.5</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.65.11</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(SolutionDir)packages\$(V8PackageName).$(V8Version)</V8Package>

--- a/vnext/ReactCommon.UnitTests/packages.config
+++ b/vnext/ReactCommon.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="boost" version="1.76.0.0" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.5" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.11" targetFramework="native" />
 </packages>

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -22,7 +22,7 @@ class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
 
  private:
-  static void ScheduleTaskCallback(
+  static void __cdecl ScheduleTaskCallback(
       napi_env env,
       napi_ext_task_callback taskCb,
       void *taskData,


### PR DESCRIPTION
Cherry pick PR #9867
Original description:

## Description

Fix JSI implementation for Node-API and update v8jsi to 0.65.11

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Node-API does not specify explicitly calling conventions for functions.
It is typically not an issue when code is compiled with the default calling conventions, but `react-native-win32.dll` is compiled with `__stdcall` calling conventions while the `v8jsi.dll` is with the `__cdecl` calling conventions.
As a result, using the Node-API function is not ABI-safe.
Foreseeing this issue, we explicitly marked all Node-API functions as `__cdecl`, but we forgot to decorate with the `__cdecl` the function pointer types. As a result, we see crashes in x86 environment when we create host functions or host objects.

### What
To fix the issue we updated the Node-API definitions and recompiled the `v8jsi.dll`.
The new DLL is deployed with V8JSI version 0.65.11.
In this PR we change ReactNative for Windows code to use the new version 0.65.11 and update the `NodeApiJsiRuntime` implementation.

The change is done originally in the 0.66 branch because this is the version that we need to fix Office code.
It will be propagated to other branches after that.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9872)