### PR TITLE
Additional compiler & linker flags for binary size 

### DIFF
--- a/change/react-native-windows-f17abf92-78b7-416e-866a-5637f77ac23e.json
+++ b/change/react-native-windows-f17abf92-78b7-416e-866a-5637f77ac23e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "adding missing flags, recommended for reducing binary size",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/Release.props
+++ b/vnext/PropertySheets/Release.props
@@ -12,10 +12,16 @@
 
   <ItemDefinitionGroup>
     <ClCompile>
+      <StringPooling>true</StringPooling>
       <Optimization>MinSpace</Optimization>
+      <AdditionalOptions>%(AdditionalOptions) /Gw</AdditionalOptions>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
+
+    <Link>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
   </ItemDefinitionGroup>
 
 </Project>


### PR DESCRIPTION
## Description
As part of an EIM initiative, did a compiler options pass for recommended flags to reduce binary size. We are mostly good; this adds the three we were missing. 

Minor savings since we had the majority set up already, but did slightly decrease binary size:
Microsoft.ReactNative.dll: 2,869,248 bytes -> 2,865,152 bytes (-4,096) 
                                 .pdb: 113,397,760 bytes -> 113,364,992 bytes (-32,768)

Comparing through SizeBench, biggest impact was on the .rdata section. 

Internal link for recommended flags [here](https://www.osgwiki.com/wiki/Compiler_and_linker_flags_recommended_for_binary_size#MSBuild_equivalents). 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10244)