### PR TITLE
Adds optional API for window sizing root

### DIFF
--- a/change/react-native-windows-f6f8bd04-f90c-40c5-8a87-a292f7297cdf.json
+++ b/change/react-native-windows-f6f8bd04-f90c-40c5-8a87-a292f7297cdf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds optional API for window sizing root",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -44,6 +44,7 @@ struct Alert : public std::enable_shared_from_this<Alert> {
   std::queue<AlertRequest> pendingAlerts{};
 
   void ProcessPendingAlertRequests() noexcept;
+  void FixContentDialogSize(xaml::Controls::ContentDialog const &dialog) noexcept;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -119,13 +119,15 @@ void LogBox::ShowOnUIThread() noexcept {
     m_logBoxContent.ReactNativeHost(host);
 
     m_popup = xaml::Controls::Primitives::Popup{};
-    xaml::FrameworkElement root{nullptr};
+    xaml::FrameworkElement root = React::XamlUIService::GetWindowSizingRoot(m_context.Properties().Handle());
 
     if (Is19H1OrHigher()) {
       // XamlRoot added in 19H1 - is required to be set for XamlIsland scenarios
       if (auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context.Properties().Handle())) {
         m_popup.XamlRoot(xamlRoot);
-        root = xamlRoot.Content().as<xaml::FrameworkElement>();
+        if (!root) {
+          root = xamlRoot.Content().as<xaml::FrameworkElement>();
+        }
       }
     }
 

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -80,6 +80,11 @@ ReactPropertyId<xaml::FrameworkElement> AccessibleRootProperty() noexcept {
   return propId;
 }
 
+ReactPropertyId<xaml::FrameworkElement> SizingRootProperty() noexcept {
+  static ReactPropertyId<xaml::FrameworkElement> propId{L"ReactNative.UIManager", L"SizingRoot"};
+  return propId;
+}
+
 /*static*/ void XamlUIService::SetXamlRoot(
     IReactPropertyBag const &properties,
     xaml::XamlRoot const &xamlRoot) noexcept {
@@ -92,12 +97,22 @@ ReactPropertyId<xaml::FrameworkElement> AccessibleRootProperty() noexcept {
   winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(AccessibleRootProperty(), accessibleRoot);
 }
 
+/*static*/ void XamlUIService::SetWindowSizingRoot(
+    IReactPropertyBag const &properties,
+    xaml::FrameworkElement const &sizingRoot) noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Set(SizingRootProperty(), sizingRoot);
+}
+
 /*static*/ xaml::XamlRoot XamlUIService::GetXamlRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(XamlRootProperty());
 }
 
 /*static*/ xaml::FrameworkElement XamlUIService::GetAccessibleRoot(IReactPropertyBag const &properties) noexcept {
   return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(AccessibleRootProperty());
+}
+
+/*static*/ xaml::FrameworkElement XamlUIService::GetWindowSizingRoot(IReactPropertyBag const &properties) noexcept {
+  return winrt::Microsoft::ReactNative::ReactPropertyBag(properties).Get(SizingRootProperty());
 }
 
 ReactPropertyId<uint64_t> XamlIslandProperty() noexcept {

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -28,8 +28,13 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
   static void SetAccessibleRoot(
       IReactPropertyBag const &properties,
       xaml::FrameworkElement const &accessibleRoot) noexcept;
+  static void SetWindowSizingRoot(
+      IReactPropertyBag const &properties,
+      xaml::FrameworkElement const &sizingRoot) noexcept;
+
   static xaml::XamlRoot GetXamlRoot(IReactPropertyBag const &properties) noexcept;
   static xaml::FrameworkElement GetAccessibleRoot(IReactPropertyBag const &properties) noexcept;
+  static xaml::FrameworkElement GetWindowSizingRoot(IReactPropertyBag const &properties) noexcept;
 
   static void SetIslandWindowHandle(IReactPropertyBag const &properties, uint64_t hwnd) noexcept;
   static uint64_t GetIslandWindowHandle(IReactPropertyBag const &properties) noexcept;

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -45,11 +45,18 @@ namespace Microsoft.ReactNative
       "to have access to functionality related to accessibility.")
     static void SetAccessibleRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement accessibleRoot);
 
+    DOC_STRING("Sets the default @Windows.UI.Xaml.FrameworkElement that will act as a proxy to the window size for the app.")
+    static void SetWindowSizingRoot(IReactPropertyBag properties, XAML_NAMESPACE.FrameworkElement sizingRoot);
+
     DOC_STRING("Retrieves the default @Windows.UI.Xaml.XamlRoot for the app.")
     static XAML_NAMESPACE.XamlRoot GetXamlRoot(IReactPropertyBag properties);
 
     DOC_STRING("Retrieves the default @Windows.UI.Xaml.FrameworkElement that will be used for the app for accessibility purposes (e.g. to announce).")
     static XAML_NAMESPACE.FrameworkElement GetAccessibleRoot(IReactPropertyBag properties);
+
+    DOC_STRING(
+        "Retrieves the default @Windows.UI.Xaml.FrameworkElement that will act as a proxy to the window size for the app.")
+    static XAML_NAMESPACE.FrameworkElement GetWindowSizingRoot(IReactPropertyBag properties);
 
     DOC_STRING(
       "Gets the window handle HWND (as an UInt64) used as the XAML Island window for the current React instance.")


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
It may not always be the case that the XamlRoot is the same size as the HWND. For example, in our app, to work around https://github.com/microsoft/microsoft-ui-xaml/issues/2101, we resize the XamlRoot content to be larger than the window by the DPI scale factor and then resizes the ReactRootView to be the same size as the HWND. However, this breaks the LogBoxModule and the AlertModule, which make the assumption that the XamlRoot is the same size as the window.

Resolves #10211

### What
To workaround this assumption, this change adds an API to XamlUIService that allows you to specify which view under XamlRoot is equivalent to the window size for the purpose of sizing things like the ContentDialog smoke screen and the LogBox popup.

## Testing
As a demonstration example, I changed the Playground-win32 app to set the ReactRootView as the window sizing root and forced the ReactRootView to be smaller than the XamlRoot grid. You'll notice that the LogBox popup and ContentDialog smoke screen still attach to the window at the origin (they are not offset to the position of the window sizing root), but this is not something I plan to change as the intention of the window sizing root is that it actually matches the size of the window (so no offsets should be required):

https://user-images.githubusercontent.com/1106239/176501861-d53483d8-d6c9-467e-bd76-d5177c523b5b.mp4

Here's the same working correctly when the ReactRootView actually matches the size of the HWND:

https://user-images.githubusercontent.com/1106239/176502260-705d743c-ee0b-4afb-b63b-f33234742e24.mp4

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10221)