### PR TITLE
Adds header to fix clang build in FileReaderModule

### DIFF
--- a/change/react-native-windows-1e43cf9b-edff-4998-83e5-74d1fc046cf5.json
+++ b/change/react-native-windows-1e43cf9b-edff-4998-83e5-74d1fc046cf5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds header to fix clang build in FileReaderModule",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -4,6 +4,7 @@
 #include "FileReaderModule.h"
 
 #include <ReactPropertyBag.h>
+#include <sstream>
 
 // Boost Library
 #include <boost/archive/iterators/base64_from_binary.hpp>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Adds `#include <sstream>` to fix clang compile issue for std::ostringstream.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10329)