### PR TITLE
Native panel

### DIFF
--- a/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
+++ b/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
@@ -24,6 +24,7 @@
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.3</LangVersion>
+    <RunAutolinkCheck>false</RunAutolinkCheck>
   </PropertyGroup>
   <PropertyGroup Label="NuGet">
     <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>

--- a/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
+++ b/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
@@ -24,13 +24,18 @@
         "type": "Direct",
         "requested": "[0.11.0-ms.6, )",
         "resolved": "0.11.0-ms.6",
-        "contentHash": "7KGeDHh4QR4ua5+aSNAfuhj1sF2PBJbTHJ9m520xo1GZZRW4cxJlyNDNjW5t/sFGeHWw/Uhs7ZrWE2maL9BOEw=="
+        "contentHash": "WAVLsSZBV4p/3hNC3W67su7xu3f/ZMSKxu0ON7g2GaKRbkJmH0Qyif1IlzcJwtvR48kuOdfgPu7Bgtz3AY+gqg=="
       },
       "XamlTreeDump": {
         "type": "Direct",
         "requested": "[1.0.9, )",
         "resolved": "1.0.9",
         "contentHash": "rvh/RZghhSG28PDL1dw56nTZRN0/ViV2TIja/ykU9FHn0gtM8pwtgD8Ebo1nobu0QnSjn8Cg6Ncu39VV19rkrw=="
+      },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -57,6 +62,16 @@
         "type": "Transitive",
         "resolved": "2.1.0",
         "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+      },
+      "Microsoft.Windows.CppWinRT": {
+        "type": "Transitive",
+        "resolved": "2.0.211028.7",
+        "contentHash": "JBGI0c3WLoU6aYJRy9Qo0MLDQfObEp+d4nrhR95iyzf7+HOgjRunHDp/6eGFREd7xq3OI1mll9ecJrMfzBvlyg=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -134,10 +149,38 @@
         "contentHash": "qF6RRZKaflI+LR1YODNyWYjq5YoX8IJ2wx5y8O+AW2xO+1t/Q6Mm+jQ38zJbWnmXbrcOqUYofn7Y3/KC6lTLBQ=="
       },
       "automationchannel": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.ReactNative": "1.0.0",
+          "Microsoft.UI.Xaml": "2.7.0",
+          "Microsoft.Windows.CppWinRT": "2.0.211028.7"
+        }
+      },
+      "common": {
         "type": "Project"
       },
-      "microsoft.reactnative": {
+      "fmt": {
         "type": "Project"
+      },
+      "folly": {
+        "type": "Project",
+        "dependencies": {
+          "boost": "1.76.0",
+          "fmt": "1.0.0"
+        }
+      },
+      "microsoft.reactnative": {
+        "type": "Project",
+        "dependencies": {
+          "Common": "1.0.0",
+          "Folly": "1.0.0",
+          "Microsoft.UI.Xaml": "2.7.0",
+          "Microsoft.Windows.CppWinRT": "2.0.211028.7",
+          "Microsoft.Windows.SDK.BuildTools": "10.0.22000.194",
+          "ReactCommon": "1.0.0",
+          "ReactNative.Hermes.Windows": "0.11.0-ms.6",
+          "boost": "1.76.0"
+        }
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
@@ -146,16 +189,25 @@
           "Microsoft.ReactNative": "1.0.0"
         }
       },
+      "reactcommon": {
+        "type": "Project",
+        "dependencies": {
+          "Folly": "1.0.0",
+          "boost": "1.76.0"
+        }
+      },
       "reactnativepicker": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "1.0.0"
+          "Microsoft.ReactNative": "1.0.0",
+          "Microsoft.UI.Xaml": "2.7.0"
         }
       },
       "reactnativexaml": {
         "type": "Project",
         "dependencies": {
-          "Microsoft.ReactNative": "1.0.0"
+          "Microsoft.ReactNative": "1.0.0",
+          "Microsoft.UI.Xaml": "2.7.0"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -58,7 +58,7 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
+        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
@@ -83,7 +83,7 @@
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -325,6 +325,19 @@ void ViewManagerBase::NotifyUnimplementedProperty(
 #endif // DEBUG
 }
 
+static xaml::DependencyObject UnwrapNativeView(xaml::DependencyObject o) {
+  if (auto grid = o.try_as<xaml::Controls::Grid>()) {
+    if (grid.Children().Size() == 1) {
+      if (auto panel = grid.Children().GetAt(0).try_as<winrt::Microsoft::ReactNative::NativeMeasuringPanel>()) {
+        if (panel.Children().Size() == 1) {
+          return panel.Children().GetAt(0);
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
 void ViewManagerBase::SetLayoutProps(
     ShadowNodeBase &nodeToUpdate,
     const XamlView &viewToUpdate,
@@ -341,6 +354,10 @@ void ViewManagerBase::SetLayoutProps(
         return;
       }
     }
+  }
+
+  if (auto unwrapped = UnwrapNativeView(viewToUpdate)) {
+    auto cn = winrt::get_class_name(unwrapped);
   }
 
   auto element = viewToUpdate.as<xaml::UIElement>();

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -53,4 +53,12 @@ namespace Microsoft.ReactNative
 
     ViewPanel GetPanel();
   }
+
+    
+  [default_interface]
+  [webhosthidden]
+  runtimeclass NativeMeasuringPanel : XAML_NAMESPACE.Controls.Grid {
+    NativeMeasuringPanel();
+  }
+
 }


### PR DESCRIPTION
In order to support layout/size changes coming from XAML (e.g. Expander gets expanded) and have it reflow through Yoga, we need a notification to be fired when the element's measure changes. 
That notification doesn't exist but we can wrap the native XAML control in a custom Panel, where we can use the MeasureOverride override to mark the corresponding yoga node as dirty and trigger a Yoga re-layout. 

However, the problem is that this panel would have its width/height set by the Yoga layout pass. As a result, XAML will not call MeasureOverride (if W/H are set, you don't need to be notified, you'll be that size!). 

To work around that, we need a second outer panel, which gets the W/H set, and hosts the panel with the notification code:

```xml
<NativeHostPanel Width="200" Height="48">
  <NativeMeasuringPanel>
    <Expander />
  </NativeMeasuringPanel>
</NativeHostPanel>
```
the Width/Height in the outermost panel will be set by Yoga based on its desired size.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10063)