### PR TITLE
Stop exporting data blocks from react-native-win32.dll

### DIFF
--- a/change/react-native-windows-4e0e762e-ea7f-458b-93c2-533b3fa3a806.json
+++ b/change/react-native-windows-4e0e762e-ea7f-458b-93c2-533b3fa3a806.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Stop exporting data blocks from react-native-win32.dll",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -5,6 +5,8 @@
 ; **************************************************************************************************
 
 EXPORTS
+??$safe_assert_terminate@$0A@@detail@folly@@YAXPEBUsafe_assert_arg@01@ZZ
+??$safe_assert_terminate@$0A@PEBD@detail@folly@@YAXAEBUsafe_assert_arg@01@PEBD@Z
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??0LayoutAnimation@react@facebook@@QEAA@Udynamic@folly@@@Z
@@ -26,8 +28,9 @@ EXPORTS
 ?atImpl@dynamic@folly@@AEGBAAEBU12@AEBU12@@Z
 ?callJSFunction@Instance@react@facebook@@QEAAX$$QEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QEAUdynamic@folly@@@Z
 ?createI18nModule@windows@react@@YA?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$unique_ptr@UII18nModule@windows@react@@U?$default_delete@UII18nModule@windows@react@@@std@@@4@@Z
-?data@?$to_ascii_powers@$09_K@detail@folly@@2U?$c_array@_K$0BE@@3@B
-?data@?$to_ascii_table@$09U?$to_ascii_alphabet@$0A@@folly@@@detail@folly@@2U?$c_array@G$0GE@@3@B
+??$to_ascii_with_route@$09U?$to_ascii_alphabet@$0A@@folly@@$0BE@@detail@folly@@YA_KAEAY0BE@D_K@Z
+??$to_ascii_with_route@$09U?$to_ascii_alphabet@$0A@@folly@@@detail@folly@@YA_KPEADPEBD_K@Z
+??$to_ascii_size_route@$09@detail@folly@@YA_K_K@Z
 ?destroy@dynamic@folly@@AEAAXXZ
 ?getModuleRegistry@Instance@react@facebook@@QEAAAEAVModuleRegistry@23@XZ
 ?get_ptr@dynamic@folly@@QEGBAPEBU12@V?$Range@PEBD@2@@Z
@@ -36,12 +39,6 @@ EXPORTS
 ?loadScriptFromString@Instance@react@facebook@@QEAAXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YA?AVConversionError@1@W4ConversionCode@1@V?$Range@PEBD@1@@Z
 ?moduleNames@ModuleRegistry@react@facebook@@QEAA?AV?$vector@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$allocator@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@2@@std@@XZ
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@V?$vector@Udynamic@folly@@V?$allocator@Udynamic@folly@@@std@@@std@@@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@_J@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@_N@dynamic@folly@@2QEBDEB
-?name@?$TypeInfo@N@dynamic@folly@@2QEBDEB
 ?assertionFailure@detail@folly@@YAXPEBD00I0H@Z
 ?parseJson@folly@@YA?AUdynamic@1@V?$Range@PEBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QEAAXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -27,8 +27,8 @@ EXPORTS
 ?atImpl@dynamic@folly@@AGBEABU12@ABU12@@Z
 ?callJSFunction@Instance@react@facebook@@QAEX$$QAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0$$QAUdynamic@folly@@@Z
 ?createI18nModule@windows@react@@YG?AV?$unique_ptr@VCxxModule@module@xplat@facebook@@U?$default_delete@VCxxModule@module@xplat@facebook@@@std@@@std@@V?$unique_ptr@UII18nModule@windows@react@@U?$default_delete@UII18nModule@windows@react@@@std@@@4@@Z
-?data@?$to_ascii_powers@$09_K@detail@folly@@2U?$c_array@_K$0BE@@3@B
-?data@?$to_ascii_table@$09U?$to_ascii_alphabet@$0A@@folly@@@detail@folly@@2U?$c_array@G$0GE@@3@B
+??$to_ascii_size_route@$09@detail@folly@@YGI_K@Z
+??$to_ascii_with_route@$09U?$to_ascii_alphabet@$0A@@folly@@$0BE@@detail@folly@@YGIAAY0BE@D_K@Z
 ?destroy@dynamic@folly@@AAEXXZ
 ?getModuleRegistry@Instance@react@facebook@@QAEAAVModuleRegistry@23@XZ
 ?get_ptr@dynamic@folly@@QGBEPBU12@V?$Range@PBD@2@@Z
@@ -36,12 +36,6 @@ EXPORTS
 ?hash@dynamic@folly@@QBEIXZ
 ?loadScriptFromString@Instance@react@facebook@@QAEXV?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@5@_N@Z
 ?makeConversionError@folly@@YG?AVConversionError@1@W4ConversionCode@1@V?$Range@PBD@1@@Z
-?name@?$TypeInfo@UObjectImpl@dynamic@folly@@@dynamic@folly@@2QBDB
-?name@?$TypeInfo@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@dynamic@folly@@2QBDB
-?name@?$TypeInfo@_J@dynamic@folly@@2QBDB
-?name@?$TypeInfo@_N@dynamic@folly@@2QBDB
-?name@?$TypeInfo@N@dynamic@folly@@2QBDB
-?name@?$TypeInfo@V?$vector@Udynamic@folly@@V?$allocator@Udynamic@folly@@@std@@@std@@@dynamic@folly@@2QBDB
 ?parseJson@folly@@YG?AUdynamic@1@V?$Range@PBD@1@@Z
 ?setGlobalVariable@Instance@react@facebook@@QAEXV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@V?$unique_ptr@$$CBVJSBigString@react@facebook@@U?$default_delete@$$CBVJSBigString@react@facebook@@@std@@@5@@Z
 ?size@dynamic@folly@@QBEIXZ

--- a/vnext/Folly/TEMP_UntilFollyUpdate/dynamic-inl.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/dynamic-inl.h
@@ -1,0 +1,1411 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+
+#include <folly/CPortability.h>
+#include <folly/Conv.h>
+#include <folly/Format.h>
+#include <folly/Likely.h>
+#include <folly/detail/Iterators.h>
+#include <folly/lang/Exception.h>
+
+namespace folly {
+namespace detail {
+
+struct DynamicHasher {
+  using is_transparent = void;
+
+  size_t operator()(dynamic const& d) const { return d.hash(); }
+
+  template <typename T>
+  std::enable_if_t<std::is_convertible<T, StringPiece>::value, size_t>
+  operator()(T const& val) const {
+    // keep consistent with dynamic::hash() for strings
+    return Hash()(static_cast<StringPiece>(val));
+  }
+};
+
+struct DynamicKeyEqual {
+  using is_transparent = void;
+
+  bool operator()(const dynamic& lhs, const dynamic& rhs) const {
+    return std::equal_to<dynamic>()(lhs, rhs);
+  }
+
+  // Dynamic objects contains a map<dynamic, dynamic>. At least one of the
+  // operands should be a dynamic. Hence, an operator() where both operands are
+  // convertible to StringPiece is unnecessary.
+  template <typename A, typename B>
+  std::enable_if_t<
+      std::is_convertible<A, StringPiece>::value &&
+          std::is_convertible<B, StringPiece>::value,
+      bool>
+  operator()(A const& lhs, B const& rhs) const = delete;
+
+  template <typename A>
+  std::enable_if_t<std::is_convertible<A, StringPiece>::value, bool> operator()(
+      A const& lhs, dynamic const& rhs) const {
+    return FOLLY_LIKELY(rhs.type() == dynamic::Type::STRING) &&
+        std::equal_to<StringPiece>()(lhs, rhs.stringPiece());
+  }
+
+  template <typename B>
+  std::enable_if_t<std::is_convertible<B, StringPiece>::value, bool> operator()(
+      dynamic const& lhs, B const& rhs) const {
+    return FOLLY_LIKELY(lhs.type() == dynamic::Type::STRING) &&
+        std::equal_to<StringPiece>()(lhs.stringPiece(), rhs);
+  }
+};
+} // namespace detail
+} // namespace folly
+
+//////////////////////////////////////////////////////////////////////
+
+namespace std {
+
+template <>
+struct hash<::folly::dynamic> {
+  size_t operator()(::folly::dynamic const& d) const { return d.hash(); }
+};
+
+} // namespace std
+
+//////////////////////////////////////////////////////////////////////
+
+// This is a higher-order preprocessor macro to aid going from runtime
+// types to the compile time type system.
+#define FB_DYNAMIC_APPLY(type, apply) \
+  do {                                \
+    switch ((type)) {                 \
+      case NULLT:                     \
+        apply(std::nullptr_t);        \
+        break;                        \
+      case ARRAY:                     \
+        apply(Array);                 \
+        break;                        \
+      case BOOL:                      \
+        apply(bool);                  \
+        break;                        \
+      case DOUBLE:                    \
+        apply(double);                \
+        break;                        \
+      case INT64:                     \
+        apply(int64_t);               \
+        break;                        \
+      case OBJECT:                    \
+        apply(ObjectImpl);            \
+        break;                        \
+      case STRING:                    \
+        apply(std::string);           \
+        break;                        \
+      default:                        \
+        abort();                      \
+    }                                 \
+  } while (0)
+
+//////////////////////////////////////////////////////////////////////
+
+namespace folly {
+
+struct FOLLY_EXPORT TypeError : std::runtime_error {
+  explicit TypeError(const std::string& expected, dynamic::Type actual);
+  explicit TypeError(
+      const std::string& expected,
+      dynamic::Type actual1,
+      dynamic::Type actual2);
+};
+
+//////////////////////////////////////////////////////////////////////
+
+namespace detail {
+
+// This helper is used in destroy() to be able to run destructors on
+// types like "int64_t" without a compiler error.
+struct Destroy {
+  template <class T>
+  static void destroy(T* t) {
+    t->~T();
+  }
+};
+
+/*
+ * Helper for implementing numeric conversions in operators on
+ * numbers.  Just promotes to double when one of the arguments is
+ * double, or throws if either is not a numeric type.
+ */
+template <template <class> class Op>
+dynamic numericOp(dynamic const& a, dynamic const& b) {
+  if (!a.isNumber() || !b.isNumber()) {
+    throw_exception<TypeError>("numeric", a.type(), b.type());
+  }
+  if (a.isDouble() || b.isDouble()) {
+    return Op<double>()(a.asDouble(), b.asDouble());
+  }
+  return Op<int64_t>()(a.asInt(), b.asInt());
+}
+
+} // namespace detail
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * We're doing this instead of a simple member typedef to avoid the
+ * undefined behavior of parameterizing F14NodeMap<> with an
+ * incomplete type.
+ *
+ * Note: Later we may add separate order tracking here (a multi-index
+ * type of thing.)
+ */
+struct dynamic::ObjectImpl : F14NodeMap<
+                                 dynamic,
+                                 dynamic,
+                                 detail::DynamicHasher,
+                                 detail::DynamicKeyEqual> {};
+
+//////////////////////////////////////////////////////////////////////
+
+// Helper object for creating objects conveniently.  See object and
+// the dynamic::dynamic(ObjectMaker&&) ctor.
+struct dynamic::ObjectMaker {
+  friend struct dynamic;
+
+  explicit ObjectMaker() : val_(dynamic::object) {}
+  explicit ObjectMaker(dynamic key, dynamic val) : val_(dynamic::object) {
+    val_.insert(std::move(key), std::move(val));
+  }
+
+  // Make sure no one tries to save one of these into an lvalue with
+  // auto or anything like that.
+  ObjectMaker(ObjectMaker&&) = default;
+  ObjectMaker(ObjectMaker const&) = delete;
+  ObjectMaker& operator=(ObjectMaker const&) = delete;
+  ObjectMaker& operator=(ObjectMaker&&) = delete;
+
+  // This returns an rvalue-reference instead of an lvalue-reference
+  // to allow constructs like this to moved instead of copied:
+  //  dynamic a = dynamic::object("a", "b")("c", "d")
+  ObjectMaker&& operator()(dynamic key, dynamic val) {
+    val_.insert(std::move(key), std::move(val));
+    return std::move(*this);
+  }
+
+ private:
+  dynamic val_;
+};
+
+inline void dynamic::array(EmptyArrayTag) {}
+
+template <class... Args>
+inline dynamic dynamic::array(Args&&... args) {
+  return dynamic(Array{std::forward<Args>(args)...});
+}
+
+inline dynamic::ObjectMaker dynamic::object() {
+  return ObjectMaker();
+}
+inline dynamic::ObjectMaker dynamic::object(dynamic a, dynamic b) {
+  return ObjectMaker(std::move(a), std::move(b));
+}
+
+//////////////////////////////////////////////////////////////////////
+
+struct dynamic::item_iterator : detail::IteratorAdaptor<
+                                    dynamic::item_iterator,
+                                    dynamic::ObjectImpl::iterator,
+                                    std::pair<dynamic const, dynamic>,
+                                    std::forward_iterator_tag> {
+  using Super = detail::IteratorAdaptor<
+      dynamic::item_iterator,
+      dynamic::ObjectImpl::iterator,
+      std::pair<dynamic const, dynamic>,
+      std::forward_iterator_tag>;
+  /* implicit */ item_iterator(dynamic::ObjectImpl::iterator b) : Super(b) {}
+
+  using object_type = dynamic::ObjectImpl;
+};
+
+struct dynamic::value_iterator : detail::IteratorAdaptor<
+                                     dynamic::value_iterator,
+                                     dynamic::ObjectImpl::iterator,
+                                     dynamic,
+                                     std::forward_iterator_tag> {
+  using Super = detail::IteratorAdaptor<
+      dynamic::value_iterator,
+      dynamic::ObjectImpl::iterator,
+      dynamic,
+      std::forward_iterator_tag>;
+  /* implicit */ value_iterator(dynamic::ObjectImpl::iterator b) : Super(b) {}
+
+  using object_type = dynamic::ObjectImpl;
+
+  dynamic& dereference() const { return base()->second; }
+};
+
+struct dynamic::const_item_iterator
+    : detail::IteratorAdaptor<
+          dynamic::const_item_iterator,
+          dynamic::ObjectImpl::const_iterator,
+          std::pair<dynamic const, dynamic> const,
+          std::forward_iterator_tag> {
+  using Super = detail::IteratorAdaptor<
+      dynamic::const_item_iterator,
+      dynamic::ObjectImpl::const_iterator,
+      std::pair<dynamic const, dynamic> const,
+      std::forward_iterator_tag>;
+  /* implicit */ const_item_iterator(dynamic::ObjectImpl::const_iterator b)
+      : Super(b) {}
+  /* implicit */ const_item_iterator(const_item_iterator const& i)
+      : Super(i.base()) {}
+  /* implicit */ const_item_iterator(item_iterator i) : Super(i.base()) {}
+
+  using object_type = dynamic::ObjectImpl const;
+};
+
+struct dynamic::const_key_iterator : detail::IteratorAdaptor<
+                                         dynamic::const_key_iterator,
+                                         dynamic::ObjectImpl::const_iterator,
+                                         dynamic const,
+                                         std::forward_iterator_tag> {
+  using Super = detail::IteratorAdaptor<
+      dynamic::const_key_iterator,
+      dynamic::ObjectImpl::const_iterator,
+      dynamic const,
+      std::forward_iterator_tag>;
+  /* implicit */ const_key_iterator(dynamic::ObjectImpl::const_iterator b)
+      : Super(b) {}
+
+  using object_type = dynamic::ObjectImpl const;
+
+  dynamic const& dereference() const { return base()->first; }
+};
+
+struct dynamic::const_value_iterator : detail::IteratorAdaptor<
+                                           dynamic::const_value_iterator,
+                                           dynamic::ObjectImpl::const_iterator,
+                                           dynamic const,
+                                           std::forward_iterator_tag> {
+  using Super = detail::IteratorAdaptor<
+      dynamic::const_value_iterator,
+      dynamic::ObjectImpl::const_iterator,
+      dynamic const,
+      std::forward_iterator_tag>;
+  /* implicit */ const_value_iterator(dynamic::ObjectImpl::const_iterator b)
+      : Super(b) {}
+  /* implicit */ const_value_iterator(value_iterator i) : Super(i.base()) {}
+  /* implicit */ const_value_iterator(dynamic::ObjectImpl::iterator i)
+      : Super(i) {}
+
+  using object_type = dynamic::ObjectImpl const;
+
+  dynamic const& dereference() const { return base()->second; }
+};
+
+//////////////////////////////////////////////////////////////////////
+
+inline dynamic::dynamic() : dynamic(nullptr) {}
+
+inline dynamic::dynamic(std::nullptr_t) : type_(NULLT) {}
+
+inline dynamic::dynamic(void (*)(EmptyArrayTag)) : type_(ARRAY) {
+  new (&u_.array) Array();
+}
+
+inline dynamic::dynamic(ObjectMaker (*)()) : type_(OBJECT) {
+  new (getAddress<ObjectImpl>()) ObjectImpl();
+}
+
+inline dynamic::dynamic(char const* s) : type_(STRING) {
+  new (&u_.string) std::string(s);
+}
+
+inline dynamic::dynamic(std::string s) : type_(STRING) {
+  new (&u_.string) std::string(std::move(s));
+}
+
+template <typename Stringish, typename>
+inline dynamic::dynamic(Stringish&& s) : type_(STRING) {
+  new (&u_.string) std::string(s.data(), s.size());
+}
+
+inline dynamic::dynamic(ObjectMaker&& maker) : type_(OBJECT) {
+  new (getAddress<ObjectImpl>())
+      ObjectImpl(std::move(*maker.val_.getAddress<ObjectImpl>()));
+}
+
+inline dynamic::dynamic(dynamic const& o) : type_(NULLT) {
+  *this = o;
+}
+
+inline dynamic::dynamic(dynamic&& o) noexcept : type_(NULLT) {
+  *this = std::move(o);
+}
+
+inline dynamic::~dynamic() noexcept {
+  destroy();
+}
+
+// Integral types except bool convert to int64_t, float types to double.
+template <class T>
+struct dynamic::NumericTypeHelper<
+    T,
+    typename std::enable_if<std::is_integral<T>::value>::type> {
+  static_assert(
+      !kIsObjC || sizeof(T) > sizeof(char),
+      "char-sized types are ambiguous in objc; cast to bool or wider type");
+  using type = int64_t;
+};
+template <>
+struct dynamic::NumericTypeHelper<bool> {
+  using type = bool;
+};
+template <>
+struct dynamic::NumericTypeHelper<float> {
+  using type = double;
+};
+template <>
+struct dynamic::NumericTypeHelper<double> {
+  using type = double;
+};
+
+inline dynamic::dynamic(std::vector<bool>::reference b)
+    : dynamic(static_cast<bool>(b)) {}
+inline dynamic::dynamic(VectorBoolConstRefCtorType b)
+    : dynamic(static_cast<bool>(b)) {}
+
+template <
+    class T,
+    class NumericType /* = typename NumericTypeHelper<T>::type */>
+dynamic::dynamic(T t) {
+  type_ = TypeInfo<NumericType>::type;
+  new (getAddress<NumericType>()) NumericType(NumericType(t));
+}
+
+template <class Iterator>
+dynamic::dynamic(Iterator first, Iterator last) : type_(ARRAY) {
+  new (&u_.array) Array(first, last);
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline dynamic::const_iterator dynamic::begin() const {
+  return get<Array>().begin();
+}
+inline dynamic::const_iterator dynamic::end() const {
+  return get<Array>().end();
+}
+
+inline dynamic::iterator dynamic::begin() {
+  return get<Array>().begin();
+}
+inline dynamic::iterator dynamic::end() {
+  return get<Array>().end();
+}
+
+template <class It>
+struct dynamic::IterableProxy {
+  typedef It iterator;
+  typedef typename It::value_type value_type;
+  typedef typename It::object_type object_type;
+
+  /* implicit */ IterableProxy(object_type* o) : o_(o) {}
+
+  It begin() const { return o_->begin(); }
+
+  It end() const { return o_->end(); }
+
+ private:
+  object_type* o_;
+};
+
+inline dynamic::IterableProxy<dynamic::const_key_iterator> dynamic::keys()
+    const {
+  return &(get<ObjectImpl>());
+}
+
+inline dynamic::IterableProxy<dynamic::const_value_iterator> dynamic::values()
+    const {
+  return &(get<ObjectImpl>());
+}
+
+inline dynamic::IterableProxy<dynamic::const_item_iterator> dynamic::items()
+    const {
+  return &(get<ObjectImpl>());
+}
+
+inline dynamic::IterableProxy<dynamic::value_iterator> dynamic::values() {
+  return &(get<ObjectImpl>());
+}
+
+inline dynamic::IterableProxy<dynamic::item_iterator> dynamic::items() {
+  return &(get<ObjectImpl>());
+}
+
+inline bool dynamic::isString() const {
+  return get_nothrow<std::string>() != nullptr;
+}
+inline bool dynamic::isObject() const {
+  return get_nothrow<ObjectImpl>() != nullptr;
+}
+inline bool dynamic::isBool() const {
+  return get_nothrow<bool>() != nullptr;
+}
+inline bool dynamic::isArray() const {
+  return get_nothrow<Array>() != nullptr;
+}
+inline bool dynamic::isDouble() const {
+  return get_nothrow<double>() != nullptr;
+}
+inline bool dynamic::isInt() const {
+  return get_nothrow<int64_t>() != nullptr;
+}
+inline bool dynamic::isNull() const {
+  return get_nothrow<std::nullptr_t>() != nullptr;
+}
+inline bool dynamic::isNumber() const {
+  return isInt() || isDouble();
+}
+
+inline dynamic::Type dynamic::type() const {
+  return type_;
+}
+
+inline std::string dynamic::asString() const {
+  return asImpl<std::string>();
+}
+inline double dynamic::asDouble() const {
+  return asImpl<double>();
+}
+inline int64_t dynamic::asInt() const {
+  return asImpl<int64_t>();
+}
+inline bool dynamic::asBool() const {
+  return asImpl<bool>();
+}
+
+inline const std::string& dynamic::getString() const& {
+  return get<std::string>();
+}
+inline double dynamic::getDouble() const& {
+  return get<double>();
+}
+inline int64_t dynamic::getInt() const& {
+  return get<int64_t>();
+}
+inline bool dynamic::getBool() const& {
+  return get<bool>();
+}
+
+inline std::string& dynamic::getString() & {
+  return get<std::string>();
+}
+inline double& dynamic::getDouble() & {
+  return get<double>();
+}
+inline int64_t& dynamic::getInt() & {
+  return get<int64_t>();
+}
+inline bool& dynamic::getBool() & {
+  return get<bool>();
+}
+
+inline std::string&& dynamic::getString() && {
+  return std::move(get<std::string>());
+}
+inline double dynamic::getDouble() && {
+  return get<double>();
+}
+inline int64_t dynamic::getInt() && {
+  return get<int64_t>();
+}
+inline bool dynamic::getBool() && {
+  return get<bool>();
+}
+
+inline const char* dynamic::c_str() const& {
+  return get<std::string>().c_str();
+}
+inline StringPiece dynamic::stringPiece() const {
+  return get<std::string>();
+}
+
+template <class T>
+struct dynamic::CompareOp {
+  static bool comp(T const& a, T const& b) { return a < b; }
+};
+template <>
+struct dynamic::CompareOp<dynamic::ObjectImpl> {
+  static bool comp(ObjectImpl const&, ObjectImpl const&) {
+    // This code never executes; it is just here for the compiler.
+    return false;
+  }
+};
+template <>
+struct dynamic::CompareOp<std::nullptr_t> {
+  static bool comp(std::nullptr_t const&, std::nullptr_t const&) {
+    return true;
+  }
+};
+
+inline dynamic& dynamic::operator+=(dynamic const& o) {
+  if (type() == STRING && o.type() == STRING) {
+    *getAddress<std::string>() += *o.getAddress<std::string>();
+    return *this;
+  }
+  *this = detail::numericOp<std::plus>(*this, o);
+  return *this;
+}
+
+inline dynamic& dynamic::operator-=(dynamic const& o) {
+  *this = detail::numericOp<std::minus>(*this, o);
+  return *this;
+}
+
+inline dynamic& dynamic::operator*=(dynamic const& o) {
+  *this = detail::numericOp<std::multiplies>(*this, o);
+  return *this;
+}
+
+inline dynamic& dynamic::operator/=(dynamic const& o) {
+  *this = detail::numericOp<std::divides>(*this, o);
+  return *this;
+}
+
+#define FB_DYNAMIC_INTEGER_OP(op)                            \
+  inline dynamic& dynamic::operator op(dynamic const& o) {   \
+    if (!isInt() || !o.isInt()) {                            \
+      throw_exception<TypeError>("int64", type(), o.type()); \
+    }                                                        \
+    *getAddress<int64_t>() op o.asInt();                     \
+    return *this;                                            \
+  }
+
+FB_DYNAMIC_INTEGER_OP(%=)
+FB_DYNAMIC_INTEGER_OP(|=)
+FB_DYNAMIC_INTEGER_OP(&=)
+FB_DYNAMIC_INTEGER_OP(^=)
+
+#undef FB_DYNAMIC_INTEGER_OP
+
+inline dynamic& dynamic::operator++() {
+  ++get<int64_t>();
+  return *this;
+}
+
+inline dynamic& dynamic::operator--() {
+  --get<int64_t>();
+  return *this;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic const&> dynamic::operator[](
+    K&& idx) const& {
+  return at(std::forward<K>(idx));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&> dynamic::operator[](
+    K&& idx) & {
+  if (!isObject() && !isArray()) {
+    throw_exception<TypeError>("object/array", type());
+  }
+  if (isArray()) {
+    return at(std::forward<K>(idx));
+  }
+  auto& obj = get<ObjectImpl>();
+  auto ret = obj.emplace(std::forward<K>(idx), nullptr);
+  return ret.first->second;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&&> dynamic::operator[](
+    K&& idx) && {
+  return std::move((*this)[std::forward<K>(idx)]);
+}
+
+inline dynamic const& dynamic::operator[](StringPiece k) const& {
+  return at(k);
+}
+
+inline dynamic&& dynamic::operator[](StringPiece k) && {
+  return std::move((*this)[k]);
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic> dynamic::getDefault(
+    K&& k, const dynamic& v) const& {
+  auto& obj = get<ObjectImpl>();
+  auto it = obj.find(std::forward<K>(k));
+  return it == obj.end() ? v : it->second;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic> dynamic::getDefault(
+    K&& k, dynamic&& v) const& {
+  auto& obj = get<ObjectImpl>();
+  auto it = obj.find(std::forward<K>(k));
+  // Avoid clang bug with ternary
+  if (it == obj.end()) {
+    return std::move(v);
+  } else {
+    return it->second;
+  }
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic> dynamic::getDefault(
+    K&& k, const dynamic& v) && {
+  auto& obj = get<ObjectImpl>();
+  auto it = obj.find(std::forward<K>(k));
+  // Avoid clang bug with ternary
+  if (it == obj.end()) {
+    return v;
+  } else {
+    return std::move(it->second);
+  }
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic> dynamic::getDefault(
+    K&& k, dynamic&& v) && {
+  auto& obj = get<ObjectImpl>();
+  auto it = obj.find(std::forward<K>(k));
+  return std::move(it == obj.end() ? v : it->second);
+}
+
+template <typename K, typename V>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&> dynamic::setDefault(
+    K&& k, V&& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(std::forward<K>(k), std::forward<V>(v)).first->second;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&> dynamic::setDefault(
+    K&& k, dynamic&& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(std::forward<K>(k), std::move(v)).first->second;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&> dynamic::setDefault(
+    K&& k, const dynamic& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(std::forward<K>(k), v).first->second;
+}
+
+template <typename V>
+dynamic& dynamic::setDefault(StringPiece k, V&& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(k, std::forward<V>(v)).first->second;
+}
+
+inline dynamic& dynamic::setDefault(StringPiece k, dynamic&& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(k, std::move(v)).first->second;
+}
+
+inline dynamic& dynamic::setDefault(StringPiece k, const dynamic& v) {
+  auto& obj = get<ObjectImpl>();
+  return obj.emplace(k, v).first->second;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic const*> dynamic::get_ptr(
+    K&& k) const& {
+  return get_ptrImpl(std::forward<K>(k));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic*> dynamic::get_ptr(
+    K&& idx) & {
+  return const_cast<dynamic*>(const_cast<dynamic const*>(this)->get_ptr(idx));
+}
+
+inline dynamic* dynamic::get_ptr(StringPiece idx) & {
+  return const_cast<dynamic*>(const_cast<dynamic const*>(this)->get_ptr(idx));
+}
+
+// clang-format off
+inline
+dynamic::resolved_json_pointer<dynamic>
+dynamic::try_get_ptr(json_pointer const& jsonPtr) & {
+  auto ret = const_cast<dynamic const*>(this)->try_get_ptr(jsonPtr);
+  if (ret.hasValue()) {
+    return json_pointer_resolved_value<dynamic>{
+        const_cast<dynamic*>(ret.value().parent),
+        const_cast<dynamic*>(ret.value().value),
+        ret.value().parent_key, ret.value().parent_index};
+  } else {
+    return makeUnexpected(
+        json_pointer_resolution_error<dynamic>{
+            ret.error().error_code,
+            ret.error().index,
+            const_cast<dynamic*>(ret.error().context)}
+        );
+  }
+}
+// clang-format on
+
+inline dynamic* dynamic::get_ptr(json_pointer const& jsonPtr) & {
+  return const_cast<dynamic*>(
+      const_cast<dynamic const*>(this)->get_ptr(jsonPtr));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic const&> dynamic::at(
+    K&& k) const& {
+  return atImpl(std::forward<K>(k));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&> dynamic::at(K&& idx) & {
+  return const_cast<dynamic&>(const_cast<dynamic const*>(this)->at(idx));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic&&> dynamic::at(K&& idx) && {
+  return std::move(at(idx));
+}
+
+inline dynamic& dynamic::at(StringPiece idx) & {
+  return const_cast<dynamic&>(const_cast<dynamic const*>(this)->at(idx));
+}
+
+inline dynamic&& dynamic::at(StringPiece idx) && {
+  return std::move(at(idx));
+}
+
+inline bool dynamic::empty() const {
+  if (isNull()) {
+    return true;
+  }
+  return !size();
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic::const_item_iterator>
+dynamic::find(K&& key) const {
+  return get<ObjectImpl>().find(std::forward<K>(key));
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, dynamic::item_iterator>
+dynamic::find(K&& key) {
+  return get<ObjectImpl>().find(std::forward<K>(key));
+}
+
+inline dynamic::const_item_iterator dynamic::find(StringPiece key) const {
+  return get<ObjectImpl>().find(key);
+}
+
+inline dynamic::item_iterator dynamic::find(StringPiece key) {
+  return get<ObjectImpl>().find(key);
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, std::size_t> dynamic::count(
+    K&& key) const {
+  return find(std::forward<K>(key)) != items().end() ? 1u : 0u;
+}
+
+inline std::size_t dynamic::count(StringPiece key) const {
+  return find(key) != items().end() ? 1u : 0u;
+}
+
+template <class K, class V>
+inline dynamic::IfNotIterator<K, void> dynamic::insert(K&& key, V&& val) {
+  auto& obj = get<ObjectImpl>();
+  obj[std::forward<K>(key)] = std::forward<V>(val);
+}
+
+template <class T>
+inline dynamic::iterator dynamic::insert(const_iterator pos, T&& value) {
+  auto& arr = get<Array>();
+  return arr.insert(pos, std::forward<T>(value));
+}
+
+inline void dynamic::update(const dynamic& mergeObj) {
+  if (!isObject() || !mergeObj.isObject()) {
+    throw_exception<TypeError>("object", type(), mergeObj.type());
+  }
+
+  for (const auto& pair : mergeObj.items()) {
+    (*this)[pair.first] = pair.second;
+  }
+}
+
+inline void dynamic::update_missing(const dynamic& mergeObj1) {
+  if (!isObject() || !mergeObj1.isObject()) {
+    throw_exception<TypeError>("object", type(), mergeObj1.type());
+  }
+
+  // Only add if not already there
+  for (const auto& pair : mergeObj1.items()) {
+    if ((*this).find(pair.first) == (*this).items().end()) {
+      (*this)[pair.first] = pair.second;
+    }
+  }
+}
+
+inline void dynamic::merge_patch(const dynamic& patch) {
+  auto& self = *this;
+  if (!patch.isObject()) {
+    self = patch;
+    return;
+  }
+  // if we are not an object, erase all contents, reset to object
+  if (!isObject()) {
+    self = object;
+  }
+  for (const auto& pair : patch.items()) {
+    if (pair.second.isNull()) {
+      // if name could be found in current object, remove it
+      auto it = self.find(pair.first);
+      if (it != self.items().end()) {
+        self.erase(it);
+      }
+    } else {
+      self[pair.first].merge_patch(pair.second);
+    }
+  }
+}
+
+inline dynamic dynamic::merge(
+    const dynamic& mergeObj1, const dynamic& mergeObj2) {
+  // No checks on type needed here because they are done in update_missing
+  // Note that we do update_missing here instead of update() because
+  // it will prevent the extra writes that would occur with update()
+  auto ret = mergeObj2;
+  ret.update_missing(mergeObj1);
+  return ret;
+}
+
+template <typename K>
+dynamic::IfIsNonStringDynamicConvertible<K, std::size_t> dynamic::erase(
+    K&& key) {
+  auto& obj = get<ObjectImpl>();
+  return obj.erase(std::forward<K>(key));
+}
+inline std::size_t dynamic::erase(StringPiece key) {
+  auto& obj = get<ObjectImpl>();
+  return obj.erase(key);
+}
+
+inline dynamic::iterator dynamic::erase(const_iterator it) {
+  auto& arr = get<Array>();
+  // std::vector doesn't have an erase method that works on const iterators,
+  // even though the standard says it should, so this hack converts to a
+  // non-const iterator before calling erase.
+  return get<Array>().erase(arr.begin() + (it - arr.begin()));
+}
+
+inline dynamic::const_key_iterator dynamic::erase(const_key_iterator it) {
+  return const_key_iterator(get<ObjectImpl>().erase(it.base()));
+}
+
+inline dynamic::const_key_iterator dynamic::erase(
+    const_key_iterator first, const_key_iterator last) {
+  return const_key_iterator(get<ObjectImpl>().erase(first.base(), last.base()));
+}
+
+inline dynamic::value_iterator dynamic::erase(const_value_iterator it) {
+  return value_iterator(get<ObjectImpl>().erase(it.base()));
+}
+
+inline dynamic::value_iterator dynamic::erase(
+    const_value_iterator first, const_value_iterator last) {
+  return value_iterator(get<ObjectImpl>().erase(first.base(), last.base()));
+}
+
+inline dynamic::item_iterator dynamic::erase(const_item_iterator it) {
+  return item_iterator(get<ObjectImpl>().erase(it.base()));
+}
+
+inline dynamic::item_iterator dynamic::erase(
+    const_item_iterator first, const_item_iterator last) {
+  return item_iterator(get<ObjectImpl>().erase(first.base(), last.base()));
+}
+
+inline void dynamic::resize(std::size_t sz, dynamic const& c) {
+  auto& arr = get<Array>();
+  arr.resize(sz, c);
+}
+
+inline void dynamic::push_back(dynamic const& v) {
+  auto& arr = get<Array>();
+  arr.push_back(v);
+}
+
+inline void dynamic::push_back(dynamic&& v) {
+  auto& arr = get<Array>();
+  arr.push_back(std::move(v));
+}
+
+inline void dynamic::pop_back() {
+  auto& arr = get<Array>();
+  arr.pop_back();
+}
+
+inline const dynamic& dynamic::back() const {
+  auto& arr = get<Array>();
+  return arr.back();
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline dynamic::dynamic(Array&& r) : type_(ARRAY) {
+  new (&u_.array) Array(std::move(r));
+}
+
+#define FOLLY_DYNAMIC_DEC_TYPEINFO(T, val)     \
+  template <>                                  \
+  struct dynamic::TypeInfo<T> {                \
+    static const char* const name;             \
+    static constexpr dynamic::Type type = val; \
+  };                                           \
+  //
+
+FOLLY_DYNAMIC_DEC_TYPEINFO(std::nullptr_t, dynamic::NULLT)
+FOLLY_DYNAMIC_DEC_TYPEINFO(bool, dynamic::BOOL)
+FOLLY_DYNAMIC_DEC_TYPEINFO(std::string, dynamic::STRING)
+FOLLY_DYNAMIC_DEC_TYPEINFO(dynamic::Array, dynamic::ARRAY)
+FOLLY_DYNAMIC_DEC_TYPEINFO(double, dynamic::DOUBLE)
+FOLLY_DYNAMIC_DEC_TYPEINFO(int64_t, dynamic::INT64)
+FOLLY_DYNAMIC_DEC_TYPEINFO(dynamic::ObjectImpl, dynamic::OBJECT)
+
+#undef FOLLY_DYNAMIC_DEC_TYPEINFO
+
+template <class T>
+T dynamic::asImpl() const {
+  switch (type()) {
+    case INT64:
+      return to<T>(*get_nothrow<int64_t>());
+    case DOUBLE:
+      return to<T>(*get_nothrow<double>());
+    case BOOL:
+      return to<T>(*get_nothrow<bool>());
+    case STRING:
+      return to<T>(*get_nothrow<std::string>());
+    case NULLT:
+    case ARRAY:
+    case OBJECT:
+    default:
+      throw_exception<TypeError>("int/double/bool/string", type());
+  }
+}
+
+// Return a T* to our type, or null if we're not that type.
+// clang-format off
+template <class T>
+T* dynamic::get_nothrow() & noexcept {
+  if (type_ != TypeInfo<T>::type) {
+    return nullptr;
+  }
+  return getAddress<T>();
+}
+// clang-format on
+
+template <class T>
+T const* dynamic::get_nothrow() const& noexcept {
+  return const_cast<dynamic*>(this)->get_nothrow<T>();
+}
+
+// Return T* for where we can put a T, without type checking.  (Memory
+// might be uninitialized, even.)
+template <class T>
+T* dynamic::getAddress() noexcept {
+  return GetAddrImpl<T>::get(u_);
+}
+
+template <class T>
+T const* dynamic::getAddress() const noexcept {
+  return const_cast<dynamic*>(this)->getAddress<T>();
+}
+
+template <class T>
+struct dynamic::GetAddrImpl {};
+template <>
+struct dynamic::GetAddrImpl<std::nullptr_t> {
+  static std::nullptr_t* get(Data& d) noexcept { return &d.nul; }
+};
+template <>
+struct dynamic::GetAddrImpl<dynamic::Array> {
+  static Array* get(Data& d) noexcept { return &d.array; }
+};
+template <>
+struct dynamic::GetAddrImpl<bool> {
+  static bool* get(Data& d) noexcept { return &d.boolean; }
+};
+template <>
+struct dynamic::GetAddrImpl<int64_t> {
+  static int64_t* get(Data& d) noexcept { return &d.integer; }
+};
+template <>
+struct dynamic::GetAddrImpl<double> {
+  static double* get(Data& d) noexcept { return &d.doubl; }
+};
+template <>
+struct dynamic::GetAddrImpl<std::string> {
+  static std::string* get(Data& d) noexcept { return &d.string; }
+};
+template <>
+struct dynamic::GetAddrImpl<dynamic::ObjectImpl> {
+  static_assert(
+      sizeof(ObjectImpl) <= sizeof(Data::objectBuffer),
+      "In your implementation, F14NodeMap<> apparently takes different"
+      " amount of space depending on its template parameters.  This is "
+      "weird.  Make objectBuffer bigger if you want to compile dynamic.");
+
+  static ObjectImpl* get(Data& d) noexcept {
+    void* data = &d.objectBuffer;
+    return static_cast<ObjectImpl*>(data);
+  }
+};
+
+// [Win - Forked to avoid using exported data across the dll boundary.  Using exported data prevents the ability to
+// delay load the dll We can remove this, once react-native-win32 stops exporting folly (gets entirely onto the ABI
+// interface)
+template <class T>
+T &dynamic::get() {
+  if (auto *p = get_nothrow<T>()) {
+    return *p;
+  }
+
+  switch (type()) {
+    case dynamic::NULLT:
+      throw_exception<TypeError>("null", dynamic::NULLT);
+      break;
+    case dynamic::BOOL:
+      throw_exception<TypeError>("boolean", dynamic::BOOL);
+      break;
+    case dynamic::STRING:
+      throw_exception<TypeError>("string", dynamic::STRING);
+      break;
+    case dynamic::ARRAY:
+      throw_exception<TypeError>("array", dynamic::ARRAY);
+      break;
+    case dynamic::DOUBLE:
+      throw_exception<TypeError>("double", dynamic::DOUBLE);
+      break;
+    case dynamic::INT64:
+      throw_exception<TypeError>("int64", dynamic::INT64);
+      break;
+    case dynamic::OBJECT:
+      throw_exception<TypeError>("object", dynamic::OBJECT);
+      break;
+    default:
+      throw_exception<TypeError>("never", dynamic::OBJECT);
+      break;
+  }
+}
+// Win]
+
+template <class T>
+T const& dynamic::get() const {
+  return const_cast<dynamic*>(this)->get<T>();
+}
+
+//////////////////////////////////////////////////////////////////////
+
+/*
+ * Helper for implementing operator<<.  Throws if the type shouldn't
+ * support it.
+ */
+template <class T>
+struct dynamic::PrintImpl {
+  static void print(dynamic const&, std::ostream& out, T const& t) { out << t; }
+};
+// Otherwise, null, being (void*)0, would print as 0.
+template <>
+struct dynamic::PrintImpl<std::nullptr_t> {
+  static void print(
+      dynamic const& /* d */, std::ostream& out, std::nullptr_t const&) {
+    out << "null";
+  }
+};
+template <>
+struct dynamic::PrintImpl<dynamic::ObjectImpl> {
+  static void print(
+      dynamic const& d, std::ostream& out, dynamic::ObjectImpl const&) {
+    d.print_as_pseudo_json(out);
+  }
+};
+template <>
+struct dynamic::PrintImpl<dynamic::Array> {
+  static void print(
+      dynamic const& d, std::ostream& out, dynamic::Array const&) {
+    d.print_as_pseudo_json(out);
+  }
+};
+
+inline void dynamic::print(std::ostream& out) const {
+#define FB_X(T) PrintImpl<T>::print(*this, out, *getAddress<T>())
+  FB_DYNAMIC_APPLY(type_, FB_X);
+#undef FB_X
+}
+
+inline std::ostream& operator<<(std::ostream& out, dynamic const& d) {
+  d.print(out);
+  return out;
+}
+
+//////////////////////////////////////////////////////////////////////
+
+inline const_dynamic_view::const_dynamic_view(dynamic const& d) noexcept
+    : d_(&d) {}
+
+inline const_dynamic_view::const_dynamic_view(dynamic const* d) noexcept
+    : d_(d) {}
+
+inline const_dynamic_view::operator bool() const noexcept {
+  return !empty();
+}
+
+inline bool const_dynamic_view::empty() const noexcept {
+  return d_ == nullptr;
+}
+
+inline void const_dynamic_view::reset() noexcept {
+  d_ = nullptr;
+}
+
+template <typename Key, typename... Keys>
+inline const_dynamic_view const_dynamic_view::descend(
+    Key const& key, Keys const&... keys) const noexcept {
+  return descend_(key, keys...);
+}
+
+template <typename Key1, typename Key2, typename... Keys>
+inline dynamic const* const_dynamic_view::descend_(
+    Key1 const& key1, Key2 const& key2, Keys const&... keys) const noexcept {
+  if (!d_) {
+    return nullptr;
+  }
+  return const_dynamic_view{descend_unchecked_(key1)}.descend_(key2, keys...);
+}
+
+template <typename Key>
+inline dynamic const* const_dynamic_view::descend_(
+    Key const& key) const noexcept {
+  if (!d_) {
+    return nullptr;
+  }
+  return descend_unchecked_(key);
+}
+
+template <typename Key>
+inline dynamic::IfIsNonStringDynamicConvertible<Key, dynamic const*>
+const_dynamic_view::descend_unchecked_(Key const& key) const noexcept {
+  if (auto* parray = d_->get_nothrow<dynamic::Array>()) {
+    if /* constexpr */ (!std::is_integral<Key>::value) {
+      return nullptr;
+    }
+    if (key < 0 || key >= parray->size()) {
+      return nullptr;
+    }
+    return &(*parray)[size_t(key)];
+  } else if (auto* pobject = d_->get_nothrow<dynamic::ObjectImpl>()) {
+    auto it = pobject->find(key);
+    if (it == pobject->end()) {
+      return nullptr;
+    }
+    return &it->second;
+  }
+  return nullptr;
+}
+
+inline dynamic const* const_dynamic_view::descend_unchecked_(
+    folly::StringPiece key) const noexcept {
+  if (auto* pobject = d_->get_nothrow<dynamic::ObjectImpl>()) {
+    auto it = pobject->find(key);
+    if (it == pobject->end()) {
+      return nullptr;
+    }
+    return &it->second;
+  }
+  return nullptr;
+}
+
+inline dynamic const_dynamic_view::value_or(dynamic&& val) const {
+  if (d_) {
+    return *d_;
+  }
+  return std::move(val);
+}
+
+template <typename T, typename... Args>
+inline T const_dynamic_view::get_copy(Args&&... args) const {
+  if (auto* v = (d_ ? d_->get_nothrow<T>() : nullptr)) {
+    return *v;
+  }
+  return T(std::forward<Args>(args)...);
+}
+
+inline std::string const_dynamic_view::string_or(char const* val) const {
+  return get_copy<std::string>(val);
+}
+
+inline std::string const_dynamic_view::string_or(std::string val) const {
+  return get_copy<std::string>(std::move(val));
+}
+
+// Specialized version for StringPiece, FixedString, and other types which are
+// not convertible to std::string, but can construct one from .data and .size
+// to std::string. Will not trigger a copy unless data and size require it.
+template <typename Stringish, typename>
+inline std::string const_dynamic_view::string_or(Stringish&& val) const {
+  return get_copy(val.data(), val.size());
+}
+
+inline double const_dynamic_view::double_or(double val) const noexcept {
+  return get_copy<double>(val);
+}
+
+inline int64_t const_dynamic_view::int_or(int64_t val) const noexcept {
+  return get_copy<int64_t>(val);
+}
+
+inline bool const_dynamic_view::bool_or(bool val) const noexcept {
+  return get_copy<bool>(val);
+}
+
+inline dynamic_view::dynamic_view(dynamic& d) noexcept
+    : const_dynamic_view(d) {}
+
+template <typename Key, typename... Keys>
+inline dynamic_view dynamic_view::descend(
+    Key const& key, Keys const&... keys) const noexcept {
+  if (auto* child = const_dynamic_view::descend_(key, keys...)) {
+    return *const_cast<dynamic*>(child);
+  }
+  return {};
+}
+
+inline dynamic dynamic_view::move_value_or(dynamic&& val) noexcept {
+  if (d_) {
+    return std::move(*const_cast<dynamic*>(d_));
+  }
+  return std::move(val);
+}
+
+template <typename T, typename... Args>
+inline T dynamic_view::get_move(Args&&... args) {
+  if (auto* v = (d_ ? const_cast<dynamic*>(d_)->get_nothrow<T>() : nullptr)) {
+    return std::move(*v);
+  }
+  return T(std::forward<Args>(args)...);
+}
+
+inline std::string dynamic_view::move_string_or(char const* val) {
+  return get_move<std::string>(val);
+}
+
+inline std::string dynamic_view::move_string_or(std::string val) noexcept {
+  return get_move<std::string>(std::move(val));
+}
+
+template <typename Stringish, typename>
+inline std::string dynamic_view::move_string_or(Stringish&& val) {
+  return get_move<std::string>(val.begin(), val.end());
+}
+
+//////////////////////////////////////////////////////////////////////
+
+// Secialization of FormatValue so dynamic objects can be formatted
+template <>
+class FormatValue<dynamic> {
+ public:
+  explicit FormatValue(const dynamic& val) : val_(val) {}
+
+  template <class FormatCallback>
+  void format(FormatArg& arg, FormatCallback& cb) const {
+    switch (val_.type()) {
+      case dynamic::NULLT:
+        FormatValue<std::nullptr_t>(nullptr).format(arg, cb);
+        break;
+      case dynamic::BOOL:
+        FormatValue<bool>(val_.asBool()).format(arg, cb);
+        break;
+      case dynamic::INT64:
+        FormatValue<int64_t>(val_.asInt()).format(arg, cb);
+        break;
+      case dynamic::STRING:
+        FormatValue<std::string>(val_.asString()).format(arg, cb);
+        break;
+      case dynamic::DOUBLE:
+        FormatValue<double>(val_.asDouble()).format(arg, cb);
+        break;
+      case dynamic::ARRAY:
+        FormatValue(val_.at(arg.splitIntKey())).format(arg, cb);
+        break;
+      case dynamic::OBJECT:
+        FormatValue(val_.at(arg.splitKey().toString())).format(arg, cb);
+        break;
+    }
+  }
+
+ private:
+  const dynamic& val_;
+};
+
+template <class V>
+class FormatValue<detail::DefaultValueWrapper<dynamic, V>> {
+ public:
+  explicit FormatValue(const detail::DefaultValueWrapper<dynamic, V>& val)
+      : val_(val) {}
+
+  template <class FormatCallback>
+  void format(FormatArg& arg, FormatCallback& cb) const {
+    auto& c = val_.container;
+    switch (c.type()) {
+      case dynamic::NULLT:
+      case dynamic::BOOL:
+      case dynamic::INT64:
+      case dynamic::STRING:
+      case dynamic::DOUBLE:
+        FormatValue<dynamic>(c).format(arg, cb);
+        break;
+      case dynamic::ARRAY: {
+        int key = arg.splitIntKey();
+        if (key >= 0 && size_t(key) < c.size()) {
+          FormatValue<dynamic>(c.at(key)).format(arg, cb);
+        } else {
+          FormatValue<V>(val_.defaultValue).format(arg, cb);
+        }
+        break;
+      }
+      case dynamic::OBJECT: {
+        auto pos = c.find(arg.splitKey());
+        if (pos != c.items().end()) {
+          FormatValue<dynamic>(pos->second).format(arg, cb);
+        } else {
+          FormatValue<V>(val_.defaultValue).format(arg, cb);
+        }
+        break;
+      }
+    }
+  }
+
+ private:
+  const detail::DefaultValueWrapper<dynamic, V>& val_;
+};
+
+} // namespace folly
+
+#undef FB_DYNAMIC_APPLY

--- a/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.cpp
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.cpp
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/lang/ToAscii.h>
+
+namespace folly {
+
+namespace detail {
+
+template <uint64_t Base, typename Alphabet>
+struct to_ascii_array {
+  using data_type_ = c_array<uint8_t, Base>;
+  static constexpr data_type_ data_() {
+    data_type_ result{};
+    Alphabet alpha;
+    for (size_t i = 0; i < Base; ++i) {
+      result.data[i] = alpha(static_cast<uint8_t>(i));
+    }
+    return result;
+  }
+  // @lint-ignore CLANGTIDY
+  static data_type_ const data;
+  constexpr char operator()(uint8_t index) const { // also an alphabet
+    return data.data[index];
+  }
+};
+
+template <uint64_t Base, typename Alphabet>
+alignas(kIsMobile ? sizeof(size_t) : hardware_constructive_interference_size)
+    typename to_ascii_array<Base, Alphabet>::data_type_ const
+    to_ascii_array<Base, Alphabet>::data =
+        to_ascii_array<Base, Alphabet>::data_();
+
+extern template to_ascii_array<8, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<8, to_ascii_alphabet_lower>::data;
+extern template to_ascii_array<10, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<10, to_ascii_alphabet_lower>::data;
+extern template to_ascii_array<16, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<16, to_ascii_alphabet_lower>::data;
+extern template to_ascii_array<8, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<8, to_ascii_alphabet_upper>::data;
+extern template to_ascii_array<10, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<10, to_ascii_alphabet_upper>::data;
+extern template to_ascii_array<16, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<16, to_ascii_alphabet_upper>::data;
+
+template <uint64_t Base, typename Alphabet>
+struct to_ascii_table {
+  using data_type_ = c_array<uint16_t, Base * Base>;
+  static constexpr data_type_ data_() {
+    data_type_ result{};
+    Alphabet alpha;
+    for (size_t i = 0; i < Base * Base; ++i) {
+      result.data[i] = //
+          (alpha(uint8_t(i / Base)) << (kIsLittleEndian ? 0 : 8)) |
+          (alpha(uint8_t(i % Base)) << (kIsLittleEndian ? 8 : 0));
+    }
+    return result;
+  }
+  // @lint-ignore CLANGTIDY
+  static data_type_ const data;
+};
+template <uint64_t Base, typename Alphabet>
+alignas(hardware_constructive_interference_size)
+    typename to_ascii_table<Base, Alphabet>::data_type_ const
+    to_ascii_table<Base, Alphabet>::data =
+        to_ascii_table<Base, Alphabet>::data_();
+
+extern template to_ascii_table<8, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<8, to_ascii_alphabet_lower>::data;
+extern template to_ascii_table<10, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<10, to_ascii_alphabet_lower>::data;
+extern template to_ascii_table<16, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<16, to_ascii_alphabet_lower>::data;
+extern template to_ascii_table<8, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<8, to_ascii_alphabet_upper>::data;
+extern template to_ascii_table<10, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<10, to_ascii_alphabet_upper>::data;
+extern template to_ascii_table<16, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<16, to_ascii_alphabet_upper>::data;
+
+template <uint64_t Base, typename I>
+struct to_ascii_powers {
+  static constexpr size_t size_(I v) {
+    return 1 + (v < Base ? 0 : size_(v / Base));
+  }
+  static constexpr size_t const size = size_(~I(0));
+  using data_type_ = c_array<I, size>;
+  static constexpr data_type_ data_() {
+    data_type_ result{};
+    for (size_t i = 0; i < size; ++i) {
+      result.data[i] = constexpr_pow(Base, i);
+    }
+    return result;
+  }
+  // @lint-ignore CLANGTIDY
+  static data_type_ const data;
+};
+template <uint64_t Base, typename I>
+constexpr size_t const to_ascii_powers<Base, I>::size;
+template <uint64_t Base, typename I>
+alignas(hardware_constructive_interference_size)
+    typename to_ascii_powers<Base, I>::data_type_ const
+    to_ascii_powers<Base, I>::data = to_ascii_powers<Base, I>::data_();
+
+extern template to_ascii_powers<8, uint64_t>::data_type_ const
+    to_ascii_powers<8, uint64_t>::data;
+extern template to_ascii_powers<10, uint64_t>::data_type_ const
+    to_ascii_powers<10, uint64_t>::data;
+extern template to_ascii_powers<16, uint64_t>::data_type_ const
+    to_ascii_powers<16, uint64_t>::data;
+
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_imuls(uint64_t v) {
+  using powers = to_ascii_powers<Base, uint64_t>;
+  uint64_t p = 1;
+  for (size_t i = 0u; i < powers::size; ++i, p *= Base) {
+    if (FOLLY_UNLIKELY(v < p)) {
+      return i + size_t(i == 0);
+    }
+  }
+  return powers::size;
+}
+
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_idivs(uint64_t v) {
+  size_t i = 1;
+  while (v >= Base) {
+    i += 1;
+    v /= Base;
+  }
+  return i;
+}
+
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_array(uint64_t v) {
+  using powers = to_ascii_powers<Base, uint64_t>;
+  for (size_t i = 0u; i < powers::size; ++i) {
+    if (FOLLY_LIKELY(v < powers::data.data[i])) {
+      return i + size_t(i == 0);
+    }
+  }
+  return powers::size;
+}
+
+//  For some architectures, we can get a little help from clzll, the "count
+//  leading zeros" builtin, which is backed by a single performant instruction.
+//
+//  Note that the compiler implements __builtin_clzll on all architectures, but
+//  only emits a single clzll instruction when the architecture has one.
+//
+//  This implementation may be faster than the basic ones in the general case
+//  because the time taken to compute this one is constant for non-zero v,
+//  whereas the basic ones take time proportional to log<2>(v). Whether this one
+//  is actually faster depends on the emitted code for this implementation and
+//  on whether the loops in the basic implementations are unrolled.
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
+  using powers = to_ascii_powers<Base, uint64_t>;
+
+  //  clzll is undefined for 0; must special case this
+  if (FOLLY_UNLIKELY(!v)) {
+    return 1;
+  }
+
+  //  log2 is approx log<2>(v)
+  size_t const vlog2 = 64 - static_cast<size_t>(__builtin_clzll(v));
+
+  //  work around msvc warning C4127 (conditional expression is constant)
+  bool false_ = false;
+
+  //  handle directly when Base is power-of-two
+  if (false_ || !(Base & (Base - 1))) {
+    constexpr auto const blog2 = constexpr_log2(Base);
+    return vlog2 / blog2 + size_t(vlog2 % blog2 != 0);
+  }
+
+  //  blog2r is approx 1 / log<2>(Base), used in log change-of-base just below
+  constexpr auto const blog2r = 8. / constexpr_log2(constexpr_pow(Base, 8));
+
+  //  vlogb is approx log<Base>(v) = log<2>(v) / log<2>(Base)
+  auto const vlogb = vlog2 * size_t(blog2r * 256) / 256;
+
+  //  return vlogb, adjusted if necessary
+  return vlogb + size_t(vlogb < powers::size && v >= powers::data.data[vlogb]);
+}
+
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_route(uint64_t v) {
+  return kIsArchAmd64 && !(Base & (Base - 1)) //
+      ? to_ascii_size_clzll<Base>(v)
+      : to_ascii_size_array<Base>(v);
+}
+
+//  The straightforward implementation, assuming the size known in advance.
+//
+//  The straightforward implementation without the size known in advance would
+//  entail emitting the bytes backward and then reversing them at the end, once
+//  the size is known.
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE void to_ascii_with_basic(
+    char* out, size_t size, uint64_t v) {
+  Alphabet const xlate;
+  for (auto pos = size - 1; pos; --pos) {
+    //  keep /, % together so a peephole optimization computes them together
+    auto const q = v / Base;
+    auto const r = v % Base;
+    out[pos] = xlate(uint8_t(r));
+    v = q;
+  }
+  out[0] = xlate(uint8_t(v));
+}
+
+//  A variant of the straightforward implementation, but using a lookup table.
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE void to_ascii_with_array(
+    char* out, size_t size, uint64_t v) {
+  using array = to_ascii_array<Base, Alphabet>; // also an alphabet
+  to_ascii_with_basic<Base, array>(out, size, v);
+}
+
+//  A trickier implementation which performs half as many divides as the other,
+//  more straightforward, implementation. On modern hardware, the divides are
+//  the bottleneck (even when the compiler emits a complicated sequence of add,
+//  sub, and mul instructions with special constants to simulate a divide by a
+//  fixed denominator).
+//
+//  The downside of this implementation is that the emitted code is larger,
+//  especially when the divide is simulated, which affects inlining decisions.
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE void to_ascii_with_table(
+    char* out, size_t size, uint64_t v) {
+  using table = to_ascii_table<Base, Alphabet>;
+  auto pos = size - 2;
+  while (FOLLY_UNLIKELY(v >= Base * Base)) {
+    //  keep /, % together so a peephole optimization computes them together
+    auto const q = v / (Base * Base);
+    auto const r = v % (Base * Base);
+    auto const val = table::data.data[size_t(r)];
+    std::memcpy(out + pos, &val, 2);
+    pos -= 2;
+    v = q;
+  }
+  auto const val = table::data.data[size_t(v)];
+  if (FOLLY_UNLIKELY(size % 2 == 0)) {
+    std::memcpy(out, &val, 2);
+  } else {
+    *out = val >> (kIsLittleEndian ? 8 : 0);
+  }
+}
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE size_t to_ascii_with_table(char* out, uint64_t v) {
+  auto const size = to_ascii_size_route<Base>(v);
+  to_ascii_with_table<Base, Alphabet>(out, size, v);
+  return size;
+}
+
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE size_t
+to_ascii_with_route(char* outb, char const* oute, uint64_t v) {
+  auto const size = to_ascii_size_route<Base>(v);
+  if (FOLLY_UNLIKELY(oute < outb || size_t(oute - outb) < size)) {
+    return 0;
+  }
+  kIsMobile //
+      ? to_ascii_with_array<Base, Alphabet>(outb, size, v)
+      : to_ascii_with_table<Base, Alphabet>(outb, size, v);
+  return size;
+}
+template <uint64_t Base, typename Alphabet, size_t N>
+FOLLY_ALWAYS_INLINE size_t to_ascii_with_route(char (&out)[N], uint64_t v) {
+  static_assert(N >= to_ascii_powers<Base, decltype(v)>::size, "out too small");
+  return to_ascii_with_table<Base, Alphabet>(out, v);
+}
+
+size_t to_ascii_size_route<10>(uint64_t v);
+
+
+template to_ascii_array<8, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<8, to_ascii_alphabet_lower>::data;
+template to_ascii_array<10, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<10, to_ascii_alphabet_lower>::data;
+template to_ascii_array<16, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_array<16, to_ascii_alphabet_lower>::data;
+template to_ascii_array<8, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<8, to_ascii_alphabet_upper>::data;
+template to_ascii_array<10, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<10, to_ascii_alphabet_upper>::data;
+template to_ascii_array<16, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_array<16, to_ascii_alphabet_upper>::data;
+
+template to_ascii_table<8, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<8, to_ascii_alphabet_lower>::data;
+template to_ascii_table<10, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<10, to_ascii_alphabet_lower>::data;
+template to_ascii_table<16, to_ascii_alphabet_lower>::data_type_ const
+    to_ascii_table<16, to_ascii_alphabet_lower>::data;
+template to_ascii_table<8, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<8, to_ascii_alphabet_upper>::data;
+template to_ascii_table<10, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<10, to_ascii_alphabet_upper>::data;
+template to_ascii_table<16, to_ascii_alphabet_upper>::data_type_ const
+    to_ascii_table<16, to_ascii_alphabet_upper>::data;
+
+template to_ascii_powers<8, uint64_t>::data_type_ const
+    to_ascii_powers<8, uint64_t>::data;
+template to_ascii_powers<10, uint64_t>::data_type_ const
+    to_ascii_powers<10, uint64_t>::data;
+template to_ascii_powers<16, uint64_t>::data_type_ const
+    to_ascii_powers<16, uint64_t>::data;
+
+// [Windows] Code to ensure functions exist to export
+void forExports() {
+  auto b = to_ascii_size_route<10>(0);
+  char cc[20];
+  auto a = to_ascii_with_route<10, to_ascii_alphabet<false>, 20>(cc, 0);
+  char d, e;
+  auto r = to_ascii_with_route<10, to_ascii_alphabet<false>>(&d, &e, static_cast<uint64_t>(0));
+}
+
+} // namespace detail
+
+} // namespace folly

--- a/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.h
+++ b/vnext/Folly/TEMP_UntilFollyUpdate/lang/ToAscii.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstring>
+
+#include <folly/ConstexprMath.h>
+#include <folly/Likely.h>
+#include <folly/Portability.h>
+#include <folly/Utility.h>
+#include <folly/lang/Align.h>
+#include <folly/lang/CArray.h>
+#include <folly/portability/Builtins.h>
+
+namespace folly {
+
+//  to_ascii_alphabet
+//
+//  Used implicity by to_ascii_lower and to_ascii_upper below.
+//
+//  This alphabet translates digits to 0-9,a-z or 0-9,A-Z. The largest supported
+//  base is 36; operator() presumes an argument less than that.
+//
+//  Alternative alphabets may be used with to_ascii_with provided they match
+//  the constructibility/destructibility and the interface of this one.
+template <bool Upper>
+struct to_ascii_alphabet {
+  //  operator()
+  //
+  //  Translates a single digit to 0-9,a-z or 0-9,A-Z.
+  //
+  //  async-signal-safe
+  constexpr char operator()(uint8_t b) const {
+    return b < 10 ? '0' + b : (Upper ? 'A' : 'a') + (b - 10);
+  }
+};
+using to_ascii_alphabet_lower = to_ascii_alphabet<false>;
+using to_ascii_alphabet_upper = to_ascii_alphabet<true>;
+
+//  to_ascii_size_max
+//  [Windows] - Replaced logic that required data with values just for the
+//  bases required to compile.
+//
+//  The maximum size buffer that might be required to hold the ascii-encoded
+//  representation of any value of unsigned type I in base Base.
+//
+//  In base 10, u64 requires at most 20 bytes, u32 at most 10, u16 at most 5,
+//  and u8 at most 3.
+/*
+template <uint64_t Base, typename I>
+FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max =
+  detail::to_ascii_powers<Base, I>::size;
+*/
+//  to_ascii_size_max_decimal
+//
+//  An alias to to_ascii_size_max<10>.
+template <typename I>
+FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max_decimal;
+
+template <>
+FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max_decimal<uint16_t> = 5;
+template <>
+FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max_decimal<uint32_t> = 10;
+template <>
+FOLLY_INLINE_VARIABLE constexpr size_t to_ascii_size_max_decimal<uint64_t> = 20;
+
+
+namespace detail {
+
+// [Windows] Moved most of the detail namespace into the cpp file to avoid having data fields on the dll boundary
+
+template <uint64_t Base>
+FOLLY_ALWAYS_INLINE size_t to_ascii_size_route(uint64_t v);
+
+
+template <uint64_t Base, typename Alphabet>
+FOLLY_ALWAYS_INLINE size_t
+to_ascii_with_route(char* outb, char const* oute, uint64_t v);
+
+template <uint64_t Base, typename Alphabet, size_t N>
+FOLLY_ALWAYS_INLINE size_t to_ascii_with_route(char (&out)[N], uint64_t v);
+
+}
+
+//  to_ascii_size
+//
+//  Returns the number of digits in the base Base representation of a uint64_t.
+//  Useful for preallocating buffers, etc.
+//
+//  async-signal-safe
+template <uint64_t Base>
+size_t to_ascii_size(uint64_t v) {
+  return detail::to_ascii_size_route<Base>(v);
+}
+
+//  to_ascii_size_decimal
+//
+//  An alias to to_ascii_size<10>.
+//
+//  async-signal-safe
+inline size_t to_ascii_size_decimal(uint64_t v) {
+  return to_ascii_size<10>(v);
+}
+
+//  to_ascii_with
+//
+//  Copies the digits of v, in base Base, translated with Alphabet, into buffer
+//  and returns the number of bytes written.
+//
+//  Does *not* append a null terminator. It is the caller's responsibility to
+//  append a null terminator if one is required.
+//
+//  Assumes buffer points to at least to_ascii_size<Base>(v) bytes of writable
+//  memory. It is the caller's responsibility to provide a writable buffer with
+//  the required min size.
+//
+//  async-signal-safe
+template <uint64_t Base, typename Alphabet>
+size_t to_ascii_with(char* outb, char const* oute, uint64_t v) {
+  return detail::to_ascii_with_route<Base, Alphabet>(outb, oute, v);
+}
+template <uint64_t Base, typename Alphabet, size_t N>
+size_t to_ascii_with(char (&out)[N], uint64_t v) {
+  return detail::to_ascii_with_route<Base, Alphabet>(out, v);
+}
+
+//  to_ascii_lower
+//
+//  Composes to_ascii_with with to_ascii_alphabet_lower.
+//
+//  async-signal-safe
+template <uint64_t Base>
+size_t to_ascii_lower(char* outb, char const* oute, uint64_t v) {
+  return to_ascii_with<Base, to_ascii_alphabet_lower>(outb, oute, v);
+}
+template <uint64_t Base, size_t N>
+size_t to_ascii_lower(char (&out)[N], uint64_t v) {
+  return to_ascii_with<Base, to_ascii_alphabet_lower>(out, v);
+}
+
+//  to_ascii_upper
+//
+//  Composes to_ascii_with with to_ascii_alphabet_upper.
+//
+//  async-signal-safe
+template <uint64_t Base>
+size_t to_ascii_upper(char* outb, char const* oute, uint64_t v) {
+  return to_ascii_with<Base, to_ascii_alphabet_upper>(outb, oute, v);
+}
+template <uint64_t Base, size_t N>
+size_t to_ascii_upper(char (&out)[N], uint64_t v) {
+  return to_ascii_with<Base, to_ascii_alphabet_upper>(out, v);
+}
+
+//  to_ascii_decimal
+//
+//  An alias to to_ascii<10, false>.
+//
+//  async-signals-afe
+inline size_t to_ascii_decimal(char* outb, char const* oute, uint64_t v) {
+  return to_ascii_lower<10>(outb, oute, v);
+}
+template <size_t N>
+inline size_t to_ascii_decimal(char (&out)[N], uint64_t v) {
+  return to_ascii_lower<10>(out, v);
+}
+
+} // namespace folly


### PR DESCRIPTION
## Description
Port #9504 to main.  -- Eventually folly usage will be removed entirely from Office, but in the meantime putting this in main so I dont have to port it to every stable branch when importing into Office.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9887)