### PR TITLE
Add --methodonly  to RNW/codegen

### DIFF
--- a/change/@react-native-windows-codegen-6a977a7a-80c1-49a4-9390-31345030db9b.json
+++ b/change/@react-native-windows-codegen-6a977a7a-80c1-49a4-9390-31345030db9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add --methodonly to RNW/codegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -33,6 +33,11 @@ const argv = yargs.options({
     describe: 'generate turbo module definition files in TypeScript',
     default: false,
   },
+  methodonly: {
+    type: 'boolean',
+    describe: 'generate only method metadata in C++ turbo module spec',
+    default: false,
+  },
   outdir: {
     type: 'string',
     describe: 'output directory',
@@ -237,7 +242,10 @@ function generate(
     'DisableFormat: true\nSortIncludes: false',
   );
 
-  const generateNM2 = createNM2Generator({namespace: argv.namespace});
+  const generateNM2 = createNM2Generator({
+    namespace: argv.namespace,
+    methodonly: argv.methodonly,
+  });
 
   const generatorPropsH =
     require('react-native-tscodegen/lib/rncodegen/src/generators/components/GeneratePropsH').generate;

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -43,7 +43,13 @@ struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 } // namespace ::_NAMESPACE_::
 `;
 
-export function createNM2Generator({namespace}: {namespace: string}) {
+export function createNM2Generator({
+  namespace,
+  methodonly,
+}: {
+  namespace: string;
+  methodonly: boolean;
+}) {
   return (
     _libraryName: string,
     schema: SchemaType,
@@ -79,7 +85,7 @@ ${methods[0]}
 
         // prepare constants
         const constants = generateValidateConstants(nativeModule, aliases);
-        if (constants !== undefined) {
+        if (constants !== undefined && !methodonly) {
           tuples = `
   static constexpr auto constants = std::tuple{
 ${constants[0]}
@@ -98,8 +104,8 @@ ${errors}`;
           `Native${preferredModuleName}Spec.g.h`,
           moduleTemplate
             .replace(/::_MODULE_ALIASED_STRUCTS_::/g, traversedAliasedStructs)
-            .replace(/::_MODULE_MEMBERS_TUPLES_::/g, tuples.substr(1))
-            .replace(/::_MODULE_MEMBERS_CHECKS_::/g, checks.substr(1))
+            .replace(/::_MODULE_MEMBERS_TUPLES_::/g, tuples.substring(1))
+            .replace(/::_MODULE_MEMBERS_CHECKS_::/g, checks.substring(1))
             .replace(/::_MODULE_MEMBERS_ERRORS_::/g, errors)
             .replace(/::_MODULE_NAME_::/g, preferredModuleName)
             .replace(/::_NAMESPACE_::/g, namespace),


### PR DESCRIPTION
Devmain is still in 0.66, this version lacks of some new features in turbo module specs. In order to make `RNW/codegen` development easy, `RNW/codegen` will have some features to make generated code compatible with old turbo module specs, instead of porting compatible changes of`RNW/codegen` back to old versions.

`--methodonly` is one of them, which skip all constant type-safety validation in specs, such validation is introduced in 0.68.

[Here](https://github.com/ZihanChen-MSFT/react-native-windows/commit/dda0aafc76ebef3d0221bee8b04b35c47bedea4e) is a test case (not included in this PR) about what will happen when using `--methodonly`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9934)