### PR TITLE
[0.69] Change CG registration for folly and fmt from `other` to `git`

### DIFF
--- a/change/react-native-windows-300bd2ca-501b-4462-8eff-3116a3b509a5.json
+++ b/change/react-native-windows-300bd2ca-501b-4462-8eff-3116a3b509a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.69] Change CG registration for folly and fmt from `other` to `git`",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -15,8 +15,12 @@
       The PR (windows-vs-pr.yml) and CI (publish.yml() turn it back on.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
+    <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit too. -->
     <FollyVersion>2021.06.28.00</FollyVersion>
+    <FollyCommitHash>f434460f8a98e85f3ddb75390ddd1cc330c8f658</FollyCommitHash>
+    <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit too. -->
     <FmtVersion>7.1.3</FmtVersion>
+    <FmtCommitHash>7bdf0628b1276379886c7f6dda2cef2b3b374f0b</FmtCommitHash>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -289,11 +289,10 @@
     "Registrations": [
         {
             "Component": {
-                "Type": "other",
-                "Other": {
-                  "Name": "folly",
-                  "Version": "$(FollyVersion)",
-                  "DownloadUrl": "https://github.com/facebook/folly/archive/v$(FollyVersion).zip"
+                "Type": "git",
+                "Git": {
+                  "RepositoryUrl": "https://github.com/facebook/folly",
+                  "CommitHash": "$(FollyCommitHash)"
                 }
             },
             "DevelopmentDependency": false

--- a/vnext/fmt/fmt.vcxproj
+++ b/vnext/fmt/fmt.vcxproj
@@ -111,11 +111,10 @@
     "Registrations": [
         {
             "Component": {
-                "Type": "other",
-                "Other": {
-                  "Name": "fmt",
-                  "Version": "$(FmtVersion)",
-                  "DownloadUrl": "https://github.com/fmtlib/fmt/archive/refs/tags/$(FmtVersion).zip"
+                "Type": "git",
+                "Git": {
+                  "RepositoryUrl": "https://github.com/fmtlib/fmt",
+                  "CommitHash": "$(FmtCommitHash)"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
This PR backports #10011 to 0.69.

In order to register our usage of the folly and fmt libraries with Component Governance, we create the appropriate cgmanifest.json file.

However  we get non-dismissable alerts that the components are unsupported by CG.

This PR attempts to resolve those alerts by switching the registration from type `other` with the name, version, and download url, to type `git`, which includes the repo url and commit hash.