### PR TITLE
Centralize getting package identity and fix a bug getting app folder

### DIFF
--- a/change/react-native-windows-f312927e-5f5d-4689-a6d1-6f9281409c06.json
+++ b/change/react-native-windows-f312927e-5f5d-4689-a6d1-6f9281409c06.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Centralize getting package identity",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/AppModelHelpers.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AppModelHelpers.h
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+// AppModel helpers
+
+#include <appmodel.h>
+
+namespace Microsoft::ReactNative {
+
+inline bool HasPackageIdentity() noexcept {
+  uint32_t length{0};
+  const bool isPackagedApp = GetCurrentPackageFullName(&length, nullptr) != APPMODEL_ERROR_NO_PACKAGE;
+  return isPackagedApp;
+}
+
+} // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/AppModelHelpers.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AppModelHelpers.h
@@ -14,4 +14,4 @@ inline bool HasPackageIdentity() noexcept {
   return isPackagedApp;
 }
 
-} // namespace winrt::Microsoft::ReactNative
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -5,6 +5,7 @@
 #include "CoreNativeModules.h"
 
 // Modules
+#include <AppModelHelpers.h>
 #include <AsyncStorageModule.h>
 #include <Modules/Animated/NativeAnimatedModule.h>
 #include <Modules/AppearanceModule.h>
@@ -24,20 +25,6 @@ using winrt::Microsoft::ReactNative::ReactPropertyBag;
 namespace {
 
 using winrt::Microsoft::ReactNative::ReactPropertyId;
-
-bool HasPackageIdentity() noexcept {
-  static const bool hasPackageIdentity = []() noexcept {
-    auto packageStatics = winrt::get_activation_factory<winrt::Windows::ApplicationModel::IPackageStatics>(
-        winrt::name_of<winrt::Windows::ApplicationModel::Package>());
-    auto abiPackageStatics = static_cast<winrt::impl::abi_t<winrt::Windows::ApplicationModel::IPackageStatics> *>(
-        winrt::get_abi(packageStatics));
-    winrt::com_ptr<winrt::impl::abi_t<winrt::Windows::ApplicationModel::IPackage>> dummy;
-    return abiPackageStatics->get_Current(winrt::put_abi(dummy)) !=
-        winrt::impl::hresult_from_win32(APPMODEL_ERROR_NO_PACKAGE);
-  }();
-
-  return hasPackageIdentity;
-}
 
 ReactPropertyId<bool> HttpUseMonolithicModuleProperty() noexcept {
   static ReactPropertyId<bool> propId{

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -5,12 +5,12 @@
 #include "MoveOnCopy.h"
 #include "MsoUtils.h"
 
+#include <AppModelHelpers.h>
 #include <Base/CoreNativeModules.h>
 #include <Threading/MessageDispatchQueue.h>
 #include <Threading/MessageQueueThreadFactory.h>
 #include <appModel.h>
 #include <comUtil/qiCast.h>
-
 #ifndef CORE_ABI
 #include <XamlUIService.h>
 #endif
@@ -469,8 +469,7 @@ void ReactInstanceWin::Initialize() noexcept {
             case JSIEngine::V8:
 #if defined(USE_V8)
             {
-              uint32_t length{0};
-              if (GetCurrentPackageFullName(&length, nullptr) != APPMODEL_ERROR_NO_PACKAGE) {
+              if (HasPackageIdentity()) {
                 preparedScriptStore =
                     std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationTempFolder());
               } else {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -469,7 +469,7 @@ void ReactInstanceWin::Initialize() noexcept {
             case JSIEngine::V8:
 #if defined(USE_V8)
             {
-              if (HasPackageIdentity()) {
+              if (Microsoft::ReactNative::HasPackageIdentity()) {
                 preparedScriptStore =
                     std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(getApplicationTempFolder());
               } else {

--- a/vnext/Shared/Utils.cpp
+++ b/vnext/Shared/Utils.cpp
@@ -4,10 +4,10 @@
 #include "Utils.h"
 #include <regex>
 
+#include <AppModelHelpers.h>
 #include <DesktopWindowBridge.h>
 #include <ShlObj.h>
 #include <Shlwapi.h>
-#include <appmodel.h>
 #include <winrt/Windows.Storage.h>
 
 #include <sstream>
@@ -56,10 +56,7 @@ std::future<std::string> getUnPackagedApplicationDataPath(const wchar_t *childFo
 } // namespace
 
 std::future<std::string> getApplicationDataPath(const wchar_t *childFolder) {
-  uint32_t length{0};
-  bool isPackagedApp = GetCurrentPackageFullName(&length, nullptr) != APPMODEL_ERROR_NO_PACKAGE;
-  std::string appDataPath;
-  if (false) {
+  if (Microsoft::ReactNative::HasPackageIdentity()) {
     co_return co_await getPackagedApplicationDataPath(childFolder);
   } else {
     co_return co_await getUnPackagedApplicationDataPath(childFolder);


### PR DESCRIPTION
## Description
There were a few places trying to do the same thing, so centralize them.
Also, discovered a bug where getting the app folder in packaged was never doing the right thing...

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10199)