### PR TITLE
Fixes clang compile issues for IReactDispatcher.h

### DIFF
--- a/change/react-native-windows-309d60eb-b042-4868-8277-62deee099760.json
+++ b/change/react-native-windows-309d60eb-b042-4868-8277-62deee099760.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes clang compile issues for IReactDispatcher.h",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -31,7 +31,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
 
   static IReactDispatcher CreateSerialDispatcher() noexcept;
 
-  static Mso::CntPtr<IDispatchQueue2> GetUIDispatchQueue2(IReactPropertyBag const &properties) noexcept;
+  static Mso::CntPtr<Mso::React::IDispatchQueue2> GetUIDispatchQueue2(IReactPropertyBag const &properties) noexcept;
   static IReactDispatcher UIThreadDispatcher() noexcept;
   static IReactPropertyName UIDispatcherProperty() noexcept;
   static IReactDispatcher GetUIDispatcher(IReactPropertyBag const &properties) noexcept;
@@ -42,8 +42,8 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
   static IReactPropertyName JSDispatcherIdleWaitStartingEventName() noexcept;
   static IReactPropertyName JSDispatcherIdleWaitCompletedEventName() noexcept;
 
-  void Post(Mso::DispatchTask &&task) const noexcept override;
-  void InvokeElsePost(Mso::DispatchTask &&task) const noexcept override;
+  void Post(Mso::DispatchTask &&task) const noexcept;
+  void InvokeElsePost(Mso::DispatchTask &&task) const noexcept;
 
  private:
   Mso::DispatchQueue m_queue;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang doesn't like attempting to override the virtual methods from the IDispatchQueue2 interface. Also, the IDispatchQueue2 type needs to be fully qualified in the `GetUIDispatchQueue2` method for clang to compile.

### What
Removes problematic override modifiers and fully qualifies IDispatchQueue2 interface.

## Testing
React Native Windows still compiles with Visual Studio.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10188)