### PR TITLE
Ignore duplicate metro-runtime verions in dev metro-config

### DIFF
--- a/packages/@rnw-scripts/metro-dev-config/metro.dev.config.js
+++ b/packages/@rnw-scripts/metro-dev-config/metro.dev.config.js
@@ -29,7 +29,7 @@ function makeMetroConfig(customConfig = {}) {
       customSerializer: MetroSerializer([
         DuplicateDependencies({
           // Duplicate dependencies introduced by external code
-          ignoredModules: ['react-is'],
+          ignoredModules: ['react-is', 'metro-runtime'],
         }),
       ]),
     },


### PR DESCRIPTION
## Description

Integration tests are failing because there are two versions of
`metro-runtime` used in our repo (0.67.0 and 0.70.1), mirroring the setup
of `react-native`.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

We are using the `@rnx-kit/metro-plugin-duplicates-checker` package
which will cause a bundle operation to fail if duplicate packages are
detected. This causes the integration tests to time-out as they try to
create the bundle and keep getting errors.

### What

This PR adds `metro-runtime` to the list of packages to ignore
duplicates.

Resolves #9929

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9928)