### PR TITLE
Added an OS key

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
   },
   "resolutions.justification": {
     "z-schema": "CVE-2021-3765 in validator. z-schema is used by rush which is a dependency of lage so should not be executed in this repo"
-  }
+  },
+  "os": "win32"
 }


### PR DESCRIPTION
## Description
Added a Win32 OS key to the package.json

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
React-native-windows does not build on Mac or Linux and causes various issues. It would be better to add the OS key.

Resolves [Add Relevant Issue Here]

### What
Building a project that references react-native-windows on Mac or Linux