### PR TITLE
Fix floating point conversions in non en-US locales

### DIFF
--- a/change/react-native-windows-ea378e65-3e8c-4b6e-a90b-d9b4d862ed17.json
+++ b/change/react-native-windows-ea378e65-3e8c-4b6e-a90b-d9b4d862ed17.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make double-conversion FP conversions be locale-invariant",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/stubs/double-conversion/double-conversion.h
+++ b/vnext/stubs/double-conversion/double-conversion.h
@@ -128,12 +128,11 @@ class StringToDoubleConverter {
     // nyi();
   }
 
-  double StringToDouble(const char *s, int l, int *consumed) {
-    size_t idx = 0;
+  double StringToDouble(const char *buf, int length, int *consumed) {
     double d{};
-    auto ret = std::from_chars(s, s + l, d);
+    auto ret = std::from_chars(buf, buf + length, d);
     if (ret.ec == std::errc{}) {
-      *consumed = static_cast<int>(ret.ptr - s);
+      *consumed = static_cast<int>(ret.ptr - buf);
     } else {
       *consumed = 0;
       assert(false && "Conversion to double failed");
@@ -141,12 +140,11 @@ class StringToDoubleConverter {
     return d;
   }
 
-  float StringToFloat(const char *s, int l, int *consumed) {
-    size_t idx = 0;
+  float StringToFloat(const char *buf, int length, int *consumed) {
     float f{};
-    auto ret = std::from_chars(s, s + l, f);
+    auto ret = std::from_chars(buf, buf + length, f);
     if (ret.ec == std::errc{}) {
-      *consumed = static_cast<int>(ret.ptr - s);
+      *consumed = static_cast<int>(ret.ptr - buf);
     } else {
       *consumed = 0;
       assert(false && "Conversion to float failed");

--- a/vnext/stubs/double-conversion/double-conversion.h
+++ b/vnext/stubs/double-conversion/double-conversion.h
@@ -8,6 +8,7 @@
 
 #include <glog/logging.h>
 #include <sstream>
+#include <charconv>
 
 static inline void nyi() {
   int *a = nullptr;
@@ -129,17 +130,27 @@ class StringToDoubleConverter {
 
   double StringToDouble(const char *s, int l, int *consumed) {
     size_t idx = 0;
-    std::string str(s, l);
-    double d = std::stod(str.c_str(), &idx);
-    *consumed = static_cast<int>(idx);
+    double d{};
+    auto ret = std::from_chars(s, s + l, d);
+    if (ret.ec == std::errc{}) {
+      *consumed = static_cast<int>(ret.ptr - s);
+    } else {
+      *consumed = 0;
+      assert(false && "Conversion to double failed");
+    }
     return d;
   }
 
-  float StringToFloat(const char *buf, int length, int *consumed) {
+  float StringToFloat(const char *s, int l, int *consumed) {
     size_t idx = 0;
-    std::string str(buf, length);
-    float f = std::stof(str, &idx);
-    *consumed = static_cast<int>(idx);
+    float f{};
+    auto ret = std::from_chars(s, s + l, f);
+    if (ret.ec == std::errc{}) {
+      *consumed = static_cast<int>(ret.ptr - s);
+    } else {
+      *consumed = 0;
+      assert(false && "Conversion to float failed");
+    }
     return f;
   }
 };

--- a/vnext/stubs/double-conversion/double-conversion.h
+++ b/vnext/stubs/double-conversion/double-conversion.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <glog/logging.h>
-#include <sstream>
 #include <charconv>
+#include <sstream>
 
 static inline void nyi() {
   int *a = nullptr;


### PR DESCRIPTION
## Description
The current stub implementation we have for double-conversion is using strtod / stod which performs float/double conversions in a locale-dependent manner. This doesn't work for reading a number from json in locales that use different digit separators (e.g. in German you'd write "1,5"  instead of "1.5", so when we try to parse a json value via folly (which uses double-conversion), we error out when we find the . as it is not a valid separator).


### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
Apps should work in all locales :)

Resolves [to be filed]

### What
This uses `from_chars` which uses the C locale and in addition is a lot faster than strtod

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10058)