### PR TITLE
Workaround Yoga bug with Text where content is sometimes truncated with ellipsis

### DIFF
--- a/change/react-native-windows-a9130de9-211e-4120-a581-691867eaf520.json
+++ b/change/react-native-windows-a9130de9-211e-4120-a581-691867eaf520.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Workaround Yoga bug with Text where content is sometimes truncated with ellipsis",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

Works around a Yoga bug where Text is sometimes truncated.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
It seems that sometimes Yoga does not invalidate nodes when it should during window resizing on display scales over 100%.

Resolves #9343

### What
To workaround this issue, we subscribe to the TextBlock.IsTextTrimmedChanged Event and in it mark the Text node as dirty and force a re-layout.

## Screenshots
To reproduce this issue you can run Playground-win32 in this branch in my fork: https://github.com/lyahdav/react-native-windows/tree/workaround-yoga-text-bug-with-example2

You need to run the app while on 150% display scale and resize the window back and forth to the point where the text should wrap. You have to keep retrying since the bug seems non-deterministic.

Before:
![image](https://user-images.githubusercontent.com/359157/167725858-c02f9db9-471c-4ab0-9382-e4a9b9a15c20.png)

After (notice in VS logs the IsTextTrimmedChanged - I logged this via breakpoint):

https://user-images.githubusercontent.com/359157/167716399-33417764-b126-4740-9bc7-dc3089680eee.mov

Ideally the Text wouldn't look truncated momentarily, but I'm not sure how to do so and I think this is a good enough fix for now.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9947)