### PR TITLE
[0.68] Fix use of [[maybe_unused]] attribute (#10103)

### DIFF
--- a/change/react-native-windows-3914f431-df32-466b-8f29-1f0db9176a75.json
+++ b/change/react-native-windows-3914f431-df32-466b-8f29-1f0db9176a75.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix use of [[maybe_unused]] attribute",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -64,10 +64,10 @@ template <class T>
 void WriteProperties(IJSValueWriter const &writer, T const &value) noexcept;
 
 template <class... TArgs>
-void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept;
+void WriteArgs(IJSValueWriter const &writer, TArgs const &...args) noexcept;
 
 template <class... TArgs>
-JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept;
+JSValueArgWriter MakeJSValueArgWriter(TArgs &&...args) noexcept;
 
 IJSValueWriter MakeJSValueTreeWriter() noexcept;
 
@@ -264,7 +264,7 @@ inline void WriteProperties(IJSValueWriter const &writer, T const &value) noexce
 }
 
 template <class... TArgs>
-inline void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept {
+inline void WriteArgs(IJSValueWriter const &writer, TArgs const &...args) noexcept {
   writer.WriteArrayBegin();
   (WriteValue(writer, args), ...);
   writer.WriteArrayEnd();
@@ -276,7 +276,7 @@ inline JSValueArgWriter MakeJSValueArgWriter(T &&argWriter) noexcept {
 }
 
 template <class... TArgs>
-inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept {
+inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&...args) noexcept {
   return [&args...](IJSValueWriter const &writer) noexcept { WriteArgs(writer, args...); };
 }
 
@@ -286,8 +286,8 @@ inline JSValueArgWriter MakeJSValueWriter(T &&argWriter) noexcept {
 }
 
 template <class... TArgs>
-inline JSValueArgWriter MakeJSValueWriter(TArgs &&... args) noexcept {
-  return [&args...](IJSValueWriter const &[[maybe_unused]] writer) noexcept { (WriteValue(writer, args), ...); };
+inline JSValueArgWriter MakeJSValueWriter(TArgs &&...args) noexcept {
+  return [&args...]([[maybe_unused]] IJSValueWriter const &writer) noexcept { (WriteValue(writer, args), ...); };
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -64,10 +64,10 @@ template <class T>
 void WriteProperties(IJSValueWriter const &writer, T const &value) noexcept;
 
 template <class... TArgs>
-void WriteArgs(IJSValueWriter const &writer, TArgs const &...args) noexcept;
+void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept;
 
 template <class... TArgs>
-JSValueArgWriter MakeJSValueArgWriter(TArgs &&...args) noexcept;
+JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept;
 
 IJSValueWriter MakeJSValueTreeWriter() noexcept;
 
@@ -264,7 +264,7 @@ inline void WriteProperties(IJSValueWriter const &writer, T const &value) noexce
 }
 
 template <class... TArgs>
-inline void WriteArgs(IJSValueWriter const &writer, TArgs const &...args) noexcept {
+inline void WriteArgs(IJSValueWriter const &writer, TArgs const &... args) noexcept {
   writer.WriteArrayBegin();
   (WriteValue(writer, args), ...);
   writer.WriteArrayEnd();
@@ -276,7 +276,7 @@ inline JSValueArgWriter MakeJSValueArgWriter(T &&argWriter) noexcept {
 }
 
 template <class... TArgs>
-inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&...args) noexcept {
+inline JSValueArgWriter MakeJSValueArgWriter(TArgs &&... args) noexcept {
   return [&args...](IJSValueWriter const &writer) noexcept { WriteArgs(writer, args...); };
 }
 
@@ -286,7 +286,7 @@ inline JSValueArgWriter MakeJSValueWriter(T &&argWriter) noexcept {
 }
 
 template <class... TArgs>
-inline JSValueArgWriter MakeJSValueWriter(TArgs &&...args) noexcept {
+inline JSValueArgWriter MakeJSValueWriter(TArgs &&... args) noexcept {
   return [&args...]([[maybe_unused]] IJSValueWriter const &writer) noexcept { (WriteValue(writer, args), ...); };
 }
 


### PR DESCRIPTION
Cherry pick PR #10103

## Description

Fix use of `[[maybe_unused]]` attribute.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

The `[[maybe_unused]]` attribute was in a wrong place in that breaks code compilation by Clang compiler.

### What

This PR adds a change file to the code originally published as PR #10078.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10126)