### PR TITLE
[0.69] Fix Microsoft.ReactNative.Cxx nuget package missing files

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -9,8 +9,10 @@ parameters:
     type: object
   - name: buildNuGetOnly
     type: boolean
+    default: false
   - name: buildWinAppSDKOnly
     type: boolean
+    default: false
   - name: buildMatrix
     type: object
     default:
@@ -58,13 +60,16 @@ parameters:
           #   configuration: Debug
           #   platform: x86
           #   projectType: app
-          #   additionalInitArguments: --useWinUI3 true
+          #   additionalInitArguments: --useWinUI3 true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+          #   additionalRunArguments: --no-deploy
+          #   useWinAppSDK: true
           - Name: X64DebugCsWinUI3
             language: cs
             configuration: Debug
             platform: x64
             projectType: app
             additionalInitArguments: --useWinUI3 true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+            additionalRunArguments: --no-deploy
             useWinAppSDK: true
           - Name: X86DebugCppHermes
             language: cpp
@@ -155,13 +160,16 @@ parameters:
           #   configuration: Debug
           #   platform: x86
           #   projectType: app
-          #   additionalInitArguments: --useWinUI3 true
+          #   additionalInitArguments: --useWinUI3 true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+          #   additionalRunArguments: --no-deploy
+          #   useWinAppSDK: true
           - Name: X64DebugCsWinUI3
             language: cs
             configuration: Debug
             platform: x64
             projectType: app
-            additionalInitArguments: --useWinUI3 true
+            additionalInitArguments: --useWinUI3 true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+            additionalRunArguments: --no-deploy
             useWinAppSDK: true
           - Name: X86DebugCppHermes
             language: cpp
@@ -347,3 +355,4 @@ jobs:
                   runWack: ${{ coalesce(matrix.runWack, false) }}
                   buildEnvironment: ${{ parameters.buildEnvironment }}
                   useNuGet: ${{ coalesce(matrix.useNuGet, false) }}
+                  useWinAppSDK: ${{ coalesce(matrix.useWinAppSDK, false) }}

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -44,6 +44,11 @@ stages:
           buildEnvironment: ${{ parameters.buildEnvironment }}
           AgentPool: ${{ parameters.AgentPool }}
           buildNuGetOnly: true
+      
+      - template: jobs/cli-init.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+          AgentPool: ${{ parameters.AgentPool }}
           buildWinAppSDKOnly: true
 
   - stage: IntegrationTests

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -80,7 +80,7 @@ steps:
   - ${{ if eq(parameters.useWinAppSDK, true) }}:
     - template: prep-and-pack-nuget.yml
       parameters:
-        artifactName: ReactWindows
+        artifactName: WindowsAppSDK
         npmVersion: $(npmVersion)
         packMicrosoftReactNativeWindowsAppSDK: true
         slices: 

--- a/change/react-native-windows-a9ac003c-8ce9-4352-8f70-6d8caa7793e3.json
+++ b/change/react-native-windows-a9ac003c-8ce9-4352-8f70-6d8caa7793e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.69] Fix Microsoft.ReactNative.Cxx nuget package missing files",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -13,7 +13,7 @@
     <TurboModule_SourcePath Condition="'$(TurboModule_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\react\nativemodule\core</TurboModule_SourcePath>
     <TurboModule_SourcePath Condition="'$(TurboModule_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\TurboModule.h')">$(MSBuildThisFileDirectory)</TurboModule_SourcePath>
     <Bridging_SourcePath Condition="'$(Bridging_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\react\bridging</Bridging_SourcePath>
-    <Bridging_SourcePath Condition="'$(Bridging_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\TurboModule.h')">$(MSBuildThisFileDirectory)</Bridging_SourcePath>
+    <Bridging_SourcePath Condition="'$(Bridging_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\CallbackWrapper.h')">$(MSBuildThisFileDirectory)ReactCommon</Bridging_SourcePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -108,7 +108,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <DisableSpecificWarnings>%(DisableSpecificWarnings);4100</DisableSpecificWarnings>
     </ClCompile>
-    <ClCompile Include="$(TurboModule_SourcePath)\..\..\bridging\LongLivedObject.cpp">
+    <ClCompile Include="$(Bridging_SourcePath)\LongLivedObject.cpp">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <DisableSpecificWarnings>%(DisableSpecificWarnings);4100</DisableSpecificWarnings>
     </ClCompile>

--- a/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-MSRN-Headers.ps1
@@ -5,18 +5,19 @@ param(
 	[string] $SourceRoot = ($PSScriptRoot | Split-Path | Split-Path | Split-Path),
 	[string] $TargetRoot = "$SourceRoot\vnext\target",
 	[System.IO.DirectoryInfo] $ReactWindowsRoot = "$SourceRoot\vnext",
-	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\node_modules\react-native",	
+	[System.IO.DirectoryInfo] $ReactNativeRoot = "$SourceRoot\node_modules\react-native",
+	[System.IO.DirectoryInfo] $ReactCommonOverrideRoot = "$ReactWindowsRoot\ReactCommon\TEMP_UntilReactCommonUpdate",
 	[string[]] $Extensions = ('h', 'hpp')
 )
 
 Write-Host "Source root: [$SourceRoot]"
 Write-Host "Destination root: [$TargetRoot]"
 Write-Host "React Native root: [$ReactNativeRoot]"
+Write-Host "ReactCommon Override root: [$ReactCommonOverrideRoot]"
 
 md -Force $TargetRoot
 
 $patterns = $Extensions| ForEach-Object {"*.$_"}
-
 
 # include headers
 Copy-Item -Force -Recurse -Path $ReactWindowsRoot\include -Destination $TargetRoot\inc
@@ -27,6 +28,9 @@ Copy-Item -Force -Recurse -Path $ReactWindowsRoot\Microsoft.ReactNative.Cxx -Des
 # Copy native module spec files
 Copy-Item -Force -Recurse -Path $ReactWindowsRoot\codegen -Destination $TargetRoot\inc
 
+# Overwrite temporary ReactCommon files (since this script can runs on a different machine than where ReactCommon was built)
+Copy-Item -Force -Recurse -Path $ReactCommonOverrideRoot\* -Destination $ReactNativeRoot\ReactCommon\
+
 # Microsoft.ReactNative.CXX project JSI files
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\decorator.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\jsi\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\instrumentation.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\jsi\
@@ -36,11 +40,11 @@ Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\jsi-inl.h -Destinati
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\jsi\jsi\threadsafe.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\jsi\
 
 # Microsoft.ReactNative.CXX project TurboModule files
-New-Item -ItemType Directory -Path $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon
+New-Item -ItemType Directory -Path $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon -Force
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\callinvoker\ReactCommon\CallInvoker.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
-Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.cpp -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\CallbackWrapper.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
-Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\nativemodule\core\ReactCommon\LongLivedObject.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
+Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.cpp -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
+Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\bridging\LongLivedObject.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\nativemodule\core\ReactCommon\TurboModule.cpp -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\nativemodule\core\ReactCommon\TurboModule.h -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\
 Copy-Item -Force -Path $ReactNativeRoot\ReactCommon\react\nativemodule\core\ReactCommon\TurboModuleUtils.cpp -Destination $TargetRoot\Microsoft.ReactNative.Cxx\ReactCommon\

--- a/vnext/template/cs-app-WinAppSDK/proj/NuGet.Config
+++ b/vnext/template/cs-app-WinAppSDK/proj/NuGet.Config
@@ -8,8 +8,10 @@
     {{#nuGetTestFeed}}
     <add key="NuGetTestFeed" value="{{ nuGetTestFeed }}" />
     {{/nuGetTestFeed}}
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+    {{#nuGetADOFeed}}
     <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+    {{/nuGetADOFeed}}
+    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
This PR backports #9967 to 0.69.

The `Microsoft.ReactNative.Cxx.vcxitems` project is used in two places - from within the file structure of the RNW package (in this repo, or via npm) and also within the `Microsoft.ReactNative.Cxx` NuGet package, which has a different (flattened) file structure.

In addition, certain files were not included in the NuGet package, which would break C++ apps building against the binaries.

This PR updates the `Layout-MSRN-Headers.ps1` script to copy the missing files, and updates the `Microsoft.ReactNative.Cxx.vcxitems` project to use the correct paths in both use cases.

This PR also fixes a bug in the pipelines that caused the CLI tests creating new apps against the NuGets from being run, which would have caught this bug.

Fixing the pipeline bug also has the side effect of actually running the CLI tests running against the WinAppSDK template, which revealed other bugs which this PR also resolves.

Closes #9966

Closes #9966

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.