### PR TITLE
[0.67] Fix RuntimeOptions for RNW Desktop (#10016)

### DIFF
--- a/change/react-native-windows-b32aaa98-0ab9-47f9-a39f-4371bf2c8bdf.json
+++ b/change/react-native-windows-b32aaa98-0ab9-47f9-a39f-4371bf2c8bdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix RuntimeOptions for RNW Desktop",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/RuntimeOptions.cpp
+++ b/vnext/Shared/RuntimeOptions.cpp
@@ -94,7 +94,7 @@ void __cdecl MicrosoftReactSetRuntimeOptionString(const char *name, const char *
     g_runtimeOptionStrings.erase(name);
 }
 
-const bool __cdecl MicrosoftReactGetRuntimeOptionBool(const char *name) noexcept {
+bool __cdecl MicrosoftReactGetRuntimeOptionBool(const char *name) noexcept {
   scoped_lock lock{g_runtimeOptionsMutex};
   auto itr = g_runtimeOptionInts.find(name);
   if (itr != g_runtimeOptionInts.end())
@@ -103,7 +103,7 @@ const bool __cdecl MicrosoftReactGetRuntimeOptionBool(const char *name) noexcept
   return false;
 }
 
-const int32_t __cdecl MicrosoftReactGetRuntimeOptionInt(const char *name) noexcept {
+int32_t __cdecl MicrosoftReactGetRuntimeOptionInt(const char *name) noexcept {
   scoped_lock lock{g_runtimeOptionsMutex};
   auto itr = g_runtimeOptionInts.find(name);
   if (itr != g_runtimeOptionInts.end())
@@ -112,7 +112,10 @@ const int32_t __cdecl MicrosoftReactGetRuntimeOptionInt(const char *name) noexce
   return 0;
 }
 
-void MicrosoftReactGetRuntimeOptionString(const char *name, MicrosoftReactGetStringCallback callBack, void *state) {
+void __cdecl MicrosoftReactGetRuntimeOptionString(
+    const char *name,
+    MicrosoftReactGetStringCallback callBack,
+    void *state) {
   scoped_lock lock{g_runtimeOptionsMutex};
   auto itr = g_runtimeOptionStrings.find(name);
   if (itr != g_runtimeOptionStrings.cend()) {

--- a/vnext/Shared/RuntimeOptions.h
+++ b/vnext/Shared/RuntimeOptions.h
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /// <summary>
 /// Sets a global boolean value identified by an arbitrary string.
 /// </summary>
@@ -26,14 +30,14 @@ void __cdecl MicrosoftReactSetRuntimeOptionString(const char *name, const char *
 /// </summary>
 /// <param name="name">Global boolean key</param>
 /// <returns>Value stored for the given key, or false if the entry doesn't exist (default)</returns>
-const bool __cdecl MicrosoftReactGetRuntimeOptionBool(const char *name) noexcept;
+bool __cdecl MicrosoftReactGetRuntimeOptionBool(const char *name) noexcept;
 
 /// <summary>
 /// Retrieves a global boolean value for the given key.
 /// </summary>
 /// <param name="name">Global key</param>
 /// <returns>Value stored for the given key, or 0 if the entry doesn't exist (default)</returns>
-const int32_t __cdecl MicrosoftReactGetRuntimeOptionInt(const char *name) noexcept;
+int32_t __cdecl MicrosoftReactGetRuntimeOptionInt(const char *name) noexcept;
 
 /// <param name="buffer">String contents. nullptr if none found</param>
 /// <param name="length">String length. 0 if none found</param>
@@ -46,4 +50,11 @@ typedef void(__cdecl *MicrosoftReactGetStringCallback)(const char *buffer, size_
 /// <param name="name">Global key</param>
 /// <param name="callBack">Handler used to access the obtained string</param>
 /// <param name="state">Arbitrary data to pass on to or retrieve from callBack</param>
-void MicrosoftReactGetRuntimeOptionString(const char *name, MicrosoftReactGetStringCallback callBack, void *state);
+void __cdecl MicrosoftReactGetRuntimeOptionString(
+    const char *name,
+    MicrosoftReactGetStringCallback callBack,
+    void *state);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Cherry pick PR #10016. Original PR description:

## Description

Fix new `RuntimeOptions.h` API declarations added in PR #9983.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

This PR fixes API issues introduced by PR #9983.
The `RuntimeOptions.h` code there has the following issues:

- It does not provide `extern "C"` for the exported functions that causes linker error when the code is used.
- `MicrosoftReactGetRuntimeOptionString` function misses the `__cdecl` calling conventions.
- Unnecessary `const` for the results returned by value.

### What

This PR fixes the issues mentioned above.

## Testing

The issue was identified when I tried to use the RNW Desktop NuGet package version 0.66.19 in Office.
After these changes and additional changes to Office code related to the `IWebSocketResource` namespace changes, I could compile and run the Office code.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10026)