### PR TITLE
Enable accessibilityRole override for buttons

### DIFF
--- a/change/react-native-windows-18441503-7ac4-453a-a7d2-1c39550331f9.json
+++ b/change/react-native-windows-18441503-7ac4-453a-a7d2-1c39550331f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow accessibilityRole override for BasicButton",
+  "packageName": "react-native-windows",
+  "email": "adamgor@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -24,6 +24,7 @@ import invariant from 'invariant';
 
 import type {
   AccessibilityState,
+  AccessibilityRole,
   AccessibilityActionEvent,
   AccessibilityActionInfo,
 } from './View/ViewAccessibility';
@@ -131,7 +132,7 @@ type ButtonProps = $ReadOnly<{|
   /**
     Role to display for blindness accessibility features.
    */
-  accessibilityRole?: ?string,
+  accessibilityRole?: ?AccessibilityRole,
 
   /**
     If `true`, disable all interactions for this component.

--- a/vnext/src/Libraries/Components/Button.windows.js
+++ b/vnext/src/Libraries/Components/Button.windows.js
@@ -129,6 +129,11 @@ type ButtonProps = $ReadOnly<{|
   accessibilityLabel?: ?string,
 
   /**
+    Role to display for blindness accessibility features.
+   */
+  accessibilityRole?: ?string,
+
+  /**
     If `true`, disable all interactions for this component.
 
     @default false
@@ -285,6 +290,7 @@ class Button extends React.Component<
   render(): React.Node {
     const {
       accessibilityLabel,
+      accessibilityRole,
       color,
       onPress,
       touchSoundDisabled,
@@ -346,7 +352,7 @@ class Button extends React.Component<
           accessibilityLabel={accessibilityLabel}
           accessibilityHint={accessibilityHint}
           accessibilityLanguage={accessibilityLanguage}
-          accessibilityRole="button"
+          accessibilityRole={accessibilityRole ?? "button"}
           accessibilityState={accessibilityState}
           hasTVPreferredFocus={hasTVPreferredFocus}
           nextFocusDown={nextFocusDown}
@@ -441,7 +447,7 @@ class Button extends React.Component<
           onAccessibilityAction={onAccessibilityAction}
           accessibilityLabel={accessibilityLabel}
           accessibilityHint={accessibilityHint}
-          accessibilityRole="button"
+          accessibilityRole={accessibilityRole ?? "button"}
           accessibilityState={accessibilityState}
           hasTVPreferredFocus={hasTVPreferredFocus}
           nextFocusDown={nextFocusDown}


### PR DESCRIPTION
## Description
Enable accessibilityRole override for buttons


### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
There is a scenario where we have a BasicButton that is an accessibilityRole="link".
As there is no "BasicLinkButton", instead we add an override to change from default role 'button'. 

Resolves:
More granular control of accessibilityRole for buttons on windows.

## Testing
We have been using it via patch-package for probably over a year now. 
