### PR TITLE
Do not use Blob/FileReader modules in UWP

### DIFF
--- a/change/react-native-windows-d4179584-e159-44b9-b6fe-c1f4c00e8004.json
+++ b/change/react-native-windows-d4179584-e159-44b9-b6fe-c1f4c00e8004.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not use Blob/FileReader modules on UWP",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -28,6 +28,7 @@ TEST_MODULE_INITIALIZE(InitModule) {
   SetRuntimeOptionBool("WebSocket.AcceptSelfSigned", true);
   SetRuntimeOptionBool("UseBeastWebSocket", false);
   SetRuntimeOptionBool("Http.UseMonolithicModule", false);
+  SetRuntimeOptionBool("Blob.EnableModule", true);
 
   // WebSocketJSExecutor can't register native log hooks.
   SetRuntimeOptionBool("RNTester.UseWebDebugger", false);

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -92,7 +92,7 @@
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -104,8 +104,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.11.0-ms.6",
-        "contentHash": "WAVLsSZBV4p/3hNC3W67su7xu3f/ZMSKxu0ON7g2GaKRbkJmH0Qyif1IlzcJwtvR48kuOdfgPu7Bgtz3AY+gqg=="
+        "resolved": "0.12.1",
+        "contentHash": "0yjt0Y2pNfqw7qUiV5Q3W8hZ2HuS3HiS135c/ILLXeRXLpQMmfq1NS3oBZ1oMZy94gSfgP9QZ/862T3qUTES1A=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -315,7 +315,7 @@
           "Microsoft.Windows.CppWinRT": "2.0.211028.7",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22000.194",
           "ReactCommon": "1.0.0",
-          "ReactNative.Hermes.Windows": "0.11.0-ms.6",
+          "ReactNative.Hermes.Windows": "0.12.1",
           "boost": "1.76.0"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -83,15 +83,15 @@
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.11.0-ms.6",
-        "contentHash": "WAVLsSZBV4p/3hNC3W67su7xu3f/ZMSKxu0ON7g2GaKRbkJmH0Qyif1IlzcJwtvR48kuOdfgPu7Bgtz3AY+gqg=="
+        "resolved": "0.12.1",
+        "contentHash": "0yjt0Y2pNfqw7qUiV5Q3W8hZ2HuS3HiS135c/ILLXeRXLpQMmfq1NS3oBZ1oMZy94gSfgP9QZ/862T3qUTES1A=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -182,7 +182,7 @@
           "Microsoft.Windows.CppWinRT": "2.0.211028.7",
           "Microsoft.Windows.SDK.BuildTools": "10.0.22000.194",
           "ReactCommon": "1.0.0",
-          "ReactNative.Hermes.Windows": "0.11.0-ms.6",
+          "ReactNative.Hermes.Windows": "0.12.1",
           "boost": "1.76.0"
         }
       },

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -618,20 +618,20 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
       []() { return std::make_unique<StatusBarManagerModule>(); },
       nativeQueue));
 
-// #10036 - Blob module not supported in UWP. Need to define property bag lifetime and onwership.
-#if (defined(_MSC_VER) && !defined(WINRT))
-  modules.push_back(std::make_unique<CxxNativeModule>(
-      m_innerInstance,
-      Microsoft::React::GetBlobModuleName(),
-      [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
-      nativeQueue));
+  // #10036 - Blob module not supported in UWP. Need to define property bag lifetime and onwership.
+  if (Microsoft::React::GetRuntimeOptionBool("Blob.EnableModule")) {
+    modules.push_back(std::make_unique<CxxNativeModule>(
+        m_innerInstance,
+        Microsoft::React::GetBlobModuleName(),
+        [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
+        nativeQueue));
 
-  modules.push_back(std::make_unique<CxxNativeModule>(
-      m_innerInstance,
-      Microsoft::React::GetFileReaderModuleName(),
-      [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
-      nativeQueue));
-#endif
+    modules.push_back(std::make_unique<CxxNativeModule>(
+        m_innerInstance,
+        Microsoft::React::GetFileReaderModuleName(),
+        [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
+        nativeQueue));
+  }
 
   return modules;
 }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -618,6 +618,8 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
       []() { return std::make_unique<StatusBarManagerModule>(); },
       nativeQueue));
 
+// #10036 - Blob module not supported in UWP. Need to define property bag lifetime and onwership.
+#if (defined(_MSC_VER) && !defined(WINRT))
   modules.push_back(std::make_unique<CxxNativeModule>(
       m_innerInstance,
       Microsoft::React::GetBlobModuleName(),
@@ -629,6 +631,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
       Microsoft::React::GetFileReaderModuleName(),
       [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
       nativeQueue));
+#endif
 
   return modules;
 }


### PR DESCRIPTION
## Description
Do not add BlobModule nor FileReaderModule to the default CxxModule list when running a UWP MSRN instance.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Undefined object sharing behavior in UWP (as opposed to Desktop) will cause a malfunction of HTTP/fetch workflows due to a misconfigured Blob module.

Resolves #10036

### What
- Conditionally compile the code that adds `BlobModule` and `FileReaderModule` to the default modules' list in the `InstanceImpl` class.
- Defined `Blob.EnableModule` runtime option.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10079)