### PR TITLE
Fix matrix multiplication logic for transforms

### DIFF
--- a/change/react-native-windows-3db31062-b08b-44b3-8158-a73f139c1714.json
+++ b/change/react-native-windows-3db31062-b08b-44b3-8158-a73f139c1714.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "yarn format",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -118,46 +118,7 @@ inline float ToRadians(const winrt::Microsoft::ReactNative::JSValue &value) {
 static void MultiplyInto(
     winrt::Windows::Foundation::Numerics::float4x4 &m,
     winrt::Windows::Foundation::Numerics::float4x4 o) {
-  // The `float4x4` type has an `operator*` implementation for matrix
-  // multiplication. However, the result of the multiplication differs from the
-  // result computed in:
-  // https://github.com/facebook/react-native/blob/master/Libraries/Utilities/MatrixMath.js
-
-  float a00 = m.m11, a01 = m.m12, a02 = m.m13, a03 = m.m14, a10 = m.m21, a11 = m.m22, a12 = m.m23, a13 = m.m24,
-        a20 = m.m31, a21 = m.m32, a22 = m.m33, a23 = m.m34, a30 = m.m41, a31 = m.m42, a32 = m.m43, a33 = m.m44;
-
-  float b0 = o.m11, b1 = o.m12, b2 = o.m13, b3 = o.m14;
-  m.m11 = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
-  m.m12 = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
-  m.m13 = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
-  m.m14 = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
-
-  b0 = o.m21;
-  b1 = o.m22;
-  b2 = o.m23;
-  b3 = o.m24;
-  m.m21 = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
-  m.m22 = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
-  m.m23 = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
-  m.m24 = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
-
-  b0 = o.m31;
-  b1 = o.m32;
-  b2 = o.m33;
-  b3 = o.m34;
-  m.m31 = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
-  m.m32 = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
-  m.m33 = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
-  m.m34 = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
-
-  b0 = o.m41;
-  b1 = o.m42;
-  b2 = o.m43;
-  b3 = o.m44;
-  m.m41 = b0 * a00 + b1 * a10 + b2 * a20 + b3 * a30;
-  m.m42 = b0 * a01 + b1 * a11 + b2 * a21 + b3 * a31;
-  m.m43 = b0 * a02 + b1 * a12 + b2 * a22 + b3 * a32;
-  m.m44 = b0 * a03 + b1 * a13 + b2 * a23 + b3 * a33;
+  m = o * m;
 }
 
 void FrameworkElementViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -236,21 +236,25 @@ bool FrameworkElementViewManager::UpdateProperty(
                     transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_rotation_x(ToRadians(innerValue)));
               } else if (transformType == "rotateY") {
-                MultiplyInto(transformMatrix,
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_rotation_y(ToRadians(innerValue)));
               } else if (transformType == "rotate" || transformType == "rotateZ") {
                 MultiplyInto(
                     transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_rotation_z(ToRadians(innerValue)));
               } else if (transformType == "scale") {
-                MultiplyInto(transformMatrix,
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_scale(
-                                      innerValue.AsSingle(), innerValue.AsSingle(), 1));
+                        innerValue.AsSingle(), innerValue.AsSingle(), 1));
               } else if (transformType == "scaleX") {
-                MultiplyInto(transformMatrix,
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_scale(innerValue.AsSingle(), 1, 1));
               } else if (transformType == "scaleY") {
-                MultiplyInto(transformMatrix,
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_scale(1, innerValue.AsSingle(), 1));
               } else if (transformType == "translate") {
                 auto &params = innerValue.AsArray();


### PR DESCRIPTION
Fixes #10111

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
As reported in #10111, float4x4's operator* does not produce the same output as expected on other RN platforms. 

Resolves #10111

### What
This change ports the logic from RN's MatrixMath.js to ensure multiplication of transforms produces the same result on Windows as on iOS and Android.

## Screenshots
|Before|After|iOS|
|----|----|----|
|<img width="322" alt="image" src="https://user-images.githubusercontent.com/1106239/173636752-c2a0bec0-2021-4e60-a565-660e0bf57ce1.png">|<img width="352" alt="image" src="https://user-images.githubusercontent.com/1106239/173637740-9cc6a26e-d1e5-43f0-a35a-eb3f05671894.png">|<img width="424" alt="Screen Shot 2022-06-14 at 1 04 06 PM" src="https://user-images.githubusercontent.com/1106239/173636549-fd14a222-8df9-487c-a0a8-11bce3228f98.png">|
|<img width="323" alt="image" src="https://user-images.githubusercontent.com/1106239/173636771-12801a4d-a81f-474e-96f2-2ba146bebf41.png">|<img width="350" alt="image" src="https://user-images.githubusercontent.com/1106239/173638362-23a74fdc-9849-442c-b83b-7126bdd7a296.png">|<img width="366" alt="Screen Shot 2022-06-14 at 1 06 04 PM" src="https://user-images.githubusercontent.com/1106239/173636594-048c3b7c-800b-4c36-9964-cedd292d3dfb.png">|

One more for good measure - notice that the JS driven animation just sends transform props (rather than computed matrix) now that we forked `processTransform.windows.js`, so the animation doesn't match expectations from the native driver / iOS:

*Before:*

https://user-images.githubusercontent.com/1106239/173640312-3a7531ff-b9a7-48b3-9b96-e24b50882c44.mp4

*After:*

https://user-images.githubusercontent.com/1106239/173640470-0368c679-c365-4d00-99d6-b2839d80c242.mp4

*iOS:*

https://user-images.githubusercontent.com/1106239/173641318-2be0f961-f12b-44e5-b0da-f8afeced282b.mov




## Testing
See screenshots / recordings above, confirmed that transforms compose as expected on iOS.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10112)