### PR TITLE
Pr/fix glob parent

### DIFF
--- a/change/@react-native-windows-codegen-848bb339-e81b-46c8-9f89-7a28efd64901.json
+++ b/change/@react-native-windows-codegen-848bb339-e81b-46c8-9f89-7a28efd64901.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update globby of @react-native-windows/codegen to remove glob-parent 3.x dependency",
+  "packageName": "@react-native-windows/codegen",
+  "email": "dannyvv@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@react-native-windows/fs": "^0.0.0-canary.2",
     "chalk": "^4.1.0",
-    "globby": "^9.2.0",
+    "globby": "^11.0.4",
     "mustache": "^4.0.1",
     "react-native-tscodegen": "0.68.4",
     "source-map-support": "^0.5.19",
@@ -32,7 +32,6 @@
     "@rnw-scripts/just-task": "2.2.3",
     "@rnw-scripts/ts-config": "2.0.2",
     "@types/chalk": "^2.2.0",
-    "@types/globby": "^9.1.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.22",
     "@types/yargs": "16.0.0",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Globby 9.x depends fast-glob 2.x which depends on glob-parent 3.x which has a CVE affecting customers who use codegen canary.30 or earlier.

### What
Update dependencies. Note the yarn.lock file is not yet updated since we have sample projects depending on the publish version of @react-native-windows/codegen canary.30... Once this version is released we can bump those and that should update the lock file...

## Testing
Local builds.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9888)