### PR TITLE
Update custom targets in Folly.vcxproj and fmt.vcxproj

### DIFF
--- a/change/react-native-windows-96cc10b8-f540-456c-a1b9-2d1f8ecb536e.json
+++ b/change/react-native-windows-96cc10b8-f540-456c-a1b9-2d1f8ecb536e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update custom targets in Folly.vcxproj and fmt.vcxproj",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -15,7 +15,7 @@
       The PR (windows-vs-pr.yml) and CI (publish.yml() turn it back on.
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
-    <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit too. -->
+    <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit and build Folly.vcxproj (to update its cgmanifest.json) too. -->
     <FollyVersion>2021.06.28.00</FollyVersion>
     <FollyCommitHash>f434460f8a98e85f3ddb75390ddd1cc330c8f658</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -18,7 +18,7 @@
     <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit too. -->
     <FollyVersion>2021.06.28.00</FollyVersion>
     <FollyCommitHash>f434460f8a98e85f3ddb75390ddd1cc330c8f658</FollyCommitHash>
-    <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit too. -->
+    <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
     <FmtVersion>8.0.0</FmtVersion>
     <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>
   </PropertyGroup>

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -267,23 +267,28 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <FollyZipDir>$(IntDir)\.follyzip</FollyZipDir>
-    </PropertyGroup>
-    <Message Importance="High" Text="Downloading folly..." Condition="!Exists('$(FollyZipDir)\folly-$(FollyVersion).zip')" />
-    <DownloadFile Condition="!Exists('$(FollyZipDir)\folly-$(FollyVersion).zip')"
+  <PropertyGroup>
+    <FollyZipDir>$(FollyDir)..\.follyzip</FollyZipDir>
+    <FollyZipFile>$(FollyZipDir)\folly-$(FollyVersion).zip</FollyZipFile>
+    <CGManifestFile>$(MSBuildThisFileDirectory)cgmanifest.json</CGManifestFile>
+  </PropertyGroup>
+  <Target Name="DownloadFolly" BeforeTargets="PrepareForBuild" Inputs="$(FollyZipFile)" Outputs="$(FollyZipFile)">
+    <Message Importance="High" Text="Downloading folly..." />
+    <DownloadFile
       SourceUrl="https://github.com/facebook/folly/archive/v$(FollyVersion).zip"
-      DestinationFileName="folly-$(FollyVersion).zip"
+      DestinationFileName="$(FollyZipFile)"
       DestinationFolder="$(FollyZipDir)"
       Retries="10"/>
   </Target>
   <Target Name="UnzipFolly" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly">
-    <Message Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." Condition="!Exists('$(FollyDir)folly\dynamic.h')" />
-    <Unzip Condition="!Exists('$(FollyDir)')" SourceFiles="$(FollyZipDir)\folly-$(FollyVersion).zip" DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))" OverwriteReadOnlyFiles="true" />
+    <Message Condition="!Exists('$(FollyDir)folly\dynamic.h')" Importance="High" Text="Unzipping folly to $([MSBuild]::NormalizePath($(FollyDir)..))." />
+    <Unzip
+      Condition="!Exists('$(FollyDir)folly\dynamic.h')"
+      SourceFiles="$(FollyZipFile)"
+      DestinationFolder="$([MSBuild]::NormalizePath($(FollyDir)..))"
+      OverwriteReadOnlyFiles="true" />
   </Target>
-  <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
-    <Message Importance="High" Text="Generating $([MSBuild]::NormalizePath($(FollyDir)..))\cgmanifest.json." Condition="!Exists('$([MSBuild]::NormalizePath($(FollyDir)..))\cgmanifest.json')" />
+  <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly" Inputs="$(FollyZipFile)" Outputs="$(CGManifestFile)">
     <PropertyGroup>
       <CGManifestText>{
     "Registrations": [
@@ -300,8 +305,9 @@
     ]
 }</CGManifestText>
     </PropertyGroup>
+    <Message Importance="High" Text="Generating $(CGManifestFile)." />
     <WriteLinesToFile
-        File="$([MSBuild]::NormalizePath($(FollyDir)..))\cgmanifest.json"
+        File="$(CGManifestFile)"
         Overwrite="true"
         Lines="$(CGManifestText)" />
   </Target>
@@ -313,7 +319,8 @@
   </ItemGroup>
   <Target Name="Deploy" />
   <!-- Reenable this task if we need to temporarily replace any folly files for fixes, while we wait for PRs to land in folly -->
-  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
+  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly" Inputs="@(TemporaryFollyPatchFiles)" Outputs="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')">
+    <Message Importance="High" Text="Applying temporary patches to folly." />
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>
   <ItemGroup>

--- a/vnext/Folly/cgmanifest.json
+++ b/vnext/Folly/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                  "RepositoryUrl": "https://github.com/facebook/folly",
+                  "CommitHash": "f434460f8a98e85f3ddb75390ddd1cc330c8f658"
+                }
+            },
+            "DevelopmentDependency": false
+        }
+    ]
+}

--- a/vnext/fmt/cgmanifest.json
+++ b/vnext/fmt/cgmanifest.json
@@ -1,0 +1,14 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                  "RepositoryUrl": "https://github.com/fmtlib/fmt",
+                  "CommitHash": "9e8b86fd2d9806672cc73133d21780dd182bfd24"
+                }
+            },
+            "DevelopmentDependency": false
+        }
+    ]
+}

--- a/vnext/fmt/fmt.vcxproj
+++ b/vnext/fmt/fmt.vcxproj
@@ -96,16 +96,28 @@
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="DownloadFmt" BeforeTargets="PrepareForBuild">
-    <Message Importance="High" Text="Downloading fmt..." Condition="!Exists('$(FmtDir)..\.fmtzip\fmt-$(FmtVersion).zip')" />
-    <DownloadFile Condition="!Exists('$(FmtDir)..\.fmtzip\fmt-$(FmtVersion).zip')" SourceUrl="https://github.com/fmtlib/fmt/archive/refs/tags/$(FmtVersion).zip" DestinationFileName="fmt-$(FmtVersion).zip" DestinationFolder="$(FmtDir)..\.fmtzip" Retries="10" />
+  <PropertyGroup>
+    <FmtZipDir>$(FmtDir)..\.fmtzip</FmtZipDir>
+    <FmtZipFile>$(FmtZipDir)\fmt-$(FmtVersion).zip</FmtZipFile>
+    <CGManifestFile>$(MSBuildThisFileDirectory)cgmanifest.json</CGManifestFile>
+  </PropertyGroup>
+  <Target Name="DownloadFmt" BeforeTargets="PrepareForBuild" Inputs="$(FmtZipFile)" Outputs="$(FmtZipFile)">
+    <Message Importance="High" Text="Downloading fmt..." />
+    <DownloadFile
+      SourceUrl="https://github.com/fmtlib/fmt/archive/refs/tags/$(FmtVersion).zip"
+      DestinationFileName="$(FmtZipFile)"
+      DestinationFolder="$(FmtZipDir)"
+      Retries="10" />
   </Target>
   <Target Name="UnzipFmt" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFmt">
-    <Message Importance="High" Text="Unzipping fmt to $([MSBuild]::NormalizePath($(FmtDir)..))." Condition="!Exists('$(FmtDir)src\format.cc')" />
-    <Unzip Condition="!Exists('$(FmtDir)')" SourceFiles="$(FmtDir)..\.fmtzip\fmt-$(FmtVersion).zip" DestinationFolder="$([MSBuild]::NormalizePath($(FmtDir)..))" OverwriteReadOnlyFiles="true" />
+    <Message Condition="!Exists('$(FmtDir)src\format.cc')" Importance="High" Text="Unzipping fmt to $([MSBuild]::NormalizePath($(FmtDir)..))."/>
+    <Unzip
+      Condition="!Exists('$(FmtDir)src\format.cc')"
+      SourceFiles="$(FmtZipFile)"
+      DestinationFolder="$([MSBuild]::NormalizePath($(FmtDir)..))"
+      OverwriteReadOnlyFiles="true" />
   </Target>
-  <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFmt">
-    <Message Importance="High" Text="Generating $([MSBuild]::NormalizePath($(FmtDir)..))\cgmanifest.json." Condition="!Exists('$([MSBuild]::NormalizePath($(FmtDir)..))\cgmanifest.json')" />
+  <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFmt" Inputs="$(FmtZipFile)" Outputs="$(CGManifestFile)">
     <PropertyGroup>
       <CGManifestText>{
     "Registrations": [
@@ -122,17 +134,19 @@
     ]
 }</CGManifestText>
     </PropertyGroup>
+    <Message Importance="High" Text="Generating $(CGManifestFile)." />
     <WriteLinesToFile
-        File="$([MSBuild]::NormalizePath($(FmtDir)..))\cgmanifest.json"
-        Overwrite="true"
-        Lines="$(CGManifestText)" />
+      File="$(CGManifestFile)"
+      Overwrite="true"
+      Lines="$(CGManifestText)" />
   </Target>
   <ItemGroup>
     <TemporaryFmtPatchFiles Include="$(MSBuildThisFileDirectory)\TEMP_UntilFmtUpdate\**\*.*" />
   </ItemGroup>
   <Target Name="Deploy" />
   <!-- Allow temporary patches if needed, while we wait for PRs to land in fmt -->
-  <Target Name="ApplyFmtTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFmt">
+  <Target Name="ApplyFmtTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFmt" Inputs="@(TemporaryFmtPatchFiles)" Outputs="@(TemporaryFmtPatchFiles->'$(FmtDir)fmt\%(RecursiveDir)%(Filename)%(Extension)')">
+    <Message Importance="High" Text="Applying temporary patches to fmt." />
     <Copy DestinationFiles="@(TemporaryFmtPatchFiles->'$(FmtDir)fmt\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFmtPatchFiles)" />
   </Target>
 </Project>


### PR DESCRIPTION
This PR updates the custom targets within the Folly.vcxproj and fmt.vcxproj projects by:

* Speeding up incremental builds by setting `Inputs` and `Outputs` properties
* Calculating paths/filenames only once
* Normalizing the download/unzip/override pattern between both projects
* Improving build logging
* Outputting the `cgmanifest.json` file within the repo to be checked-in
  (rather than under `node_modules`)

Closes #10212

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10349)