### PR TITLE
[0.69] Import WinUI package only if OverrideWinUIPackage is not true

### DIFF
--- a/change/react-native-windows-0440ff4e-5b47-4657-acb1-939f8568d6eb.json
+++ b/change/react-native-windows-0440ff4e-5b47-4657-acb1-939f8568d6eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Import WinUI package only if OverrideWinUIPackage is not set to \"true\" (#10267)",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -725,7 +725,7 @@
     <PackageReference Include="boost" Version="1.76.0.0" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
   </ItemGroup>
   <Choose>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -16,12 +16,12 @@
 
   <ItemGroup>
     <!-- WinUI package name and version are set by WinUI.props -->
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
     <!-- Hermes version is set by JSEngine.props -->
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" Condition="$(UseHermes)" />
   </ItemGroup>
 
-  <Import Project="$(ReactNativeWindowsDir)PropertySheets\ManagedCodeGen\Microsoft.ReactNative.Managed.CodeGen.targets" 
+  <Import Project="$(ReactNativeWindowsDir)PropertySheets\ManagedCodeGen\Microsoft.ReactNative.Managed.CodeGen.targets"
           Condition="'$(ReactNativeCodeGenEnabled)' == 'true' and '$(UseExperimentalNuget)' != 'true'" />
 
    <!-- The props file for bundling is not set up to be just defaults, it assumes to be run at the end of the project. -->
@@ -31,17 +31,17 @@
   <Import Project="$(ProjectDir)\AutolinkedNativeModules.g.targets"
           Condition="Exists('$(ProjectDir)\AutolinkedNativeModules.g.targets')" />
 
-  <Import Project="$(AppxPackageRecipe)"  
+  <Import Project="$(AppxPackageRecipe)"
           Condition="Exists('$(AppxPackageRecipe)') And '$(DeployLayout)'=='true'" />
   <Target Name="Deploy" Condition="'$(DeployLayout)'=='true'">
-    <Error Condition="!Exists('$(AppxPackageRecipe)')" 
+    <Error Condition="!Exists('$(AppxPackageRecipe)')"
            Text="You must first build the project before deploying it. Did not find: $(AppxPackageRecipe)" />
-    <Copy SourceFiles="%(AppxPackagedFile.Identity)" 
+    <Copy SourceFiles="%(AppxPackagedFile.Identity)"
           DestinationFiles="$(MSBuildProjectDirectory)\$(OutputPath)Appx\%(AppxPackagedFile.PackagePath)" />
-    <Copy SourceFiles="%(AppXManifest.Identity)" 
-          DestinationFiles="$(MSBuildProjectDirectory)\$(OutputPath)Appx\%(AppxManifest.PackagePath)" 
+    <Copy SourceFiles="%(AppXManifest.Identity)"
+          DestinationFiles="$(MSBuildProjectDirectory)\$(OutputPath)Appx\%(AppxManifest.PackagePath)"
           Condition="'%(AppxManifest.SubType)'!='Designer'"/>
-    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(MSBuildProjectDirectory)\$(OutputPath)Appx\AppxManifest.xml" 
+    <Exec Command="powershell -NonInteractive -NoProfile -Command Add-AppxPackage -Register $(MSBuildProjectDirectory)\$(OutputPath)Appx\AppxManifest.xml"
           ContinueOnError="false" />
   </Target>
 

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -16,12 +16,12 @@
 
   <ItemGroup>
     <!-- WinUI package name and version are set by WinUI.props -->
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
   </ItemGroup>
 
   <Target Name="Deploy" />
 
-  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ManagedCodeGen\Microsoft.ReactNative.Managed.CodeGen.targets" 
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\ManagedCodeGen\Microsoft.ReactNative.Managed.CodeGen.targets"
           Condition="'$(ReactNativeCodeGenEnabled)' == 'true' and '$(UseExperimentalNuget)' != 'true'" />
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <!-- WinUI package name and version are set by WinUI.props -->
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
     <!-- Hermes version is set by JSEngine.props -->
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" Condition="$(UseHermes)" />
   </ItemGroup>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.targets
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- 
+<!--
   Copyright (c) Microsoft Corporation.
   Licensed under the MIT License.
 
@@ -16,13 +16,13 @@
 
   <ItemGroup>
     <!-- WinUI package name and version are set by WinUI.props -->
-    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
   </ItemGroup>
 
   <Target Name="Deploy" />
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\RequireSolution.targets" />
-  
+
   <ItemDefinitionGroup>
     <Reference>
         <Private Condition="'$(ConfigurationType)' != 'Application'">false</Private>


### PR DESCRIPTION
Backport of #10267



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10273)