### PR TITLE
Adds logic to retain undo/redo history for TextInput

### DIFF
--- a/change/react-native-windows-9bafa41c-fc12-4ffa-b62c-8a2820372974.json
+++ b/change/react-native-windows-9bafa41c-fc12-4ffa-b62c-8a2820372974.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds logic to retain undo/redo history for TextInput",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -726,8 +726,9 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
               diffStartIndex++;
             // 2. Find last character the mismatches beyond the first mismatch iterating backwards
             while (diffEndIndex < oldValue.size() - diffStartIndex && diffEndIndex < newValue.size() - diffStartIndex &&
-                   oldValue[oldValue.size() - diffEndIndex - 1] == newValue[newValue.size() - diffEndIndex - 1])
+                   oldValue[oldValue.size() - diffEndIndex - 1] == newValue[newValue.size() - diffEndIndex - 1]) {
               diffEndIndex++;
+            }
             // 3. Select the range between the start and end index in the "old value"
             textBox.SelectionStart(diffStartIndex);
             textBox.SelectionLength(oldValue.size() - diffStartIndex - diffEndIndex);

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -733,7 +733,8 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
             textBox.SelectionLength(oldValue.size() - diffStartIndex - diffEndIndex);
             // 4. Replace the selected text with the range between start and end index in the "new value"
             // Copies the substring view into a new winrt::hstring due to occasional crash
-            winrt::hstring replacementValue{std::wstring_view{newValue}.substr(diffStartIndex, newValue.size() - diffStartIndex - diffEndIndex)};
+            winrt::hstring replacementValue{
+                std::wstring_view{newValue}.substr(diffStartIndex, newValue.size() - diffStartIndex - diffEndIndex)};
             textBox.SelectedText(replacementValue);
           } else {
             textBox.Text(newValue);

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -722,8 +722,9 @@ void TextInputShadowNode::SetText(const winrt::Microsoft::ReactNative::JSValue &
             // single diff in the values:
             // 1. Find first character that mismatches iterating forwards
             while (diffStartIndex < oldValue.size() && diffStartIndex < newValue.size() &&
-                   oldValue[diffStartIndex] == newValue[diffStartIndex])
+                   oldValue[diffStartIndex] == newValue[diffStartIndex]) {
               diffStartIndex++;
+            }
             // 2. Find last character the mismatches beyond the first mismatch iterating backwards
             while (diffEndIndex < oldValue.size() - diffStartIndex && diffEndIndex < newValue.size() - diffStartIndex &&
                    oldValue[oldValue.size() - diffEndIndex - 1] == newValue[newValue.size() - diffEndIndex - 1]) {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
As described in #10132, controlled text updates from JS to XAML TextBox for TextInput cause the undo redo history to be lost because imperatively setting the XAML TextBox::Text property resets history on the TextBox.

Resolves #10132

### What
This change finds a single diff in the before and after string and uses the SelectedText property which retains undo/redo history.

## Testing

https://user-images.githubusercontent.com/1106239/174148621-695de902-72be-4e28-a15e-0dd16dcee61b.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10133)