### PR TITLE
Fixes various issues with fast text optimization

### DIFF
--- a/change/react-native-windows-80ab1dcb-5a57-4983-be91-37a76beeb23d.json
+++ b/change/react-native-windows-80ab1dcb-5a57-4983-be91-37a76beeb23d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes various issues with fast text optimization",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -67,7 +67,8 @@ class TextShadowNode final : public ShadowNodeBase {
     }
 
     auto addInline = true;
-    if (index == 0) {
+    // Only convert to fast text when exactly one child is attached to the root Text node
+    if (index == 0 && m_children.size() == 1) {
       auto run = childNode.GetView().try_as<winrt::Run>();
       if (run != nullptr) {
         m_firstChildNode = &child;
@@ -75,7 +76,8 @@ class TextShadowNode final : public ShadowNodeBase {
         textBlock.Text(run.Text());
         addInline = false;
       }
-    } else if (index == 1 && m_firstChildNode != nullptr) {
+    } else if (m_firstChildNode != nullptr) {
+      assert(m_children.size() == 2);
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
       textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
       Super::AddView(*m_firstChildNode, 0);
@@ -101,7 +103,8 @@ class TextShadowNode final : public ShadowNodeBase {
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
-    if (indexToRemove == 0 && m_firstChildNode) {
+    if (m_firstChildNode) {
+      assert(indexToRemove == 0);
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
       textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
       m_firstChildNode = nullptr;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #10354, a few scenarios are described where unexpected text changes occur out of sync with the shadow tree from RN, and some scenarios even crash the app.

Resolves #10354

### What
This change ensures that we only use the fast text optimization when there is exactly one raw text child in the shadow tree, and also switches out of the fast text optimization when the number of children increases to greater than 1, rather than only when a text value is appended (i.e., we also have to switch out of fast text optimization when for a child that might be prepended at index 0).

## Testing
Before:

https://user-images.githubusercontent.com/1106239/182199687-270b86d1-f347-4cd4-9df5-9cf576e8dda3.mp4

After:

https://user-images.githubusercontent.com/1106239/182199155-0d12d584-c94f-4b56-aaca-cd724c62413a.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10355)