### PR TITLE
Fix BinSkim analysis not running for Universal

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -156,7 +156,7 @@
 
                 - task: BinSkim@3
                   displayName: Run Binskim Analysis
-                  condition: and(succeeded(), eq('${{ matrix.BuildConfiguration }}', 'Release'), eq('${{ matrix.FastBuild }}', 'false'), ne('${{ matrix.BuildPlatform }}', 'ARM64'))
+                  condition: and(succeeded(), eq('${{ matrix.BuildConfiguration }}', 'Release'), ne('${{ matrix.BuildPlatform }}', 'ARM64'))
                   inputs:
                       InputType: 'Basic'
                       Function: 'analyze'


### PR DESCRIPTION
## Description
While looking into the issues with binskim in Desktop, I realized binskim was no longer running for universal. Looks like https://github.com/microsoft/react-native-windows/pull/9017/files removed the `FastBuild` property from builds which the binksim task condition relied on -- removing the reference to FastBuild and the analysis should run now

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

