### PR TITLE
[0.66] Exclude HttpResourceIntegrationTest from CI

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -23,7 +23,8 @@ jobs:
           (FullyQualifiedName!=RNTesterIntegrationTests::AsyncStorage)&
           (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
           (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
-          (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)
+          (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)&
+          (FullyQualifiedName!~HttpResourceIntegrationTest::)
 
       #6799 -
       #       HostFunctionTest              - Crashes under JSI/V8


### PR DESCRIPTION
## Description
Excludes networking tests in class HttpResourceIntegrationTest from continuous integration.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Tests under class HttpResourceIntegrationTest appear to hang CI loops in branch `0.66-stable`.
This is blocking release `0.66.18`.

### What
Add class `HttpResourceIntegrationTest` to integration test skip filter.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9919)