### PR TITLE
Run debug feature tests in ADO pipelines

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -20,6 +20,12 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground.sln
+          - Name: X64DebugUniversal
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            RunWack: true
+            UploadAppx: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -43,6 +49,12 @@ parameters:
             UploadAppx: true
           - Name: X64ReleaseUniversal
             BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            RunWack: true
+            UploadAppx: true
+          - Name: X64DebugUniversal
+            BuildConfiguration: Debug
             BuildPlatform: x64
             SolutionFile: Playground.sln
             RunWack: true
@@ -118,6 +130,42 @@ jobs:
                 ${{if eq(config.BuildEnvironment, 'Continuous')}}:
                   msbuildArgs:
                     /p:PackageCertificateKeyFile=$(Build.SourcesDirectory)\EncodedKey.pfx
+
+            # Execute debug feature tests
+            #
+            # This step loose-file-deploys the UWP Playground app and uses it as an RNW host for a series
+            # of debug feature tests. In the future, these tests should be performed against a host app
+            # better suited for automated tests (probably the E2E test app).
+            - powershell: |
+                $appRecipeToolPath = Join-Path (Get-CimInstance MSFT_VSInstance | Sort-Object -Property 'Version' -Descending)[0].InstallLocation "Common7\IDE\DeployAppRecipe.exe"
+                if (!(Test-Path $appRecipeToolPath)) { throw "can't find '$appRecipeToolPath'" }
+                $platDirs = @{ "x64" = "x64\"; "x86" = ""} # map from ADO BuildPlatform arg to VS build output dir part 
+                $appRecipePath = "$(Build.SourcesDirectory)\packages\playground\windows\$($platDirs['${{ matrix.BuildPlatform }}'])${{ matrix.BuildConfiguration }}\playground\playground.build.appxrecipe"
+                if (!(Test-Path $appRecipePath)) { throw "can't find '$appRecipePath'" }
+                &$appRecipeToolPath $appRecipePath
+                if (!(Get-AppxPackage 'RNPlayground')) {throw "RNPlayground app does not appear to be installed"}
+                Set-Location "$(Build.SourcesDirectory)\packages\debug-test"
+                $env:DEBUGTEST_LOGFOLDER = "$($env:AGENT_TEMPDIRECTORY)\DebugTestLogs"
+                yarn debugtest
+              displayName: Run Debug Feature Tests
+              # skip this step for the Win32 Playground app and for release builds
+              condition: and(endsWith('${{ matrix.Name }}', 'Universal'), eq('${{ matrix.BuildConfiguration }}', 'Debug'))
+              timeoutInMinutes: 5
+
+            - powershell: |
+                foreach ($logFile in (ls "$env:AGENT_TEMPDIRECTORY\DebugTestLogs\*.log")) {
+                  Write-Host "logFile: '$logFile'"
+                  Get-Content $logFile | ForEach-Object {Write-Host "##[debug]$_"}
+                }
+              displayName: Incorporate Log File Content into ADO Log Stream
+              condition: failed()
+
+            - task: PublishBuildArtifacts@1
+              displayName: Publish Debug Test Logs
+              condition: failed()
+              inputs:
+                pathToPublish: '$(Agent.TempDirectory)\DebugTestLogs'
+                artifactName: Debug Test Logs
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/cleanup-certificate.yml

--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -18,7 +18,6 @@ import {testLog} from './TestLog';
 import {formatDateTime} from './Utilities';
 import {pid} from 'process';
 import fs from '@react-native-windows/fs';
-//import {AutomationElement} from '@react-native-windows/automation';
 
 // jest does not appear to support custom command-line arguments; making do with environment variables.
 

--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -9,27 +9,61 @@ import * as http from 'http';
 import {getDebugTargets, CDPDebugger} from './CDPDebugger';
 import {Metro} from './MetroAutomation';
 import * as path from 'path';
-import {PlaygroundDebugSettings, selectPackage} from './PlaygroundAutomation';
+import {
+  PlaygroundDebugSettings,
+  loadPackage,
+  primePackageComboBox,
+} from './PlaygroundAutomation';
 import {testLog} from './TestLog';
 import {formatDateTime} from './Utilities';
+import {pid} from 'process';
+import fs from '@react-native-windows/fs';
+//import {AutomationElement} from '@react-native-windows/automation';
 
-testLog.fileName = `${process.env.TEMP}/${path.basename(
-  __filename,
-  '.ts',
-)}.${formatDateTime(new Date())}.log`;
+// jest does not appear to support custom command-line arguments; making do with environment variables.
+
+if (process.env.DEBUGTEST_LOGFOLDER) {
+  if (!fs.existsSync(process.env.DEBUGTEST_LOGFOLDER)) {
+    (async () => {
+      try {
+        await fs.mkdir(process.env.DEBUGTEST_LOGFOLDER!);
+      } catch (e) {
+        console.log(e);
+      }
+    })();
+  }
+
+  testLog.setFileName(
+    `${process.env.DEBUGTEST_LOGFOLDER}/${path.basename(
+      __filename,
+      '.ts',
+    )}.${formatDateTime(new Date())}.log`,
+  );
+} else {
+  testLog.setFileName(
+    `${process.env.TEMP}/${path.basename(__filename, '.ts')}.${formatDateTime(
+      new Date(),
+    )}.log`,
+  );
+}
 
 const metro = new Metro();
 
 beforeAll(async () => {
+  testLog.message(`executing beforeAll on PID ${pid}`);
   await metro.start();
+  const window = (await $$('./Window'))[0];
+  await window.maximizeWindow();
+  await primePackageComboBox();
 });
 
 afterAll(() => {
+  testLog.message(`executing afterAll on PID ${pid}`);
   metro.stop();
 });
 
 test('debug target properties', async () => {
-  testLog.message(`test debug target properties`);
+  testLog.message(`executing 'debug target properties' on PID ${pid}`);
 
   const settings = await PlaygroundDebugSettings.set({
     webDebugger: false,
@@ -37,7 +71,8 @@ test('debug target properties', async () => {
     jsEngine: 'Hermes',
   });
   try {
-    await selectPackage('Samples\\debugTest01');
+    const isBundleServed = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed);
 
     const options: http.RequestOptions = {
       hostname: 'localhost',
@@ -74,7 +109,7 @@ test('debug target properties', async () => {
 });
 
 test('enable, disable', async () => {
-  testLog.message(`test enable, disable`);
+  testLog.message(`executing 'enable, disable' test on PID ${pid}`);
 
   const settings = await PlaygroundDebugSettings.set({
     webDebugger: false,
@@ -82,7 +117,8 @@ test('enable, disable', async () => {
     jsEngine: 'Hermes',
   });
   try {
-    await selectPackage('Samples\\debugTest01');
+    const isBundleServed = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed);
 
     const debugTargets = await getDebugTargets();
     const dbg = new CDPDebugger(debugTargets[0].webSocketDebuggerUrl);
@@ -98,7 +134,7 @@ test('enable, disable', async () => {
 });
 
 test('pause, resume', async () => {
-  testLog.message(`test pause, resume`);
+  testLog.message(`executing 'pause, resume' test on PID ${pid}`);
 
   const settings = await PlaygroundDebugSettings.set({
     webDebugger: false,
@@ -106,7 +142,8 @@ test('pause, resume', async () => {
     jsEngine: 'Hermes',
   });
   try {
-    await selectPackage('Samples\\debugTest01');
+    const isBundleServed = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed);
 
     const debugTargets = await getDebugTargets();
     const dbg = new CDPDebugger(debugTargets[0].webSocketDebuggerUrl);
@@ -160,7 +197,7 @@ test('pause, resume', async () => {
 });
 
 test('set, remove breakpoint', async () => {
-  testLog.message(`test set, remove breakpoint`);
+  testLog.message(`executing 'set, remove breakpoint' test on PID ${pid}`);
 
   const settings = await PlaygroundDebugSettings.set({
     webDebugger: false,
@@ -168,7 +205,8 @@ test('set, remove breakpoint', async () => {
     jsEngine: 'Hermes',
   });
   try {
-    await selectPackage('Samples\\debugTest01');
+    const isBundleServed = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed);
 
     const debugTargets = await getDebugTargets();
     const dbg = new CDPDebugger(debugTargets[0].webSocketDebuggerUrl);

--- a/packages/debug-test/MetroAutomation.ts
+++ b/packages/debug-test/MetroAutomation.ts
@@ -33,9 +33,6 @@ export class Metro {
         stdio: 'pipe',
       });
 
-      if (this.metroProcess === null)
-        throw new Error('Metro process did not start correctly');
-
       testLog.message(`Metro process ID ${this.metroProcess.pid}`);
 
       // keep an eye on Metro

--- a/packages/debug-test/PlaygroundAutomation.ts
+++ b/packages/debug-test/PlaygroundAutomation.ts
@@ -26,6 +26,8 @@
 
 import {testLog} from './TestLog';
 import {app, AutomationElement} from '@react-native-windows/automation';
+import {saveScreenShot, sleep} from './Utilities';
+// import fs from '@react-native-windows/fs';
 
 async function setCheckedState(
   checkBox: AutomationElement,
@@ -42,29 +44,189 @@ async function setCheckedState(
   testLog.message(`"${checkBoxName}" has checkbox state ${checkedState}`);
 }
 
+export async function primePackageComboBox() {
+  // On ADO agents, initial expansion of the drop list can result in a UIA tree that's missing nodes for
+  // some list items. We're trying to "prime" the drop list by dropping and collapsing it prior to test
+  // execution.
+  testLog.message('start primePackageComboBox');
+  const entryPointComboBox = (
+    await $$('//Window/ComboBox[@AutomationId="x_entryPointCombo"]')
+  )[0];
+
+  // found to be necessary in ADO runs - perhaps it puts the app into the foreground
+  await entryPointComboBox.click();
+  await sleep(500);
+
+  await entryPointComboBox.click(); // focus combo box
+  await sleep(500);
+
+  await entryPointComboBox.keys(['ArrowDown']); // drop drop list
+  await sleep(500);
+  await entryPointComboBox.keys(['End']); // move cursor to end of edit box
+  await sleep(500);
+  await entryPointComboBox.keys(['End']); //select last drop list item
+  await sleep(500);
+
+  await app.waitUntil(
+    async () =>
+      (
+        await $$(
+          '//Window/ComboBox[@AutomationId="x_entryPointCombo"]/ListItem',
+        )
+      ).length > 1,
+    {timeout: 20000},
+  );
+
+  const listItems = await $$(
+    '//Window/ComboBox[@AutomationId="x_entryPointCombo"]/ListItem',
+  );
+
+  for (let i = 0; i < listItems.length; ++i) {
+    const listItemText = await listItems[i].getText();
+    testLog.message(`text of list item ${i}: "${listItemText}"`);
+  }
+  await saveScreenShot('After Initial Combo Box Expansion');
+
+  await entryPointComboBox.keys(['Home']); // move cursor to start of edit box
+  await sleep(500);
+  await entryPointComboBox.keys(['Home']); // select first drop list item
+  await sleep(500);
+  await entryPointComboBox.keys(['Tab']); // collapse drop list
+  await sleep(500);
+
+  await saveScreenShot('After Initial Combo Box Collapse');
+  testLog.message('end primePackageComboBox');
+}
+
+async function selectPackage(packageName: string) {
+  // It was hard to get this operation to succeed on ADO agents. The fundamental problem appears to be
+  // that UIA interactions - which are inherently asynchronous - seem to execute much slower
+  // on ADO agents. This requires synchronization "checkpoints" that are hard to implement due to
+  // - missing WebDriver API elements (mainly events)
+  // - missing WinAppDriver implementations of WebDriver commands
+  // - peculiarities of the UIA implementation of the XAML combo box causing WinAppDriver commands
+  //   to behave in unexpected ways.
+  // Many alternatives have been tried; the steps below are the ones that were found to be working.
+  // The frailty of this indicates that we should probably switch from a WDIO-based automation solution
+  // to an automation channel that is simpler and our under our full control.
+  //
+  // Findings:
+  // - combo box setValue() used to work but is now broken in that subsequent calls drop the first letter
+  // - combo box does not support isFocused()
+  // - combo box does not support getText()
+  // - combo box does not support getValue()
+  // - combo box value can be retrieved via getText() on a nested edit control, but the edit control
+  //   may only be present when keyboard focus is in the combo box
+  // - upon initial expansion of the drop list, not all UIA nodes for the list items may get generated
+  // - selectByVisibleText() on the combo box does not work (perhaps it only fails for the last item
+  //   for the reason listed above, or because the list item is scrolled out of view and marked off-screen)
+
+  testLog.message(`start selecting package "${packageName}"`);
+
+  const entryPointComboBox = (
+    await $$('//Window/ComboBox[@AutomationId="x_entryPointCombo"]')
+  )[0];
+
+  // expand drop list
+  await entryPointComboBox.click(); // focus drop list
+  await entryPointComboBox.keys(['ArrowDown']); // expand drop list
+
+  // synchronize with the appearance of the drop list
+  // When collapsed, there's one list item (the currently selected one). To
+  // sync with the expansion of the drop list, we need to test for more than
+  // one list item. We would need to restructure the algorithm if there is
+  // only one list item (no selection change required).
+  await app.waitUntil(
+    async () =>
+      (
+        await $$(
+          './Window/ComboBox[@AutomationId="x_entryPointCombo"]/ListItem',
+        )
+      ).length > 1,
+    {timeout: 10000},
+  );
+  await saveScreenShot('After Dropping Combo Box');
+
+  const listItems = await $$(
+    '//Window/ComboBox[@AutomationId="x_entryPointCombo"]/ListItem',
+  );
+  testLog.message(`list item count: ${listItems.length}`);
+
+  let currentIndex = -1;
+  let targetIndex = -1;
+
+  for (let i = 0; i < listItems.length; ++i) {
+    const listItemText = await listItems[i].getText();
+    testLog.message(`text of list item ${i}: "${listItemText}"`);
+    if (await listItems[i].isSelected()) currentIndex = i;
+    if (listItemText === packageName) targetIndex = i;
+    if (currentIndex !== -1 && targetIndex !== -1) break;
+  }
+
+  if (currentIndex === -1)
+    throw new Error(`can't find currently selected drop list item`);
+  if (targetIndex === -1) throw new Error(`can't find target drop list item`);
+
+  testLog.message(`currentIndex: ${currentIndex}`);
+  testLog.message(`targetIndex: ${targetIndex}`);
+
+  if (targetIndex > currentIndex) {
+    for (let i = 0; i < targetIndex - currentIndex; ++i) {
+      await entryPointComboBox.keys(['ArrowDown']);
+      await sleep(100);
+    }
+  } else if (targetIndex < currentIndex) {
+    for (let i = 0; i < currentIndex - targetIndex; ++i) {
+      await entryPointComboBox.keys(['ArrowUp']);
+      await sleep(100);
+    }
+  }
+
+  // select the item and collapse the drop list
+  await entryPointComboBox.keys(['Return']);
+
+  // synchronize with the collapse of the drop list
+  await app.waitUntil(
+    async () =>
+      (
+        await $$(
+          './Window/ComboBox[@AutomationId="x_entryPointCombo"]/ListItem',
+        )
+      ).length <= 1,
+    {timeout: 10000},
+  );
+  testLog.message(`done selecting package "${packageName}"`);
+  await saveScreenShot('After Selecting Combo Box Item');
+}
+
 /**
  * Selects (loads) a package in the Playground app.
  *
  * @param packageName Name of the package to load.
  * @returns Promise indicating that the package was loaded.
  */
-export async function selectPackage(packageName: string): Promise<void> {
+export async function loadPackage(
+  packageName: string,
+  bundleServed: Promise<void>,
+): Promise<void> {
   testLog.message(`selecting "${packageName}" bundle`);
 
-  const entryPointComboBox = (
-    await $$('./Window/ComboBox[@AutomationId="x_entryPointCombo"]')
-  )[0];
-  await entryPointComboBox.setValue(packageName);
+  await selectPackage(packageName);
 
-  const rootComponentComboBox = (
-    await $$('./Window/ComboBox[@AutomationId="x_rootComponentNameCombo"]')
-  )[0];
-  await rootComponentComboBox.click();
+  //   const rootComponentComboBox = (
+  //     await $$('./Window/ComboBox[@AutomationId="x_rootComponentNameCombo"]')
+  //   )[0];
+  //   await rootComponentComboBox.click();
+  //   testLog.message(`clicked on root component combo`);
 
   const loadButton = (
     await $$('./Window/Button[@AutomationId="x_LoadButton"]')
   )[0];
   await loadButton.click();
+  testLog.message(`clicked on load button`);
+
+  await bundleServed;
+  testLog.message(`Metro appears to have served the bundle`);
 
   // synchronize with the bundle getting loaded
   await app.waitUntil(

--- a/packages/debug-test/PlaygroundAutomation.ts
+++ b/packages/debug-test/PlaygroundAutomation.ts
@@ -27,7 +27,6 @@
 import {testLog} from './TestLog';
 import {app, AutomationElement} from '@react-native-windows/automation';
 import {saveScreenShot, sleep} from './Utilities';
-// import fs from '@react-native-windows/fs';
 
 async function setCheckedState(
   checkBox: AutomationElement,
@@ -212,12 +211,6 @@ export async function loadPackage(
   testLog.message(`selecting "${packageName}" bundle`);
 
   await selectPackage(packageName);
-
-  //   const rootComponentComboBox = (
-  //     await $$('./Window/ComboBox[@AutomationId="x_rootComponentNameCombo"]')
-  //   )[0];
-  //   await rootComponentComboBox.click();
-  //   testLog.message(`clicked on root component combo`);
 
   const loadButton = (
     await $$('./Window/Button[@AutomationId="x_LoadButton"]')

--- a/packages/debug-test/TestLog.ts
+++ b/packages/debug-test/TestLog.ts
@@ -8,7 +8,6 @@
  */
 
 import fs from '@react-native-windows/fs';
-import {formatDateTime} from './Utilities';
 
 // REVIEW: Does jest have a more suitable logging facility?
 
@@ -40,9 +39,13 @@ export const testLog = new (class {
   private write(message: string) {
     // console.log(message);
     const time = new Date();
-    fs.writeFileSync(this.fileName, `${this.formatTime(time)}: ${message}\n`, {
-      flag: 'a',
-    });
+    fs.writeFileSync(
+      this.getFileName(),
+      `${this.formatTime(time)}: ${message}\n`,
+      {
+        flag: 'a',
+      },
+    );
   }
 
   private formatTime(dt: Date) {
@@ -53,10 +56,28 @@ export const testLog = new (class {
     return `${hh}:${mm}:${ss}.${ms}`;
   }
 
-  /**
-   * Path and name of the test log file. Default value intended to be overwritten by a test-suite-specific name.
-   */
-  public fileName: string = `${process.env.TEMP}/test.${formatDateTime(
-    new Date(),
-  )}.log`;
+  private getFileName(): string {
+    if (this._fileName === '') {
+      throw new Error(
+        'log file name needs to get set prior to first logging call',
+      );
+    }
+    return this._fileName;
+  }
+
+  public setFileName(fileName: string) {
+    if (this._fileName === '') {
+      this._fileName = fileName;
+      if (fs.existsSync(this._fileName)) {
+        fs.unlinkSync(this._fileName);
+        this.message('a log file with this path existed and was overwritten');
+      }
+    } else {
+      throw new Error(
+        `log file name is being reassigned, old value "${this._fileName}", new value "${fileName}"`,
+      );
+    }
+  }
+
+  private _fileName: string = '';
 })();

--- a/packages/debug-test/Utilities.ts
+++ b/packages/debug-test/Utilities.ts
@@ -7,6 +7,9 @@
  * @format
  */
 
+import fs from '@react-native-windows/fs';
+import {testLog} from './TestLog';
+
 /**
  * Pauses execution for the specified amount of time.
  * @param ms Time, in milliseconds, to pause execution.
@@ -44,4 +47,27 @@ export function formatDateTime(dt: Date) {
   const mm = ('0' + dt.getMinutes()).slice(-2);
   const ss = ('0' + dt.getSeconds()).slice(-2);
   return `${YYYY}${MM}${DD}-${hh}${mm}${ss}`;
+}
+
+export async function saveScreenShot(fileNameSuffix?: string) {
+  let fileNameBase = process.env.DEBUGTEST_LOGFOLDER
+    ? `${process.env.DEBUGTEST_LOGFOLDER}\\Screenshot`
+    : `${process.env.TEMP}\\Screenshot`;
+
+  if (fileNameSuffix) {
+    fileNameBase += ` - ${fileNameSuffix}`;
+  }
+
+  let fileNameCandidate = `${fileNameBase}.png`;
+  for (let i = 2; i < 10000; ++i) {
+    if (!fs.existsSync(fileNameCandidate)) {
+      testLog.message(`saving screenshot as "${fileNameCandidate}"`);
+      return global.browser.saveScreenshot(fileNameCandidate);
+    }
+    fileNameCandidate = `${fileNameBase} (${i}).png`;
+  }
+
+  return Promise.reject(
+    new Error('could not find a file name to save screenshot under'),
+  );
 }


### PR DESCRIPTION
## Run Debug Feature Tests in ADO Pipelines

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
I previously added a couple of debug feature tests (packages\debug-test). So far, they required manual execution (and are thus useless except to those that are aware of their existence). This change executes these tests as part our ADO pipelines.

### What
- modify test TS code to successfully execute on ADO agents, chiefly by adding more sync points between test code and UI of test host app (Playground)
- add ADO steps in YAML to execute tests as part of the pipeline
- add ADO steps to publish test logs and screenshots to aid failure investigation 

## Screenshots
n/a

## Testing
- run abbreviated ADO pipeline (https://dev.azure.com/ms/react-native-windows/_build?definitionId=267) to ensure resonable success rate of the tests 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10242)