### PR TITLE
Add import lib if the app sets the UseRNCoreApp property

### DIFF
--- a/change/react-native-windows-6167fbe2-bc35-447b-a0eb-5b947cc5b538.json
+++ b/change/react-native-windows-6167fbe2-bc35-447b-a0eb-5b947cc5b538.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add import lib if the app sets the UseRNCoreApp property",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/Microsoft.ReactNative.targets
+++ b/vnext/Scripts/Microsoft.ReactNative.targets
@@ -18,4 +18,11 @@
     <ReferenceCopyLocalPaths Condition="$(Configuration) == 'Debug'" Include="$(_rnwFolder)**\*.xbf" />
 
   </ItemGroup>
+
+  <ItemDefinitionGroup Condition="'$(UseRNCoreApp)'=='true'">
+    <Link>
+      <AdditionalDependencies>$(MSBuildThisFileDirectory)..\..\lib\$(Native-Platform)\Microsoft.ReactNative.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
 </Project>


### PR DESCRIPTION
## Description
Creates an msbuild property for the app to set that we check in order to link in the import library (used for RNCoreApp APIs).

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Makes it easy to consume RNCoreApp APIs



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10351)