### PR TITLE
Fix clang-check errors in NativeModules.h

### DIFF
--- a/change/react-native-windows-49693198-37f8-41ce-a678-bf4756dcaf0e.json
+++ b/change/react-native-windows-49693198-37f8-41ce-a678-bf4756dcaf0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix clang-check errors in NativeModules.h",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -1091,7 +1091,7 @@ template <class TModule, int I, class TMethodSpec>
 struct ReactMethodVerifier {
   static constexpr bool Verify() noexcept {
     ReactMethodVerifier verifier{};
-    ReactMemberInfoIterator<TModule>{}.GetMemberInfo<I>(verifier);
+    ReactMemberInfoIterator<TModule>{}.template GetMemberInfo<I>(verifier);
     return verifier.m_result;
   }
 
@@ -1109,7 +1109,7 @@ template <class TModule, int I, class TMethodSpec>
 struct ReactSyncMethodVerifier {
   static constexpr bool Verify() noexcept {
     ReactSyncMethodVerifier verifier{};
-    ReactMemberInfoIterator<TModule>{}.GetMemberInfo<I>(verifier);
+    ReactMemberInfoIterator<TModule>{}.template GetMemberInfo<I>(verifier);
     return verifier.m_result;
   }
 


### PR DESCRIPTION
Add missing `template` keywords in `NativeModules.h` to make clang happy. Devmain requires NativeModules.h to be compatible with msvc and clang if we want to introduce turbo module there.

Related PRs:
[For 0.66-stable](https://github.com/microsoft/react-native-windows/pull/9903)
[For 0.67-stable](https://github.com/microsoft/react-native-windows/pull/9904)
[For 0.68-stable](https://github.com/microsoft/react-native-windows/pull/9905)
[For main](https://github.com/microsoft/react-native-windows/pull/9906)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9906)