### PR TITLE
Adds missing headers for HttpRequestHeaderCollection

### DIFF
--- a/change/react-native-windows-ed8de10f-3224-4e5d-8624-ff9f24b9cbb1.json
+++ b/change/react-native-windows-ed8de10f-3224-4e5d-8624-ff9f24b9cbb1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds missing headers for HttpRequestHeaderCollection",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -12,6 +12,7 @@
 #include <boost/lexical_cast/try_lexical_convert.hpp>
 
 // Windows API
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 
 // Standard Library

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string.hpp>
 
 // Windows API
+#include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.Headers.h>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
These headers are needed in case alternative PCH are used to compile (e.g., with clang/BUCK).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10277)