### PR TITLE
Use interface for ReactImage memory streams

### DIFF
--- a/change/react-native-windows-b064d013-f809-4f41-8d4f-6427c428618a.json
+++ b/change/react-native-windows-b064d013-f809-4f41-8d4f-6427c428618a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use interface for ReactImage memory streams",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.cpp
@@ -45,7 +45,7 @@ winrt::fire_and_forget GetImageSizeAsync(
     bool needsDownload = (scheme == L"http") || (scheme == L"https");
     bool inlineData = scheme == L"data";
 
-    winrt::InMemoryRandomAccessStream memoryStream;
+    winrt::IRandomAccessStream memoryStream;
     if (needsDownload) {
       memoryStream = co_await GetImageStreamAsync(source);
     } else if (inlineData) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -171,7 +171,7 @@ void ReactImage::Source(ReactImageSource source) {
   }
 }
 
-winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> ReactImage::GetImageMemoryStreamAsync(
+winrt::IAsyncOperation<winrt::IRandomAccessStream> ReactImage::GetImageMemoryStreamAsync(
     ReactImageSource source) {
   switch (source.sourceType) {
     case ImageSourceType::Download:
@@ -223,7 +223,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   const bool fromStream{
       source.sourceType == ImageSourceType::Download || source.sourceType == ImageSourceType::InlineData};
 
-  winrt::InMemoryRandomAccessStream memoryStream{nullptr};
+  winrt::IRandomAccessStream memoryStream{nullptr};
 
   // get weak reference before any co_await calls
   auto weak_this{get_weak()};
@@ -443,7 +443,7 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   }
 }
 
-winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageStreamAsync(ReactImageSource source) {
+winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImageSource source) {
   try {
     co_await winrt::resume_background();
 
@@ -480,7 +480,7 @@ winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageStreamAsync(Re
   co_return nullptr;
 }
 
-winrt::IAsyncOperation<winrt::InMemoryRandomAccessStream> GetImageInlineDataAsync(ReactImageSource source) {
+winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageInlineDataAsync(ReactImageSource source) {
   size_t start = source.uri.find(',');
   if (start == std::string::npos || start + 1 > source.uri.length())
     co_return nullptr;

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -171,8 +171,7 @@ void ReactImage::Source(ReactImageSource source) {
   }
 }
 
-winrt::IAsyncOperation<winrt::IRandomAccessStream> ReactImage::GetImageMemoryStreamAsync(
-    ReactImageSource source) {
+winrt::IAsyncOperation<winrt::IRandomAccessStream> ReactImage::GetImageMemoryStreamAsync(ReactImageSource source) {
   switch (source.sourceType) {
     case ImageSourceType::Download:
       co_return co_await GetImageStreamAsync(source);

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -69,7 +69,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
  private:
   xaml::Media::Stretch ResizeModeToStretch();
   xaml::Media::Stretch ResizeModeToStretch(winrt::Windows::Foundation::Size size);
-  winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
   GetImageMemoryStreamAsync(ReactImageSource source);
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
 
@@ -91,8 +91,8 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
 };
 
 // Helper functions
-winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
 GetImageStreamAsync(ReactImageSource source);
-winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::InMemoryRandomAccessStream>
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
 GetImageInlineDataAsync(ReactImageSource source);
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -91,8 +91,8 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
 };
 
 // Helper functions
-winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
-GetImageStreamAsync(ReactImageSource source);
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> GetImageStreamAsync(
+    ReactImageSource source);
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
 GetImageInlineDataAsync(ReactImageSource source);
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- N/A (code cleanup)
### Why
We only depend on the IRandomAccessStream interface at call sites where the image stream is used, so no need to return the specific InMemoryRandomAccessStream implementation detail.

### What
Rather than using the concrete `InMemoryRandomAccessStream` type for the ReactImage helper methods, switching to the `IRandomAccessStream` interface. We fork this code to add webp support and changing to this interface keeps the diff smaller.

## Testing
Images still work as expected in RNTester.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10222)