### PR TITLE
[0.67] Implement importantForAccessibility="no-hide-accessibility"

### DIFF
--- a/change/@office-iss-react-native-win32-66e95e8b-c77f-4122-bcbb-fcb1e6ce5077.json
+++ b/change/@office-iss-react-native-win32-66e95e8b-c77f-4122-bcbb-fcb1e6ce5077.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement no-hide-accessibility",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-93fc478e-4970-43db-9342-1f0e9aa42483.json
+++ b/change/react-native-windows-93fc478e-4970-43db-9342-1f0e9aa42483.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Implement no-hide-accessibility",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -75,6 +75,26 @@ const View: React.AbstractComponent<
     props.onKeyUpCapture && props.onKeyUpCapture(event);
   };
 
+  // [Windows
+  const childrenWithImportantForAccessibility = children => {
+    return React.Children.map(children, child => {
+      if (React.isValidElement(child)) {
+        if (child.props.children) {
+          return React.cloneElement(child, {
+            accessible: false,
+            children: childrenWithImportantForAccessibility(
+              child.props.children,
+            ),
+          });
+        } else {
+          return React.cloneElement(child, {accessible: false});
+        }
+      }
+      return child;
+    });
+  };
+  // Windows]
+
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See
@@ -94,6 +114,18 @@ const View: React.AbstractComponent<
             onKeyDownCapture={_keyDownCapture}
             onKeyUp={_keyUp}
             onKeyUpCapture={_keyUpCapture}
+            // [Windows
+            accessible={
+              props.importantForAccessibility === 'no-hide-descendants'
+                ? false
+                : props.accessible
+            }
+            children={
+              props.importantForAccessibility === 'no-hide-descendants'
+                ? childrenWithImportantForAccessibility(props.children)
+                : props.children
+            }
+            // Windows]
           />
         );
       }}

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -75,25 +75,25 @@ const View: React.AbstractComponent<
     props.onKeyUpCapture && props.onKeyUpCapture(event);
   };
 
-    // [Windows
-    const childrenWithImportantForAccessibility = children => {
-      return React.Children.map(children, child => {
-        if (React.isValidElement(child)) {
-          if (child.props.children) {
-            return React.cloneElement(child, {
-              accessible: false,
-              children: childrenWithImportantForAccessibility(
-                child.props.children,
-              ),
-            });
-          } else {
-            return React.cloneElement(child, {accessible: false});
-          }
+  // [Windows
+  const childrenWithImportantForAccessibility = children => {
+    return React.Children.map(children, child => {
+      if (React.isValidElement(child)) {
+        if (child.props.children) {
+          return React.cloneElement(child, {
+            accessible: false,
+            children: childrenWithImportantForAccessibility(
+              child.props.children,
+            ),
+          });
+        } else {
+          return React.cloneElement(child, {accessible: false});
         }
-        return child;
-      });
-    };
-    // Windows]
+      }
+      return child;
+    });
+  };
+  // Windows]
 
   return (
     // [Windows

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -75,6 +75,26 @@ const View: React.AbstractComponent<
     props.onKeyUpCapture && props.onKeyUpCapture(event);
   };
 
+    // [Windows
+    const childrenWithImportantForAccessibility = children => {
+      return React.Children.map(children, child => {
+        if (React.isValidElement(child)) {
+          if (child.props.children) {
+            return React.cloneElement(child, {
+              accessible: false,
+              children: childrenWithImportantForAccessibility(
+                child.props.children,
+              ),
+            });
+          } else {
+            return React.cloneElement(child, {accessible: false});
+          }
+        }
+        return child;
+      });
+    };
+    // Windows]
+
   return (
     // [Windows
     // In core this is a TextAncestor.Provider value={false} See
@@ -94,6 +114,18 @@ const View: React.AbstractComponent<
             onKeyDownCapture={_keyDownCapture}
             onKeyUp={_keyUp}
             onKeyUpCapture={_keyUpCapture}
+            // [Windows
+            accessible={
+              props.importantForAccessibility === 'no-hide-descendants'
+                ? false
+                : props.accessible
+            }
+            children={
+              props.importantForAccessibility === 'no-hide-descendants'
+                ? childrenWithImportantForAccessibility(props.children)
+                : props.children
+            }
+            // Windows]
           />
         );
       }}


### PR DESCRIPTION
## Description
Backporting #9898 to resolve #9977. Tested with an example app to confirm fix.

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Implement importantForAccessibility="no-hide-accessibility". When specified on a view-based component should remove accessibility for the element itself and its descendants.

Resolves #5113

### What
Recursively apply accessible={false} prop to children of view-based component.

Attempted implementation used by Garrison team but it was not sufficient for Desktop, as focusable elements were still focusable even after being removed from the UIA tree.

## Testing
Tested in playground with multiple configurations of nested components.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/9898)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10280)