### PR TITLE
Add partial PlatformColor support for Image's tintColor

### DIFF
--- a/change/react-native-windows-ed697687-b653-4c00-a2ea-341bcc4bae8e.json
+++ b/change/react-native-windows-ed697687-b653-4c00-a2ea-341bcc4bae8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add PlatformColor support for Image's tintColor",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import {Picker} from '@react-native-picker/picker';
-import {AppRegistry, Image, View, Text, Switch, StyleSheet} from 'react-native';
+import {AppRegistry, Image, View, Text, Switch, StyleSheet, PlatformColor} from 'react-native';
 
 const largeImageUri =
   'https://cdn.freebiesupply.com/logos/large/2x/react-logo-png-transparent.png';
@@ -69,7 +69,7 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>ResizeMode</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.selectedResizeMode}
             onValueChange={value => this.setState({selectedResizeMode: value})}>
             <Picker.Item label="cover" value="cover" />
@@ -82,7 +82,7 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Image Source</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.selectedSource}
             onValueChange={value => this.switchImageUri(value)}>
             <Picker.Item label="small" value="small" />
@@ -95,7 +95,7 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Blur Radius</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.blurRadius}
             onValueChange={value => this.setState({blurRadius: value})}>
             <Picker.Item label="0" value={0} />
@@ -106,12 +106,13 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Tint Color</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.tintColor}
             onValueChange={value => this.setState({tintColor: value})}>
             <Picker.Item label="None" value="transparent" />
             <Picker.Item label="Purple" value="purple" />
             <Picker.Item label="Green" value="green" />
+            <Picker.Item label="SystemAccentColor" value="platformcolor"/>
           </Picker>
         </View>
         <View style={styles.rowContainer}>
@@ -130,7 +131,7 @@ export default class Bootstrap extends React.Component<
             style={[
               styles.image,
               this.state.includeBorder ? styles.imageWithBorder : {},
-              {tintColor: this.state.tintColor},
+              this.state.tintColor === "platformcolor" ? styles.imageWithPlatformColor : {tintColor: this.state.tintColor},
             ]}
             source={
               this.state.selectedSource === 'svg'
@@ -158,6 +159,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 5,
   },
+  picker: {
+    width: 175,
+  },
   imageContainer: {
     marginTop: 5,
     backgroundColor: 'orange',
@@ -173,6 +177,9 @@ const styles = StyleSheet.create({
     borderWidth: 10,
     borderColor: 'green',
     backgroundColor: 'red',
+  },
+  imageWithPlatformColor: {
+    tintColor: PlatformColor('SystemAccentColor'),
   },
   title: {
     fontWeight: 'bold',

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -5,7 +5,15 @@
  */
 import React from 'react';
 import {Picker} from '@react-native-picker/picker';
-import {AppRegistry, Image, View, Text, Switch, StyleSheet, PlatformColor} from 'react-native';
+import {
+  AppRegistry,
+  Image,
+  View,
+  Text,
+  Switch,
+  StyleSheet,
+  PlatformColor,
+} from 'react-native';
 
 const largeImageUri =
   'https://cdn.freebiesupply.com/logos/large/2x/react-logo-png-transparent.png';
@@ -112,7 +120,7 @@ export default class Bootstrap extends React.Component<
             <Picker.Item label="None" value="transparent" />
             <Picker.Item label="Purple" value="purple" />
             <Picker.Item label="Green" value="green" />
-            <Picker.Item label="SystemAccentColor" value="platformcolor"/>
+            <Picker.Item label="SystemAccentColor" value="platformcolor" />
           </Picker>
         </View>
         <View style={styles.rowContainer}>
@@ -131,7 +139,9 @@ export default class Bootstrap extends React.Component<
             style={[
               styles.image,
               this.state.includeBorder ? styles.imageWithBorder : {},
-              this.state.tintColor === "platformcolor" ? styles.imageWithPlatformColor : {tintColor: this.state.tintColor},
+              this.state.tintColor === 'platformcolor'
+                ? styles.imageWithPlatformColor
+                : {tintColor: this.state.tintColor},
             ]}
             source={
               this.state.selectedSource === 'svg'

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -118,17 +118,21 @@ struct BrushCache {
       return RegisterBrush(resourceName, brush);
     }
 
-    winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
+    const auto appResources{winrt::Application::Current().Resources()};
+    const auto boxedResourceName{winrt::box_value(resourceName)};
+    if (appResources.HasKey(boxedResourceName)) {
+      winrt::IInspectable resource{appResources.Lookup(boxedResourceName)};
 
-    if (auto brush = resource.try_as<xaml::Media::Brush>()) {
-      return RegisterBrush(resourceName, brush);
-    } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
-      auto brush = xaml::Media::SolidColorBrush(color.value());
-      return RegisterBrush(resourceName, brush);
+      if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+        return RegisterBrush(resourceName, brush);
+      } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+        auto brush = xaml::Media::SolidColorBrush(color.value());
+        return RegisterBrush(resourceName, brush);
+      }
     }
 
     assert(false && "Resource is not a Color or Brush");
-    return nullptr;
+    return xaml::Media::SolidColorBrush(winrt::Colors::Transparent());
   }
 
   xaml::Media::Brush RegisterBrush(winrt::hstring resourceName, const xaml::Media::Brush &brush) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -141,13 +141,12 @@ bool ImageViewManager::UpdateProperty(
        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)) {
     reactImage->BlurRadius(propertyValue.AsSingle());
   } else if (propertyName == "tintColor") {
-    if (propertyValue.IsNull()) {
-      reactImage->TintColor(winrt::Colors::Transparent());
-    } else if (IsValidColorValue(propertyValue)) {
-      if (auto brush = SolidColorBrushFrom(propertyValue)) {
-        reactImage->TintColor(brush.Color());
-      }
+    const auto isValidColorValue = IsValidColorValue(propertyValue);
+    if (isValidColorValue || propertyValue.IsNull()) {
+      const auto color = isValidColorValue ? SolidColorBrushFrom(propertyValue).Color() : winrt::Colors::Transparent();
+      reactImage->TintColor(color);
     }
+
     // Override default accessibility behavior
   } else if (propertyName == "accessible" && propertyValue.IsNull()) {
     xaml::Automation::AutomationProperties::SetAccessibilityView(*reactImage, winrt::AccessibilityView::Raw);

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -141,10 +141,12 @@ bool ImageViewManager::UpdateProperty(
        propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64)) {
     reactImage->BlurRadius(propertyValue.AsSingle());
   } else if (propertyName == "tintColor") {
-    const auto isValidColorValue = IsValidColorValue(propertyValue);
-    if (isValidColorValue || propertyValue.IsNull()) {
-      const auto color = isValidColorValue ? ColorFrom(propertyValue) : winrt::Colors::Transparent();
-      reactImage->TintColor(color);
+    if (propertyValue.IsNull()) {
+      reactImage->TintColor(winrt::Colors::Transparent());
+    } else if (IsValidColorValue(propertyValue)) {
+      if (auto brush = SolidColorBrushFrom(propertyValue)) {
+        reactImage->TintColor(brush.Color());
+      }
     }
     // Override default accessibility behavior
   } else if (propertyName == "accessible" && propertyValue.IsNull()) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -146,7 +146,6 @@ bool ImageViewManager::UpdateProperty(
       const auto color = isValidColorValue ? SolidColorBrushFrom(propertyValue).Color() : winrt::Colors::Transparent();
       reactImage->TintColor(color);
     }
-
     // Override default accessibility behavior
   } else if (propertyName == "accessible" && propertyValue.IsNull()) {
     xaml::Automation::AutomationProperties::SetAccessibilityView(*reactImage, winrt::AccessibilityView::Raw);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #10177 

### What
Image uses ColorSourceEffect to implement tintColor which takes in a Windows::UI::Color and does not know about XAML brushes. This change adds PlatformColor support for when the windowsbrush being used is a SolidColorBrush that we can extract the color from.  

## Testing
Manually tested and added case to the playground's Image page. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10192)