### PR TITLE
Fix issue with CLI tests failing in PRs

### DIFF
--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -164,16 +164,18 @@ steps:
       buildLogDirectory: $(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs
       workingDirectory: $(Agent.BuildDirectory)\testcli
       restoreLockedMode: false # Allow new lockfile to be created
+      moreMSBuildProps: ',UseBundle=false' # Temporary until https://github.com/react-native-community/cli/pull/1605 is fixed and released
 
   - template: upload-build-logs.yml
     parameters:
       buildLogDirectory: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
 
   # Only test bundling in debug since we already bundle as part of release builds
-  - ${{ if and(eq(parameters.projectType, 'app'), eq(parameters.configuration, 'Debug')) }}:
-    - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
-      displayName: Create bundle testcli
-      workingDirectory: $(Agent.BuildDirectory)\testcli
+  # Temporarily disabled until https://github.com/react-native-community/cli/pull/1605 is fixed and released
+  # - ${{ if and(eq(parameters.projectType, 'app'), eq(parameters.configuration, 'Debug')) }}:
+  #   - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
+  #     displayName: Create bundle testcli
+  #     workingDirectory: $(Agent.BuildDirectory)\testcli
 
   - ${{ if eq(parameters.runWack, true) }}:
     - template: ../templates/run-wack.yml

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -27,6 +27,9 @@ parameters:
   - name: restoreForceEvaluate
     type: boolean
     default: true
+  - name: moreMSBuildProps
+    type: string
+    default: ''
 
 steps:
   - ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
@@ -36,7 +39,7 @@ steps:
         --no-launch
         --logging
         --buildLogDirectory ${{ parameters.buildLogDirectory }}
-        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }}
+        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }}${{ parameters.moreMSBuildProps }}
         ${{ parameters.deployOption }}
       displayName: run-windows (Debug)
       workingDirectory: ${{ parameters.workingDirectory }}
@@ -49,7 +52,7 @@ steps:
         --no-launch
         --logging
         --buildLogDirectory ${{ parameters.buildLogDirectory }}
-        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }}
+        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }}${{ parameters.moreMSBuildProps }}
         ${{ parameters.deployOption }}
       displayName: run-windows (Release) - PR
       workingDirectory: ${{ parameters.workingDirectory }}
@@ -66,7 +69,7 @@ steps:
         --no-launch
         --logging
         --buildLogDirectory ${{ parameters.buildLogDirectory }}
-        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+        --msbuildprops RestoreLockedMode=${{ parameters.restoreLockedMode }},RestoreForceEvaluate=${{ parameters.restoreForceEvaluate }},PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx${{ parameters.moreMSBuildProps }}
         ${{ parameters.deployOption }}
       displayName: run-windows (Release) - CI
       workingDirectory: ${{ parameters.workingDirectory }}


### PR DESCRIPTION
This PR disables bundling when running the CLI tests temporarily, until https://github.com/react-native-community/cli/pull/1605 gets resolved and published.

Closes https://github.com/microsoft/react-native-windows/issues/9939

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9943)