### PR TITLE
[0.67] Run more checks against stable branch PRs

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -99,6 +99,52 @@ parameters:
             platform: x86
             projectType: app
             useNuGet: true
+          - Name: Arm64DebugCpp
+            language: cpp
+            configuration: Debug
+            platform: arm64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64DebugCs
+            language: cs
+            configuration: Debug
+            platform: arm64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64ReleaseCpp
+            language: cpp
+            configuration: Release
+            platform: arm64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: Arm64ReleaseCs
+            language: cs
+            configuration: Release
+            platform: arm64
+            projectType: app
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          - Name: X86ReleaseCpp
+            language: cpp
+            configuration: Release
+            platform: x86
+            projectType: app
+            runWack: true
+          - Name: X86ReleaseCs
+            language: cs
+            configuration: Release
+            platform: x86
+            projectType: app
+            runWack: true
+          - Name: X64DebugCpp
+            language: cpp
+            configuration: Debug
+            platform: x64
+            projectType: app
+          - Name: X64DebugCs
+            language: cs
+            configuration: Debug
+            platform: x64
+            projectType: app
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64ReleaseCpp

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -19,6 +19,15 @@ parameters:
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
+          - Name: Arm64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: ARM64
+          - Name: Arm64Release
+            BuildConfiguration: Release
+            BuildPlatform: ARM64
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Debug

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -13,11 +13,19 @@ parameters:
         Matrix:
           - Name: X64Chakra
             BuildPlatform: x64
-            DeployOptions: --deploy-from-layout
+            DeployOptions:
             UseHermes: false
           - Name: X64Hermes
             BuildPlatform: x64
-            DeployOptions: --deploy-from-layout
+            DeployOptions:
+            UseHermes: true
+          - Name: X86Chakra
+            BuildPlatform: x86
+            DeployOptions:
+            UseHermes: false
+          - Name: X86Hermes
+            BuildPlatform: x86
+            DeployOptions:
             UseHermes: true
       - BuildEnvironment: Continuous
         Matrix:

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -10,6 +10,11 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
+          - Name: Arm64Debug
+            BuildPlatform: ARM64
+            BuildConfiguration: Debug
+            DeployOptions: --no-deploy # We don't have Arm agents
+            UseHermes: false
           - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
@@ -17,6 +22,16 @@ parameters:
             UseHermes: false
           - Name: X64ReleaseHermes
             BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
+            UseHermes: true
+          - Name: X86WebDebug
+            BuildPlatform: x86
+            BuildConfiguration: Debug
+            DeployOptions:
+            UseHermes: false
+          - Name: X86ReleaseHermes
+            BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
             UseHermes: true

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -18,6 +18,22 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             DeployOption:
+          - Name: Arm64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: ARM64
+            DeployOption: --no-deploy # We don't have Arm agents
+          - Name: Arm64Release
+            BuildConfiguration: Release
+            BuildPlatform: ARM64
+            DeployOption: --no-deploy # We don't have Arm agents
+          - Name: X64Debug
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            DeployOption:
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
+            DeployOption:
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Release

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -10,6 +10,32 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
+            - Name: Arm64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: ARM64
+              FastBuild: false
+            - Name: Arm64Release
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+              FastBuild: false
+            - Name: X64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              FastBuild: false
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              FastBuild: false
+            - Name: X86Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              LayoutHeaders: true
+              CreateApiDocs: true
+              FastBuild: false
+            - Name: X86Release
+              BuildConfiguration: Release
+              BuildPlatform: x86
+              FastBuild: false
             - Name: X64ReleaseFast
               BuildConfiguration: Release
               BuildPlatform: x64
@@ -18,7 +44,6 @@
               BuildConfiguration: Debug
               BuildPlatform: x86
               LayoutHeaders: true
-              CreateApiDocs: true
               FastBuild: true
         - BuildEnvironment: Continuous
           Matrix:


### PR DESCRIPTION
This PR expands the matrix of build configurations for PRs by adding the
combinations that run in CI. This is to prevent PRs from passing and
then immediately failing in CI and/or publishing and breaking the stable
branch.

Related: #8851

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10051)