### PR TITLE
Replace all codegen includes without relative path

### DIFF
--- a/change/react-native-windows-66d09faf-17be-44e3-8d63-fb07a333dd18.json
+++ b/change/react-native-windows-66d09faf-17be-44e3-8d63-fb07a333dd18.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Replace all codegen includes without relative path",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeAccessibilityInfoSpec.g.h"
+#include "codegen/NativeAccessibilityInfoSpec.g.h"
 #include <NativeModules.h>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeDialogManagerWindowsSpec.g.h"
+#include "codegen/NativeDialogManagerWindowsSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppStateModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeAppStateSpec.g.h"
+#include "codegen/NativeAppStateSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
@@ -9,7 +9,7 @@
 #include <cxxreact/MessageQueueThread.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 
-#include "../../codegen/NativeAppThemeSpec.g.h"
+#include "codegen/NativeAppThemeSpec.g.h"
 #include <NativeModules.h>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeClipboardSpec.g.h"
+#include "codegen/NativeClipboardSpec.g.h"
 #include <NativeModules.h>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DevSettingsModule.h
@@ -5,7 +5,7 @@
 #include <cxxreact/CxxModule.h>
 #include <functional/functor.h>
 
-#include "../../codegen/NativeDevSettingsSpec.g.h"
+#include "codegen/NativeDevSettingsSpec.g.h"
 #include <NativeModules.h>
 #include <ReactHost/React.h>
 

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeDeviceInfoSpec.g.h"
+#include "codegen/NativeDeviceInfoSpec.g.h"
 #include <NativeModules.h>
 #include <React.h>
 #include <ReactNotificationService.h>

--- a/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/I18nManagerModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeI18nManagerSpec.g.h"
+#include "codegen/NativeI18nManagerSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../../codegen/NativeImageLoaderIOSSpec.g.h"
+#include "codegen/NativeImageLoaderIOSSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../../codegen/NativeLinkingManagerSpec.g.h"
+#include "codegen/NativeLinkingManagerSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeLogBoxSpec.g.h"
+#include "codegen/NativeLogBoxSpec.g.h"
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "../../codegen/NativeUIManagerSpec.g.h"
+#include "codegen/NativeUIManagerSpec.g.h"
 #include <CxxMessageQueue.h>
 #include <INativeUIManager.h>
 #include <NativeModules.h>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Based on feedback from #10275, we should not be using `..` in #includes. As an added bonus, this works with our clang builds (we forked these files previously).

### What
This changes all codegen includes to not use relative paths.

## Testing
RN Windows solution builds.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10311)