### PR TITLE
Adds windows.h include to memoryApi.cpp

### DIFF
--- a/change/react-native-windows-f6aa6009-1b42-488a-a477-5bb800e19895.json
+++ b/change/react-native-windows-f6aa6009-1b42-488a-a477-5bb800e19895.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds windows.h include to memoryApi.cpp",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/memoryApi/memoryApi.cpp
+++ b/vnext/Mso/src/memoryApi/memoryApi.cpp
@@ -4,6 +4,9 @@
 #include "memoryApi/memoryApi.h"
 #include <cstdlib>
 #include <memory>
+#ifdef DEBUG
+#include <windows.h>
+#endif
 
 #if !__clang__ && !__GNUC__
 #pragma detect_mismatch("Allocator", "Crt")


### PR DESCRIPTION
Fixes clang compile issue for debug builds.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10330)