### PR TITLE
Fix relative include path for Views/Image

### DIFF
--- a/change/react-native-windows-17c67a31-ebaf-4153-84f6-d830f7910ddb.json
+++ b/change/react-native-windows-17c67a31-ebaf-4153-84f6-d830f7910ddb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix relative include path for Views/Image",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -14,8 +14,8 @@
 #include <IReactInstance.h>
 #include <Utils/PropertyHandlerUtils.h>
 #include <Utils/PropertyUtils.h>
+#include <Views/DynamicAutomationProperties.h>
 #include <Views/ShadowNodeBase.h>
-#include "../DynamicAutomationProperties.h"
 #include "ReactImage.h"
 
 namespace winrt {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -15,7 +15,7 @@
 #include <Utils/PropertyHandlerUtils.h>
 #include <Utils/PropertyUtils.h>
 #include <Views/ShadowNodeBase.h>
-#include "DynamicAutomationProperties.h"
+#include "../DynamicAutomationProperties.h"
 #include "ReactImage.h"
 
 namespace winrt {

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -13,7 +13,7 @@
 #include <winrt/Windows.Web.Http.h>
 
 #include <Utils/ValueUtils.h>
-#include "../DynamicAutomationPeer.h"
+#include <Views/DynamicAutomationPeer.h>
 #include "Unicode.h"
 #include "XamlView.h"
 #include "cdebug.h"

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -13,7 +13,7 @@
 #include <winrt/Windows.Web.Http.h>
 
 #include <Utils/ValueUtils.h>
-#include "DynamicAutomationPeer.h"
+#include "../DynamicAutomationPeer.h"
 #include "Unicode.h"
 #include "XamlView.h"
 #include "cdebug.h"


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
The DynamicAutomationPeer.h header is in the parent `Views` folder and this include path is not supported by clang. 

### What
This change adjusts the include path.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10275)