### PR TITLE
[0.66] Support PreparedScriptStore for V8 Node-API

### DIFF
--- a/change/react-native-windows-8f4cd7f3-9cd6-4681-8d63-b378c912d67d.json
+++ b/change/react-native-windows-8f4cd7f3-9cd6-4681-8d63-b378c912d67d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support PreparedScriptStore for V8 Node-API.",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/packages.config
+++ b/vnext/Desktop.DLL/packages.config
@@ -4,6 +4,6 @@
   <package id="Microsoft.Build.Tasks.Git" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.Common" version="1.0.0" targetFramework="native" developmentDependency="true" />
   <package id="Microsoft.SourceLink.GitHub" version="1.0.0" targetFramework="native" developmentDependency="true" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.11" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.15" targetFramework="native" />
   <package id="ReactWindows.OpenSSL.StdCall.Static" version="1.0.2-p.5" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.11" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.15" targetFramework="native" />
 </packages>

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
@@ -20,6 +20,54 @@ namespace Microsoft::JSI {
 ///
 std::unique_ptr<facebook::jsi::Runtime> __cdecl MakeNodeApiJsiRuntime(napi_env env) noexcept;
 
+template <typename T>
+struct NativeObjectWrapper;
+
+template <typename T>
+struct NativeObjectWrapper<std::unique_ptr<T>> {
+  static napi_ext_native_data Wrap(std::unique_ptr<T> &&obj) noexcept {
+    napi_ext_native_data nativeData{};
+    nativeData.data = obj.release();
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void * /*finalizeHint*/) {
+      std::unique_ptr<T> obj{reinterpret_cast<T *>(data)};
+    };
+    return nativeData;
+  }
+
+  static T *Unwrap(napi_ext_native_data &nativeData) noexcept {
+    return reinterpret_cast<T *>(nativeData.data);
+  }
+};
+
+template <typename T>
+struct NativeObjectWrapper<std::shared_ptr<T>> {
+  static napi_ext_native_data Wrap(std::shared_ptr<T> &&obj) noexcept {
+    static_assert(
+        sizeof(SharedPtrHolder) == sizeof(std::shared_ptr<T>), "std::shared_ptr expected to have size of two pointers");
+    SharedPtrHolder ptrHolder;
+    new (std::addressof(ptrHolder)) std::shared_ptr(std::move(obj));
+    napi_ext_native_data nativeData{};
+    nativeData.data = ptrHolder.ptr1;
+    nativeData.finalize_hint = ptrHolder.ptr2;
+    nativeData.finalize_cb = [](napi_env /*env*/, void *data, void *finalizeHint) {
+      SharedPtrHolder ptrHolder{data, finalizeHint};
+      std::shared_ptr<T> obj(std::move(*reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder))));
+    };
+    return nativeData;
+  }
+
+  static std::shared_ptr<T> Unwrap(napi_ext_native_data &nativeData) noexcept {
+    SharedPtrHolder ptrHolder{nativeData.data, nativeData.finalize_hint};
+    return *reinterpret_cast<std::shared_ptr<T> *>(std::addressof(ptrHolder));
+  }
+
+ private:
+  struct SharedPtrHolder {
+    void *ptr1;
+    void *ptr2;
+  };
+};
+
 } // namespace Microsoft::JSI
 
 #endif // MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME

--- a/vnext/Microsoft.ReactNative/packages.config
+++ b/vnext/Microsoft.ReactNative/packages.config
@@ -8,5 +8,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native" />
   <package id="ReactNative.Hermes.Windows" version="0.9.0-ms.4" targetFramework="native" />
-  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.11" targetFramework="native" / -->
+  <!-- package id="ReactNative.V8Jsi.Windows.UWP" version="0.65.15" targetFramework="native" / -->
 </packages>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -16,7 +16,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.65.11</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.65.15</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(SolutionDir)packages\$(V8PackageName).$(V8Version)</V8Package>

--- a/vnext/ReactCommon.UnitTests/packages.config
+++ b/vnext/ReactCommon.UnitTests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="boost" version="1.76.0.0" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" version="1.8.1.4" targetFramework="native" />
-  <package id="ReactNative.V8Jsi.Windows" version="0.65.11" targetFramework="native" />
+  <package id="ReactNative.V8Jsi.Windows" version="0.65.15" targetFramework="native" />
 </packages>

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -31,6 +31,8 @@ class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       void *finalizeHint);
 
   void InitRuntime() noexcept;
+  napi_ext_script_cache InitScriptCache(
+      std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
 
   std::shared_ptr<facebook::jsi::Runtime> m_runtime;
   std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;


### PR DESCRIPTION
## Description

Implement support for PreparedScriptStore in V8 Node-API.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Why

This PR is concerning the Desktop version of RNW which currently uses `v8jsi.dll` through non-ABI safe JSI.
We would like to change `react-native-win32.dll` to start using `v8jsi.dll` through the ABI-safe Node-API.
Majority of the code was written before. The only missing part is the support for cached bytecode managed by the `PreparedScriptStore` class.
In this PR we are bridging the gap by implementing the support for the `PreparedScriptStore`. It must enable us switching to Node-API in Office code.

### What

This change requires v8-jsi version starting from 0.65.15.
The `NapiJsiV8RuntimeHolder` is wrapping up provided `PreparedScriptStore` instance into the ABI-safe `napi_ext_script_cache` struct and passes it to the function that creates Node-API environment.
This `napi_ext_script_cache` is going to be used by the new `napi_ext_run_script_buffer` Node-API extension function.

## Testing

The code is manually tested to work in Office environment.
It is required changes in PR #10016 to compile and run the code that includes this PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9995)