### PR TITLE
Two small fixes:

### DIFF
--- a/change/react-native-windows-dd0c144f-9d1d-455c-b871-a45c09942d29.json
+++ b/change/react-native-windows-dd0c144f-9d1d-455c-b871-a45c09942d29.json
@@ -1,0 +1,10 @@
+{
+  "type": "none",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "react-native-windows",
+  "email": "hpratt@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/yoga/yoga/CompactValue.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/yoga/yoga/CompactValue.h
@@ -11,6 +11,8 @@
 
 #ifdef __cpp_lib_bit_cast
 #include <bit>
+#else
+#include <cstring>
 #endif
 #include "YGValue.h"
 #include "YGMacros.h"
@@ -169,7 +171,7 @@ class YOGA_EXPORT CompactValue {
 
   static float asFloat(uint32_t u) {
 #ifdef __cpp_lib_bit_cast
-    return std::bit_cast<float>(data);
+    return std::bit_cast<float>(u);
 #else
     float f;
     static_assert(sizeof(f) == sizeof(u));


### PR DESCRIPTION
1. memcpy is declared in `<cstring>`; add that include to make sure
   CompactValue.h is self-contained
2. asFloat does not work correctly when __cpp_lib_bit_cast is true; an
   old version of the input parameter's name is used accidentally. Since
   this is conditionally compiled code that is only enabled for C++20,
   and C++20 is not yet used in the RNW project, this does not currently
   break anything, but fixing it now is still a good idea.

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10306)