### PR TITLE
Fix compiler issue for older versions of C++/WinRT

### DIFF
--- a/change/react-native-windows-4559f97f-bb39-4fe8-a1a9-c3e950ae966e.json
+++ b/change/react-native-windows-4559f97f-bb39-4fe8-a1a9-c3e950ae966e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix compiler issue for older versions of C++/WinRT",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -653,21 +653,26 @@ ResponseOperation OriginPolicyHttpFilter::SendPreflightAsync(HttpRequestMessage 
   preflightRequest.Headers().Insert(L"Access-Control-Request-Method", coRequest.Method().ToString());
 
   auto headerNames = wstring{};
-  auto headerItr = coRequest.Headers().begin();
-  if (headerItr != coRequest.Headers().end()) {
-    headerNames += (*headerItr).Key();
+  auto writeSeparator = false;
+  for (const auto &header : coRequest.Headers()) {
+    if (writeSeparator) {
+      headerNames += L", ";
+    } else {
+      writeSeparator = true;
+    }
 
-    while (++headerItr != coRequest.Headers().end())
-      headerNames += L", " + (*headerItr).Key();
+    headerNames += header.Key();
   }
 
   if (coRequest.Content()) {
-    headerItr = coRequest.Content().Headers().begin();
-    if (headerItr != coRequest.Content().Headers().end()) {
-      headerNames += (*headerItr).Key();
+    for (const auto &header : coRequest.Content().Headers()) {
+      if (writeSeparator) {
+        headerNames += L", ";
+      } else {
+        writeSeparator = true;
+      }
 
-      while (++headerItr != coRequest.Content().Headers().end())
-        headerNames += L", " + (*headerItr).Key();
+      headerNames += header.Key();
     }
   }
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In older versions of cppwinrt, the header generated for Windows.Foundation.Collections.h do not include the begin and end methods for `IIterable`.

### What
This just switches the logic for compatibility with older versions of cppwinrt. Note, it may also include a bug fix where a comma separator is not emitted between headers from the request header collection and headers from the content header collection.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10278)