### PR TITLE
Telemetry updates to meet server-side requirements

### DIFF
--- a/change/@react-native-windows-cli-9b90ea8d-57a8-49b1-a2c3-1dbf5dc120bc.json
+++ b/change/@react-native-windows-cli-9b90ea8d-57a8-49b1-a2c3-1dbf5dc120bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Telemetry updates to meet server-side requirements",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-576950f0-e0ad-4946-afbd-7def82c5885b.json
+++ b/change/@react-native-windows-telemetry-576950f0-e0ad-4946-afbd-7def82c5885b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Telemetry updates to meet server-side requirements",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/commandWithProgress.ts
@@ -133,9 +133,10 @@ export function commandWithProgress(
         reject(
           new CodedError(
             errorCategory,
-            `${taskDoingName} - error code ${code}`,
+            `${taskDoingName} - exit error code ${code}`,
             {
-              errorCode: code,
+              taskName: taskDoingName,
+              taskExitCode: code,
             },
           ),
         );

--- a/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/msbuildtools.ts
@@ -160,12 +160,27 @@ export default class MSBuildTools {
       );
     } catch (e) {
       let error = e;
-      if (!e) {
-        const firstMessage = (await fs.readFile(errorLog))
-          .toString()
-          .split(EOL)[0];
-        error = new CodedError('MSBuildError', firstMessage);
-        (error as any).logfile = errorLog;
+      if (e instanceof CodedError) {
+        const origCodedError = e as CodedError;
+        if (origCodedError.type === 'MSBuildError') {
+          // Try to parse msbuild errors from errorLog
+          const errorLogContents = (await fs.readFile(errorLog))
+            .toString()
+            .split(EOL)
+            .filter(s => s)
+            .map(s => s.trim());
+          if (errorLogContents.length > 0) {
+            const firstMessage = errorLogContents[0];
+            error = new CodedError(
+              'MSBuildError',
+              firstMessage,
+              origCodedError.data,
+            );
+            // Hide error messages in a field that won't automatically get reported
+            // with telemetry but is still available to be parsed and sanitized
+            (error as any).msBuildErrorMessages = errorLogContents;
+          }
+        }
       }
       throw error;
     }

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -413,9 +413,12 @@ export class Telemetry {
     };
 
     // Set remaining common props
-    Object.assign(props, extraProps);
     props.project = Telemetry.projectProp;
     props.versions = Telemetry.versionsProp;
+
+    // Set extra props
+    props.extraProps = {};
+    Object.assign(props.extraProps, extraProps);
 
     // Fire event
     Telemetry.client!.trackEvent({name: props.eventName, properties: props});
@@ -455,9 +458,12 @@ export class Telemetry {
     }
 
     // Set remaining common props
-    Object.assign(props, extraProps);
     props.project = Telemetry.projectProp;
     props.versions = Telemetry.versionsProp;
+
+    // Set extra props
+    props.extraProps = {};
+    Object.assign(props.extraProps, extraProps);
 
     // Fire event
     Telemetry.client!.trackException({

--- a/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
@@ -18,6 +18,20 @@ test('deviceId() does not change', async () => {
   expect(await basePropUtils.deviceId()).toBe(await basePropUtils.deviceId());
 });
 
+test('deviceArchitecture() is valid', () => {
+  const value = basePropUtils.deviceArchitecture();
+  expect(value).toBeDefined();
+  expect(value).not.toBe('');
+  expect(value).not.toBeNull();
+});
+
+test('devicePlatform() is valid', () => {
+  const value = basePropUtils.devicePlatform();
+  expect(value).toBeDefined();
+  expect(value).not.toBe('');
+  expect(value).not.toBeNull();
+});
+
 test('deviceLocale() is valid', async () => {
   const value = await basePropUtils.deviceLocale();
   expect(value).toBeDefined();

--- a/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/errorUtils.test.ts
@@ -193,6 +193,18 @@ test('sanitizeErrorMessage() with cpu/thread id', () => {
   );
 });
 
+test('sanitizeErrorMessage() with standard MSBuild error', () => {
+  expect(
+    errorUtils.sanitizeErrorMessage(
+      `2:6>C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\XamlCompiler\\Microsoft.Windows.UI.Xaml.Common.targets(486,5): error MSB4181: The "CompileXaml" task returned false but did not log an error. [${process.cwd()}\\windows\\teltest68\\teltest68.csproj]`,
+    ),
+  ).toEqual(
+    `[path](486,5): error MSB4181: The CompileXaml task returned false but did not log an error. [windows]\\???.csproj(${
+      'teltest68\\teltest68.csproj'.length
+    })`,
+  );
+});
+
 test('sanitizeErrorStackFrame() with empty frame', () => {
   const emptyFrame: appInsights.Contracts.StackFrame = {
     level: 0,

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 
 import {
   Telemetry,
+  TelemetryOptions,
   CommandStartInfo,
   CommandEndInfo,
   CommandEventName,
@@ -25,7 +26,7 @@ export class TelemetryTest extends Telemetry {
   protected static testTelemetryProvidersRan: boolean;
 
   /** Run at the beginning of each test. */
-  static async startTest() {
+  static async startTest(options?: Partial<TelemetryOptions>) {
     TelemetryTest.hasTestTelemetryProviders = false;
     TelemetryTest.testTelemetryProvidersRan = false;
 
@@ -38,17 +39,19 @@ export class TelemetryTest extends Telemetry {
     // Ensure that we don't actually fire events when testing
     Telemetry.isTest = true;
 
-    await Telemetry.setup({preserveErrorMessages: true});
+    await Telemetry.setup(options);
   }
 
   /** Run at the end of each test where telemetry was fired. */
-  static endTest(finalCallback: () => void): void {
+  static endTest(finalCallback?: () => void): void {
     Telemetry.client?.flush({
       callback: _ => {
         if (TelemetryTest.hasTestTelemetryProviders) {
           expect(TelemetryTest.testTelemetryProvidersRan).toBe(true);
         }
-        finalCallback();
+        if (finalCallback) {
+          finalCallback();
+        }
       },
     });
   }
@@ -70,6 +73,11 @@ export class TelemetryTest extends Telemetry {
       : null;
   }
 
+  /** Retrieves the value of the preserveErrorMessages option. */
+  static getPreserveErrorMessages(): boolean {
+    return TelemetryTest.options.preserveErrorMessages;
+  }
+
   /** Adds a telemetry processor, usually for verifying the envelope. */
   static addTelemetryProcessor(
     telemetryProcessor: (
@@ -84,19 +92,21 @@ export class TelemetryTest extends Telemetry {
   }
 }
 
-beforeEach(async () => {
+test('setup() verify session id is valid and a common property', async done => {
   await TelemetryTest.startTest();
-});
 
-test('setup() verify session id is valid and a common property', async () => {
   const sessionId = TelemetryTest.getSessionId();
   expect(sessionId).toBeDefined();
   expect(sessionId!).toHaveLength(32);
   expect(sessionId!).toBe(basePropUtils.getSessionId());
-  expect(sessionId!).toBe(TelemetryTest.getCommonProperty('sessionId'));
+  expect(TelemetryTest.getCommonProperty('sessionId')).toBe(sessionId!);
+
+  TelemetryTest.endTest(done);
 });
 
-test('setup() verify static common property values with async sources', async () => {
+test('setup() verify static common property values with async sources', async done => {
+  await TelemetryTest.startTest();
+
   const props: Record<string, () => Promise<string | undefined>> = {
     deviceId: basePropUtils.deviceId,
     deviceLocale: basePropUtils.deviceLocale,
@@ -104,42 +114,57 @@ test('setup() verify static common property values with async sources', async ()
 
   for (const key in props) {
     if (!(key in Object.prototype)) {
-      const value = await props[key]();
+      const value = TelemetryTest.getCommonProperty(key);
       expect(value).toBeDefined();
-      expect(value).toBe(TelemetryTest.getCommonProperty(key));
+      expect(value).toBe(await props[key]());
     }
   }
+
+  TelemetryTest.endTest(done);
 });
 
-test('setup() verify static common property values with sync sources', () => {
+test('setup() verify static common property values with sync sources', async done => {
+  await TelemetryTest.startTest();
+
   const props: Record<string, () => string | undefined> = {
+    deviceArchitecture: () => basePropUtils.deviceArchitecture(),
+    devicePlatform: () => basePropUtils.devicePlatform(),
     deviceNumCPUs: () => basePropUtils.deviceNumCPUs().toString(),
     deviceTotalMemory: () => basePropUtils.deviceTotalMemory().toString(),
     ciCaptured: () => basePropUtils.captureCI().toString(),
     ciType: () => basePropUtils.ciType(),
     isMsftInternal: () => basePropUtils.isMsftInternal().toString(),
+    sampleRate: () => basePropUtils.sampleRate().toString(),
     isTest: () => 'true',
   };
 
   for (const key in props) {
     if (!(key in Object.prototype)) {
-      const value = props[key]();
+      const value = TelemetryTest.getCommonProperty(key);
       expect(value).toBeDefined();
-      expect(value).toBe(TelemetryTest.getCommonProperty(key));
+      expect(value).toBe(props[key]());
     }
   }
+
+  TelemetryTest.endTest(done);
 });
 
-test('setup() verify other common property values are defined', () => {
+test('setup() verify other common property values are defined', async done => {
+  await TelemetryTest.startTest();
+
   const props: string[] = ['deviceDiskFreeSpace'];
 
   for (const key of props) {
     const value = TelemetryTest.getCommonProperty(key);
     expect(value).toBeDefined();
   }
+
+  TelemetryTest.endTest(done);
 });
 
-test('setup() verify tool versions are populated', async () => {
+test('setup() verify tool versions are populated', async done => {
+  await TelemetryTest.startTest();
+
   const props: Record<string, () => Promise<string | null>> = {
     node: versionUtils.getNodeVersion,
     npm: versionUtils.getNpmVersion,
@@ -153,18 +178,26 @@ test('setup() verify tool versions are populated', async () => {
       expect(value).toBe(TelemetryTest.getVersion(key));
     }
   }
+
+  TelemetryTest.endTest(done);
 });
 
-test('tryUpdateVersionsProp() returns true for adding a new version', async () => {
+test('tryUpdateVersionsProp() returns true for adding a new version', async done => {
+  await TelemetryTest.startTest();
+
   const name = 'test';
   const version = '1.0';
   expect(
     await TelemetryTest.tryUpdateVersionsProp(name, async () => version),
   ).toBe(true);
   expect(TelemetryTest.getVersion(name)).toBe(version);
+
+  TelemetryTest.endTest(done);
 });
 
-test('tryUpdateVersionsProp() returns false for adding an existing version with refresh is false', async () => {
+test('tryUpdateVersionsProp() returns false for adding an existing version with refresh is false', async done => {
+  await TelemetryTest.startTest();
+
   const name = 'test';
   const version = '1.0';
 
@@ -181,9 +214,13 @@ test('tryUpdateVersionsProp() returns false for adding an existing version with 
   ).toBe(false);
 
   expect(getValueCalled).toBe(false);
+
+  TelemetryTest.endTest(done);
 });
 
-test('tryUpdateVersionsProp() returns true for adding an existing version with refresh is true', async () => {
+test('tryUpdateVersionsProp() returns true for adding an existing version with refresh is true', async done => {
+  await TelemetryTest.startTest();
+
   const name = 'test';
   const version = '1.0';
 
@@ -204,6 +241,8 @@ test('tryUpdateVersionsProp() returns true for adding an existing version with r
   ).toBe(true);
 
   expect(getValueCalled).toBe(true);
+
+  TelemetryTest.endTest(done);
 });
 
 /** Returns the CommandStartInfo for our fake 'test-command'. */
@@ -345,6 +384,19 @@ function verifyTestCommandTelemetryProcessor(
         // Verify event name
         expect(properties.eventName).toBe(CodedErrorEventName);
 
+        // Verify exception info
+        const exceptions = envelope.data.baseData?.exceptions;
+        expect(exceptions).toBeDefined();
+        expect(exceptions.length).toBe(1);
+        expect(exceptions[0].message).toBeDefined();
+        expect(exceptions[0].message).not.toBe('');
+
+        expect(exceptions[0].message).toBe(
+          TelemetryTest.getPreserveErrorMessages()
+            ? errorUtils.sanitizeErrorMessage(expectedError?.message || 'None')
+            : '[Removed]',
+        );
+
         // Verify coded error info
         const codedError = JSON.parse(properties.codedError);
         expect(codedError).toBeDefined();
@@ -403,6 +455,8 @@ function verifyTestCommandTelemetryProcessor(
 }
 
 test('Telemetry run test command end to end, verify event fires', async done => {
+  await TelemetryTest.startTest();
+
   // AI eats errors thrown in telemetry processors
   const caughtErrors: Error[] = [];
   TelemetryTest.addTelemetryProcessor(
@@ -418,114 +472,155 @@ test('Telemetry run test command end to end, verify event fires', async done => 
   });
 });
 
-test('Telemetry run test command end to end with CodedError, verify events fire', async done => {
-  const expectedError = new errorUtils.CodedError('MSBuildError', 'test error');
+const testTelemetryOptions = [
+  {preserveErrorMessages: false},
+  {preserveErrorMessages: true},
+];
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    verifyTestCommandTelemetryProcessor(
-      caughtErrors,
-      expectedError.type,
-      expectedError,
-    ),
-  );
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with CodedError, verify events fire %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-  await runTestCommandE2E(() => testCommandBody(expectedError));
+    const expectedError = new errorUtils.CodedError(
+      'MSBuildError',
+      'test error',
+    );
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        expectedError.type,
+        expectedError,
+      ),
+    );
 
-test('Telemetry run test command end to end with CodedError (with error in message), verify events fire', async done => {
-  const expectedError = new errorUtils.CodedError(
-    'MSBuildError',
-    'error FOO2020: test error',
-  );
+    await runTestCommandE2E(() => testCommandBody(expectedError));
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    verifyTestCommandTelemetryProcessor(
-      caughtErrors,
-      expectedError.type,
-      expectedError,
-    ),
-  );
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
 
-  await runTestCommandE2E(() => testCommandBody(expectedError));
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with CodedError (with error in message), verify events fire %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    const expectedError = new errorUtils.CodedError(
+      'MSBuildError',
+      'error FOO2020: test error',
+    );
 
-test('Telemetry run test command end to end with CodedError (with data), verify events fire', async done => {
-  const expectedError = new errorUtils.CodedError(
-    'MSBuildError',
-    'test error',
-    {foo: 42},
-  );
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        expectedError.type,
+        expectedError,
+      ),
+    );
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    verifyTestCommandTelemetryProcessor(
-      caughtErrors,
-      expectedError.type,
-      expectedError,
-    ),
-  );
+    await runTestCommandE2E(() => testCommandBody(expectedError));
 
-  await runTestCommandE2E(() => testCommandBody(expectedError));
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with CodedError (with data), verify events fire %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-test('Telemetry run test command end to end with Error, verify events fire', async done => {
-  const expectedError = new Error('error FOO2020: test error');
+    const expectedError = new errorUtils.CodedError(
+      'MSBuildError',
+      'test error',
+      {foo: 42},
+    );
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    verifyTestCommandTelemetryProcessor(caughtErrors, 'Unknown', expectedError),
-  );
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        expectedError.type,
+        expectedError,
+      ),
+    );
 
-  await runTestCommandE2E(() => testCommandBody(expectedError));
+    await runTestCommandE2E(() => testCommandBody(expectedError));
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
 
-test('Telemetry run test command end to end with Error (no message), verify events fire', async done => {
-  const expectedError = new Error();
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with Error, verify events fire %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    verifyTestCommandTelemetryProcessor(caughtErrors, 'Unknown', expectedError),
-  );
+    const expectedError = new Error('error FOO2020: test error');
 
-  await runTestCommandE2E(() => testCommandBody(expectedError));
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        'Unknown',
+        expectedError,
+      ),
+    );
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    await runTestCommandE2E(() => testCommandBody(expectedError));
+
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
+
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with Error (no message), verify events fire %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
+
+    const expectedError = new Error();
+
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      verifyTestCommandTelemetryProcessor(
+        caughtErrors,
+        'Unknown',
+        expectedError,
+      ),
+    );
+
+    await runTestCommandE2E(() => testCommandBody(expectedError));
+
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
 
 function b(s: string) {
   throw new Error('hello ' + s);
@@ -554,8 +649,13 @@ function getVerifyStackTelemetryProcessor(
         const data = (envelope.data as any).baseData;
         expect(data.exceptions).toBeDefined();
         expect(data.exceptions.length).toBe(1);
+        expect(data.exceptions[0].message).toBeDefined();
+        expect(data.exceptions[0].message).not.toBe('');
+
         expect(data.exceptions[0].message).toBe(
-          errorUtils.sanitizeErrorMessage(expectedError.message),
+          TelemetryTest.getPreserveErrorMessages()
+            ? errorUtils.sanitizeErrorMessage(expectedError.message || 'None')
+            : '[Removed]',
         );
 
         const stack = data.exceptions[0].parsedStack;
@@ -582,44 +682,54 @@ function getVerifyStackTelemetryProcessor(
   };
 }
 
-test('Telemetry run test command end to end with Error, verify sanitized message and stack', async done => {
-  const expectedError = new Error('hello world');
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with Error, verify sanitized message and stack %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
-  );
+    const expectedError = new Error('hello world');
 
-  await runTestCommandE2E(async () => {
-    await promiseDelay(100);
-    a('world');
-  });
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
+    );
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    await runTestCommandE2E(async () => {
+      await promiseDelay(100);
+      a('world');
+    });
 
-test('Telemetry run test command end to end with Error, verify sanitized message with path and stack', async done => {
-  const expectedError = new Error(`hello ${process.cwd()}`);
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);
 
-  // AI eats errors thrown in telemetry processors
-  const caughtErrors: Error[] = [];
-  TelemetryTest.addTelemetryProcessor(
-    getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
-  );
+test.each(testTelemetryOptions)(
+  'Telemetry run test command end to end with Error, verify sanitized message with path and stack %s',
+  async (options, done: any) => {
+    await TelemetryTest.startTest(options);
 
-  await runTestCommandE2E(async () => {
-    await promiseDelay(100);
-    a(process.cwd());
-  });
+    const expectedError = new Error(`hello ${process.cwd()}`);
 
-  TelemetryTest.endTest(() => {
-    // Check if any errors were thrown
-    expect(caughtErrors).toHaveLength(0);
-    done();
-  });
-});
+    // AI eats errors thrown in telemetry processors
+    const caughtErrors: Error[] = [];
+    TelemetryTest.addTelemetryProcessor(
+      getVerifyStackTelemetryProcessor(caughtErrors, expectedError),
+    );
+
+    await runTestCommandE2E(async () => {
+      await promiseDelay(100);
+      a(process.cwd());
+    });
+
+    TelemetryTest.endTest(() => {
+      // Check if any errors were thrown
+      expect(caughtErrors).toHaveLength(0);
+      done();
+    });
+  },
+);

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -406,9 +406,7 @@ function verifyTestCommandTelemetryProcessor(
             ? expectedError.type
             : 'Unknown',
         );
-        expect(codedError.rawErrorCode).toBe(
-          errorUtils.tryGetErrorCode(expectedError?.message ?? '') ?? '',
-        );
+
         expect(codedError.data).toStrictEqual(
           (expectedError as errorUtils.CodedError).data ?? {},
         );

--- a/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/telemetry.test.ts
@@ -432,17 +432,7 @@ function verifyTestCommandTelemetryProcessor(
 
         // Verify extra props
         const extraProps = getExtraProps();
-        for (const key of Object.keys(extraProps)) {
-          switch (typeof extraProps[key]) {
-            case 'object':
-              expect(JSON.parse(properties[key])).toStrictEqual(
-                extraProps[key],
-              );
-              break;
-            default:
-              expect(properties[key]).toBe(extraProps[key].toString());
-          }
-        }
+        expect(JSON.parse(properties.extraProps)).toStrictEqual(extraProps);
       }
     } catch (ex) {
       caughtErrors.push(

--- a/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
@@ -5,7 +5,7 @@
  */
 
 import {execSync} from 'child_process';
-import {totalmem, cpus} from 'os';
+import {totalmem, cpus, arch, platform} from 'os';
 
 import ci from 'ci-info';
 import {randomBytes} from 'crypto';
@@ -18,6 +18,22 @@ import osLocale from 'os-locale';
  */
 export async function deviceId(): Promise<string> {
   return await machineId(false);
+}
+
+/**
+ * Gets the device architecture, like x64/arm64.
+ * @returns The device architecture.
+ */
+export function deviceArchitecture(): string {
+  return arch();
+}
+
+/**
+ * Gets the device platform, like darwin/linux/win32.
+ * @returns The device platform.
+ */
+export function devicePlatform(): string {
+  return platform();
 }
 
 /**

--- a/packages/@react-native-windows/telemetry/src/utils/errorUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/errorUtils.ts
@@ -106,8 +106,13 @@ export function tryGetErrorCode(msg: string): string | undefined {
  * @return The message with any paths anonymized.
  */
 export function sanitizeErrorMessage(msg: string): string {
+  const msBuildErrorMessage =
+    /^\d+:\d+>(.*)(\(\d+,\d+\)): error (\w+\d+): (.*)/g;
+  msg = msg.replace(msBuildErrorMessage, '[$1]$2: error $3: $4');
+
   const cpuThreadId = /^\d+(:\d+)?>/g;
   msg = msg.replace(cpuThreadId, '');
+
   const parts = msg.split(/['[\]"]/g);
   const clean = [];
   const pathRegEx =

--- a/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/sanitizeUtils.ts
@@ -69,7 +69,7 @@ export function getAnonymizedPath(
     const rest = filepath.slice(projectRoot.length);
     if (rest.toLowerCase().startsWith(windows)) {
       // We are under the windows path, anonymize with [windows]
-      return `[windows]\\???${ext}(${rest.length - windows.length - 1})`;
+      return `[windows]\\???${ext}(${rest.length - windows.length})`;
     } else {
       // We are just within the projectRoot, anonymize with [project_dir]
       if (rest === '' || rest === '\\') {


### PR DESCRIPTION
This PR makes several changes so that the reported CLI telemetry meets ApplicationInsights (AI)'s server-side requirements:

* Ensures that reported errors have a defined, non-empty error message, to pass AI schema validation
* Fixes MSBuild error parsing not running during `run-wiundows`, now we extract the actual error codes, not the process exit code
* Updates `RNWCLI.CodedError` schema to better reflect what is being returned
* Adds `deviceArchitecture`, `devicePlatform`, and `sampleRate` as explicit properties, since otherwise AI strips them
* Command `extraProps` are now stored in their own field as an object, rather than injected as peers with the other properties, to make server-side processing easier and enable future extensions
* `isTest` boolean property is now included all the time (`isTest: true` and `isTest: false`, rather than `isTest: true` and `isTest: undefined` ) to make server-side processing easier
* Add new tests to cover the new functionality
* Slightly refactored tests to ensure better test cleanup

Closes #9861
Closes #9870
Closes #9878

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9873)