### PR TITLE
Native layout panel

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/XAML/XAMLExample.tsx
+++ b/packages/@react-native-windows/tester/src/js/examples-win/XAML/XAMLExample.tsx
@@ -41,6 +41,7 @@ export function XAMLExamples() {
 
   return (
     <View testID="ReactNativeXAMLRoot">
+      <WinUI.Expander content="the content" header={{string: 'header'}} />
       <TextBox text="simple TextBox" />
       <TextBlock
         text="right aligned TextBlock"

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -63,6 +63,11 @@ YGSize DefaultYogaSelfMeasureFunc(
   try {
     winrt::Windows::Foundation::Size availableSpace(constrainToWidth, constrainToHeight);
 
+    auto cn = winrt::get_class_name(element);
+    if (cn == L"Microsoft.ReactNative.NativeMeasuringPanel") {
+      auto x = 0;
+    }
+
     // Clear out current size so it doesn't constrain the measurement
     auto widthProp = xaml::FrameworkElement::WidthProperty();
     auto heightProp = xaml::FrameworkElement::HeightProperty();
@@ -357,8 +362,17 @@ void ViewManagerBase::SetLayoutProps(
   ViewPanel::SetLeft(element, left);
   ViewPanel::SetTop(element, top);
 
-  fe.Width(width);
-  fe.Height(height);
+  if (RequiresNativeLayout()) {
+    auto x = 0;
+    auto s = fe.DesiredSize();
+    auto [w, h] = fe.ActualSize();
+    return;
+
+  } else 
+  {
+    fe.Width(width);
+    fe.Height(height);
+  }
 
   // Fire Events
   if (layoutHasChanged && nodeToUpdate.m_onLayoutRegistered) {

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -53,4 +53,11 @@ namespace Microsoft.ReactNative
 
     ViewPanel GetPanel();
   }
+
+  [default_interface]
+  [webhosthidden]
+  runtimeclass NativeMeasuringPanel : XAML_NAMESPACE.Controls.ContentControl {
+    NativeMeasuringPanel();
+  }
+
 }

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -56,7 +56,7 @@ namespace Microsoft.ReactNative
 
   [default_interface]
   [webhosthidden]
-  runtimeclass NativeMeasuringPanel : XAML_NAMESPACE.Controls.ContentControl {
+  runtimeclass NativeMeasuringPanel : XAML_NAMESPACE.Controls.Grid {
     NativeMeasuringPanel();
   }
 


### PR DESCRIPTION
In order to support layout/size changes coming from XAML (e.g. Expander gets expanded) and have it reflow through Yoga, we need a notification to be fired when the element's measure changes. 
That notification doesn't exist but we can wrap the native XAML control in a custom Panel, where we can use the MeasureOverride override to mark the corresponding yoga node as dirty and trigger a Yoga re-layout. 

However, the problem is that this panel would have its width/height set by the Yoga layout pass. As a result, XAML will not call MeasureOverride (if W/H are set, you don't need to be notified, you'll be that size!). 

To work around that, we need a second outer panel, which gets the W/H set, and hosts the panel with the notification code:

```xml
<NativeHostPanel Width="200" Height="48">
  <NativeMeasuringPanel>
    <Expander />
  </NativeMeasuringPanel>
</NativeHostPanel>
```
the Width/Height in the outermost panel will be set by Yoga based on its desired size.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10044)