### PR TITLE
Use logical OR to assert HTTP responseType

### DIFF
--- a/change/react-native-windows-1653495d-e9db-497e-a6e2-bb5fbcc05317.json
+++ b/change/react-native-windows-1653495d-e9db-497e-a6e2-bb5fbcc05317.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use logical OR to assert HTTP responseType",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -68,7 +68,7 @@ void WinRTHttpResource::SendRequest(
     bool withCredentials,
     std::function<void(int64_t)> &&callback) noexcept /*override*/ {
   // Enforce supported args
-  assert(responseType == "text" || responseType == "base64" | responseType == "blob");
+  assert(responseType == "text" || responseType == "base64" || responseType == "blob");
 
   if (callback) {
     callback(requestId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,13 +1957,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-picker/picker/-/picker-2.2.0.tgz#e96ecc0808bdf2a706a263b422864bee5a0e6b76"
   integrity sha512-zhzXsppY9t6TU39WMx/x1L1PyP3dPgGhtav7Yo8nlfihNGIAFwHnNcNuyC8CLdWxKj9n2+Z6+ZR6r/Kda82JnA==
 
-"@react-native-windows/virtualized-list@0.0.0-canary.43":
-  version "0.0.0-canary.43"
-  resolved "https://registry.yarnpkg.com/@react-native-windows/virtualized-list/-/virtualized-list-0.0.0-canary.43.tgz#276fbc01cb7fdfa722207140dd92bd302ae69fe6"
-  integrity sha512-/z96pncNhoBgffrLcEtA4SvrrdC+AguuzLf0P25/KqFdIfhsD6gU6ywb8nN8GYQeTHEXhMdfwUhT3g39Bp6e/w==
-  dependencies:
-    invariant "^2.2.4"
-
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
- Use logical OR to assert HTTP responseType

## Description
Trivial change. Debug-only.

Use logical OR to assert HTTP responseType

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Assert (debug-only) that ensures the correct response types in HTTP resource uses a bit-wise OR instead of the expected logical OR `||`.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10095)