### PR TITLE
Install .net 5 for ESRP

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -322,6 +322,17 @@ jobs:
         inputs:
           versionSpec: ">=5.8.0"
 
+      # The signing tools require .net 5
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core sdk 5.x'
+        inputs:
+          packageType: sdk
+          version: '5.x'
+
+      - script: |
+          dotnet --info
+        displayName: 'Display .NET Core info'
+
       - template: templates/prep-and-pack-nuget.yml
         parameters:
           publishCommitId: $(publishCommitId)


### PR DESCRIPTION
## Description
Manually install .net as needed by ESRP

### Type of Change
Fix pipeline

### Why
.Net 5 is EOL so requires manual force install required by ESPR


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10137)