### PR TITLE
Update autolinking to not error if a dependency is misconfigured

### DIFF
--- a/change/@react-native-windows-cli-c9f9301d-177d-4cda-8f4b-165434d5a5dd.json
+++ b/change/@react-native-windows-cli-c9f9301d-177d-4cda-8f4b-165434d5a5dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update autolinking to not error if a dependency is misconfigured",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/autolink.ts
@@ -416,29 +416,23 @@ export class AutolinkWindows {
           );
           verboseMessage(windowsDependency, this.options.logging);
 
-          let dependencyIsValid = true;
+          let dependencyIsValid = false;
 
-          dependencyIsValid = !!(
-            dependencyIsValid &&
+          const hasValidSourceDir =
             'sourceDir' in windowsDependency &&
-            windowsDependency.sourceDir &&
-            !windowsDependency.sourceDir.startsWith('Error: ')
-          );
+            windowsDependency.sourceDir !== undefined &&
+            !windowsDependency.sourceDir.startsWith('Error: ');
 
-          if (
+          const hasProjectsInProjectsArray =
             'projects' in windowsDependency &&
-            Array.isArray(windowsDependency.projects)
-          ) {
-            if (
-              windowsDependency.projects.length === 0 &&
-              dependencyName.includes('react-native')
-            ) {
-              // the dependency is probably a react native module, but we didn't find a module project
-              throw new CodedError(
-                'Autolinking',
-                `Found a Windows solution for ${dependencyName} but no React Native for Windows native module projects`,
-              );
-            }
+            Array.isArray(windowsDependency.projects) &&
+            windowsDependency.projects.length > 0;
+
+          if (hasValidSourceDir && hasProjectsInProjectsArray) {
+            // Module is source-based and has projects
+            dependencyIsValid = true;
+
+            // Validate each source project
             windowsDependency.projects.forEach(project => {
               const itemsToCheck: Array<keyof ProjectDependency> = [
                 'projectFile',


### PR DESCRIPTION
While validating dependencies during autolinking, we threw a misleading error message in one very specific case of a module being misconfigured, but otherwise just logged the validation failure and move on.

This PR changes the behavior such that autolinking just logs the validation failure in all cases.

I recognize that we may *want* to throw errors and alert the user, but I think adding new errors is a breaking behavior change that users might not appreciate. I want this PR to be non-breaking and backportable (at least to 0.68), and I've opened #10013 to track how we might introduce that breaking behavior more thoughtfully.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10014)