### PR TITLE
[0.69] Fix matrix multiplication logic for transforms (#10112)

### DIFF
--- a/change/react-native-windows-3db31062-b08b-44b3-8158-a73f139c1714.json
+++ b/change/react-native-windows-3db31062-b08b-44b3-8158-a73f139c1714.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "yarn format",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -115,6 +115,12 @@ inline float ToRadians(const winrt::Microsoft::ReactNative::JSValue &value) {
   return static_cast<float>(num); // assume suffix is "rad"
 }
 
+static void MultiplyInto(
+    winrt::Windows::Foundation::Numerics::float4x4 &m,
+    winrt::Windows::Foundation::Numerics::float4x4 o) {
+  m = o * m;
+}
+
 void FrameworkElementViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
   Super::GetNativeProps(writer);
 
@@ -181,52 +187,60 @@ bool FrameworkElementViewManager::UpdateProperty(
                 innerMatrix.m42 = static_cast<float>(innerValue[13].AsDouble());
                 innerMatrix.m43 = static_cast<float>(innerValue[14].AsDouble());
                 innerMatrix.m44 = static_cast<float>(innerValue[15].AsDouble());
-                transformMatrix = transformMatrix * innerMatrix;
+                MultiplyInto(transformMatrix, innerMatrix);
               } else if (transformType == "perspective") {
                 auto innerMatrix = winrt::Windows::Foundation::Numerics::float4x4::identity();
                 innerMatrix.m34 = -1 / innerValue.AsSingle();
-                transformMatrix = transformMatrix * innerMatrix;
+                MultiplyInto(transformMatrix, innerMatrix);
               } else if (transformType == "rotateX") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_x(ToRadians(innerValue));
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_x(ToRadians(innerValue)));
               } else if (transformType == "rotateY") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_y(ToRadians(innerValue));
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_y(ToRadians(innerValue)));
               } else if (transformType == "rotate" || transformType == "rotateZ") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_z(ToRadians(innerValue));
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_rotation_z(ToRadians(innerValue)));
               } else if (transformType == "scale") {
-                transformMatrix = transformMatrix *
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_scale(
-                                      innerValue.AsSingle(), innerValue.AsSingle(), 1);
+                        innerValue.AsSingle(), innerValue.AsSingle(), 1));
               } else if (transformType == "scaleX") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_scale(innerValue.AsSingle(), 1, 1);
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_scale(innerValue.AsSingle(), 1, 1));
               } else if (transformType == "scaleY") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_scale(1, innerValue.AsSingle(), 1);
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_scale(1, innerValue.AsSingle(), 1));
               } else if (transformType == "translate") {
                 auto &params = innerValue.AsArray();
-                transformMatrix =
-                    transformMatrix *
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::make_float4x4_translation(
-                        params[0].AsSingle(), params[1].AsSingle(), params.size() > 2 ? params[2].AsSingle() : 0.f);
+                        params[0].AsSingle(), params[1].AsSingle(), params.size() > 2 ? params[2].AsSingle() : 0.f));
               } else if (transformType == "translateX") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_translation(innerValue.AsSingle(), 0.f, 0.f);
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_translation(innerValue.AsSingle(), 0.f, 0.f));
               } else if (transformType == "translateY") {
-                transformMatrix = transformMatrix *
-                    winrt::Windows::Foundation::Numerics::make_float4x4_translation(0.f, innerValue.AsSingle(), 0.f);
+                MultiplyInto(
+                    transformMatrix,
+                    winrt::Windows::Foundation::Numerics::make_float4x4_translation(0.f, innerValue.AsSingle(), 0.f));
               } else if (transformType == "skewX") {
-                transformMatrix =
-                    transformMatrix *
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::float4x4(
-                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(innerValue.AsSingle(), 0.f));
+                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(innerValue.AsSingle(), 0.f)));
               } else if (transformType == "skewY") {
-                transformMatrix =
-                    transformMatrix *
+                MultiplyInto(
+                    transformMatrix,
                     winrt::Windows::Foundation::Numerics::float4x4(
-                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(0.f, innerValue.AsSingle()));
+                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(0.f, innerValue.AsSingle())));
               }
             }
           }


### PR DESCRIPTION
## Description

Backporting #10112 into v0.69.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
As reported in #10111, float4x4's operator* does not produce the same output as expected on other RN platforms. 

Resolves #10111 

### What
This change ports the logic from RN's MatrixMath.js to ensure multiplication of transforms produces the same result on Windows as on iOS and Android.

## Screenshots
|Before|After|iOS|
|----|----|----|
|<img width="322" alt="image" src="https://user-images.githubusercontent.com/1106239/173636752-c2a0bec0-2021-4e60-a565-660e0bf57ce1.png">|<img width="352" alt="image" src="https://user-images.githubusercontent.com/1106239/173637740-9cc6a26e-d1e5-43f0-a35a-eb3f05671894.png">|<img width="424" alt="Screen Shot 2022-06-14 at 1 04 06 PM" src="https://user-images.githubusercontent.com/1106239/173636549-fd14a222-8df9-487c-a0a8-11bce3228f98.png">|
|<img width="323" alt="image" src="https://user-images.githubusercontent.com/1106239/173636771-12801a4d-a81f-474e-96f2-2ba146bebf41.png">|<img width="350" alt="image" src="https://user-images.githubusercontent.com/1106239/173638362-23a74fdc-9849-442c-b83b-7126bdd7a296.png">|<img width="366" alt="Screen Shot 2022-06-14 at 1 06 04 PM" src="https://user-images.githubusercontent.com/1106239/173636594-048c3b7c-800b-4c36-9964-cedd292d3dfb.png">|

One more for good measure - notice that the JS driven animation just sends transform props (rather than computed matrix) now that we forked `processTransform.windows.js`, so the animation doesn't match expectations from the native driver / iOS:

*Before:*

https://user-images.githubusercontent.com/1106239/173640312-3a7531ff-b9a7-48b3-9b96-e24b50882c44.mp4

*After:*

https://user-images.githubusercontent.com/1106239/173640470-0368c679-c365-4d00-99d6-b2839d80c242.mp4

*iOS:*

https://user-images.githubusercontent.com/1106239/173641318-2be0f961-f12b-44e5-b0da-f8afeced282b.mov

## Testing
See screenshots / recordings above, confirmed that transforms compose as expected on iOS.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10121)