### PR TITLE
Check for DP::UnsetValue() rather than nullptr

### DIFF
--- a/change/react-native-windows-29f353b2-b099-47fe-ba94-0a0f91672af7.json
+++ b/change/react-native-windows-29f353b2-b099-47fe-ba94-0a0f91672af7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check for DP::UnsetValue() rather than nullptr",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
@@ -17,7 +17,7 @@ void TransferProperty(
     xaml::DependencyProperty oldViewDP,
     xaml::DependencyProperty newViewDP) {
   auto oldValue = oldView.ReadLocalValue(oldViewDP);
-  if (oldValue != nullptr) {
+  if (oldValue != xaml::DependencyProperty::UnsetValue()) {
     oldView.ClearValue(oldViewDP);
     newView.SetValue(newViewDP, oldValue);
   }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
When transferring properties in the FrameworkElementViewManager, we were testing whether the result of `DP::ReadLocalValue` was null before clearing the property on the old view and transferring the property to the new view.

### What
`ReadLocalValue` actually returns `DP::UnsetValue`, not nullptr, so this check has been faulty and unnecessarily transfers unset values. This commit switches the conditional to test for UnsetValue instead of null.

### Screenshots

<img width="581" alt="image" src="https://user-images.githubusercontent.com/1106239/178516385-1674aea0-cf82-485b-9776-b1c70b2d35d7.png">

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10257)