### PR TITLE
Fix Focusable/Accessible Prop Behavior for TextInput

### DIFF
--- a/change/react-native-windows-d5714a62-4b4a-4f7f-b763-fffe99ce60b4.json
+++ b/change/react-native-windows-d5714a62-4b4a-4f7f-b763-fffe99ce60b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix TextInput Props",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -1407,6 +1407,8 @@ function InternalTextInput(props: Props): React.Node {
       <WindowsTextInput
         ref={_setNativeRef}
         {...props}
+        accessible={accessible}
+        focusable={focusable}
         dataDetectorTypes={props.dataDetectorTypes}
         mostRecentEventCount={mostRecentEventCount}
         onBlur={_onBlur}


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
TextInput accessible and focusable prop behavior should match that of iOS and Android. The behavior should be that the prop value passed to the native is true unless the prop value is specified as false. Thus, we should pass in the adjusted accesssible/focusable value and not the original prop value. 


### What
Match TextInput accessible and focusable prop behavior to that of iOS and Android.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9885)