### PR TITLE
[0.68] Avoid crashing when running unpackaged apps

### DIFF
--- a/change/react-native-windows-75d3cf97-675c-4257-b49c-bcc7bfbd0e27.json
+++ b/change/react-native-windows-75d3cf97-675c-4257-b49c-bcc7bfbd0e27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Avoid crash in DevSupportManager when running in unpackaged apps with Hermes",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/DevSupportManager.cpp
+++ b/vnext/Shared/DevSupportManager.cpp
@@ -34,6 +34,8 @@
 
 #include <future>
 
+#include <AppModel.h>
+
 #if _MSC_VER <= 1913
 // VC 19 (2015-2017.6) cannot optimize co_await/cppwinrt usage
 #pragma optimize("", off)
@@ -242,8 +244,11 @@ void DevSupportManager::StartInspector(
     [[maybe_unused]] const uint16_t packagerPort) noexcept {
 #ifdef HERMES_ENABLE_DEBUGGER
   std::string packageName("RNW");
-  if (auto currentPackage = winrt::Windows::ApplicationModel::Package::Current()) {
-    packageName = winrt::to_string(currentPackage.DisplayName());
+  wchar_t fullName[PACKAGE_FULL_NAME_MAX_LENGTH]{};
+  UINT32 size = ARRAYSIZE(fullName);
+  if (SUCCEEDED(GetCurrentPackageFullName(&size, fullName))) {
+    // we are in an unpackaged app
+    packageName = winrt::to_string(fullName);
   }
 
   std::string deviceName("RNWHost");


### PR DESCRIPTION
## Description

Ports #9756 to 0.68
Fixes an issue in DevSupport manager where we crash trying to set up the inspector

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9911)