### PR TITLE
Use u8path for bundle loading

### DIFF
--- a/change/react-native-windows-ac8e48c4-1cf1-4db8-bb98-ba177bf7a5c1.json
+++ b/change/react-native-windows-ac8e48c4-1cf1-4db8-bb98-ba177bf7a5c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use u8path for bundle loading",
+  "packageName": "react-native-windows",
+  "email": "ericroz@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -508,7 +508,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       }
     } else {
 #if (defined(_MSC_VER) && !defined(WINRT))
-      std::string bundlePath = (fs::path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
+      std::string bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
       auto bundleString = FileMappingBigString::fromPath(bundlePath);
 #else
       std::string bundlePath;
@@ -517,7 +517,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
             winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath));
         bundlePath = winrt::to_string(uri.ToString());
       } else {
-        bundlePath = (fs::path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
+        bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
For side-loaded or unpackaged apps built with React Native, it's not a guarantee that the JS bundle will be in an ASCII path. For example, if the bundle is installed into the %LOCALAPPDATA% folder, it's possible that this path contains UTF-8 characters for the user name. `fs::path` does not support UTF-8 characters.

### What
This change switches to u8path in case there are UTF-8 characters in the path where the bundle is located.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10297)