### PR TITLE
Expose LoadingState on ReactContext

### DIFF
--- a/change/react-native-windows-48cb9d1d-48bd-4997-b425-b576e6f72e2f.json
+++ b/change/react-native-windows-48cb9d1d-48bd-4997-b425-b576e6f72e2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose LoadingState on ReactContext",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -96,6 +96,23 @@ Windows::Foundation::IInspectable ReactContext::JSRuntime() noexcept {
   return m_context->JsiRuntime();
 }
 
+LoadingState ReactContext::LoadingState() noexcept {
+  switch(m_context->State()) {
+    case Mso::React::ReactInstanceState::Loading :
+    case Mso::React::ReactInstanceState::WaitingForDebugger:
+      return LoadingState::Loading;
+    case Mso::React::ReactInstanceState::Loaded:
+      return LoadingState::Loaded;
+    case Mso::React::ReactInstanceState::HasError:
+      return LoadingState::HasError;
+    case Mso::React::ReactInstanceState::Unloaded:
+      return LoadingState::Unloaded;
+    default:
+      assert(false);
+      return LoadingState::HasError;
+  };
+}
+
 #ifndef CORE_ABI
 // Deprecated: Use XamlUIService directly.
 void ReactContext::DispatchEvent(

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -42,6 +42,8 @@ struct ReactContext : winrt::implements<ReactContext, IReactContext> {
   IReactDispatcher UIDispatcher() noexcept;
   IReactDispatcher JSDispatcher() noexcept;
   IInspectable JSRuntime() noexcept;
+  LoadingState LoadingState() noexcept;
+
 #ifndef CORE_ABI
   void DispatchEvent(
       xaml::FrameworkElement const &view,

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -13,6 +13,18 @@ import "IReactPropertyBag.idl";
 
 namespace Microsoft.ReactNative
 {
+
+  DOC_STRING(
+    "Used to represent the state of the React Native JavaScript instance")
+  enum LoadingState
+  {
+    Loading = 0,
+    Loaded = 1,
+    HasError = 2,
+    Unloaded = 3,
+    Fatal = 4
+  };
+
   [webhosthidden]
   DOC_STRING("An immutable snapshot of the @ReactInstanceSettings used to create the current React instance.")
   interface IReactSettingsSnapshot
@@ -167,5 +179,9 @@ namespace Microsoft.ReactNative
       "The `paramsArgWriter` is a @JSValueArgWriter delegate that receives @IJSValueWriter to serialize "
       "the event parameters.")
     void EmitJSEvent(String eventEmitterName, String eventName, JSValueArgWriter paramsArgWriter);
+
+    DOC_STRING(
+      "Gets the state of the ReactNative instance.")
+    LoadingState LoadingState { get; };
   }
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
## Description
This property is required to properly implement a pluggable UI and handle the instance reload case.  ReactRootView calls into the State property on the Mso::ReactContext.  Any pluggable UI implementation should also only AttachMeasuredRootView when the context is in the loaded state.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Required for Office to get onto the ABI.