### PR TITLE
Implement importantForAccessibility="no-hide-accessibility"

### DIFF
--- a/change/@office-iss-react-native-win32-2233ce57-16d8-4600-a96d-ce46a11cadde.json
+++ b/change/@office-iss-react-native-win32-2233ce57-16d8-4600-a96d-ce46a11cadde.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement no-hide-accessibility",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-454d3cec-b8c1-4e81-b92a-0b747f9ab9ef.json
+++ b/change/react-native-windows-454d3cec-b8c1-4e81-b92a-0b747f9ab9ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement no-hide-accessibility",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -75,6 +75,24 @@ const View: React.AbstractComponent<
     props.onKeyUpCapture && props.onKeyUpCapture(event);
   };
 
+  // [Windows
+const childrenWithImportantForAccessibility = children => {
+  return React.Children.map(
+    children,
+    (child) => {
+      if (React.isValidElement(child)) {
+          if (child.props.children){
+            return React.cloneElement(child, {accessible: false, children: childrenWithImportantForAccessibility(child.props.children)});
+          }else{
+            return React.cloneElement(child, {accessible: false});
+          }
+      }
+      return child;
+    },
+  );
+}
+// Windows]
+
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See
@@ -94,6 +112,9 @@ const View: React.AbstractComponent<
             onKeyDownCapture={_keyDownCapture}
             onKeyUp={_keyUp}
             onKeyUpCapture={_keyUpCapture}
+            // [Windows
+            children={props.importantForAccessibility == 'no-hide-descendants' ? childrenWithImportantForAccessibility(props.children) : props.children}
+            // Windows]
           />
         );
       }}

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -75,6 +75,24 @@ const View: React.AbstractComponent<
     props.onKeyUpCapture && props.onKeyUpCapture(event);
   };
 
+// [Windows
+const childrenWithImportantForAccessibility = children => {
+      return React.Children.map(
+        children,
+        (child) => {
+          if (React.isValidElement(child)) {
+              if (child.props.children){
+                return React.cloneElement(child, {accessible: false, children: childrenWithImportantForAccessibility(child.props.children)});
+              }else{
+                return React.cloneElement(child, {accessible: false});
+              }
+          }
+          return child;
+        },
+      );
+}
+// Windows]
+
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See
@@ -94,6 +112,9 @@ const View: React.AbstractComponent<
             onKeyDownCapture={_keyDownCapture}
             onKeyUp={_keyUp}
             onKeyUpCapture={_keyUpCapture}
+            // [Windows
+            children={props.importantForAccessibility == 'no-hide-descendants' ? childrenWithImportantForAccessibility(props.children) : props.children}
+            // Windows]
           />
         );
       }}


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Implement importantForAccessibility="no-hide-accessibility". When specified on a view-based component should remove accessibility for the element itself and its descendants.

Resolves #5113

### What
Recursively apply accessible={false} prop to children of view-based component.

Attempted implementation used by Garrison team but it was not sufficient for Desktop, as focusable elements were still focusable even after being removed from the UIA tree.

## Testing
Tested in playground with multiple configurations of nested components.

_Optional_: Describe the tests that you ran locally to verify your changes.