### PR TITLE
Remove call to nyi() in TransformableText

### DIFF
--- a/change/react-native-windows-3be31b9b-9aec-4dcd-b938-25de7534b9c0.json
+++ b/change/react-native-windows-3be31b9b-9aec-4dcd-b938-25de7534b9c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove call to nyi() in TransformableText",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -24,7 +24,7 @@ struct TransformableText final {
         dwMapFlags |= LCMAP_TITLECASE;
         break;
       default:
-        nyi();
+        assert(false);
         return originalText;
     }
 


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We probably do not want this to crash the app in production, and it's somewhat strange to depend on an inlined function from the double-conversion.h that is not being used anywhere else.

### What
For now, just switching to `assert(false)`, which should only crash in debug builds and is used in other places throughout RN Windows.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10322)