### PR TITLE
Fix use of [[maybe_unused]] attribute

### DIFF
--- a/change/react-native-windows-3914f431-df32-466b-8f29-1f0db9176a75.json
+++ b/change/react-native-windows-3914f431-df32-466b-8f29-1f0db9176a75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix use of [[maybe_unused]] attribute",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -287,7 +287,7 @@ inline JSValueArgWriter MakeJSValueWriter(T &&argWriter) noexcept {
 
 template <class... TArgs>
 inline JSValueArgWriter MakeJSValueWriter(TArgs &&...args) noexcept {
-  return [&args...](IJSValueWriter const &[[maybe_unused]] writer) noexcept { (WriteValue(writer, args), ...); };
+  return [&args...]([[maybe_unused]] IJSValueWriter const &writer) noexcept { (WriteValue(writer, args), ...); };
 }
 
 } // namespace winrt::Microsoft::ReactNative


### PR DESCRIPTION
## Description

Fix use of `[[maybe_unused]]` attribute.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

The `[[maybe_unused]]` attribute was in a wrong place in that breaks code compilation by Clang compiler.

### What

This PR adds a change file to the code originally published as PR #10078.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10103)