### PR TITLE
Fix crash when replacing elements in a resource dictionary

### DIFF
--- a/change/react-native-windows-1111fd41-4aab-4526-8c9e-60813e3b3b0b.json
+++ b/change/react-native-windows-1111fd41-4aab-4526-8c9e-60813e3b3b0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash when adding a key to a resource dictionary that already existed",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -30,10 +30,9 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 }
 
 void InsertBrushCopy(
-  const xaml::ResourceDictionary &resources,
-  const std::wstring &resourceName,
-  const xaml::Media::Brush &brush) {
-
+    const xaml::ResourceDictionary &resources,
+    const std::wstring &resourceName,
+    const xaml::Media::Brush &brush) {
   if (auto solidBrush = brush.try_as<xaml::Media::SolidColorBrush>()) {
     auto copyBrush = xaml::Media::SolidColorBrush();
     copyBrush.Color(solidBrush.Color());

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -31,7 +31,7 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 
 void InsertBrushCopy(
     const xaml::ResourceDictionary &resources,
-    const winrt::hstring &resourceName,
+    const winrt::Windows::Foundation::IReference<winrt::hstring> &resourceName,
     const xaml::Media::Brush &brush) {
   if (auto solidBrush = brush.try_as<xaml::Media::SolidColorBrush>()) {
     auto copyBrush = xaml::Media::SolidColorBrush();

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -32,7 +32,7 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 void UpdateResourceBrush(
     const xaml::FrameworkElement &element,
     const std::wstring &resourceName,
-    const xaml::Media::Brush& brush) {
+    const xaml::Media::Brush &brush) {
   // check for null pointers
   if (const auto resources = element.Resources()) {
     auto key = winrt::box_value(resourceName);

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -32,42 +32,31 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 void UpdateResourceBrush(
     const xaml::FrameworkElement &element,
     const std::wstring &resourceName,
-    const xaml::Media::Brush brush) {
-  const auto resources = element.Resources();
-  if (resources != nullptr) {
-    if (brush != nullptr) {
-      resources.Insert(winrt::box_value(resourceName), brush);
-    } else {
-      resources.Remove(winrt::box_value(resourceName));
-    }
-  }
-}
-
-void UpdateToggleResourceBrush(
-    const xaml::FrameworkElement &element,
-    const std::wstring &resourceName,
-    const xaml::Media::Brush brush) {
+    const xaml::Media::Brush& brush) {
   // check for null pointers
   if (const auto resources = element.Resources()) {
+    auto key = winrt::box_value(resourceName);
     if (brush) {
       // check if resources has key
-      if (resources.HasKey(winrt::box_value(resourceName))) {
-        auto resourceBrush = resources.Lookup(winrt::box_value(resourceName));
+      if (resources.HasKey(key)) {
+        auto resourceBrush = resources.Lookup(key);
         // if both the old Resource Brush and new Resource Brush is a SolidColorBrush, change the color of the brush to
         // support runtime changes
         auto colorBrush = brush.try_as<xaml::Media::SolidColorBrush>();
         auto resourceColorBrush = resourceBrush.try_as<xaml::Media::SolidColorBrush>();
-        if (colorBrush && resourceColorBrush)
+        if (colorBrush && resourceColorBrush) {
           resourceColorBrush.Color(colorBrush.Color());
-        else
-          resources.Insert(winrt::box_value(resourceName), brush);
+        } else {
+          resources.Remove(key);
+          resources.Insert(key, brush);
+        }
       } else {
         // else, add the new brush to the resource directory (will need to reload component to see changes)
-        resources.Insert(winrt::box_value(resourceName), brush);
+        resources.Insert(key, brush);
       }
       // if the brush is null, remove the resource
     } else {
-      resources.Remove(winrt::box_value(resourceName));
+      resources.Remove(key);
     }
   }
 }
@@ -122,33 +111,33 @@ void UpdateToggleSwitchBorderResourceBrushes(
 void UpdateToggleSwitchThumbResourceBrushes(
     const xaml::Controls::ToggleSwitch &toggleSwitch,
     const xaml::Media::Brush thumbBrush) {
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOff, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPointerOver, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPressed, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffDisabled, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOff, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPointerOver, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffPressed, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOffDisabled, thumbBrush);
 
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOn, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnPointerOver, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnPressed, thumbBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnDisabled, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOn, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnPointerOver, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnPressed, thumbBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchKnobFillOnDisabled, thumbBrush);
 }
 
 void UpdateToggleSwitchTrackResourceBrushesOn(
     const xaml::Controls::ToggleSwitch &toggleSwitch,
     const xaml::Media::Brush onTrackBrush) {
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOn, onTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOnPointerOver, onTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOnPressed, onTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOnDisabled, onTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOn, onTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOnPointerOver, onTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOnPressed, onTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOnDisabled, onTrackBrush);
 }
 
 void UpdateToggleSwitchTrackResourceBrushesOff(
     const xaml::Controls::ToggleSwitch &toggleSwitch,
     const xaml::Media::Brush offTrackBrush) {
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOff, offTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOffPointerOver, offTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOffPressed, offTrackBrush);
-  UpdateToggleResourceBrush(toggleSwitch, c_toggleSwitchFillOffDisabled, offTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOff, offTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOffPointerOver, offTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOffPressed, offTrackBrush);
+  UpdateResourceBrush(toggleSwitch, c_toggleSwitchFillOffDisabled, offTrackBrush);
 }
 
 bool IsObjectATextControl(const xaml::DependencyObject &object) {

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -31,7 +31,7 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 
 void InsertBrushCopy(
     const xaml::ResourceDictionary &resources,
-    const winrt::Windows::Foundation::IReference<winrt::hstring> &resourceName,
+    const winrt::Windows::Foundation::IInspectable &resourceName,
     const xaml::Media::Brush &brush) {
   if (auto solidBrush = brush.try_as<xaml::Media::SolidColorBrush>()) {
     auto copyBrush = xaml::Media::SolidColorBrush();
@@ -65,7 +65,7 @@ void UpdateResourceBrush(
         }
       } else {
         // else, add the new brush to the resource directory (will need to reload component to see changes)
-        InsertBrushCopy(resources, key, brush)
+        InsertBrushCopy(resources, key, brush);
       }
       // if the brush is null, remove the resource
     } else {

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -29,6 +29,21 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
   return m_defaultBorderBrush;
 }
 
+void InsertBrushCopy(
+  const xaml::ResourceDictionary &resources,
+  const std::wstring &resourceName,
+  const xaml::Media::Brush &brush) {
+
+  if (auto solidBrush = brush.try_as<xaml::Media::SolidColorBrush>()) {
+    auto copyBrush = xaml::Media::SolidColorBrush();
+    copyBrush.Color(solidBrush.Color());
+    resources.Insert(resourceName, copyBrush);
+  } else {
+    assert(false && "InsertBrushCopy only implemented for solid color brushes");
+    resources.Insert(resourceName, brush);
+  }
+}
+
 void UpdateResourceBrush(
     const xaml::FrameworkElement &element,
     const std::wstring &resourceName,
@@ -47,12 +62,11 @@ void UpdateResourceBrush(
         if (colorBrush && resourceColorBrush) {
           resourceColorBrush.Color(colorBrush.Color());
         } else {
-          resources.Remove(key);
-          resources.Insert(key, brush);
+          InsertBrushCopy(resources, key, brush);
         }
       } else {
         // else, add the new brush to the resource directory (will need to reload component to see changes)
-        resources.Insert(key, brush);
+        InsertBrushCopy(resources, key, brush)
       }
       // if the brush is null, remove the resource
     } else {

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.cpp
@@ -31,7 +31,7 @@ xaml::Media::Brush DefaultBrushStore::GetDefaultBorderBrush() {
 
 void InsertBrushCopy(
     const xaml::ResourceDictionary &resources,
-    const std::wstring &resourceName,
+    const winrt::hstring &resourceName,
     const xaml::Media::Brush &brush) {
   if (auto solidBrush = brush.try_as<xaml::Media::SolidColorBrush>()) {
     auto copyBrush = xaml::Media::SolidColorBrush();

--- a/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ResourceBrushUtils.h
@@ -53,6 +53,6 @@ void UpdateToggleSwitchTrackResourceBrushesOff(
 void UpdateResourceBrush(
     const xaml::FrameworkElement &element,
     const std::wstring &resourceName,
-    const xaml::Media::Brush brush);
+    const xaml::Media::Brush &brush);
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

~Contrary to the docs/interface contract, `ResourceDictionary.Insert` throws if you try to insert an existing key (it should succeed and return a bool indicating whether the key existed before or not).~
~Also updating the docs: https://github.com/MicrosoftDocs/winrt-api/pull/2250~

The plot thickens; because of this XAML bug: microsoft/microsoft-ui-xaml#7306, our current approach of setting brushes into resource dictionaries is flawed because we are reusing the same brush with different keys. This currently doesn't work in XAML. Asking to remove an entry from the DO in this state can end up removing a different entry, and later the call to insert into the map fails because the right key never got removed.

The workaround for now is to create copies of brushes... I fully expect this to have a negative impact in memory usage, but it is the only workaround I can think of (beyond using separate resource dictionaries for every resource which would be worse) :(

### Type of Change
- Bug fix (non-breaking change which fixes an issue)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10219)