### PR TITLE
Initialize TextTransformParentVisitor state

### DIFF
--- a/change/react-native-windows-8f7a774e-310a-4df6-9266-1173ee277b01.json
+++ b/change/react-native-windows-8f7a774e-310a-4df6-9266-1173ee277b01.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Initialize TextTransformParentVisitor state",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Text/TextTransformParentVisitor.h
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextTransformParentVisitor.h
@@ -12,7 +12,7 @@ class TextTransformParentVisitor : public TextParentVisitor {
   using Super = TextParentVisitor;
 
  public:
-  TextTransform textTransform;
+  TextTransform textTransform{TextTransform::Undefined};
 
  protected:
   void VisitText(ShadowNodeBase *node) override;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
The textTransform logic is designed in a way that inherited transforms work properly. To accomplish this, when any change is made to raw text, it traverses its parent tree to find the first inherited transform.

When the raw text node is first created, it does not find any parent, so it uses the default initialized state value for textTransform in the TextTransformParentVisitor. Depending on compiler settings, this is not always 0 / undefined.

### What
This change ensures the textTransform parent state is always set to Undefined.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10331)