### PR TITLE
Explicitly add headers for clang build

### DIFF
--- a/change/react-native-windows-1e527570-f5d5-4193-a6b8-dc4eb1571f33.json
+++ b/change/react-native-windows-1e527570-f5d5-4193-a6b8-dc4eb1571f33.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Explicitly add headers for clang build",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/GlyphViewManager.cpp
@@ -8,6 +8,7 @@
 #include "GlyphViewManager.h"
 
 #include <UI.Xaml.Documents.h>
+#include <UI.Xaml.Media.h>
 #include <Utils/ValueUtils.h>
 #include <Views/ShadowNodeBase.h>
 

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -5,6 +5,7 @@
 #include "BatchingEventEmitter.h"
 #include "DynamicWriter.h"
 #include "JSValueWriter.h"
+#include <UI.Xaml.Media.h>
 
 namespace winrt::Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/BatchingEventEmitter.cpp
@@ -3,9 +3,9 @@
 
 #include "pch.h"
 #include "BatchingEventEmitter.h"
+#include <UI.Xaml.Media.h>
 #include "DynamicWriter.h"
 #include "JSValueWriter.h"
-#include <UI.Xaml.Media.h>
 
 namespace winrt::Microsoft::ReactNative {
 


### PR DESCRIPTION
I assume that because we may not be using the same PCH, this causes the build to fail. Adding headers used in BatchingEventEmitter and GlyphViewManager to fix this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10248)