### PR TITLE
Fix crash in DynamicAutomationPeer::GetContentName

### DIFF
--- a/change/react-native-windows-cd8eaf8d-1ab0-463a-9f8c-3efd78aa308d.json
+++ b/change/react-native-windows-cd8eaf8d-1ab0-463a-9f8c-3efd78aa308d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash in DynamicAutomationPeer::GetContentName",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -312,13 +312,15 @@ winrt::hstring DynamicAutomationPeer::GetContentName() const {
 
   try {
     if (auto const &viewControl = Owner().try_as<winrt::Microsoft::ReactNative::ViewControl>()) {
-      auto viewPanel = viewControl.GetPanel();
-
-      for (auto const &child : viewPanel.Children()) {
-        if (auto const &textBlock = child.try_as<winrt::TextBlock>()) {
-          name = name.empty() ? textBlock.Text() : (L" " + name + textBlock.Text());
-        } else if (auto const &stringableName = child.try_as<winrt::IStringable>()) {
-          name = (name.empty() ? L"" : L" ") + name + stringableName.ToString();
+      // It's possible that the ViewPanel is null, perhaps when this is invoked around the same time
+      // that a View is being unmounted, causing a fast fail for EXCEPTION_ACCESS_VIOLATION_READ.
+      if (auto viewPanel = viewControl.GetPanel()) {
+        for (auto const &child : viewPanel.Children()) {
+          if (auto const &textBlock = child.try_as<winrt::TextBlock>()) {
+            name = name.empty() ? textBlock.Text() : (L" " + name + textBlock.Text());
+          } else if (auto const &stringableName = child.try_as<winrt::IStringable>()) {
+            name = (name.empty() ? L"" : L" ") + name + stringableName.ToString();
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We occasionally see a crash when the ViewPanel is null while running DynamicAutomationPeer::GetContentName. While we don't have a consistent repro, this change mitigated the issue. My guess is that there is some edge case where the ViewControl can be unmounted, calling `removeAllChildren`, which cleans up the `ViewPanel`, but somehow the automation peer still holds a reference to the ViewControl and tries to do work.

## Testing
This change has been in production in Messenger Desktop for more than a month and no new instances are coming from this line in versions where the fix has deployed.