### PR TITLE
Fixes issue when alert is not only descendant of PopupRoot

### DIFF
--- a/change/react-native-windows-f2020c58-e8e2-4364-a3a9-619e3cd68c88.json
+++ b/change/react-native-windows-f2020c58-e8e2-4364-a3a9-619e3cd68c88.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issue when alert is not only descendant of PopupRoot",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -68,19 +68,22 @@ void Alert::ProcessPendingAlertRequests() noexcept {
         const auto rootSize = xamlRoot.Size();
         const auto popupRoot = xaml::Media::VisualTreeHelper::GetParent(dialog);
         const auto nChildren = xaml::Media::VisualTreeHelper::GetChildrenCount(popupRoot);
-        if (nChildren == 2) {
-          // The first is supposed to be the smoke screen (Rectangle), and the second the content dialog
-          if (const auto smoke =
-                  xaml::Media::VisualTreeHelper::GetChild(popupRoot, 0).try_as<xaml::Shapes::Rectangle>()) {
-            const auto assertDialog =
-                xaml::Media::VisualTreeHelper::GetChild(popupRoot, 1).try_as<xaml::Controls::ContentDialog>();
-            if (assertDialog == dialog) {
-              smoke.Width(rootSize.Width);
-              smoke.Height(rootSize.Height);
-              dialog.Width(rootSize.Width);
-              dialog.Height(rootSize.Height);
-            }
+        xaml::Shapes::Rectangle smoke = nullptr;
+        xaml::Controls::ContentDialog assertDialog = nullptr;
+        for (int32_t i = 0; i < nChildren - 1; ++i) {
+          smoke = xaml::Media::VisualTreeHelper::GetChild(popupRoot, i).try_as<xaml::Shapes::Rectangle>();
+          assertDialog =
+              xaml::Media::VisualTreeHelper::GetChild(popupRoot, i + 1).try_as<xaml::Controls::ContentDialog>();
+          if (smoke && assertDialog == dialog) {
+            break;
           }
+        }
+
+        if (smoke && assertDialog == dialog) {
+          smoke.Width(rootSize.Width);
+          smoke.Height(rootSize.Height);
+          dialog.Width(rootSize.Width);
+          dialog.Height(rootSize.Height);
         }
       });
 


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
The AlertModule assumes the Alert is the only active item in the PopupRoot, which may not be the case if any other flyouts or popups are being shown while the alert is being built.

### What
This change fixes that assumption by searching for the correct dialog / smoke screen element rather than assuming the smoke screen and dialog are at index 0 and 1.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10209)