### PR TITLE
Fix XamlRoot crashes in FlyoutViewManager

### DIFF
--- a/change/react-native-windows-1ec41f70-0685-4d1f-8037-dbb4cfd0d22a.json
+++ b/change/react-native-windows-1ec41f70-0685-4d1f-8037-dbb4cfd0d22a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix XamlRoot crashes in FlyoutViewManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
There are two cases where a flyout may crash when opened:

1. If the native view corresponding to the target tag is unmounted before the flyout is shown.
2. If the XamlRoot on the flyout differs from the XamlRoot of the target.

This can happen if the XamlRoot changes (e.g., window loses focus) before the UIManager operation to create the Flyout and set the isOpen prop executes. 

Note - this is only relevant to multi-window RN applications.

### What
This change logs the error and does not attempt to show the flyout if either of these cases occur.

## Testing
This change has been in production in Messenger Desktop for more than a year and has fixed a significant crash that occurred when attempting to show a flyout just before opening a call window.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10314)