### PR TITLE
Disambiguate ReactContext in ReactInstanceWin

### DIFF
--- a/change/react-native-windows-3f7196aa-b677-4cfd-8417-61aafaf0a51e.json
+++ b/change/react-native-windows-3f7196aa-b677-4cfd-8417-61aafaf0a51e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disambiguate ReactContext in ReactInstanceWin",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -153,7 +153,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   const bool m_useDirectDebugger : 1;
   const bool m_useWebDebugger : 1;
 
-  const Mso::CntPtr<ReactContext> m_reactContext;
+  const Mso::CntPtr<::Mso::React::ReactContext> m_reactContext;
 
   std::atomic<bool> m_isLoaded{false};
   std::atomic<bool> m_isDestroyed{false};


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang fails to disambiguate the ReactContext namespace for the field used on the ReactInstance.

### What
Fully qualifies the ReactContext namespace for ReactInstanceWin.

## Testing
react-native-windows still compiles in Visual Studio and works correctly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10184)