### PR TITLE
[0.67] Add listitem accessibility role and accessibilityControls test example

### DIFF
--- a/change/@office-iss-react-native-win32-d14f43ea-5d87-42e6-ac59-932aaee0dd9e.json
+++ b/change/@office-iss-react-native-win32-d14f43ea-5d87-42e6-ac59-932aaee0dd9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ListItem as an accessibilityRole type and add a List, ListItem, ControllerFor test example",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "patboyd@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@office-iss-react-native-win32-d14f43ea-5d87-42e6-ac59-932aaee0dd9e.json
+++ b/change/@office-iss-react-native-win32-d14f43ea-5d87-42e6-ac59-932aaee0dd9e.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Add ListItem as an accessibilityRole type and add a List, ListItem, ControllerFor test example",
   "packageName": "@office-iss/react-native-win32",
   "email": "patboyd@microsoft.com",

--- a/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/utils/RNTesterList.win32.js
@@ -23,6 +23,10 @@ const Components: Array<RNTesterModuleInfo> = [
     category: 'UI',
     module: require('../examples/Button/ButtonExample'),
   },
+  {
+    key: 'AccessibilityExampleWin32',
+    module: require('../examples-win32/Accessibility/AccessibilityExampleWin32'),
+  },
   /*
   {
     key: 'FlatListExampleIndex',

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -12,9 +12,9 @@
     "flow-check": "flow check",
     "lint:fix": "rnw-scripts lint:fix",
     "lint": "rnw-scripts lint",
-    "run-win32-dev-web": "npx @office-iss/rex-win32@0.63.36-devmain.14419.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain --useWebDebugger",
-    "run-win32-devmain": "npx @office-iss/rex-win32@0.63.36-devmain.14419.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain",
-    "run-win32": "npx @office-iss/rex-win32@0.63.36-devmain.14419.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8",
+    "run-win32-dev-web": "npx @office-iss/rex-win32@0.66.15-devmain.15226.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain --useWebDebugger",
+    "run-win32-devmain": "npx @office-iss/rex-win32@0.66.15-devmain.15226.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain",
+    "run-win32": "npx @office-iss/rex-win32@0.66.15-devmain.15226.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useWebDebugger",
     "start": "react-native start --projectRoot ../react-native-win32-tester",
     "test": "jest",
     "validate-overrides": "react-native-platform-override validate"

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -45,6 +45,7 @@ export type ARIARole =
   | 'dialog'
   | 'group'
   | 'link'
+  | 'listitem'
   | 'menu'
   | 'menubar'
   | 'menuitem'

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -45,6 +45,7 @@ export type ARIARole =
   | 'dialog'
   | 'group'
   | 'link'
+  | 'list'
   | 'listitem'
   | 'menu'
   | 'menubar'


### PR DESCRIPTION
## Description
Backport of #9902

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
 To allow developers to use listitem accessibilityRole in previous versions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10105)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10106)