### PR TITLE
Add API Version

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -96,7 +96,7 @@
                   - powershell: |
                       $winmd2md_url = "https://github.com/asklar/winmd2md/releases/download/v0.1.13/winmd2md.exe"
                       Invoke-WebRequest -UseBasicParsing $winmd2md_url -OutFile $env:TEMP\winmd2md.exe
-                      & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
+                      & $env:TEMP\winmd2md.exe /experimental /outputDirectory vnext\target\winmd2md /apiversion 0.69 vnext\target\x86\Debug\Microsoft.ReactNative\Microsoft.ReactNative.winmd
                     displayName: "Generate WinRT API docs"
 
                   - task: PublishBuildArtifacts@1


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Release Task

### Why
Now that website documentation for 0.69 has been cut, updating API docs generation source to add doc versioning information in case future doc updates for v0.69 are needed. 