### PR TITLE
Use ProcDump to capture crash dumps in CI pipelines

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -61,12 +61,6 @@ jobs:
                 Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
               displayName: Set BuildLogDirectory
 
-            - task: CmdLine@2
-              displayName: Set LocalDumps
-              inputs:
-                script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd RNTesterApp
-                workingDirectory: $(Build.SourcesDirectory)
-
             - task: PowerShell@2
               displayName: Start tracing
               inputs:
@@ -133,20 +127,19 @@ jobs:
               condition: failed()
 
             - task: PublishPipelineArtifact@1
-              displayName: "Publish Artifact:RNTesterApp"
+              displayName: "Publish Artifact: RNTesterApp"
               inputs:
-                artifactName: RNTesterApp-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+                artifactName: RNTesterApp-${{ matrix.Name }}-$(System.JobAttempt)
                 targetPath: $(Build.StagingDirectory)/RNTesterApp
               condition: failed()
 
             - task: PublishPipelineArtifact@1
-              displayName: "Publish Artifact:Snapshots"
+              displayName: "Publish Artifact: Snapshots"
               inputs:
-                artifactName: Snapshots-${{ matrix.BuildPlatform }}-$(System.JobAttempt)
+                artifactName: Snapshots - RNTesterApp-${{ matrix.Name }}-$(System.JobAttempt)
                 targetPath: $(Build.StagingDirectory)/snapshots
               condition: failed()
 
             - template: ../templates/upload-build-logs.yml
               parameters:
                 buildLogDirectory: '$(BuildLogDirectory)'
-                condition: succeededOrFailed()

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -71,9 +71,6 @@ jobs:
                 Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ matrix.BuildPlatform }}\BuildLogs"
               displayName: Set BuildLogDirectory
 
-            - script: .ado\scripts\SetupLocalDumps.cmd integrationtest
-              displayName: Set LocalDumps
-
             - task: PowerShell@2
               displayName: Start tracing
               inputs:
@@ -185,4 +182,3 @@ jobs:
             - template: ../templates/upload-build-logs.yml
               parameters:
                 buildLogDirectory: '$(BuildLogDirectory)'
-                condition: succeededOrFailed()

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -147,41 +147,51 @@ jobs:
                   msbuildArgs:
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
 
-            # Execute debug feature tests
-            #
-            # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
-            # of debug feature tests. In the future, these tests should be performed against a host app
-            # better suited for automated tests (probably the E2E test app).
-            - powershell: |
-                $appRecipeToolPath = Join-Path (Get-CimInstance MSFT_VSInstance | Sort-Object -Property 'Version' -Descending)[0].InstallLocation "Common7\IDE\DeployAppRecipe.exe"
-                if (!(Test-Path $appRecipeToolPath)) { throw "can't find '$appRecipeToolPath'" }
-                $platDirs = @{ "x64" = "x64\"; "x86" = ""} # map from ADO BuildPlatform arg to VS build output dir part 
-                $appRecipePath = "$(Build.SourcesDirectory)\packages\playground\windows\$($platDirs['${{ matrix.BuildPlatform }}'])${{ matrix.BuildConfiguration }}\playground\playground.build.appxrecipe"
-                if (!(Test-Path $appRecipePath)) { throw "can't find '$appRecipePath'" }
-                &$appRecipeToolPath $appRecipePath
-                if (!(Get-AppxPackage 'RNPlayground')) {throw "RNPlayground app does not appear to be installed"}
-                Set-Location "$(Build.SourcesDirectory)\packages\debug-test"
-                $env:DEBUGTEST_LOGFOLDER = "$($env:AGENT_TEMPDIRECTORY)\DebugTestLogs"
-                yarn debugtest
-              displayName: Run Debug Feature Tests
-              # skip this step for the Win32 Playground app and for release builds
-              condition: and(endsWith('${{ matrix.Name }}', 'Universal'), eq('${{ matrix.BuildConfiguration }}', 'Debug'))
-              timeoutInMinutes: 5
+            - ${{if and(endsWith(matrix.Name, 'Universal'), eq(matrix.BuildConfiguration, 'Debug')) }}:
+              # Execute debug feature tests (skip this step for the Win32 Playground app and for release builds)
+              
+              # Need to re-setup ProcDump a 2nd time for this to work correctly
+              - powershell: |
+                    Write-Host "##vso[task.setvariable variable=CrashDumpRootPath]$(Build.StagingDirectory)\DebugTestCrashDumps"
+                    New-Item -Path '$(Build.StagingDirectory)\DebugTestCrashDumps' -ItemType Directory
+                displayName: Set CrashDumpRootPath
 
-            - powershell: |
-                foreach ($logFile in (ls "$env:AGENT_TEMPDIRECTORY\DebugTestLogs\*.log")) {
-                  Write-Host "logFile: '$logFile'"
-                  Get-Content $logFile | ForEach-Object {Write-Host "##[debug]$_"}
-                }
-              displayName: Incorporate Log File Content into ADO Log Stream
-              condition: failed()
+              - task: PowerShell@2
+                displayName: Setup ProcDump as AeDebug
+                inputs:
+                  targetType: filePath # filePath | inline
+                  filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
+                  arguments: "-ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose"
 
-            - task: PublishBuildArtifacts@1
-              displayName: Publish Debug Test Logs
-              condition: failed()
-              inputs:
-                pathToPublish: '$(Agent.TempDirectory)\DebugTestLogs'
-                artifactName: Debug Test Logs
+              # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
+              # of debug feature tests. In the future, these tests should be performed against a host app
+              # better suited for automated tests (probably the E2E test app).
+              - powershell: |
+                  $appRecipeToolPath = Join-Path (Get-CimInstance MSFT_VSInstance | Sort-Object -Property 'Version' -Descending)[0].InstallLocation "Common7\IDE\DeployAppRecipe.exe"
+                  if (!(Test-Path $appRecipeToolPath)) { throw "can't find '$appRecipeToolPath'" }
+                  $platDirs = @{ "x64" = "x64\"; "x86" = ""} # map from ADO BuildPlatform arg to VS build output dir part 
+                  $appRecipePath = "$(Build.SourcesDirectory)\packages\playground\windows\$($platDirs['${{ matrix.BuildPlatform }}'])${{ matrix.BuildConfiguration }}\playground\playground.build.appxrecipe"
+                  if (!(Test-Path $appRecipePath)) { throw "can't find '$appRecipePath'" }
+                  &$appRecipeToolPath $appRecipePath
+                  if (!(Get-AppxPackage 'RNPlayground')) {throw "RNPlayground app does not appear to be installed"}
+                  Set-Location "$(Build.SourcesDirectory)\packages\debug-test"
+                  $env:DEBUGTEST_LOGFOLDER = "$(Build.StagingDirectory)\DebugTestLogs"
+                  yarn debugtest
+                displayName: Run Debug Feature Tests
+                timeoutInMinutes: 5
+
+              - powershell: |
+                  foreach ($logFile in (ls "$(Build.StagingDirectory)\DebugTestLogs\*.log")) {
+                    Write-Host "logFile: '$logFile'"
+                    Get-Content $logFile | ForEach-Object {Write-Host "##[debug]$_"}
+                  }
+                displayName: Incorporate Log File Content into ADO Log Stream
+                condition: failed()
+
+              - template: ../templates/upload-build-logs.yml
+                parameters:
+                  artifactName: 'DebugTest $(Agent.JobName)-$(System.JobAttempt)'
+                  buildLogDirectory: '$(Build.StagingDirectory)\DebugTestLogs'
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/cleanup-certificate.yml
@@ -191,10 +201,5 @@ jobs:
                 displayName: Upload App Package
                 inputs:
                   pathtoPublish: 'packages/playground/windows/AppPackages/playground'
-                  artifactName: 'Playground ${matrix.Name} AppX Package (Attempt $(System.JobAttempt))'
-
-            - task: PublishBuildArtifacts@1
-              displayName: Upload crash dumps
-              inputs:
-                pathtoPublish: '$(Build.StagingDirectory)/CrashDumps/'
-                artifactName: 'Playground ${matrix.Name} Crash Dumps (Attempt $(System.JobAttempt))'
+                  artifactName: 'Playground-${{ matrix.Name }}-$(System.JobAttempt)'
+                condition: succeededOrFailed()

--- a/.ado/scripts/RunProcDump.ps1
+++ b/.ado/scripts/RunProcDump.ps1
@@ -1,0 +1,54 @@
+# RunProcDump.ps1 [Args]
+# Ex: .\RunProcDump.ps1 @('-ma', '-e', '-x', 'C:\WER\UserDumps', 'RNTesterApp_8wekyb3d8bbwe!App')
+# Ex: .\RunProcDump.ps1 @('-mm', '-i', 'C:\WER\UserDumps') -Verbose
+# 
+# This script downloads and runs the ProcDump tool with the given arguments.
+
+param(
+    [Parameter(Mandatory=$true)]
+    [String[]]$ProcDumpArgs,
+    [string]$ProcDumpInstallPath = "$env:TEMP\ProcDump",
+    [string]$ProcDumpExe = "procdump64.exe",
+    [string]$ProcDumpUrl = "https://download.sysinternals.com/files/Procdump.zip"
+)
+
+function Get-ProcDump64Path {
+    Write-Verbose "Looking for $ProcDumpExe in path...";
+    try {
+        [string]$procDumpPath = (Get-Command $ProcDumpExe -ErrorAction Stop).Path;
+        Write-Verbose "$ProcDumpExe already in path at $procDumpPath";
+        return $procDumpPath;
+    } catch {
+        Write-Debug $_
+    }
+
+    [string]$procDumpZipPath = "$env:TEMP\Procdump.zip";
+
+    Write-Verbose "$ProcDumpExe not in path, downloading zip to $procDumpZipPath...";
+    Invoke-WebRequest -UseBasicParsing $ProcDumpUrl -OutFile $procDumpZipPath;
+
+    [string]$procDumpOutPath = "$ProcDumpInstallPath";
+    Write-Verbose "Unzipping archive...";
+    Expand-Archive $procDumpZipPath -DestinationPath $procDumpOutPath -Force;
+
+    [string]$procDumpPath = Join-Path $procDumpOutPath $ProcDumpExe;
+    if (Test-Path $procDumpPath) {
+        Write-Verbose "$ProcDumpExe installed to $procDumpPath";
+        return $procDumpPath;
+    }
+    
+    throw "Unable to find and/or install $ProcDumpExe";
+}
+
+try {
+    Write-Host "Looking for $ProcDumpExe...";
+    [string]$procDumpPath = Get-ProcDump64Path;
+
+    Write-Host "Running ProcDump...";
+    & $procDumpPath -accepteula $ProcDumpArgs;
+
+    exit 0;
+} catch {
+    Write-Debug $_
+    exit 1;
+}

--- a/.ado/scripts/SetupLocalDumps.cmd
+++ b/.ado/scripts/SetupLocalDumps.cmd
@@ -1,14 +1,37 @@
-setlocal
-if "%1"=="" (echo Must provide an executable name to set up local crash dumps for && exit /b 1)
-if "%BUILD_ARTIFACTSTAGINGDIRECTORY%"=="" (echo BUILD_ARTIFACTSTAGINGDIRECTORY must be set to the artifact staging directory && exit /b 2)
+@echo off
+REM SetupLocalDumps.cmd [ExecutableName] [DumpFolder]
+REM Ex: .\SetupLocalDumps.cmd RNTesterApp C:\WER\UserDumps
+REM
+REM This script sets the registry so that, if an executable of the given name crashes, to
+REM prevent any automatic debugger from attaching, and instead save a full crash dump to
+REM the given folder.
 
-set CRASHDUMPS_FOLDER=%BUILD_ARTIFACTSTAGINGDIRECTORY%\CrashDumps
-reg add  "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpFolder /t REG_SZ /d %CRASHDUMPS_FOLDER%
+setlocal
+
+if "%1"=="" (
+    @echo Must provide an executable name to set up local crash dumps
+    exit /b 1
+)
+if "%2"=="" (
+    @echo Must provide a writable folder to save local crash dumps
+    exit /b 1
+)
+
+set CRASHDUMPS_FOLDER=%2
+@echo Configuring registry to save "%1.exe" crash dumps to "%CRASHDUMPS_FOLDER%"...
+reg add  "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpFolder /t REG_EXPAND_SZ /d %CRASHDUMPS_FOLDER%
 reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpType /t REG_DWORD /d 2
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /v DumpCount /t REG_DWORD /d 3
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\AutoExclusionList" /v %1.exe  /t REG_DWORD /d 1
 if not exist %CRASHDUMPS_FOLDER% (
+    @echo Creating %CRASHDUMPS_FOLDER%
     md %CRASHDUMPS_FOLDER%
 )
 
-reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" /s
+@echo Registry configuration:
+reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\%1.exe" /s
+reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug\AutoExclusionList"
 
 endlocal
+
+exit /b %ERRORLEVEL%

--- a/.ado/templates/cleanup-certificate.yml
+++ b/.ado/templates/cleanup-certificate.yml
@@ -4,3 +4,4 @@ steps:
       Write-Host $PfxPath
       Remove-Item -path $PfxPath
     displayName: Remove Certificate
+    condition: succeededOrFailed()

--- a/.ado/templates/prepare-build-env.yml
+++ b/.ado/templates/prepare-build-env.yml
@@ -35,18 +35,29 @@ steps:
       configuration: ${{ parameters.configuration }}
       buildEnvironment: ${{ parameters.buildEnvironment }}
 
-  - script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd cl
-    displayName: Set LocalDumps for cl.exe
-    workingDirectory: $(Build.SourcesDirectory)
-
-  - script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd link
-    displayName: Set LocalDumps for link.exe
-    workingDirectory: $(Build.SourcesDirectory)
-
-  - script: $(Build.SourcesDirectory)\.ado\scripts\SetupLocalDumps.cmd msbuild
-    displayName: Set LocalDumps for msbuild.exe
-    workingDirectory: $(Build.SourcesDirectory)
+  - powershell: |
+        & reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /s
+        & reg query "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /s
+        & reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\AeDebug" /s
+        Enable-WindowsErrorReporting
+    displayName: Check and enable Windows Error Reporting
 
   - powershell: |
-        Write-Host "##vso[task.setvariable variable=MSBUILDDEBUGPATH]$(Build.StagingDirectory)\CrashDumps"
+        Write-Host "##vso[task.setvariable variable=CrashDumpRootPath]$(Build.StagingDirectory)\CrashDumps"
+        New-Item -Path '$(Build.StagingDirectory)\CrashDumps' -ItemType Directory
+    displayName: Set CrashDumpRootPath
+
+  - powershell: |
+        Write-Host "##vso[task.setvariable variable=MSBUILDDEBUGPATH]$(CrashDumpRootPath)"
     displayName: Set MSBUILDDEBUGPATH
+
+  - powershell: |
+        Write-Host "##vso[task.setvariable variable=ProcDumpPath]$(Build.StagingDirectory)\Procdump"
+    displayName: Set ProcDumpPath
+
+  - task: PowerShell@2
+    displayName: Setup ProcDump as AeDebug
+    inputs:
+      targetType: filePath # filePath | inline
+      filePath: $(Build.SourcesDirectory)\.ado\scripts\RunProcDump.ps1
+      arguments: "-ProcDumpArgs @('-mm', '-i', '$(CrashDumpRootPath)') -ProcDumpInstallPath '$(ProcDumpPath)' -Verbose"

--- a/.ado/templates/upload-build-logs.yml
+++ b/.ado/templates/upload-build-logs.yml
@@ -1,25 +1,51 @@
 parameters:
+  artifactName: $(Agent.JobName)-$(System.JobAttempt)
   buildLogDirectory: $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
+  uploadBuildLogs: true
+  uploadCrashDumps: true
 
 steps:
   - task: PublishBuildArtifacts@1
     displayName: Upload build logs
-    condition:  succeededOrFailed()
+    condition:  and(succeededOrFailed(), ${{ parameters.uploadBuildLogs }})
     inputs:
       pathtoPublish: '${{ parameters.buildLogDirectory }}'
-      artifactName: 'Build logs - $(Agent.JobName)-$(System.JobAttempt)'
+      artifactName: 'Build logs - ${{ parameters.artifactName }}'
 
-  - task: CmdLine@2
-    displayName: dir CrashDumps
+  - task: PowerShell@2
+    displayName: Cleanup ProcDump
+    condition:  succeededOrFailed()
     inputs:
-      script: dir $(Build.StagingDirectory)\CrashDumps /s
-      failOnStderr: false
-    condition:  failed()
-
+      targetType: inline # filePath | inline
+      script: |
+        Write-Host "Looking for procdump64 processes...";
+        Get-Process | ForEach-Object {
+          if ($_.ProcessName -eq 'procdump64') {
+            try {
+              Write-Host "Waiting on process $($_.Id)...";
+              Wait-Process -Id $_.Id -Timeout 360;
+            } catch { }
+          }
+        }
+        if (Test-Path '$(ProcDumpPath)') {
+          Write-Host "Uninstalling ProcDump as AeDebug";
+          & $(ProcDumpPath)\procdump64.exe -u
+        }
+  
+  - task: PowerShell@2
+    displayName: List crash dumps
+    condition:  and(succeededOrFailed(), ${{ parameters.uploadCrashDumps }})
+    inputs:
+      targetType: inline # filePath | inline
+      script: |
+        Write-Host "Looking for crash dumps in $(CrashDumpRootPath)...";
+        Get-ChildItem -Path $(CrashDumpRootPath) -File -Recurse;
+        $HasCrashDumps = (Get-ChildItem -Path $(CrashDumpRootPath) -File -Recurse | Measure-Object).Count -gt 0;
+        Write-Host "##vso[task.setvariable variable=HasCrashDumps]$HasCrashDumps";
 
   - task: PublishBuildArtifacts@1
     displayName: Upload crash dumps
+    condition: and(succeededOrFailed(), ${{ parameters.uploadCrashDumps }}, eq(variables.HasCrashDumps, 'True'))
     inputs:
-      pathtoPublish: '$(Build.StagingDirectory)/CrashDumps'
-      artifactName: 'Crash dumps - $(Agent.JobName)-$(System.JobAttempt)'
-    condition: failed()
+      pathtoPublish: '$(CrashDumpRootPath)'
+      artifactName: 'Crash dumps - ${{ parameters.artifactName }}'

--- a/packages/integration-test-app/windows/integrationtest/Package.appxmanifest
+++ b/packages/integration-test-app/windows/integrationtest/Package.appxmanifest
@@ -7,7 +7,7 @@
   IgnorableNamespaces="uap mp">
 
   <Identity
-    Name="7889084a-58b3-490f-9d1c-2abf27e2edb4"
+    Name="integrationtest"
     Publisher="CN=react-native-windows-testing"
     Version="1.0.0.0" />
 


### PR DESCRIPTION
## Description

This PR fixes the capturing of crash dumps of (UWP) applications run
during CI, specifically for the `e2e-test-app`, `playground` and the
`integration-test-app` test apps.

The standard method of capturing local dumps is to set the appropriate
registry keys for Windows Error Reporting to create the dumps in a local
directory. This is what our `SetupLocalDumps.cmd` script sets up for us.

However, this does not work on Azure DevOps machines. I suspect this is
due to a conflict with either the Datacenter/Azure Windows Server
images, or in how the Azure Watson service works, which uploads
crash dumps from ADO machines in an anonymized way MSFT.

No amount of configuring WER, disabling auto-debuggers, analyzing the
Windows Event Log, etc. has worked for trying to get WER to save local
crash dumps we can upload as build artifacts.

To get around all that, I've added a `RunProcDump.ps1` script which
downloads and sets up the ProcDump utility as the AeDebugger to capture
crash dumps instead. This is the *only* solution I've found that works on
ADO machines.

Closes #9037

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We want crash dumps to help debug failures that only repro in CI.

Closes #9037

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10087)