### PR TITLE
Fix doxysaurus error logging to handle Error objects

### DIFF
--- a/change/@rnw-scripts-doxysaurus-13ba6601-91c6-4360-80cd-7b98e4e90bce.json
+++ b/change/@rnw-scripts-doxysaurus-13ba6601-91c6-4360-80cd-7b98e4e90bce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix doxysaurus error logging to handle Error objects",
+  "packageName": "@rnw-scripts/doxysaurus",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/doxysaurus/src/doxysaurus.ts
+++ b/packages/@rnw-scripts/doxysaurus/src/doxysaurus.ts
@@ -124,7 +124,11 @@ function fireAndForget(asyncFunc: () => Promise<void>): void {
       await asyncFunc();
     } catch (err) {
       try {
-        log.error(err as any);
+        if (err instanceof Error) {
+          log.error(`${err.stack !== undefined ? err.stack : err.message}`);
+        } else {
+          log.error(err as any);
+        }
       } catch (logError) {
         console.error(logError);
       }

--- a/packages/@rnw-scripts/doxysaurus/src/doxysaurus.ts
+++ b/packages/@rnw-scripts/doxysaurus/src/doxysaurus.ts
@@ -127,7 +127,7 @@ function fireAndForget(asyncFunc: () => Promise<void>): void {
         if (err instanceof Error) {
           log.error(`${err.stack !== undefined ? err.stack : err.message}`);
         } else {
-          log.error(err as any);
+          log.error(`${err}`);
         }
       } catch (logError) {
         console.error(logError);


### PR DESCRIPTION
Doxysaurus' `Logger.writeLog` expects a string message, but in the case
of logging errors, doxysaurus can pass caught exceptions of the `Error`
type, which causes the logging itself to fail and give an unrelated
error, hiding the original error.

This PR fixes the issue by making sure that caught `Error`s are passed
in string form to the `Logger.writeLog` API.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10315)