### PR TITLE
Fixed metro config when using `--useDevMode`

### DIFF
--- a/change/react-native-windows-53a5b9fa-249c-4cf1-bf1f-f18b7d6be767.json
+++ b/change/react-native-windows-53a5b9fa-249c-4cf1-bf1f-f18b7d6be767.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed metro config when using `--useDevMode`",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/metro.devMode.config.js
+++ b/vnext/template/metro.devMode.config.js
@@ -1,2 +1,49 @@
-const {makeMetroConfig} = require('@rnw-scripts/metro-dev-config');
-module.exports = makeMetroConfig();
+/**
+ * Metro configuration for React Native
+ * https://github.com/facebook/react-native
+ *
+ * @format
+ */
+const fs = require('fs');
+const path = require('path');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
+
+const rnwPath = fs.realpathSync(
+  path.resolve(require.resolve('react-native-windows/package.json'), '..'),
+);
+
+// [devMode
+const rnwRootNodeModules = path.resolve(rnwPath, '..', 'node_modules');
+const rnwPackages = path.resolve(rnwPath, '..', 'packages');
+// devMode]
+
+module.exports = {
+  // [devMode
+  watchFolders: [rnwPath, rnwRootNodeModules, rnwPackages],
+  // devMode]
+  resolver: {
+    blockList: exclusionList([
+      // This stops "react-native run-windows" from causing the metro server to crash if its already running
+      new RegExp(
+        `${path.resolve(__dirname, 'windows').replace(/[/\\]/g, '/')}.*`,
+      ),
+      // This prevents "react-native run-windows" from hitting: EBUSY: resource busy or locked, open msbuild.ProjectImports.zip or other files produced by msbuild
+      new RegExp(`${rnwPath}/build/.*`),
+      new RegExp(`${rnwPath}/target/.*`),
+      /.*\.ProjectImports\.zip/,
+    ]),
+    // [devMode
+    extraNodeModules: {
+      'react-native-windows': rnwPath,
+    },
+    // devMode]
+  },
+  transformer: {
+    getTransformOptions: async () => ({
+      transform: {
+        experimentalImportSupport: false,
+        inlineRequires: true,
+      },
+    }),
+  },
+};


### PR DESCRIPTION
## Description

When calling `react-native-windows-init --useDevMode`, it created metro config similar to the ones used by packages within the RNW monorepo. However, that config is only useful when running init to create new test apps within this repo, which is a rare occurrence.

This PR changes the dev mode metro config to instead work when testing how the CLI commands work while creating new projects outside of the repo, which is much more useful.

Closes #9691

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

This fixes the issue with metro not working when testing a new app created using `--useDevMode`.

### What
This PR changes the dev mode metro config to instead work when testing how the CLI commands work while creating new projects outside of the repo, which is much more useful.

## Testing

Tested locally that `run-windows` works properly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10082)