### PR TITLE
[0.68] Run more checks against stable branch PRs

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -89,9 +89,33 @@ parameters:
             projectType: app
             additionalInitArguments: --useHermes
             runWack: true
-          - Name: X64DebugCppNuget
+          - Name: X86DebugCppNuget
             language: cpp
             configuration: Debug
+            platform: x86
+            projectType: app
+            useNuGet: true
+          - Name: X86DebugCsNuget
+            language: cs
+            configuration: Debug
+            platform: x86
+            projectType: app
+            useNuGet: true
+          - Name: X86ReleaseCppNuget
+            language: cpp
+            configuration: Release
+            platform: x86
+            projectType: app
+            useNuGet: true
+          - Name: X86ReleaseCsNuget
+            language: cs
+            configuration: Release
+            platform: x86
+            projectType: app
+            useNuGet: true
+          - Name: X64ReleaseCppNuget
+            language: cpp
+            configuration: Release
             platform: x64
             projectType: app
             useNuGet: true
@@ -101,9 +125,75 @@ parameters:
             platform: x64
             projectType: app
             useNuGet: true
+          - Name: Arm64ReleaseCppNuget
+            language: cpp
+            configuration: Release
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy
+            useNuGet: true
+          - Name: Arm64ReleaseCsNuget
+            language: cs
+            configuration: Release
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy
+            useNuGet: true
+          - Name: Arm64DebugCpp
+            language: cpp
+            configuration: Debug
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64DebugCs
+            language: cs
+            configuration: Debug
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64ReleaseCpp
+            language: cpp
+            configuration: Release
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64ReleaseCs
+            language: cs
+            configuration: Release
+            platform: ARM64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: X86ReleaseCpp
+            language: cpp
+            configuration: Release
+            platform: x86
+            projectType: app
+            runWack: true
+          - Name: X86ReleaseCs
+            language: cs
+            configuration: Release
+            platform: x86
+            projectType: app
+            runWack: true
+          - Name: X64DebugCpp
+            language: cpp
+            configuration: Debug
+            platform: x64
+            projectType: app
+          - Name: X64DebugCs
+            language: cs
+            configuration: Debug
+            platform: x64
+            projectType: app
           - Name: X64DebugCppLowResource
             language: cpp
             configuration: Debug
+            platform: x64
+            projectType: app
+            lowResource: true
+          - Name: X64ReleaseCppLowResource
+            language: cpp
+            configuration: Release
             platform: x64
             projectType: app
             lowResource: true

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -23,6 +23,15 @@ parameters:
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
+          - Name: Arm64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: ARM64
+          - Name: Arm64Release
+            BuildConfiguration: Release
+            BuildPlatform: ARM64
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Debug

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -19,6 +19,12 @@ parameters:
           - Name: X64Hermes
             BuildPlatform: x64
             UseHermes: true
+          - Name: X86Chakra
+            BuildPlatform: x86
+            UseHermes: false
+          - Name: X86Hermes
+            BuildPlatform: x86
+            UseHermes: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Chakra

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -12,6 +12,11 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
+          - Name: Arm64Debug
+            BuildPlatform: ARM64
+            BuildConfiguration: Debug
+            DeployOptions: --no-deploy # We don't have Arm agents
+            UseHermes: false
           - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
@@ -19,6 +24,16 @@ parameters:
             UseHermes: false
           - Name: X64ReleaseHermes
             BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions:
+            UseHermes: true
+          - Name: X86WebDebug
+            BuildPlatform: x86
+            BuildConfiguration: Debug
+            DeployOptions:
+            UseHermes: false
+          - Name: X86ReleaseHermes
+            BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions:
             UseHermes: true

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -20,6 +20,22 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             DeployOption:
+          - Name: Arm64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: ARM64
+            DeployOption: --no-deploy # We don't have Arm agents
+          - Name: Arm64Release
+            BuildConfiguration: Release
+            BuildPlatform: ARM64
+            DeployOption: --no-deploy # We don't have Arm agents
+          - Name: X64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            DeployOption:
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
+            DeployOption:
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Release

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -12,6 +12,15 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
+            - Name: Arm64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: ARM64
+            - Name: Arm64Release
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+            - Name: X64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x64
             - Name: X64Release
               BuildConfiguration: Release
               BuildPlatform: x64
@@ -19,6 +28,9 @@
               BuildConfiguration: Debug
               BuildPlatform: x86
               CreateApiDocs: true
+            - Name: X86Release
+              BuildConfiguration: Release
+              BuildPlatform: x86
         - BuildEnvironment: Continuous
           Matrix:
             - Name: Arm64Debug


### PR DESCRIPTION
This PR expands the matrix of build configurations for PRs by adding the
combinations that run in CI. This is to prevent PRs from passing and
then immediately failing in CI and/or publishing and breaking the stable
branch.

Related: #8851

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10050)