### PR TITLE
Call `BridgeUIBatchInstanceCallback::onBatchComplete` after loading bundles synchronously

### DIFF
--- a/change/react-native-windows-1150af72-58d6-44df-8e4a-f9b30c659f64.json
+++ b/change/react-native-windows-1150af72-58d6-44df-8e4a-f9b30c659f64.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Call `BridgeUIBatchInstanceCallback::onBatchComplete` after loading bundles synchronously",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
`JsToNativeBridge::callNativeModules` only calls the stored `BridgeUIBatchInstanceCallback::onBatchComplete` if it's at the end of a batch, and either a native/turbo module method had been called previously, or if there are new incoming method calls. This call to `onBatchComplete` is what causes the batched UI queue to be processed, rendering changes in the native UI.

However, some (simple) JS apps, such as the default template for a new RN app, don't make any native function calls during app startup. When loading bundles asynchronously from Metro, the `onBatchComplete` call to process the UI queue gets posted to the native queue, so it gets run appropriately.

However, when loading bundles synchronously (from a pre-built bundle file), the first `onBatchComplete` will only be called if a native/turbo module was called during app startup. Without it, the app is *technically running*, but batched UI queue just sits there with the tasks to build the initial UI unprocessed.

The result is a "blank app", i.e. the `ReactRootView` has no children. "Technically" the app has loaded and is running (if you click we'll dispatch events to the JS side).

This PR fixes the issue by explicitly calling the `onBatchComplete` after the app has loaded from a synchronous bundle load. If the batch has already been processed, then it's essentially a slightly wasteful no-op.

I have tested that this resolves the issue for the "simple" apps, and seems to have no adverse effect on apps that have already caused `onBatchComplete` to be called normally.

Closes #10255

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10296)