### PR TITLE
Use programmatic focus for UIManager.focus

### DIFF
--- a/change/react-native-windows-a5041465-ffcd-4b52-b4d1-34cb0370b209.json
+++ b/change/react-native-windows-a5041465-ffcd-4b52-b4d1-34cb0370b209.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use programmatic focus for UIManager.focus",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -1119,7 +1119,7 @@ void NativeUIManager::findSubviewIn(
 
 void NativeUIManager::focus(int64_t reactTag) {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(reactTag))) {
-    xaml::Input::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Keyboard);
+    xaml::Input::FocusManager::TryFocusAsync(shadowNode->GetView(), winrt::FocusState::Programmatic);
   }
 }
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Switching from xaml::FocusState::Programmatic to xaml::FocusState::Keyboard causes focus rings to be shown for "default focus" scenarios in our app (e.g., defaulting a "Done" button in a modal), which are not intended to have focus rings (at least until the user explicitly changes focus with the Keyboard).

Resolves #10265

### What
This change reverts to Programmatic focus in the UIManager.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10266)