### PR TITLE
Update NuGet config files to reduce Secure Supply Chain Analysis warnings

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,11 +4,4 @@
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />
   </packageRestore>
-  <packageSources>
-    <clear />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>  
 </configuration>

--- a/change/react-native-windows-e24cec68-175e-4980-ac12-788e91464627.json
+++ b/change/react-native-windows-e24cec68-175e-4980-ac12-788e91464627.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update NuGet config files to reduce Secure Supply Chain Analysis warnings",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/windows/NuGet.Config
+++ b/packages/e2e-test-app/windows/NuGet.Config
@@ -3,12 +3,4 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
-  <packageSources>
-    <clear />
-    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>  
 </configuration>

--- a/packages/integration-test-app/windows/NuGet.Config
+++ b/packages/integration-test-app/windows/NuGet.Config
@@ -3,12 +3,4 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
-  <packageSources>
-    <clear />
-    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>  
 </configuration>

--- a/packages/playground/windows/NuGet.Config
+++ b/packages/playground/windows/NuGet.Config
@@ -3,11 +3,4 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
-  <packageSources>
-    <clear />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>  
 </configuration>

--- a/packages/sample-apps/windows/NuGet.Config
+++ b/packages/sample-apps/windows/NuGet.Config
@@ -3,12 +3,4 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
-  <packageSources>
-    <clear />
-    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>  
 </configuration>

--- a/vnext/NuGet.Config
+++ b/vnext/NuGet.Config
@@ -5,10 +5,11 @@
   </config>
   <packageSources>
     <clear />
+    <!-- Unable to create a compliant NuGet feed which meets our needs. See #9996. -->
     <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
     <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />
-  </disabledPackageSources>  
+  </disabledPackageSources>
 </configuration>


### PR DESCRIPTION
This PR updates all used NuGet.Config files to reduce the number of warnings produced by the Secure Supply Chain Analysis task. This does not completely address them however.

Related issues: https://github.com/microsoft/react-native-windows/issues/9992, https://github.com/microsoft/react-native-windows/issues/9993, https://github.com/microsoft/react-native-windows/issues/9996, https://github.com/microsoft/react-native-windows/issues/9997

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9976)