### PR TITLE
[0.68] Fix floating point conversions in non en-US locales

### DIFF
--- a/change/react-native-windows-81fdd983-b7d9-4e03-9175-a9545a5e8599.json
+++ b/change/react-native-windows-81fdd983-b7d9-4e03-9175-a9545a5e8599.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Make double-conversion FP conversions be locale-invariant",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/stubs/double-conversion/double-conversion.h
+++ b/vnext/stubs/double-conversion/double-conversion.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <charconv>
 #include <sstream>
 
 static inline void nyi() {
@@ -136,10 +137,14 @@ class StringToDoubleConverter {
   }
 
   float StringToFloat(const char *buf, int length, int *consumed) {
-    size_t idx = 0;
-    std::string str(buf, length);
-    float f = std::stof(str, &idx);
-    *consumed = static_cast<int>(idx);
+    float f{};
+    auto ret = std::from_chars(buf, buf + length, f);
+    if (ret.ec == std::errc{}) {
+      *consumed = static_cast<int>(ret.ptr - buf);
+    } else {
+      *consumed = 0;
+      assert(false && "Conversion to float failed");
+    }
     return f;
   }
 };

--- a/vnext/stubs/double-conversion/double-conversion.h
+++ b/vnext/stubs/double-conversion/double-conversion.h
@@ -128,11 +128,15 @@ class StringToDoubleConverter {
     // nyi();
   }
 
-  double StringToDouble(const char *s, int l, int *consumed) {
-    size_t idx = 0;
-    std::string str(s, l);
-    double d = std::stod(str.c_str(), &idx);
-    *consumed = static_cast<int>(idx);
+  double StringToDouble(const char *buf, int length, int *consumed) {
+    double d{};
+    auto ret = std::from_chars(buf, buf + length, d);
+    if (ret.ec == std::errc{}) {
+      *consumed = static_cast<int>(ret.ptr - buf);
+    } else {
+      *consumed = 0;
+      assert(false && "Conversion to double failed");
+    }
     return d;
   }
 


### PR DESCRIPTION
## Description
Backporting #10058 into 0.68
Resolves #10272

The current stub implementation we have for double-conversion is using strtod / stod which performs float/double conversions in a locale-dependent manner. This doesn't work for reading a number from json in locales that use different digit separators (e.g. in German you'd write "1,5"  instead of "1.5", so when we try to parse a json value via folly (which uses double-conversion), we error out when we find the . as it is not a valid separator).


### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
Apps should work in all locales :)

### What
This uses `from_chars` which uses the C locale and in addition is a lot faster than strtod

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10058)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10289)