### PR TITLE
Add code owners for networking stack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,4 +83,7 @@
 /vnext/template/**/*.idl  @microsoft/react-native-windows-api-review @microsoft/react-native-windows-cli @microsoft/react-native-windows-write
 
 # Networking implementation
-/vnext/Shared/Networking/**/*  @microsoft/jshost
+/vnext/Shared/Modules/BlobModule.*      @microsoft/jshost
+/vnext/Shared/Modules/HttpModule.*      @microsoft/jshost
+/vnext/Shared/Modules/WebSocketModule.* @microsoft/jshost
+/vnext/Shared/Networking/**/*           @microsoft/jshost

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,3 +81,6 @@
 # API Review and CLI for the new project templates
 /vnext/template/**/*.def  @microsoft/react-native-windows-api-review @microsoft/react-native-windows-cli @microsoft/react-native-windows-write
 /vnext/template/**/*.idl  @microsoft/react-native-windows-api-review @microsoft/react-native-windows-cli @microsoft/react-native-windows-write
+
+# Networking implementation
+/vnext/Shared/Networking/**/*  @microsoft/jshost


### PR DESCRIPTION
Sets code owners for the networking stack to @microsoft/jshost.