### PR TITLE
Adds gesture cancellation to pointer event handling

### DIFF
--- a/change/react-native-windows-f387ef6b-5fac-48a8-86bf-42e6afbd3744.json
+++ b/change/react-native-windows-f387ef6b-5fac-48a8-86bf-42e6afbd3744.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds gesture cancellation to pointer event handling",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPointerEventArgs.cpp
@@ -16,8 +16,18 @@ PointerEventKind ReactPointerEventArgs::Kind() const noexcept {
 }
 
 void ReactPointerEventArgs::Kind(PointerEventKind kind) noexcept {
-  // The only event type change that is supported is CaptureLost to End.
-  assert(kind == PointerEventKind::End && m_kind == PointerEventKind::CaptureLost);
+  // The only event type transitions that are supported are:
+  // 1. PointerEventKind::CaptureLost to PointerEventKind::End to support cases
+  //    where XAML firing the CaptureLost event should be treated as a gesture
+  //    completion event, e.g., for pointer events in selectable text that do
+  //    not result in text selection.
+  // 2. PointerEventKind::End to PointerEventKind::Cancel to support cases
+  //    where a custom view manager implementing `IViewManagerWithPointerEvents`
+  //    wants to cancel a gesture, e.g., for a custom drag handle where the end
+  //    of the gesture should not be treated as a completed press event.
+  assert(
+      (kind == PointerEventKind::End && m_kind == PointerEventKind::CaptureLost) ||
+      (kind == PointerEventKind::Cancel && m_kind == PointerEventKind::End));
   m_kind = kind;
 }
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
In https://github.com/microsoft/react-native-windows/pull/8495, we added an interface for 3rd party view managers to override pointer event handling in the TouchEventHandler module from RNW. The features of this PR supported press events on selectable text, but to generalize this further, we need to allow 3rd party view managers to conditionally cancel pointer event sequences and prevent press events.

Resolves #10202

### What
This change adds the ability for view managers implementing the IViewManagerWithPointerEvents interface to change an "End" event to a "Cancel" event to achieve gesture cancellation.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10203)