### PR TITLE
Fix the run loop

### DIFF
--- a/change/react-native-windows-b0c290d3-c8b2-4afe-82b3-2c1aa7a5741c.json
+++ b/change/react-native-windows-b0c290d3-c8b2-4afe-82b3-2c1aa7a5741c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix run loop in loopScheduler.cpp",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/dispatchQueue/looperScheduler.cpp
+++ b/vnext/Mso/src/dispatchQueue/looperScheduler.cpp
@@ -53,7 +53,7 @@ LooperScheduler::~LooperScheduler() noexcept {
           }
           queue->InvokeTask(std::move(task), std::nullopt);
           if (taskCompleted) {
-            taskStarting(DispatchQueue{Mso::CntPtr(queue)});
+            taskCompleted(DispatchQueue{Mso::CntPtr(queue)});
           }
         }
       }

--- a/vnext/Mso/src/dispatchQueue/looperScheduler.cpp
+++ b/vnext/Mso/src/dispatchQueue/looperScheduler.cpp
@@ -44,14 +44,14 @@ LooperScheduler::~LooperScheduler() noexcept {
   for (;;) {
     if (auto self = weakSelf.GetStrongPtr()) {
       if (auto queue = self->m_queue.GetStrongPtr()) {
-        DispatchQueue q{ Mso::CntPtr(queue) };
+        DispatchQueue q{Mso::CntPtr(queue)};
         DispatchTask task;
         while (queue->TryDequeTask(task)) {
-          if (auto& func = self->m_settings.TaskStarting) {
+          if (auto &func = self->m_settings.TaskStarting) {
             func(q);
           }
           queue->InvokeTask(std::move(task), std::nullopt);
-          if (auto& func = self->m_settings.TaskCompleted) {
+          if (auto &func = self->m_settings.TaskCompleted) {
             func(q);
           }
         }
@@ -62,8 +62,8 @@ LooperScheduler::~LooperScheduler() noexcept {
       }
 
       if (auto queue = self->m_queue.GetStrongPtr()) {
-        DispatchQueue q{ Mso::CntPtr(queue) };
-        if (auto& func = self->m_settings.IdleWaitStarting) {
+        DispatchQueue q{Mso::CntPtr(queue)};
+        if (auto &func = self->m_settings.IdleWaitStarting) {
           func(q);
         }
       }
@@ -72,8 +72,8 @@ LooperScheduler::~LooperScheduler() noexcept {
       self->m_wakeUpEvent.Reset();
 
       if (auto queue = self->m_queue.GetStrongPtr()) {
-        DispatchQueue q{ Mso::CntPtr(queue) };
-        if (auto& func = self->m_settings.IdleWaitCompleted) {
+        DispatchQueue q{Mso::CntPtr(queue)};
+        if (auto &func = self->m_settings.IdleWaitCompleted) {
           func(q);
         }
 


### PR DESCRIPTION
## Description
Fix the run loop in loopScheduler.cpp

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.
In my previous pull request here: https://github.com/microsoft/react-native-windows/pull/9900, I found that I unexpectedly changed the scoping on some of the run loop code. This pull request fixes that.

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.
The scoping of the while loop in looperScheduler::RunLoop

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.
To test that we can subscribe to the notification, I added the following testing in the Playground-Win32.cpp (line 96)
```
 if (!m_instanceSettings) {
      m_instanceSettings = winrt::Microsoft::ReactNative::ReactInstanceSettings();
      m_instanceSettings.Notifications().Subscribe(winrt::Microsoft::ReactNative::ReactDispatcherHelper::JSDispatcherTaskStarting(), nullptr,
          [](winrt::Windows::Foundation::IInspectable const&,
              winrt::Microsoft::ReactNative::IReactNotificationArgs const& args) noexcept {
              OutputDebugStringA("notification ----------------------------------------------------------\n");
      });
    }
```

_Optional_: Describe the tests that you ran locally to verify your changes.
The VS output panel can see the print out of "notification ----------------------------------------------------------" very frequently

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9965)