### PR TITLE
Skip user agent HTTP header validation

### DIFF
--- a/change/react-native-windows-b0a84e25-6abf-44f7-ab49-48c8982eb792.json
+++ b/change/react-native-windows-b0a84e25-6abf-44f7-ab49-48c8982eb792.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Skip user agent HTTP header validation",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -218,6 +218,12 @@ fire_and_forget WinRTHttpResource::PerformSendRequest(HttpRequestMessage &&reque
       if (!success && m_onError) {
         co_return m_onError(coReqArgs->RequestId, "Failed to append Authorization");
       }
+    } else if (boost::iequals(header.first.c_str(), "User-Agent")) {
+      bool success =
+          coRequest.Headers().TryAppendWithoutValidation(to_hstring(header.first), to_hstring(header.second));
+      if (!success && m_onError) {
+        co_return m_onError(coReqArgs->RequestId, "Failed to append User-Agent");
+      }
     } else {
       try {
         coRequest.Headers().Append(to_hstring(header.first), to_hstring(header.second));


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #8392, we added logic to skip HTTP header validation for `User-Agent` in the NetworkingModule. Now that NetworkingModule is being refactored, we need this change in the new implementation.

### What
This change skips user agent validation in the new networking module.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10279)