### PR TITLE
Fix ExecuteJsi on instance shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ package-lock.json
 
 # Visual C++ cache files
 ipch/
+*.ipch
 *.aps
 *.ncb
 *.opendb

--- a/change/react-native-windows-f4c57fc5-105d-4b9b-bae5-77b41456c140.json
+++ b/change/react-native-windows-f4c57fc5-105d-4b9b-bae5-77b41456c140.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ExecuteJsi on instance shutdown",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -132,6 +132,7 @@
     </ClCompile>
     <ClCompile Include="ReactContextTest.cpp" />
     <ClCompile Include="ReactModuleBuilderMock.cpp" />
+    <ClCompile Include="ReactPromiseTest.cpp" />
     <ClCompile Include="TurboModuleTest.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactPromiseTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactPromiseTest.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <ReactPromise.h>
+
+using namespace winrt::Microsoft::ReactNative;
+
+namespace ReactNativeTests {
+
+TEST_CLASS (ReactPromiseTest) {
+  TEST_METHOD(Test_ReactPromise_void_resolve) {
+    bool isSucceded = false;
+    bool isFailed = false;
+    ReactPromise<void> promise(
+        [&isSucceded]() noexcept { isSucceded = true; },
+        [&isFailed](ReactError const &) noexcept { isFailed = true; });
+    promise.Resolve();
+
+    TestCheck(isSucceded);
+    TestCheck(!isFailed);
+  }
+
+  TEST_METHOD(Test_ReactPromise_void_reject) {
+    bool isSucceded = false;
+    bool isFailed = false;
+    ReactPromise<void> promise(
+        [&isSucceded]() noexcept { isSucceded = true; }, [&isFailed](ReactError const &) noexcept { isFailed = true; });
+    promise.Reject("Failed");
+
+    TestCheck(!isSucceded);
+    TestCheck(isFailed);
+  }
+
+  TEST_METHOD(Test_ReactPromise_int_resolve) {
+    int resultValue = 0;
+    bool isFailed = false;
+    ReactPromise<int> promise(
+        [&resultValue](int value) noexcept { resultValue = value; },
+        [&isFailed](ReactError const &) noexcept { isFailed = true; });
+    promise.Resolve(42);
+
+    TestCheckEqual(resultValue, 42);
+    TestCheck(!isFailed);
+  }
+
+  TEST_METHOD(Test_ReactPromise_int_reject) {
+    int resultValue = 0;
+    bool isFailed = false;
+    ReactPromise<int> promise(
+        [&resultValue](int value) noexcept { resultValue = value; },
+        [&isFailed](ReactError const &) noexcept { isFailed = true; });
+    promise.Reject("Failed");
+
+    TestCheckEqual(resultValue, 0);
+    TestCheck(isFailed);
+  }
+};
+
+} // namespace ReactNativeTests

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiApiContext.h
@@ -7,26 +7,55 @@
 
 #include "../ReactContext.h"
 #include "JsiAbiApi.h"
+#include "ReactPromise.h"
 
 namespace winrt::Microsoft::ReactNative {
 
-// Get JSI Runtime from the current JS dispatcher thread.
-// If it is not found, then create it and store it in the context.Properties().
-// Make sure that the JSI runtime holder is removed when the instance is unloaded.
-facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) noexcept;
+// Try to get JSI Runtime for the current JS dispatcher thread.
+// If it is not found, then create it based on context JSI runtime and store it in the context.Properties().
+// The function returns nullptr if the current context does not have JSI runtime.
+// It makes sure that the JSI runtime holder is removed when the instance is unloaded.
+facebook::jsi::Runtime *TryGetOrCreateContextRuntime(ReactContext const &context) noexcept;
+
+// Calls TryGetOrCreateContextRuntime to get JSI runtime.
+// It crashes when TryGetOrCreateContextRuntime returns null.
+// Note: deprecated in favor of TryGetOrCreateContextRuntime.
+[[deprecated]] facebook::jsi::Runtime &GetOrCreateContextRuntime(ReactContext const &context) noexcept;
 
 // Call provided lambda with the facebook::jsi::Runtime& parameter.
 // For example: ExecuteJsi(context, [](facebook::jsi::Runtime& runtime){...})
 // The code is executed synchronously if it is already in JSDispatcher, or asynchronously otherwise.
 template <class TCodeWithRuntime>
-void ExecuteJsi(ReactContext const &context, TCodeWithRuntime const &code) {
+void ExecuteJsi(ReactContext const &context, TCodeWithRuntime const &code, ReactPromise<void> *callStatus = nullptr) {
   ReactDispatcher jsDispatcher = context.JSDispatcher();
+  auto callCode = [](ReactContext const &context, TCodeWithRuntime const &code, ReactPromise<void> *callStatus) {
+    facebook::jsi::Runtime *runtime = TryGetOrCreateContextRuntime(context);
+    if (runtime) {
+      code(*runtime);
+    }
+
+    // Report status of the call
+    if (callStatus) {
+      if (runtime) {
+        callStatus->Resolve();
+      } else {
+        callStatus->Reject("No JSI runtime");
+      }
+    }
+  };
+
   if (jsDispatcher.HasThreadAccess()) {
     // Execute immediately if we are in JS thread.
-    code(GetOrCreateContextRuntime(context));
+    callCode(context, code, callStatus);
   } else {
     // Otherwise, schedule work in JS thread.
-    jsDispatcher.Post([context, code]() noexcept { code(GetOrCreateContextRuntime(context)); });
+    jsDispatcher.Post([callCode,
+                       context,
+                       code,
+                       callStatus = callStatus ? std::make_unique<ReactPromise<void>>(*callStatus)
+                                               : std::unique_ptr<ReactPromise<void>>(nullptr)]() noexcept {
+      callCode(context, code, callStatus.get());
+    });
   }
 }
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactPromise.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactPromise.h
@@ -5,6 +5,10 @@
 // vnext/Microsoft.ReactNative.Cxx/README.md
 
 #pragma once
+#include "JSValueReader.h"
+#include "JSValueTreeReader.h"
+#include "JSValueTreeWriter.h"
+#include "JSValueWriter.h"
 #include "ReactError.h"
 #include "winrt/Microsoft.ReactNative.h"
 
@@ -35,6 +39,7 @@ struct ReactPromiseBase {
 
  protected:
   bool TrySetState(State newState) const noexcept;
+  static MethodResultCallback GetRejectResultCallback(std::function<void(ReactError const &)> const &reject) noexcept;
 
  protected:
   const std::shared_ptr<std::atomic<State>> m_state;
@@ -47,6 +52,10 @@ template <class T>
 struct ReactPromise : ReactPromiseBase {
   using ReactPromiseBase::ReactPromiseBase;
 
+  ReactPromise(
+      std::function<void(T const &)> const &resolve,
+      std::function<void(ReactError const &)> const &reject) noexcept;
+
   // Successfully resolve the IReactPromise with an optional value.
   void Resolve(T const &value) const noexcept;
 };
@@ -55,9 +64,26 @@ template <>
 struct ReactPromise<void> : ReactPromiseBase {
   using ReactPromiseBase::ReactPromiseBase;
 
+  ReactPromise(std::function<void()> const &resolve, std::function<void(ReactError const &)> const &reject) noexcept;
+
   // Successfully resolve the IReactPromise with an optional value.
   void Resolve() const noexcept;
 };
+
+template <class T>
+ReactPromise<T>::ReactPromise(
+    std::function<void(T const &)> const &resolve,
+    std::function<void(ReactError const &)> const &reject) noexcept
+    : ReactPromiseBase(
+          winrt::make<JSValueTreeWriter>(),
+          [resolve](IJSValueWriter const &outputWriter) noexcept {
+            winrt::com_ptr<JSValueTreeWriter> writer = outputWriter.as<JSValueTreeWriter>();
+            auto reader = winrt::make<JSValueTreeReader>(writer->TakeValue());
+            T result{};
+            ReadArgs(reader, result);
+            resolve(result);
+          },
+          GetRejectResultCallback(reject)) {}
 
 // Successfully resolve the ReactPromise with an optional value.
 template <class T>

--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
@@ -23,7 +23,7 @@ void AddTurboModuleProvider(IReactPackageBuilder const &packageBuilder, std::wst
         IJsiHostObject abiTurboModule{nullptr};
         // We expect the initializer to be called immediately for TurboModules
         moduleBuilder.AddInitializer([&abiTurboModule](IReactContext const &context) mutable {
-          GetOrCreateContextRuntime(ReactContext{context}); // Ensure the JSI runtime is created.
+          TryGetOrCreateContextRuntime(ReactContext{context}); // Ensure the JSI runtime is created.
           auto callInvoker = MakeAbiCallInvoker(context.JSDispatcher());
           auto turboModule = std::make_shared<TTurboModule>(callInvoker);
           abiTurboModule = winrt::make<JsiHostObjectWrapper>(std::move(turboModule));

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.cpp
@@ -98,6 +98,22 @@ struct TestExecuteJsiModule {
     });
   }
 
+  REACT_METHOD(TestExecuteJsiPromise, L"testExecuteJsiPromise")
+  void TestExecuteJsiPromise() noexcept {
+    // Make sure that the promise is succeeded when we call ExecuteJsi.
+    TestEventService::LogEvent("testExecuteJsiPromise started", nullptr);
+
+    ReactPromise<void> callResult(
+        []() noexcept { TestEventService::LogEvent("testExecuteJsiPromise promise succeeded", nullptr); },
+        [](ReactError const &error) noexcept {
+          TestEventService::LogEvent("testExecuteJsiPromise promise failed", error.Message.c_str());
+        });
+    ExecuteJsi(
+        m_reactContext,
+        [](Runtime &rt) { TestEventService::LogEvent("testExecuteJsiPromise completed", nullptr); },
+        &callResult);
+  }
+
  private:
   ReactContext m_reactContext;
 };
@@ -112,23 +128,54 @@ struct TestPackageProvider : winrt::implements<TestPackageProvider, IReactPackag
 
 TEST_CLASS (ExecuteJsiTests) {
   TEST_METHOD(Run_JSDrivenTests) {
-    TestEventService::Initialize();
+    {
+      TestEventService::Initialize();
 
-    auto reactNativeHost = TestReactNativeHostHolder(L"ExecuteJsiTests", [](ReactNativeHost const &host) noexcept {
-      host.PackageProviders().Append(winrt::make<TestPackageProvider>());
-    });
+      winrt::event_token onDestroyed{};
+      auto reactNativeHost =
+          TestReactNativeHostHolder(L"ExecuteJsiTests", [&onDestroyed](ReactNativeHost const &host) noexcept {
+            host.PackageProviders().Append(winrt::make<TestPackageProvider>());
+            onDestroyed = host.InstanceSettings().InstanceDestroyed(
+                [](winrt::Windows::Foundation::IInspectable const &obj, InstanceDestroyedEventArgs const &args) {
+                  OnInstanceDestroyed(args.Context());
+                });
+          });
+
+      TestEventService::ObserveEvents({
+          TestEvent{"initialize", nullptr},
+          TestEvent{"testSimpleExecuteJsi started", nullptr},
+          TestEvent{"testSimpleExecuteJsi completed", nullptr},
+          TestEvent{"testHostFunction started", nullptr},
+          TestEvent{"testHostFunction completed", nullptr},
+          TestEvent{"testHostObject started", nullptr},
+          TestEvent{"testHostObject completed", nullptr},
+          TestEvent{"testSameJsiRuntime started", nullptr},
+          TestEvent{"testSameJsiRuntime completed", nullptr},
+          TestEvent{"testExecuteJsiPromise started", nullptr},
+          TestEvent{"testExecuteJsiPromise completed", nullptr},
+          TestEvent{"testExecuteJsiPromise promise succeeded", nullptr},
+      });
+    }
 
     TestEventService::ObserveEvents({
-        TestEvent{"initialize", nullptr},
-        TestEvent{"testSimpleExecuteJsi started", nullptr},
-        TestEvent{"testSimpleExecuteJsi completed", nullptr},
-        TestEvent{"testHostFunction started", nullptr},
-        TestEvent{"testHostFunction completed", nullptr},
-        TestEvent{"testHostObject started", nullptr},
-        TestEvent{"testHostObject completed", nullptr},
-        TestEvent{"testSameJsiRuntime started", nullptr},
-        TestEvent{"testSameJsiRuntime completed", nullptr},
+        TestEvent{"OnInstanceDestroyed started", nullptr},
+        TestEvent{"OnInstanceDestroyed promise failed", "No JSI runtime"},
     });
+  }
+
+  static void OnInstanceDestroyed(ReactContext const &reactContext) {
+    // See that ExecuteJsi failed to execute
+    TestEventService::LogEvent("OnInstanceDestroyed started", nullptr);
+
+    ReactPromise<void> callResult(
+        []() noexcept { TestEventService::LogEvent("OnInstanceDestroyed promise succeeded", nullptr); },
+        [](ReactError const &error) noexcept {
+          TestEventService::LogEvent("OnInstanceDestroyed promise failed", error.Message.c_str());
+        });
+    ExecuteJsi(
+        reactContext,
+        [](Runtime &rt) { TestEventService::LogEvent("OnInstanceDestroyed completed", nullptr); },
+        &callResult);
   }
 };
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ExecuteJsiTests.js
@@ -6,3 +6,4 @@ TestExecuteJsiModule.testSimpleExecuteJsi();
 TestExecuteJsiModule.testHostFunction();
 TestExecuteJsiModule.testHostObject();
 TestExecuteJsiModule.testSameJsiRuntime();
+TestExecuteJsiModule.testExecuteJsiPromise();


### PR DESCRIPTION
## Description

Do not crash process in `ExecuteJsi` function when React instance is already shutdown.
Instead, we do not execute the provided code.
The success or failure condition can be reported using optional `ReactPromise` parameter.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

There was a crash report from a partner team that the `ExecuteJsi` method sometimes causes a crash.
The investigation has shown that the root cause of issue is that React instance is being destroyed and the underlying JS engine is not available anymore. In such case, the `GetOrCreateContextRuntime` function is crashing because its return value is a reference and not allowed to be null.

### What

- New `TryGetOrCreateContextRuntime` function is replacing the `GetOrCreateContextRuntime` function. The new function returns a pointer to JSI runtime. It returns `nullptr` if JSI runtime is unavailable.
- `ExecuteJsi` function is changed to check the result of the `TryGetOrCreateContextRuntime` function. It does nothing if the JSI runtime pointer is `nullptr`.
- A new optional parameter `ReactPromise<void> *callStatus` is added to the `ExecuteJsi` function. If this parameter is not null, then the `ExecuteJsi` resolves the `callStatus` promise on success and rejects it on failure.
- New simplified constructor is added to `ReactPromise` class to be used in this scenario
- New `ReactPromiseTest.cpp` is added to test the new `ReactPromise` constructor.
- The existing `ExecuteJsiTests.cpp` is augmented to test usage of `ReactPromise` in success and failed scenarios.

## Testing

New and existing `Microsoft.ReactNative.sln` unit tests are passing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10148)