### PR TITLE
Minor fix for clang compile

### DIFF
--- a/change/react-native-windows-88b0da78-0c4c-43a0-b3b6-63ed97519d68.json
+++ b/change/react-native-windows-88b0da78-0c4c-43a0-b3b6-63ed97519d68.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor fix for clang compile",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -6,8 +6,8 @@
 #include <DynamicWriter.h>
 #include <IReactContext.h>
 #include <IReactRootView.h>
-#include <Modules/PaperUIManagerModule.h>
 #include <Modules/NativeUIManager.h>
+#include <Modules/PaperUIManagerModule.h>
 #include <Views/ViewManager.h>
 #include <XamlUtils.h>
 #include "ShadowNodeBase.h"

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -7,7 +7,7 @@
 #include <IReactContext.h>
 #include <IReactRootView.h>
 #include <Modules/PaperUIManagerModule.h>
-#include <Modules\NativeUIManager.h>
+#include <Modules/NativeUIManager.h>
 #include <Views/ViewManager.h>
 #include <XamlUtils.h>
 #include "ShadowNodeBase.h"


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang doesn't like backslashes in includes.

### What
Changes  backslash in include to forwardslash.

## Screenshots
N/A

## Testing
RNW still compiles.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10156)