### PR TITLE
Fix UTF8 Bug in vswhere Command

### DIFF
--- a/change/@react-native-windows-cli-3f8700bf-ee14-4a3e-82b6-873d10aa6fc0.json
+++ b/change/@react-native-windows-cli-3f8700bf-ee14-4a3e-82b6-873d10aa6fc0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Workaround for UTF8",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -43,8 +43,10 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
     );
   }
 
-  const cmdline = `"${vsWherePath}" ${args.join(' ')} -format json -utf8`;
-  const json = JSON.parse(execSync(cmdline, {encoding: 'utf8'}).toString());
+  const cmdline = `cmd /c chcp 65001>nul && "${vsWherePath}" ${args.join(
+    ' ',
+  )} -format json -utf8`;
+  const json = JSON.parse(execSync(cmdline).toString());
 
   for (const entry of json) {
     entry.prerelease = entry.catalog.productMilestoneIsPreRelease;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -43,7 +43,9 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
     );
   }
 
-  const cmdline = `"${vsWherePath}" ${args.join(' ')} -format json -utf8`;
+  const cmdline = `cmd /c chcp 65001>nul && "${vsWherePath}" ${args.join(
+    ' ',
+  )} -format json -utf8`;
   const json = JSON.parse(execSync(cmdline).toString('utf8'));
 
   for (const entry of json) {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -43,7 +43,8 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
     );
   }
 
-  const cmdline = `cmd /c chcp 65001>nul && "${vsWherePath}" ${args.join(
+  const system32 = `${process.env.SystemRoot}\\System32`;
+  const cmdline = `${system32}\\cmd.exe /c ${system32}\\chcp.com 65001>nul && "${vsWherePath}" ${args.join(
     ' ',
   )} -format json -utf8`;
   const json = JSON.parse(execSync(cmdline).toString());

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -44,9 +44,7 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
   }
 
   const cmdline = `"${vsWherePath}" ${args.join(' ')} -format json -utf8`;
-  const json = JSON.parse(
-    execSync(cmdline, {encoding: 'utf8'}).toString('utf8'),
-  );
+  const json = JSON.parse(execSync(cmdline, {encoding: 'utf8'}).toString());
 
   for (const entry of json) {
     entry.prerelease = entry.catalog.productMilestoneIsPreRelease;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -43,10 +43,10 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
     );
   }
 
-  const cmdline = `cmd /c chcp 65001>nul && "${vsWherePath}" ${args.join(
-    ' ',
-  )} -format json -utf8`;
-  const json = JSON.parse(execSync(cmdline).toString('utf8'));
+  const cmdline = `"${vsWherePath}" ${args.join(' ')} -format json -utf8`;
+  const json = JSON.parse(
+    execSync(cmdline, {encoding: 'utf8'}).toString('utf8'),
+  );
 
   for (const entry of json) {
     entry.prerelease = entry.catalog.productMilestoneIsPreRelease;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
The default cmd.exe is not in utf8 mode when launched from node. When run-windows is run, the vswhere command fails when their are unexpected characters in the description. We need a workaround to standardize the characters before vswhere is run.

Resolves #10034 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10123)