### PR TITLE
Fix telemetery e2e tests

### DIFF
--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -31,5 +31,5 @@ jobs:
           inputs:
             versionSpec: '${{ nodeVersion }}.x'
 
-        - script: yarn test --concurrency 1
+        - script: yarn test
           displayName: yarn test

--- a/change/@react-native-windows-telemetry-4f2dfd2c-bd77-4c67-8079-427bb5d099ff.json
+++ b/change/@react-native-windows-telemetry-4f2dfd2c-bd77-4c67-8079-427bb5d099ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix telemetery e2e tests",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -30,8 +30,6 @@ export class TelemetryTest extends Telemetry {
     TelemetryTest.hasTestTelemetryProviders = false;
     TelemetryTest.testTelemetryProvidersRan = false;
 
-    jest.setTimeout(10000); // These E2E tests can run longer than the default 5000ms
-
     if (TelemetryTest.isEnabled()) {
       Telemetry.reset();
     }


### PR DESCRIPTION
This PR:

* Removes yarn test concurrency limiter in ADO
* Moves telemetry.test.ts into an e2etest folder

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9889)