### PR TITLE
[0.69] Update source of DeviceID for telemetry

### DIFF
--- a/change/@react-native-windows-telemetry-731eae08-aad0-4223-98a0-59137f9c271d.json
+++ b/change/@react-native-windows-telemetry-731eae08-aad0-4223-98a0-59137f9c271d.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "[0.69] Update source of DeviceID for telemetry",
   "packageName": "@react-native-windows/telemetry",
   "email": "jthysell@microsoft.com",

--- a/change/@react-native-windows-telemetry-731eae08-aad0-4223-98a0-59137f9c271d.json
+++ b/change/@react-native-windows-telemetry-731eae08-aad0-4223-98a0-59137f9c271d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.69] Update source of DeviceID for telemetry",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -26,7 +26,6 @@
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",
     "lodash": "^4.17.21",
-    "node-machine-id": "^1.1.12",
     "os-locale": "^5.0.0",
     "xpath": "^0.0.27"
   },

--- a/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
+++ b/packages/@react-native-windows/telemetry/src/utils/basePropUtils.ts
@@ -9,15 +9,27 @@ import {totalmem, cpus, arch, platform} from 'os';
 
 import ci from 'ci-info';
 import {randomBytes} from 'crypto';
-import {machineId} from 'node-machine-id';
 import osLocale from 'os-locale';
+
+const DeviceIdRegPath = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\SQMClient';
+const DeviceIdRegKey = 'MachineId';
 
 /**
  * Gets a telemetry-safe stable device ID.
  * @returns A telemetry-safe stable device ID.
  */
 export async function deviceId(): Promise<string> {
-  return await machineId(false);
+  try {
+    const output = execSync(
+      `${process.env.windir}\\System32\\reg.exe query ${DeviceIdRegPath} /v ${DeviceIdRegKey}`,
+    ).toString();
+
+    const result = output.match(/\{([0-9A-Fa-f-]{36})\}/);
+    if (result && result.length > 1) {
+      return `s:${result[1]}`;
+    }
+  } catch {}
+  return '';
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -8802,11 +8802,6 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-node-machine-id@^1.1.12:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/node-machine-id/-/node-machine-id-1.1.12.tgz#37904eee1e59b320bb9c5d6c0a59f3b469cb6267"
-  integrity sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==
-
 node-notifier@^8.0.0, node-notifier@^9.0.0:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.1.tgz#cea837f4c5e733936c7b9005e6545cea825d1af4"


### PR DESCRIPTION
This PR backports #10139 to 0.69.

Previously, we used the `node-machine-id` package to get a unique,
stable device id. However, that id cannot be correlated with any other
telemetry.

This PR removes the dependency on `node-machine-id` and instead gets a
more useful, unique device id (the same as you'll see in Settings >
System > About).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10168)