### PR TITLE
Implement HTTP client timeout

### DIFF
--- a/change/react-native-windows-42dec614-af90-4b29-b8c7-f266415ea240.json
+++ b/change/react-native-windows-42dec614-af90-4b29-b8c7-f266415ea240.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement HTTP client timeout",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/HttpOriginPolicyIntegrationTest.cpp
+++ b/vnext/Desktop.IntegrationTests/HttpOriginPolicyIntegrationTest.cpp
@@ -147,7 +147,7 @@ TEST_CLASS(HttpOriginPolicyIntegrationTest)
       {},                         /*data*/
       "text",
       false,                      /*useIncrementalUpdates*/
-      1000,                       /*timeout*/
+      0,                       /*timeout*/
       clientArgs.WithCredentials, /*withCredentials*/
       [](int64_t){}               /*reactCallback*/
     );
@@ -201,7 +201,7 @@ TEST_CLASS(HttpOriginPolicyIntegrationTest)
       {},                         /*data*/
       "text",
       false,                      /*useIncrementalUpdates*/
-      1000,                       /*timeout*/
+      0,                       /*timeout*/
       clientArgs.WithCredentials, /*withCredentials*/
       [](int64_t) {}              /*reactCallback*/
     );
@@ -300,7 +300,7 @@ TEST_CLASS(HttpOriginPolicyIntegrationTest)
       //{} /*bodyData*/,
       "text",
       false /*useIncrementalUpdates*/,
-      1000 /*timeout*/,
+      0 /*timeout*/,
       false /*withCredentials*/,
       [](int64_t) {} /*callback*/
     );

--- a/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
@@ -78,7 +78,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
         {}, /*data*/
         "text",
         false,
-        1000 /*timeout*/,
+        0 /*timeout*/,
         false /*withCredentials*/,
         [](int64_t) {});
 
@@ -139,7 +139,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
         {}, /*data*/
         "text",
         false,
-        1000 /*timeout*/,
+        0 /*timeout*/,
         false /*withCredentials*/,
         [](int64_t) {});
     //clang-format on
@@ -172,7 +172,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
       promise.set_value();
     });
 
-    resource->SendRequest("GET", "http://nonexistinghost", 0, {}, {}, "text", false, 1000, false, [](int64_t) {});
+    resource->SendRequest("GET", "http://nonexistinghost", 0, {}, {}, "text", false, 0, false, [](int64_t) {});
 
     promise.get_future().wait();
 
@@ -256,7 +256,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
         {}, /*data*/
         "text",
         false,
-        1000 /*timeout*/,
+        0 /*timeout*/,
         false /*withCredentials*/,
         [](int64_t) {});
     //clang-format on
@@ -339,7 +339,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
         {}, /*data*/
         "text",
         false, /*useIncrementalUpdates*/
-        1000 /*timeout*/,
+        0 /*timeout*/,
         false /*withCredentials*/,
         [](int64_t) {});
     //clang-format on
@@ -353,6 +353,104 @@ TEST_CLASS (HttpResourceIntegrationTest) {
     Assert::AreEqual({}, error, L"Error encountered");
     Assert::AreEqual(static_cast<int64_t>(200), getResponse.StatusCode);
     Assert::AreEqual({"Redirect Content"}, content);
+  }
+
+  TEST_METHOD(TimeoutSucceeds) {
+    auto port = s_port;
+    string url = "http://localhost:" + std::to_string(port);
+
+    promise<void> getPromise;
+    string error;
+    int statusCode = 0;
+
+    auto server = std::make_shared<HttpServer>(s_port);
+    server->Callbacks().OnGet = [&getPromise](const DynamicRequest &request) -> ResponseWrapper {
+      DynamicResponse response;
+      response.result(http::status::ok);
+
+      // Hold response to test client timeout
+      promise<void> timer;
+      timer.get_future().wait_for(std::chrono::milliseconds(2000));
+
+      return {std::move(response)};
+    };
+    server->Start();
+
+    auto resource = IHttpResource::Make();
+    resource->SetOnResponse([&getPromise, &statusCode](int64_t, IHttpResource::Response response) {
+      statusCode = static_cast<int>(response.StatusCode);
+      getPromise.set_value();
+    });
+    resource->SetOnError([&getPromise, &error, &server](int64_t, string &&errorMessage) {
+      error = std::move(errorMessage);
+      getPromise.set_value();
+    });
+    resource->SendRequest(
+        "GET",
+        std::move(url),
+        0, /*requestId*/
+        {}, /*headers*/
+        {}, /*data*/
+        "text", /*responseType*/
+        false, /*useIncrementalUpdates*/
+        6000, /*timeout*/
+        false, /*withCredentials*/
+        [](int64_t) {} /*callback*/);
+
+    getPromise.get_future().wait();
+    server->Stop();
+
+    Assert::AreEqual({}, error);
+    Assert::AreEqual(200, statusCode);
+  }
+
+  TEST_METHOD(TimeoutFails) {
+    auto port = s_port;
+    string url = "http://localhost:" + std::to_string(port);
+
+    promise<void> getPromise;
+    string error;
+    int statusCode = 0;
+
+    auto server = std::make_shared<HttpServer>(s_port);
+    server->Callbacks().OnGet = [&getPromise](const DynamicRequest &request) -> ResponseWrapper {
+      DynamicResponse response;
+      response.result(http::status::ok);
+
+      // Hold response to test client timeout
+      promise<void> timer;
+      timer.get_future().wait_for(std::chrono::milliseconds(4000));
+
+      return {std::move(response)};
+    };
+    server->Start();
+
+    auto resource = IHttpResource::Make();
+    resource->SetOnResponse([&getPromise, &statusCode](int64_t, IHttpResource::Response response) {
+      statusCode = static_cast<int>(response.StatusCode);
+      getPromise.set_value();
+    });
+    resource->SetOnError([&getPromise, &error, &server](int64_t, string &&errorMessage) {
+      error = std::move(errorMessage);
+      getPromise.set_value();
+    });
+    resource->SendRequest(
+        "GET",
+        std::move(url),
+        0, /*requestId*/
+        {}, /*headers*/
+        {}, /*data*/
+        "text", /*responseType*/
+        false, /*useIncrementalUpdates*/
+        2000, /*timeout*/
+        false, /*withCredentials*/
+        [](int64_t) {} /*callback*/);
+
+    getPromise.get_future().wait();
+    server->Stop();
+
+    Assert::AreEqual({"[0x800705b4] This operation returned because the timeout period expired."}, error);
+    Assert::AreEqual(0, statusCode);
   }
 };
 

--- a/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
@@ -364,7 +364,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
     int statusCode = 0;
 
     auto server = std::make_shared<HttpServer>(s_port);
-    server->Callbacks().OnGet = [&getPromise](const DynamicRequest &request) -> ResponseWrapper {
+    server->Callbacks().OnGet = [](const DynamicRequest &) -> ResponseWrapper {
       DynamicResponse response;
       response.result(http::status::ok);
 
@@ -381,7 +381,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
       statusCode = static_cast<int>(response.StatusCode);
       getPromise.set_value();
     });
-    resource->SetOnError([&getPromise, &error, &server](int64_t, string &&errorMessage) {
+    resource->SetOnError([&getPromise, &error](int64_t, string &&errorMessage) {
       error = std::move(errorMessage);
       getPromise.set_value();
     });
@@ -413,7 +413,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
     int statusCode = 0;
 
     auto server = std::make_shared<HttpServer>(s_port);
-    server->Callbacks().OnGet = [&getPromise](const DynamicRequest &request) -> ResponseWrapper {
+    server->Callbacks().OnGet = [](const DynamicRequest &) -> ResponseWrapper {
       DynamicResponse response;
       response.result(http::status::ok);
 
@@ -430,7 +430,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
       statusCode = static_cast<int>(response.StatusCode);
       getPromise.set_value();
     });
-    resource->SetOnError([&getPromise, &error, &server](int64_t, string &&errorMessage) {
+    resource->SetOnError([&getPromise, &error](int64_t, string &&errorMessage) {
       error = std::move(errorMessage);
       getPromise.set_value();
     });

--- a/vnext/Shared/Networking/IHttpResource.h
+++ b/vnext/Shared/Networking/IHttpResource.h
@@ -71,6 +71,7 @@ struct IHttpResource {
   /// </param>
   /// <param name="timeout">
   /// Request timeout in miliseconds.
+  /// Note: A value of 0 means no timeout. The resource will await the response indefinitely.
   /// </param>
   /// <param name="withCredentials">
   /// Allow including credentials in request.

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -303,23 +303,28 @@ fire_and_forget WinRTHttpResource::PerformSendRequest(HttpRequestMessage &&reque
     auto timedOut = std::make_shared<bool>(false);
     //TODO: Look into using AsyncStatus?
     //      https://docs.microsoft.com/en-us/uwp/api/windows.foundation.iasyncoperationwithprogress-2?view=winrt-22621
-    auto sendRequestTimeout = [](auto timedOut) -> ResponseOperation {
-      co_await winrt::resume_after(4s);
+    auto sendRequestTimeout = [](auto timedOut, auto milliseconds) -> ResponseOperation {
+      // Convert milliseconds to "ticks" (10^-7 seconds)
+      co_await winrt::resume_after(winrt::Windows::Foundation::TimeSpan{milliseconds * 10000});
       *timedOut = true;
       co_return nullptr;
-    }(timedOut);
+    }(timedOut, coReqArgs->Timeout);
 
     auto sendRequestAny = winrt::when_any(sendRequestOp, sendRequestTimeout);
     co_await lessthrow_await_adapter<ResponseOperation>{sendRequestAny};
 
+    // Cancel either still unfinished coroutine.
+    sendRequestTimeout.Cancel();
+    sendRequestOp.Cancel();
+
     if (*timedOut) {
       if (self->m_onError) {
-        //winrt::hresult_error(HRESULT_FROM_WIN32(ERROR_TIMEOUT))
         self->m_onError(coReqArgs->RequestId, Utilities::HResultToString(HRESULT_FROM_WIN32(ERROR_TIMEOUT)));
       }
       co_return self->UntrackResponse(coReqArgs->RequestId);
     }
 
+    //TODO: REMOVE!
     //co_await lessthrow_await_adapter<ResponseOperation>{sendRequestOp};
     auto result = sendRequestOp.ErrorCode();
     if (result < 0) {

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -307,8 +307,7 @@ fire_and_forget WinRTHttpResource::PerformSendRequest(HttpRequestMessage &&reque
         co_return nullptr;
       }(timedOut, coReqArgs->Timeout);
 
-      auto sendRequestAny = winrt::when_any(sendRequestOp, sendRequestTimeout);
-      co_await lessthrow_await_adapter<ResponseOperation>{sendRequestAny};
+      co_await lessthrow_await_adapter<ResponseOperation>{winrt::when_any(sendRequestOp, sendRequestTimeout)};
 
       // Cancel either still unfinished coroutine.
       sendRequestTimeout.Cancel();


### PR DESCRIPTION
## Description
Implements client-side timeout for HTTP requests.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #9538

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

- `Microsoft::React::WinRTHttpResource`\
  Windows.Web.Http APIs do not provide a timeout mechanism.\
  Using "co-routine competing" explained in https://devblogs.microsoft.com/oldnewthing/20220415-00/?p=106486 relying on `winrt::resume_after` to signal the timeout based on the value passed from JavaScript.

## Testing
Added tests:
- `HttpResourceIntegrationTest::TimeoutFails`
- `HttpResourceIntegrationTest::TimeoutSucceeds`


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10261)