### PR TITLE
[0.68] Built in turbomodules should not override app provided versions

### DIFF
--- a/change/react-native-windows-12b8ebce-b24a-4945-aabb-3021ecb46003.json
+++ b/change/react-native-windows-12b8ebce-b24a-4945-aabb-3021ecb46003.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Built in turbomodules should not override app provided versions",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -302,7 +302,7 @@ void ReactInstanceWin::LoadModules(
     if (m_options.UseWebDebugger()) {
       nativeModulesProvider->AddModuleProvider(name, provider);
     } else {
-      turboModulesProvider->AddModuleProvider(name, provider);
+      turboModulesProvider->AddModuleProvider(name, provider, false);
     }
   };
 

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -38,7 +38,7 @@ void ReactPackageBuilder::AddViewManager(
 void ReactPackageBuilder::AddTurboModule(
     hstring const &moduleName,
     ReactModuleProvider const &moduleProvider) noexcept {
-  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider);
+  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -336,12 +336,13 @@ void TurboModulesProvider::SetReactContext(const IReactContext &reactContext) no
 
 void TurboModulesProvider::AddModuleProvider(
     winrt::hstring const &moduleName,
-    ReactModuleProvider const &moduleProvider) noexcept {
+    ReactModuleProvider const &moduleProvider,
+    bool overwriteExisting) noexcept {
   auto key = to_string(moduleName);
   auto it = m_moduleProviders.find(key);
   if (it == m_moduleProviders.end()) {
     m_moduleProviders.insert({key, moduleProvider});
-  } else {
+  } else if (overwriteExisting) {
     // turbo modules should be replaceable before the first time it is requested
     it->second = moduleProvider;
   }

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -21,7 +21,10 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
 
  public:
   void SetReactContext(const IReactContext &reactContext) noexcept;
-  void AddModuleProvider(winrt::hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
+  void AddModuleProvider(
+      winrt::hstring const &moduleName,
+      ReactModuleProvider const &moduleProvider,
+      bool overwriteExisting) noexcept;
 
  private:
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;


### PR DESCRIPTION
## Description

Port #9519 to 0.68

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9912)