### PR TITLE
Only fire `onLongPress` for left clicks

### DIFF
--- a/change/react-native-windows-da8894e2-9136-4e6a-a357-e9ab8981d965.json
+++ b/change/react-native-windows-da8894e2-9136-4e6a-a357-e9ab8981d965.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Only fire `onLongPress` for left clicks",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -810,7 +810,10 @@ export default class Pressability {
 
     if (isPressInSignal(prevState) && signal === 'LONG_PRESS_DETECTED') {
       const {onLongPress} = this._config;
-      if (onLongPress != null && this._isDefaultPressButton(getTouchFromPressEvent(event).button)) {
+      if (
+        onLongPress != null &&
+        this._isDefaultPressButton(getTouchFromPressEvent(event).button)
+      ) {
         onLongPress(event);
       }
     }

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -810,7 +810,7 @@ export default class Pressability {
 
     if (isPressInSignal(prevState) && signal === 'LONG_PRESS_DETECTED') {
       const {onLongPress} = this._config;
-      if (onLongPress != null) {
+      if (onLongPress != null && this._isDefaultPressButton(getTouchFromPressEvent(event).button)) {
         onLongPress(event);
       }
     }


### PR DESCRIPTION


## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #9603, we re-introduced right click events to react-native-windows. We specifically prevent `onPressIn`, `onPressOut`, and `onPress` events for anything other than the default button (e.g., left click). We should do the same for `onLongPress` events. Note, it is still possible to emulate "right click" behaviors for long press on touch devices as these types of presses are still treated as the default button.

### What
This change checks if the event uses the default button before firing the onLongPress event.

## Testing
In the videos below, I test left click behaviors first, then leave the button (see hover in / hover out messages), then test right click behaviors. In the before video, notice that after hover out/in, you see longPress messages because onLongPress was still firing for right clicks. In the after video, notice that longPress messages do not appear (even though I'm holding down the right click button).

Before:

https://user-images.githubusercontent.com/1106239/181301259-965e1aa1-d80a-4d59-b06a-ff8671e41cbd.mp4

After:

https://user-images.githubusercontent.com/1106239/181301274-41aefb33-3ac7-45c3-852d-ec62e1cd6eb9.mp4




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10325)