### PR TITLE
Allow batches to complete during load

### DIFF
--- a/change/react-native-windows-cb076a1b-e4cb-40ad-a74d-f7b826107a3d.json
+++ b/change/react-native-windows-cb076a1b-e4cb-40ad-a74d-f7b826107a3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow batches to complete during load",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -132,7 +132,8 @@ struct BridgeUIBatchInstanceCallback final : public facebook::react::InstanceCal
   virtual ~BridgeUIBatchInstanceCallback() = default;
   void onBatchComplete() override {
     if (auto instance = m_wkInstance.GetStrongPtr()) {
-      if (instance->IsLoaded()) {
+      auto state = instance->State();
+      if (state != ReactInstanceState::HasError && state != ReactInstanceState::Unloaded) {
         if (instance->UseWebDebugger()) {
           // While using a CxxModule for UIManager (which we do when running under webdebugger)
           // We need to post the batch complete to the NativeQueue to ensure that the UIManager

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -71,23 +71,23 @@ void BatchingQueueThread::decoratedNativeCallInvokerReady(
   std::scoped_lock lck(m_mutex);
   if (auto instance = wkInstance.lock()) {
     // When items were queued in the undecoratedNativeCallInvoker it will not have called
-    // recordTurboModuleAsyncMethodCall. Calling invokeAsync on the decoratedNativeCallInvoker ensures that the new
-    // queue is properly flushed, on the next batch complete
+    // recordTurboModuleAsyncMethodCall. Calling invokeAsync on the decoratedNativeCallInvoker
+    // ensures that the queue is properly flushed, on the next batch complete
     auto decoratedCallInvoker = instance->getDecoratedNativeCallInvoker(m_callInvoker);
-    decoratedCallInvoker->invokeAsync([decoratedCallInvoker, wkInstance, this]
+    decoratedCallInvoker->invokeAsync([decoratedCallInvoker, wkInstance, this] {
       if (auto instance = wkInstance.lock()) {
-      std::scoped_lock lckQuitting(m_mutexQuitting);
+        std::scoped_lock lckQuitting(m_mutexQuitting);
 
-      // If we are shutting down, then then the mutex is being held in quitSynchronous
-      // Which is waiting for this task to complete, so we cannot take the mutex if quitSynchronous
-      // is running. -- and since we are shutting down anyway, we can just skip this work.
-      if (!m_quitting) {
-        std::scoped_lock lck(m_mutex);
-        m_callInvoker = decoratedCallInvoker;
+        // If we are shutting down, then then the mutex is being held in quitSynchronous
+        // Which is waiting for this task to complete, so we cannot take the mutex if quitSynchronous
+        // is running. -- and since we are shutting down anyway, we can just skip this work.
+        if (!m_quitting) {
+          std::scoped_lock lck(m_mutex);
+          m_callInvoker = decoratedCallInvoker;
+        }
       }
-      }
-  });
-}
+    });
+  }
 }
 
 BatchingQueueThread::~BatchingQueueThread() noexcept {}


### PR DESCRIPTION
During boot we have an undecorated callInvoker since the decorated one is not available until later in the instance boot sequence.  This means that early calls into turbomodules do not call into `NativeToJsBridge::recordTurboModuleAsyncMethodCall` which causes `NativeToJsBridge` to not call `onBatchComplete` at the end of a batch.

Changing the if in `BridgeUIBatchInstanceCallback::onBatchComplete` to allow batches to be completed during boot helps so that we do not miss any batch completions that are triggered.  But we also need to ensure that any calls queued before we were using the decoratedCallInvoker also triggers an `onBatchComplete`, which we do by using the decoratedCallInvoker when queuing the switch between the invokers.

Closes https://github.com/microsoft/react-native-windows/issues/10255

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10298)