### PR TITLE
[0.68] Add missing export for x86, and publish patched folly files in office nuget

### DIFF
--- a/change/react-native-windows-898d69e8-a95e-4148-96d5-b1ade9bc89fc.json
+++ b/change/react-native-windows-898d69e8-a95e-4148-96d5-b1ade9bc89fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add additional export for desktop x86 dll",
+  "packageName": "react-native-windows",
+  "email": "acoates@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -5,6 +5,7 @@
 ; **************************************************************************************************
 
 EXPORTS
+??$safe_assert_terminate@$0A@@detail@folly@@YAXPBUsafe_assert_arg@01@ZZ
 ??$str_to_floating@N@detail@folly@@YG?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0LayoutAnimation@react@facebook@@QAE@Udynamic@folly@@@Z

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -54,6 +54,13 @@ Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Objec
 	-Force
 }
 
+# Folly overrides
+Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
+	-Path        $ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate\$_ `
+	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\$(Split-Path $_) -Force) `
+	-Force
+}
+
 # stubs headers
 Get-ChildItem -Path $ReactWindowsRoot\stubs -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
 	-Path        $ReactWindowsRoot\stubs\$_ `

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -55,7 +55,7 @@ Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Objec
 }
 
 # Folly overrides
-Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
+Get-ChildItem -Path $ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
 	-Path        $ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate\$_ `
 	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\$(Split-Path $_) -Force) `
 	-Force


### PR DESCRIPTION
null

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10344)