### PR TITLE
Additional fix required for UTF-8 characters in bundle path

### DIFF
--- a/change/react-native-windows-14e96a89-26af-4535-b3d9-517842df1df6.json
+++ b/change/react-native-windows-14e96a89-26af-4535-b3d9-517842df1df6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Additional fix required for UTF-8 characters in bundle path",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -508,7 +508,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       }
     } else {
 #if (defined(_MSC_VER) && !defined(WINRT))
-      std::string bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / jsBundleRelativePath).generic_u8string();
+      std::string bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / jsBundleRelativePath).u8string();
       auto bundleString = FileMappingBigString::fromPath(bundlePath);
 #else
       std::string bundlePath;
@@ -518,7 +518,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
         bundlePath = winrt::to_string(uri.ToString());
       } else {
         bundlePath =
-            (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).generic_u8string();
+            (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).u8string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -508,7 +508,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
       }
     } else {
 #if (defined(_MSC_VER) && !defined(WINRT))
-      std::string bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / jsBundleRelativePath).string();
+      std::string bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / jsBundleRelativePath).generic_u8string();
       auto bundleString = FileMappingBigString::fromPath(bundlePath);
 #else
       std::string bundlePath;
@@ -517,7 +517,8 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
             winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath));
         bundlePath = winrt::to_string(uri.ToString());
       } else {
-        bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).string();
+        bundlePath =
+            (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).generic_u8string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -517,8 +517,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
             winrt::to_hstring(m_devSettings->bundleRootPath), winrt::to_hstring(jsBundleRelativePath));
         bundlePath = winrt::to_string(uri.ToString());
       } else {
-        bundlePath =
-            (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).u8string();
+        bundlePath = (fs::u8path(m_devSettings->bundleRootPath) / (jsBundleRelativePath + ".bundle")).u8string();
       }
 
       auto bundleString = std::make_unique<::Microsoft::ReactNative::StorageFileBigString>(bundlePath);


### PR DESCRIPTION


## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Converting the u8path back to a string causing character encoding issues. Since we pass std::strings around for bundle loading, we need to extract the generic_u8string from the fs::u8path.

### What
Switches from std::filesystem::u8path::string to std::filesystem::u8path::generic_u8string to extract the correctly encoded data from the u8path.

## Testing
Confirmed on v0.68 that this resolves the issue rather than v0.63 😬.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10317)