### PR TITLE
Fix crash when enabling Yoga logging

### DIFF
--- a/change/react-native-windows-9193a9f7-cac3-4657-b640-ac468b782823.json
+++ b/change/react-native-windows-9193a9f7-cac3-4657-b640-ac468b782823.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash when enabling Yoga logging",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -38,7 +38,7 @@ static int YogaLog(
     YGLogLevel /*level*/,
     const char *format,
     va_list args) {
-  int len = _scprintf(format, args);
+  const int len = _vscprintf(format, args);
   std::string buffer(len + 1, '\0');
   vsnprintf_s(&buffer[0], len + 1, _TRUNCATE, format, args);
   buffer.resize(len);


### PR DESCRIPTION
## Description
The logging function tries to calculate the length of the buffer using a function that takes varargs instead of va_list.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9972)