### PR TITLE
Adds QuirkSetting to always use sqlite3 for AsyncStorage

### DIFF
--- a/change/react-native-windows-c5451e58-4d47-41c8-a1d2-a2ad164c3ca8.json
+++ b/change/react-native-windows-c5451e58-4d47-41c8-a1d2-a2ad164c3ca8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds QuirkSetting to always use sqlite3 for AsyncStorage",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "CoreNativeModules.h"
+#include "QuirkSettings.h"
 
 // Modules
 #include <AppModelHelpers.h>
@@ -59,10 +60,12 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
 
   // AsyncStorageModule doesn't work without package identity (it indirectly depends on
   // Windows.Storage.StorageFile), so check for package identity before adding it.
+  const auto useSqliteStorage = winrt::Microsoft::ReactNative::implementation::QuirkSettings::GetUseSqliteAsyncStorage(
+      ReactPropertyBag(context->Properties()));
   modules.emplace_back(
       "AsyncLocalStorage",
-      []() -> std::unique_ptr<facebook::xplat::module::CxxModule> {
-        if (HasPackageIdentity()) {
+      [useSqliteStorage]() -> std::unique_ptr<facebook::xplat::module::CxxModule> {
+        if (HasPackageIdentity() && !useSqliteStorage) {
           return std::make_unique<facebook::react::AsyncStorageModule>(L"asyncStorage");
         } else {
           return std::make_unique<facebook::react::AsyncStorageModuleWin32>();

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -58,10 +58,22 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   return propId;
 }
 
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> UseSqliteAsyncStorageProperty() noexcept {
+  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"UseSqliteAsyncStorageProperty"};
+  return propId;
+}
+
 /*static*/ void QuirkSettings::SetMapWindowDeactivatedToAppStateInactive(
     winrt::Microsoft::ReactNative::ReactPropertyBag properties,
     bool value) noexcept {
   properties.Set(MapWindowDeactivatedToAppStateInactiveProperty(), value);
+}
+
+/*static*/ void QuirkSettings::SetUseSqliteAsyncStorage(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    bool value) noexcept {
+  properties.Set(UseSqliteAsyncStorageProperty(), value);
 }
 
 #pragma region IDL interface
@@ -96,6 +108,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   SetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag(settings.Properties()), value);
 }
 
+/*static*/ void QuirkSettings::SetUseSqliteAsyncStorage(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
+  SetUseSqliteAsyncStorage(ReactPropertyBag(settings.Properties()), value);
+}
+
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
@@ -118,6 +136,10 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 
 /*static*/ bool QuirkSettings::GetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag properties) noexcept {
   return properties.Get(MapWindowDeactivatedToAppStateInactiveProperty()).value_or(false);
+}
+
+/*static*/ bool QuirkSettings::GetUseSqliteAsyncStorage(ReactPropertyBag properties) noexcept {
+  return properties.Get(UseSqliteAsyncStorageProperty()).value_or(false);
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -37,6 +37,9 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
   static bool GetMapWindowDeactivatedToAppStateInactive(
       winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
+  static void SetUseSqliteAsyncStorage(winrt::Microsoft::ReactNative::ReactPropertyBag properties, bool value) noexcept;
+  static bool GetUseSqliteAsyncStorage(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
 #pragma region Public API - part of IDL interface
   static void SetMatchAndroidAndIOSStretchBehavior(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
@@ -52,6 +55,10 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       winrt::Microsoft::ReactNative::BackNavigationHandlerKind kind) noexcept;
 
   static void SetMapWindowDeactivatedToAppStateInactive(
+      winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+      bool value) noexcept;
+
+  static void SetUseSqliteAsyncStorage(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
       bool value) noexcept;
 #pragma endregion Public API - part of IDL interface

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -53,5 +53,11 @@ namespace Microsoft.ReactNative
       "`inactive` tracks the [Window.Activated Event](https://docs.microsoft.com/uwp/api/windows.ui.core.corewindow.activated) when the window is deactivated.")
     DOC_DEFAULT("false")
     static void SetMapWindowDeactivatedToAppStateInactive(ReactInstanceSettings settings, Boolean value);
+
+    DOC_STRING(
+      "By default `react-native-windows` will use file storage for the AsyncStorage native module for UWP apps. "
+      "Setting this to true uses the sqlite3 implementation of AsyncStorage for any `react-native-windows` app.")
+    DOC_DEFAULT("false")
+    static void SetUseSqliteAsyncStorage(ReactInstanceSettings settings, Boolean value);
   }
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Currently, apps with package identity default to using Windows.Storage files for AsyncStorage, but these apps may want the option to opt in to the sqlite3 implementation.

Resolves #10312

### What
This commit adds a quirk setting to enable opt-in to sqlite3 storage.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10313)