### PR TITLE
Fix invalid code in JSValueWriter.h

### DIFF
--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -287,7 +287,7 @@ inline JSValueArgWriter MakeJSValueWriter(T &&argWriter) noexcept {
 
 template <class... TArgs>
 inline JSValueArgWriter MakeJSValueWriter(TArgs &&...args) noexcept {
-  return [&args...](IJSValueWriter const &[[maybe_unused]] writer) noexcept { (WriteValue(writer, args), ...); };
+  return [&args...]([[maybe_unused]] IJSValueWriter const & writer) noexcept { (WriteValue(writer, args), ...); };
 }
 
 } // namespace winrt::Microsoft::ReactNative


### PR DESCRIPTION
This code is invalid and breaks the Office build.

https://developercommunity.visualstudio.com/t/accepts-invalid-MSVC-accepts-attribute/10051607?space=62&scope=follow&sort=newest

D:\dbs\el\odm\Import\x64\debug\mso\x-none\x64\opensource_reactnative\x-none\include\Microsoft.ReactNative.Cxx\JSValueWriter.h(290,45): error: 'maybe_unused' attribute cannot be applied to types
  return [&args...](IJSValueWriter const &[[maybe_unused]] writer) noexcept { (WriteValue(writer, args), ...); };
                                            ^

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10078)