### PR TITLE
Promote 0.68 to Legacy

### DIFF
--- a/change/@office-iss-react-native-win32-822aa9aa-dd03-47cc-9641-5a714c0f13bb.json
+++ b/change/@office-iss-react-native-win32-822aa9aa-dd03-47cc-9641-5a714c0f13bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-afcd1c6f-ef03-4e9b-80f9-73fd869ba11c.json
+++ b/change/@react-native-windows-cli-afcd1c6f-ef03-4e9b-80f9-73fd869ba11c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-bab7238d-4bb2-4dac-9dc8-5fe4fbc66cc8.json
+++ b/change/@react-native-windows-codegen-bab7238d-4bb2-4dac-9dc8-5fe4fbc66cc8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-725be6a3-dd4d-4879-b338-31471f1eda57.json
+++ b/change/@react-native-windows-find-repo-root-725be6a3-dd4d-4879-b338-31471f1eda57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-ee682c2e-b200-4951-abe9-db240ba9b1b0.json
+++ b/change/@react-native-windows-fs-ee682c2e-b200-4951-abe9-db240ba9b1b0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-c3004455-1999-4e4e-b24d-b4cc5905ecc7.json
+++ b/change/@react-native-windows-package-utils-c3004455-1999-4e4e-b24d-b4cc5905ecc7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-45267e5b-6d12-4c3d-ba08-b7a02e502bb5.json
+++ b/change/@react-native-windows-telemetry-45267e5b-6d12-4c3d-ba08-b7a02e502bb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-virtualized-list-b915c21f-52f5-4a10-8548-d9388cd41c81.json
+++ b/change/@react-native-windows-virtualized-list-b915c21f-52f5-4a10-8548-d9388cd41c81.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "@react-native-windows/virtualized-list",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-63c2a80d-0da8-4078-bde7-e0a6d8310a19.json
+++ b/change/react-native-windows-63c2a80d-0da8-4078-bde7-e0a6d8310a19.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.68 to legacy",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -82,7 +82,7 @@
     "react-native": "^0.68.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -68,7 +68,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -51,7 +51,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -39,7 +39,7 @@
   },
   "promoteRelease": true,
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -50,7 +50,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/virtualized-list/package.json
+++ b/packages/@react-native-windows/virtualized-list/package.json
@@ -33,7 +33,7 @@
     "react-native": "0.68.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -85,7 +85,7 @@
     "react-native": "^0.68.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.68-stable",
     "gitTags": true,
     "disallowedChangeTypes": [
       "major",


### PR DESCRIPTION
## Description

### Type of Change
- Release Cycle

### What
Promote 0.68 to Legacy

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10189)