### PR TITLE
Add PoliCheck and CredScan config files

### DIFF
--- a/.ado/compliance.yml
+++ b/.ado/compliance.yml
@@ -96,7 +96,7 @@ jobs:
           result: PoliCheck.xml
           optionsFC: 1
           optionsXS: 1
-          # optionsUEPath: $(Build.SourcesDirectory)\PolicheckExclusions.xml
+          optionsUEPath: $(Build.SourcesDirectory)\.ado\config\PolicheckExclusions.xml
           optionsHMENABLE: 0
         continueOnError: true
 
@@ -106,7 +106,7 @@ jobs:
         displayName: '⚖️ Run CredScan'
         inputs:
           outputFormat: pre
-          # suppressionsFile: LocalSuppressions.json
+          suppressionsFile: $(Build.SourcesDirectory)\.ado\config\CredScanSuppressions.json
           batchSize: 20
           debugMode: false
         continueOnError: true

--- a/.ado/compliance.yml
+++ b/.ado/compliance.yml
@@ -96,7 +96,7 @@ jobs:
           result: PoliCheck.xml
           optionsFC: 1
           optionsXS: 1
-          optionsUEPath: $(Build.SourcesDirectory)\.ado\config\PolicheckExclusions.xml
+          optionsUEPath: $(Build.SourcesDirectory)\.ado\config\PoliCheckExclusions.xml
           optionsHMENABLE: 0
         continueOnError: true
 

--- a/.ado/config/CredScanSuppressions.json
+++ b/.ado/config/CredScanSuppressions.json
@@ -1,0 +1,9 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": "\\node_modules\\react-native\\template\\android\\app\\debug.keystore",
+            "_justification": "Debug secret created and consumed by third-party library"
+        }
+    ]
+}

--- a/.ado/config/PoliCheckExclusions.xml
+++ b/.ado/config/PoliCheckExclusions.xml
@@ -1,0 +1,25 @@
+<!--
+This file is used to configure PoliCheck scanning.
+See https://aka.ms/gdn-azdo-policheck
+
+NOTE: Use ALL CAPS for excluded terms below else it will silently ignore them. Also read the comments
+      not the filter name as those are misleading (e.g. FolderPathFull does match an absolute path)
+-->
+<PoliCheckExclusions>
+	<!-- Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
+	<Exclusion Type="FolderPathFull">
+		.GIT|ARM|ARM64|BUILD|DIST|GENERATED FILES|NODE_MODULES|OUTPUT|TARGET|X64|X86|PATCHES
+	</Exclusion>
+	<!-- Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
+	<Exclusion Type="FolderPathStart">
+		PACKAGES\BOOST.|PACKAGES\REACTNATIVE.|PACKAGES\MICROSOFT.
+	</Exclusion>
+	<!-- Each of these file types will be completely skipped for the entire scan -->
+	<Exclusion Type="FileType">
+		.BUNDLE
+	</Exclusion>
+	<!-- The specified file names will be skipped during the scan regardless which folder they are in -->
+	<Exclusion Type="FileName">
+		POLICHECKEXCLUSIONS.XML
+	</Exclusion>
+</PoliCheckExclusions>

--- a/.ado/jobs/linting.yml
+++ b/.ado/jobs/linting.yml
@@ -19,7 +19,9 @@ jobs:
       - template: ../templates/checkout-shallow.yml
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-        displayName: 'Run Credential Scanner'
+        displayName: '⚖️ Run CredScan'
+        inputs:
+          suppressionsFile: $(Build.SourcesDirectory)\.ado\config\CredScanSuppressions.json
 
       - template: ../templates/prepare-js-env.yml
 

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -52,7 +52,9 @@ jobs:
       - template: templates/checkout-full.yml
 
       - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-        displayName: 'Run Credential Scanner'
+        displayName: '⚖️ Run CredScan'
+        inputs:
+          suppressionsFile: $(Build.SourcesDirectory)\.ado\config\CredScanSuppressions.json
 
       - powershell: gci env:/BUILD_*
         displayName: Show build information


### PR DESCRIPTION
This PR adds the PoliCheck and CredScan config files to prevent them
from checking the wrong files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10039)