### PR TITLE
Restore Git Tags for Canaries

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -86,11 +86,11 @@ jobs:
         displayName: git pull
 
       - script: npx @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
-        displayName: Create GitHub Releases (local version)
+        displayName: Create GitHub Releases (New Canary Version)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ eq(variables['Build.SourceBranchName'], 'main') }} )
 
       - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
-        displayName: Create GitHub Releases (latest published version)
+        displayName: Create GitHub Releases (New Stable Version)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )
 
       - template: templates/set-version-vars.yml

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -78,20 +78,19 @@ jobs:
         displayName: Enable No-Publish
         condition: ${{ parameters.skipGitPush }}
 
-      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***" --no-git-tags
-        displayName: Beachball Publish (Main Branch)
-        condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
-
       - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
-        displayName: Beachball Publish (Stable Branch)
-        condition: and(succeeded(), ne(variables['Build.SourceBranchName'], 'main'))
+        displayName: Beachball Publish
 
       # Beachball reverts to local state after publish, but we want the updates it added
       - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
         displayName: git pull
 
+      - script: npx @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
+        displayName: Create GitHub Releases (local version)
+        condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ eq(variables['Build.SourceBranchName'], 'main') }} )
+
       - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
-        displayName: Create GitHub Releases for New Tags (Stable Branch)
+        displayName: Create GitHub Releases (latest published version)
         condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )
 
       - template: templates/set-version-vars.yml

--- a/change/@rnw-scripts-create-github-releases-d11e1dcc-5c40-4505-bf1a-5a7c149f5114.json
+++ b/change/@rnw-scripts-create-github-releases-d11e1dcc-5c40-4505-bf1a-5a7c149f5114.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Restore Some Git Tags",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-bc36feae-f0a1-49ed-a2db-08c5a0377d44.json
+++ b/change/react-native-windows-bc36feae-f0a1-49ed-a2db-08c5a0377d44.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Restore Some Git Tags",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -8,14 +8,19 @@
 import {execSync} from 'child_process';
 import {findRepoPackageSync} from '@react-native-windows/package-utils';
 
-import type {BeachballOptions} from 'beachball/lib/types/BeachballOptions';
+import type {RepoOptions} from 'beachball/lib/types/BeachballOptions';
 import type {ChangeInfo} from 'beachball/lib/types/ChangeInfo';
  
-const Options: BeachballOptions = {
+const Options: RepoOptions = {
   ...require("@rnw-scripts/generated-beachball-config"),
    
-  // Do not generate tags for monorepo packages by default, to avoid a GitHub
-  // release for every package.
+  // Do not generate tags for monorepo packages by default. May be overridden in
+  // a package's "package.json" by adding:
+  // ```
+  // "beachball": {
+  //   "gitTags": true
+  // }
+  // ```
   gitTags: false,
 
   hooks: {

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -28,6 +28,8 @@ const RNW_REPO = {
   repo: 'react-native-windows',
 };
 
+const ELIGIBLE_PACKAGES = ['react-native-windows'];
+
 /**
  * Representation the JSON chanelog comment obejct
  */
@@ -157,6 +159,13 @@ function needsRelease(
   localTags: string[],
   githubReleases: Array<{tag_name: string}>,
 ) {
+  if (
+    !ELIGIBLE_PACKAGES.includes(release.packageName) ||
+    release.version.prerelease[0] === 'canary'
+  ) {
+    return false;
+  }
+
   const releaseTags = githubReleases.map(r => r.tag_name);
   return localTags.includes(release.tag) && !releaseTags.includes(release.tag);
 }

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -92,7 +92,8 @@
       "major",
       "minor",
       "patch"
-    ]
+    ],
+    "gitTags": true
   },
   "files": [
     "/codegen",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
Years ago the RNW repo published new package revisions for every commit to the repo. Beachball's default is to create a new git tag for every package revision. This led to a Git tag, for every package, for every commit. GitHub previously included every tag  as an indivdual release in its "Releases" view. This drowned out the public-facing release notes, leading to a change to only tag package revisions where release notes were wanted.

GitHub has changed their UI, to no longer include tags in the "Releases" view. A current example where there are many tags but no releases is https://github.com/microsoft/fluentui-react-native/releases. This decoupling allows walking back sparseness of tagging.

### What
This change adds git tags for canaries and for the CLI package. These can be useful for local debugging, and provide a way to correlate package versions to a git revision, without having to embed a commit hash into the version. Tags created by beachball conform to the standard of `{package}_v${version}`, including for scoped and prerelease packages.

This requires changing a bit of logic in `@rnw-scripts/create-github-releases` as well, which currently assumes it should automatically create releases for anything with a Git Tag.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10256)