### PR TITLE
Update nuget feed declarations

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,4 +4,5 @@
     <add key="enabled" value="True" />
     <add key="automatic" value="True" />
   </packageRestore>
+  <!-- Note: Do not specify any NuGet feeds in this file, everything is available on the fallback NuGet.org. -->
 </configuration>

--- a/change/react-native-windows-018abdbd-de95-40a0-ad82-807c96ba29fa.json
+++ b/change/react-native-windows-018abdbd-de95-40a0-ad82-807c96ba29fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update nuget feed declarations",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.ABITests/NuGet.Config
+++ b/vnext/Desktop.ABITests/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Note: Do not add any more NuGet feeds in this file, this project should only rely on the ADO feed. -->
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/vnext/Desktop.DLL/NuGet.Config
+++ b/vnext/Desktop.DLL/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/vnext/Desktop.IntegrationTests/NuGet.Config
+++ b/vnext/Desktop.IntegrationTests/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Note: Do not add any more NuGet feeds in this file, this project should only rely on the ADO feed. -->
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/vnext/Desktop.UnitTests/NuGet.Config
+++ b/vnext/Desktop.UnitTests/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Note: Do not add any more NuGet feeds in this file, this project should only rely on the ADO feed. -->
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/vnext/Desktop/NuGet.Config
+++ b/vnext/Desktop/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Note: Do not add any more NuGet feeds in this file, this project should only rely on the ADO feed. -->
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/vnext/NuGet.Config
+++ b/vnext/NuGet.Config
@@ -3,13 +3,5 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
-  <packageSources>
-    <clear />
-    <!-- Unable to create a compliant NuGet feed which meets our needs. See #9996. -->
-    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
-    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-  <disabledPackageSources>
-    <clear />
-  </disabledPackageSources>
+  <!-- Note: Do not specify any NuGet feeds in this file, everything is available on the fallback NuGet.org. -->
 </configuration>

--- a/vnext/ReactCommon.UnitTests/NuGet.Config
+++ b/vnext/ReactCommon.UnitTests/NuGet.Config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- Note: Do not add any more NuGet feeds in this file, this project should only rely on the ADO feed. -->
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This PR changes our `NuGet.Config` files to be compliant. It assumes the following paradigm:

1. The NuGet.org feed contains all of the packages that RNW Universal/WinAppSDK projects require.
2. The `react-native-public` ADO feed conatins all of the packages that RNW Desktop projects requires.

With this in mind, the `NuGet.Config` files have been updated as follows:

* The root and `vnext` `NuGet.Config` files no longer specify any package sources, so restores will default to the user's default, (usually NuGet.org).
* The Desktop* projects specify only the `react-native-public` ADO feed as a package source.

From an app/module customer point-of-view, unless they're trying to test canary builds of our `Microsoft.ReactNative.*`, they shouldn't need to use our ADO feeds at all. And even if they do, that's still fine. These changes are just making sure that when we build the official nugets in our pipelines, we're compliant. These `NuGet.Config` files aren't published to npm at all.

Closes #9992
Closes #9993
Closes #9996
Closes #9997