### PR TITLE
[0.66] Run more checks against stable branch PRs

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -16,38 +16,35 @@ jobs:
         - template: ../variables/vs2019.yml
       displayName: Verify Cli
       strategy:
-        matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
-          # Start Continuous only
-          ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-            Arm64DebugCpp:
-              language: cpp
-              configuration: Debug
-              platform: arm64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments: --no-deploy # We don't have Arm agents
-            Arm64DebugCs:
-              language: cs
-              configuration: Debug
-              platform: arm64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments: --no-deploy # We don't have Arm agents
-            Arm64ReleaseCpp:
-              language: cpp
-              configuration: Release
-              platform: arm64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments: --no-deploy # We don't have Arm agents
-            Arm64ReleaseCs:
-              language: cs
-              configuration: Release
-              platform: arm64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments: --no-deploy # We don't have Arm agents
-          # End Continuous only
+        matrix:
+          Arm64DebugCpp:
+            language: cpp
+            configuration: Debug
+            platform: arm64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          Arm64DebugCs:
+            language: cs
+            configuration: Debug
+            platform: arm64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          Arm64ReleaseCpp:
+            language: cpp
+            configuration: Release
+            platform: arm64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments: --no-deploy # We don't have Arm agents
+          Arm64ReleaseCs:
+            language: cs
+            configuration: Release
+            platform: arm64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments: --no-deploy # We don't have Arm agents
           X64ReleaseCpp:
             language: cpp
             configuration: Release
@@ -76,38 +73,34 @@ jobs:
             projectType: app
             additionalInitArguments: --namespace MyCompany.MyApplication.MyComponent
             additionalRunArguments:
-          # Start Continuous only
-          ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-            X86ReleaseCpp:
-              language: cpp
-              configuration: Release
-              platform: x86
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments:
-            X86ReleaseCs:
-              language: cs
-              configuration: Release
-              platform: x86
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments:
-            X64DebugCpp:
-              language: cpp
-              configuration: Debug
-              platform: x64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments:
-            X64DebugCs:
-              language: cs
-              configuration: Debug
-              platform: x64
-              projectType: app
-              additionalInitArguments:
-              additionalRunArguments:
-          # End Continuous only
-
+          X86ReleaseCpp:
+            language: cpp
+            configuration: Release
+            platform: x86
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments:
+          X86ReleaseCs:
+            language: cs
+            configuration: Release
+            platform: x86
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments:
+          X64DebugCpp:
+            language: cpp
+            configuration: Debug
+            platform: x64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments:
+          X64DebugCs:
+            language: cs
+            configuration: Debug
+            platform: x64
+            projectType: app
+            additionalInitArguments:
+            additionalRunArguments:
           X86DebugCppLib:
             language: cpp
             configuration: Debug
@@ -122,7 +115,6 @@ jobs:
             projectType: lib
             additionalInitArguments:
             additionalRunArguments: --no-autolink --no-deploy
-
           X86DebugCppWinUI3:
             language: cpp
             configuration: Debug

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -39,14 +39,12 @@ jobs:
 
     strategy:
       matrix:
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          Arm64Debug:
-            BuildConfiguration: Debug
-            BuildPlatform: ARM64
-          Arm64Release:
-            BuildConfiguration: Release
-            BuildPlatform: ARM64
-        # End Continuous only
+        Arm64Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: ARM64
+        Arm64Release:
+          BuildConfiguration: Release
+          BuildPlatform: ARM64
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
@@ -56,12 +54,9 @@ jobs:
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          X86Release:
-            BuildConfiguration: Release
-            BuildPlatform: x86
-        # End Continuous only
+        X86Release:
+          BuildConfiguration: Release
+          BuildPlatform: x86
     pool: $(AgentPool.Medium)
     timeoutInMinutes: 60 # how long to run the job before automatically cancelling
     cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -13,11 +13,19 @@ parameters:
         Matrix:
           - Name: X64Chakra
             BuildPlatform: x64
-            DeployOptions: --deploy-from-layout
+            DeployOptions:
             UseHermes: false
           - Name: X64Hermes
             BuildPlatform: x64
-            DeployOptions: --deploy-from-layout
+            DeployOptions:
+            UseHermes: true
+          - Name: X86Chakra
+            BuildPlatform: x86
+            DeployOptions:
+            UseHermes: false
+          - Name: X86Hermes
+            BuildPlatform: x86
+            DeployOptions:
             UseHermes: true
       - BuildEnvironment: Continuous
         Matrix:

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -10,6 +10,11 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
+          - Name: Arm64Debug
+            BuildPlatform: ARM64
+            BuildConfiguration: Debug
+            DeployOptions: --no-deploy # We don't have Arm agents
+            UseHermes: false
           - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
@@ -17,6 +22,16 @@ parameters:
             UseHermes: false
           - Name: X64ReleaseHermes
             BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
+            UseHermes: true
+          - Name: X86WebDebug
+            BuildPlatform: x86
+            BuildConfiguration: Debug
+            DeployOptions:
+            UseHermes: false
+          - Name: X86ReleaseHermes
+            BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions: --deploy-from-layout # We avoid certs for AppX generation
             UseHermes: true

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -12,7 +12,7 @@ jobs:
       - template: ../variables/vs2019.yml
     displayName: Playground
     strategy:
-      matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
+      matrix:
         X86DebugUniversal:
           BuildConfiguration: Debug
           BuildPlatform: x86

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -14,22 +14,19 @@ jobs:
         value: $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
     displayName: Sample Apps
     strategy:
-      matrix: # Why we only build some flavors: https://github.com/microsoft/react-native-windows/issues/4308
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          Arm64Debug:
-            BuildConfiguration: Debug
-            BuildPlatform: ARM64
-            DeployOption: --no-deploy # We don't have Arm agents
-          Arm64Release:
-            BuildConfiguration: Release
-            BuildPlatform: ARM64
-            DeployOption: --no-deploy # We don't have Arm agents
-          X64Debug:
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            DeployOption:
-        # End Continuous only
+      matrix:
+        Arm64Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: ARM64
+          DeployOption: --no-deploy # We don't have Arm agents
+        Arm64Release:
+          BuildConfiguration: Release
+          BuildPlatform: ARM64
+          DeployOption: --no-deploy # We don't have Arm agents
+        X64Debug:
+          BuildConfiguration: Debug
+          BuildPlatform: x64
+          DeployOption:
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
@@ -38,13 +35,10 @@ jobs:
           BuildConfiguration: Debug
           BuildPlatform: x86
           DeployOption:
-        # Start Continuous only
-        ${{ if eq(parameters.buildEnvironment, 'Continuous') }}:
-          X86Release:
-            BuildConfiguration: Release
-            BuildPlatform: x86
-            DeployOption:
-        # End Continuous only
+        X86Release:
+          BuildConfiguration: Release
+          BuildPlatform: x86
+          DeployOption:
     timeoutInMinutes: 60
     cancelTimeoutInMinutes: 5
     pool: $(AgentPool.Medium)

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -10,6 +10,31 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
+            - Name: Arm64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: ARM64
+              FastBuild: false
+            - Name: Arm64Release
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+              FastBuild: false
+            - Name: X64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              FastBuild: false
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              FastBuild: false
+            - Name: X86Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              LayoutHeaders: true
+              FastBuild: false
+            - Name: X86Release
+              BuildConfiguration: Release
+              BuildPlatform: x86
+              FastBuild: false
             - Name: X64ReleaseFast
               BuildConfiguration: Release
               BuildPlatform: x64


### PR DESCRIPTION
This PR expands the matrix of build configurations for PRs by adding the
combinations that run in CI. This is to prevent PRs from passing and
then immediately failing in CI and/or publishing and breaking the stable
branch.

Related: #8851

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10052)