### PR TITLE
[0.68] Fix telemetry e2e tests

### DIFF
--- a/change/@react-native-windows-telemetry-b387b859-9502-40a1-bbb5-b00c1584501f.json
+++ b/change/@react-native-windows-telemetry-b387b859-9502-40a1-bbb5-b00c1584501f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.68] Fix telemetry e2e tests",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
+++ b/packages/@react-native-windows/telemetry/src/e2etest/telemetry.test.ts
@@ -30,8 +30,6 @@ export class TelemetryTest extends Telemetry {
     TelemetryTest.hasTestTelemetryProviders = false;
     TelemetryTest.testTelemetryProvidersRan = false;
 
-    jest.setTimeout(10000); // These E2E tests can run longer than the default 5000ms
-
     if (TelemetryTest.isEnabled()) {
       Telemetry.reset();
     }


### PR DESCRIPTION
This PR backports #9889 to 0.68.

This PR:

* Moves telemetry.test.ts into an e2etest folder

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9890)