### PR TITLE
Adds Systrace to view management APIs for UIManager

### DIFF
--- a/change/react-native-windows-4e62363e-6ce0-4ca5-9015-2667e8695d98.json
+++ b/change/react-native-windows-4e62363e-6ce0-4ca5-9015-2667e8695d98.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds Systrace to view management APIs for UIManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -7,6 +7,7 @@
 #include <UI.Xaml.Input.h>
 #include <UI.Xaml.Media.h>
 #include <Views/ShadowNodeBase.h>
+#include <cxxreact/SystraceSection.h>
 #include "Modules/I18nManagerModule.h"
 #include "NativeUIManager.h"
 
@@ -23,6 +24,8 @@ using namespace xaml;
 using namespace xaml::Controls;
 using namespace xaml::Media;
 } // namespace winrt
+
+using namespace facebook::react;
 
 namespace Microsoft::ReactNative {
 
@@ -222,6 +225,7 @@ int64_t NativeUIManager::AddMeasuredRootView(facebook::react::IReactRootView *ro
 }
 
 void NativeUIManager::AddRootView(ShadowNode &shadowNode, facebook::react::IReactRootView *pReactRootView) {
+  SystraceSection s("NativeUIManager::AddRootView");
   auto xamlRootView = static_cast<IXamlRootView *>(pReactRootView);
   XamlView view = xamlRootView->GetXamlView();
   m_tagsToXamlReactControl.emplace(
@@ -244,11 +248,13 @@ void NativeUIManager::AddRootView(ShadowNode &shadowNode, facebook::react::IReac
 }
 
 void NativeUIManager::removeRootView(Microsoft::ReactNative::ShadowNode &shadow) {
+  SystraceSection s("NativeUIManager::removeRootView");
   m_tagsToXamlReactControl.erase(shadow.m_tag);
   RemoveView(shadow, true);
 }
 
 void NativeUIManager::onBatchComplete() {
+  SystraceSection s("NativeUIManager::onBatchComplete");
   if (m_inBatch) {
     DoLayout();
     m_inBatch = false;
@@ -768,6 +774,7 @@ static void StyleYogaNode(
 }
 
 void NativeUIManager::CreateView(ShadowNode &shadowNode, React::JSValueObject &props) {
+  SystraceSection s("NativeUIManager::CreateView");
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto *pViewManager = node.GetViewManager();
 
@@ -859,6 +866,7 @@ void NativeUIManager::ReplaceView(ShadowNode &shadowNode) {
 }
 
 void NativeUIManager::UpdateView(ShadowNode &shadowNode, winrt::Microsoft::ReactNative::JSValueObject &props) {
+  SystraceSection s("NativeUIManager::UpdateView");
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
   auto *pViewManager = node.GetViewManager();
 
@@ -889,20 +897,29 @@ void NativeUIManager::UpdateExtraLayout(int64_t tag) {
 }
 
 void NativeUIManager::DoLayout() {
-  // Process vector of RN controls needing extra layout here.
-  const auto extraLayoutNodes = m_extraLayoutNodes;
-  for (const int64_t tag : extraLayoutNodes) {
-    ShadowNodeBase *node = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag));
-    if (node) {
-      auto element = node->GetView().as<xaml::FrameworkElement>();
-      element.UpdateLayout();
+  SystraceSection s("NativeUIManager::DoLayout");
+
+  {
+    SystraceSection s("NativeUIManager::DoLayout::UpdateLayout");
+    // Process vector of RN controls needing extra layout here.
+    const auto extraLayoutNodes = m_extraLayoutNodes;
+    for (const int64_t tag : extraLayoutNodes) {
+      ShadowNodeBase *node = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag));
+      if (node) {
+        auto element = node->GetView().as<xaml::FrameworkElement>();
+        element.UpdateLayout();
+      }
     }
+    // Values need to be cleared from the vector before next call to DoLayout.
+    m_extraLayoutNodes.clear();
   }
-  // Values need to be cleared from the vector before next call to DoLayout.
-  m_extraLayoutNodes.clear();
+
   auto &rootTags = m_host->GetAllRootTags();
   for (int64_t rootTag : rootTags) {
-    UpdateExtraLayout(rootTag);
+    {
+      SystraceSection s("NativeUIManager::DoLayout::UpdateExtraLayout");
+      UpdateExtraLayout(rootTag);
+    }
 
     ShadowNodeBase &rootShadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(rootTag));
     if (YGNodeRef rootNode = GetYogaNode(rootTag)) {
@@ -911,33 +928,39 @@ void NativeUIManager::DoLayout() {
       float actualWidth = static_cast<float>(rootElement.ActualWidth());
       float actualHeight = static_cast<float>(rootElement.ActualHeight());
 
-      // We must always run layout in LTR mode, which might seem unintuitive.
-      // We will flip the root of the tree into RTL by forcing the root XAML node's FlowDirection to RightToLeft
-      // which will inherit down the XAML tree, allowing all native controls to pick it up.
-      YGNodeCalculateLayout(rootNode, actualWidth, actualHeight, YGDirectionLTR);
+      {
+        SystraceSection s("NativeUIManager::DoLayout::YGNodeCalculateLayout");
+        // We must always run layout in LTR mode, which might seem unintuitive.
+        // We will flip the root of the tree into RTL by forcing the root XAML node's FlowDirection to RightToLeft
+        // which will inherit down the XAML tree, allowing all native controls to pick it up.
+        YGNodeCalculateLayout(rootNode, actualWidth, actualHeight, YGDirectionLTR);
+      }
     } else {
       assert(false);
       return;
     }
   }
 
-  for (auto &tagToYogaNode : m_tagsToYogaNodes) {
-    int64_t tag = tagToYogaNode.first;
-    YGNodeRef yogaNode = tagToYogaNode.second.get();
+  {
+    SystraceSection s("NativeUIManager::DoLayout::SetLayoutProps");
+    for (auto &tagToYogaNode : m_tagsToYogaNodes) {
+      int64_t tag = tagToYogaNode.first;
+      YGNodeRef yogaNode = tagToYogaNode.second.get();
 
-    if (!YGNodeGetHasNewLayout(yogaNode))
-      continue;
-    YGNodeSetHasNewLayout(yogaNode, false);
+      if (!YGNodeGetHasNewLayout(yogaNode))
+        continue;
+      YGNodeSetHasNewLayout(yogaNode, false);
 
-    float left = YGNodeLayoutGetLeft(yogaNode);
-    float top = YGNodeLayoutGetTop(yogaNode);
-    float width = YGNodeLayoutGetWidth(yogaNode);
-    float height = YGNodeLayoutGetHeight(yogaNode);
+      float left = YGNodeLayoutGetLeft(yogaNode);
+      float top = YGNodeLayoutGetTop(yogaNode);
+      float width = YGNodeLayoutGetWidth(yogaNode);
+      float height = YGNodeLayoutGetHeight(yogaNode);
 
-    ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-    auto view = shadowNode.GetView();
-    auto pViewManager = shadowNode.GetViewManager();
-    pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+      ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
+      auto view = shadowNode.GetView();
+      auto pViewManager = shadowNode.GetViewManager();
+      pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+    }
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -10,9 +10,12 @@
 #include <Modules/PaperUIManagerModule.h>
 #include <Views/ViewManager.h>
 #include <XamlUtils.h>
+#include <cxxreact/SystraceSection.h>
 #include "ShadowNodeBase.h"
 #include "Unicode.h"
 #include "XamlUIService.h"
+
+using namespace facebook::react;
 
 namespace Microsoft::ReactNative {
 
@@ -582,6 +585,7 @@ void UIManager::createView(
                                                          viewName = std::move(viewName),
                                                          rootTag,
                                                          props = std::move(props)]() mutable {
+    SystraceSection s("UIManager::createView");
     if (auto module = m.lock()) {
       module->createView(static_cast<int64_t>(reactTag), viewName, static_cast<int64_t>(rootTag), std::move(props));
     }
@@ -593,6 +597,7 @@ void UIManager::updateView(double reactTag, std::string viewName, React::JSValue
                                                          reactTag,
                                                          viewName = std::move(viewName),
                                                          props = std::move(props)]() mutable {
+    SystraceSection s("UIManager::updateView");
     if (auto module = m.lock()) {
       module->updateView(static_cast<int64_t>(reactTag), viewName, std::move(props));
     }
@@ -601,6 +606,7 @@ void UIManager::updateView(double reactTag, std::string viewName, React::JSValue
 
 void UIManager::focus(double reactTag) noexcept {
   m_batchingUIMessageQueue->runOnQueue([m = std::weak_ptr<UIManagerModule>(m_module), reactTag]() {
+    SystraceSection s("UIManager::focus");
     if (auto module = m.lock()) {
       module->focus(static_cast<int64_t>(reactTag));
     }
@@ -609,6 +615,7 @@ void UIManager::focus(double reactTag) noexcept {
 
 void UIManager::blur(double reactTag) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), reactTag]() {
+    SystraceSection s("UIManager::blur");
     if (auto module = m.lock()) {
       module->blur(static_cast<int64_t>(reactTag));
     }
@@ -624,6 +631,7 @@ void UIManager::findSubviewIn(
                                                          reactTag,
                                                          point = std::move(point),
                                                          callback = std::move(callback)]() mutable {
+    SystraceSection s("UIManager::findSubviewIn");
     if (auto module = m.lock()) {
       module->findSubviewIn(static_cast<int64_t>(reactTag), std::move(point), std::move(callback));
     }
@@ -638,6 +646,7 @@ void UIManager::dispatchViewManagerCommand(
                                                          reactTag,
                                                          commandID = std::move(commandID),
                                                          commandArgs = std::move(commandArgs)]() mutable {
+    SystraceSection s("UIManager::dispatchViewManagerCommand");
     if (auto module = m.lock()) {
       module->dispatchViewManagerCommand(static_cast<int64_t>(reactTag), std::move(commandID), std::move(commandArgs));
     }
@@ -650,6 +659,7 @@ void UIManager::measure(
         &callback) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor(
       [m = std::weak_ptr<UIManagerModule>(m_module), reactTag, callback = std::move(callback)]() mutable {
+        SystraceSection s("UIManager::measure");
         if (auto module = m.lock()) {
           module->measure(static_cast<int64_t>(reactTag), std::move(callback));
         }
@@ -661,6 +671,7 @@ void UIManager::measureInWindow(
     std::function<void(double x, double y, double width, double height)> const &callback) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor(
       [m = std::weak_ptr<UIManagerModule>(m_module), reactTag, callback = std::move(callback)]() mutable {
+        SystraceSection s("UIManager::measureInWindow");
         if (auto module = m.lock()) {
           module->measureInWindow(static_cast<int64_t>(reactTag), std::move(callback));
         }
@@ -675,6 +686,7 @@ void UIManager::viewIsDescendantOf(
                                                          reactTag,
                                                          ancestorReactTag,
                                                          callback = std::move(callback)]() mutable {
+    SystraceSection s("UIManager::viewIsDescendantOf");
     if (auto module = m.lock()) {
       module->viewIsDescendantOf(
           static_cast<int64_t>(reactTag), static_cast<int64_t>(ancestorReactTag), std::move(callback));
@@ -692,6 +704,7 @@ void UIManager::measureLayout(
                                                          ancestorReactTag,
                                                          errorCallback = std::move(errorCallback),
                                                          callback = std::move(callback)]() mutable {
+    SystraceSection s("UIManager::measureLayout");
     if (auto module = m.lock()) {
       module->measureLayout(
           static_cast<int64_t>(reactTag),
@@ -710,6 +723,7 @@ void UIManager::measureLayoutRelativeToParent(
                                                          reactTag,
                                                          errorCallback = std::move(errorCallback),
                                                          callback = std::move(callback)]() mutable {
+    SystraceSection s("UIManager::measureLayoutRelativeToParent");
     if (auto module = m.lock()) {
       module->measureLayoutRelativeToParent(
           static_cast<int64_t>(reactTag), std::move(errorCallback), std::move(callback));
@@ -720,6 +734,7 @@ void UIManager::measureLayoutRelativeToParent(
 void UIManager::setJSResponder(double reactTag, bool blockNativeResponder) noexcept {
   m_batchingUIMessageQueue->runOnQueue(
       Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), reactTag, blockNativeResponder]() mutable {
+        SystraceSection s("UIManager::setJSResponder");
         if (auto module = m.lock()) {
           module->setJSResponder(static_cast<int64_t>(reactTag), blockNativeResponder);
         }
@@ -728,6 +743,7 @@ void UIManager::setJSResponder(double reactTag, bool blockNativeResponder) noexc
 
 void UIManager::clearJSResponder() noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module)]() mutable {
+    SystraceSection s("UIManager::clearJSResponder");
     if (auto module = m.lock()) {
       module->clearJSResponder();
     }
@@ -742,6 +758,7 @@ void UIManager::configureNextLayoutAnimation(
                                                          config = std::move(config),
                                                          callback = std::move(callback),
                                                          errorCallback = std::move(errorCallback)]() mutable {
+    SystraceSection s("UIManager::configureNextLayoutAnimation");
     if (auto module = m.lock()) {
       module->configureNextLayoutAnimation(std::move(config), std::move(callback), std::move(errorCallback));
     }
@@ -750,6 +767,7 @@ void UIManager::configureNextLayoutAnimation(
 
 void UIManager::removeSubviewsFromContainerWithID(double containerID) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), containerID]() {
+    SystraceSection s("UIManager::removeSubviewsFromContainerWithID");
     if (auto module = m.lock()) {
       module->removeSubviewsFromContainerWithID(static_cast<int64_t>(containerID));
     }
@@ -759,6 +777,7 @@ void UIManager::removeSubviewsFromContainerWithID(double containerID) noexcept {
 void UIManager::replaceExistingNonRootView(double reactTag, double newReactTag) noexcept {
   m_batchingUIMessageQueue->runOnQueue(
       Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), reactTag, newReactTag]() {
+        SystraceSection s("UIManager::replaceExistingNonRootView");
         if (auto module = m.lock()) {
           module->replaceExistingNonRootView(static_cast<int64_t>(reactTag), static_cast<int64_t>(newReactTag));
         }
@@ -767,6 +786,7 @@ void UIManager::replaceExistingNonRootView(double reactTag, double newReactTag) 
 
 void UIManager::removeRootView(double reactTag) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), reactTag]() {
+    SystraceSection s("UIManager::removeRootView");
     if (auto module = m.lock()) {
       module->removeRootView(static_cast<int64_t>(reactTag));
     }
@@ -776,6 +796,7 @@ void UIManager::removeRootView(double reactTag) noexcept {
 void UIManager::setChildren(double containerTag, React::JSValueArray &&reactTags) noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor(
       [m = std::weak_ptr<UIManagerModule>(m_module), containerTag, reactTags = std::move(reactTags)]() mutable {
+        SystraceSection s("UIManager::setChildren");
         if (auto module = m.lock()) {
           module->setChildren(static_cast<int64_t>(containerTag), std::move(reactTags));
         }
@@ -796,6 +817,7 @@ void UIManager::manageChildren(
                                                          addChildReactTags = std::move(addChildReactTags),
                                                          addAtIndices = std::move(addAtIndices),
                                                          removeAtIndices = std::move(removeAtIndices)]() mutable {
+    SystraceSection s("UIManager::manageChildren");
     if (auto module = m.lock()) {
       module->manageChildren(
           static_cast<int64_t>(containerTag),
@@ -811,6 +833,7 @@ void UIManager::manageChildren(
 void UIManager::setLayoutAnimationEnabledExperimental(bool enabled) noexcept {
   m_batchingUIMessageQueue->runOnQueue(
       Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), enabled]() mutable {
+        SystraceSection s("UIManager::setLayoutAnimationEnabledExperimental");
         if (auto module = m.lock()) {
           module->setLayoutAnimationEnabledExperimental(enabled);
         }
@@ -820,6 +843,7 @@ void UIManager::setLayoutAnimationEnabledExperimental(bool enabled) noexcept {
 void UIManager::sendAccessibilityEvent(double reactTag, double eventType) noexcept {
   m_batchingUIMessageQueue->runOnQueue(
       Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module), reactTag, eventType]() mutable {
+        SystraceSection s("UIManager::sendAccessibilityEvent");
         if (auto module = m.lock()) {
           module->sendAccessibilityEvent(static_cast<int64_t>(reactTag), eventType);
         }
@@ -836,6 +860,7 @@ void UIManager::showPopupMenu(
                                                          items = std::move(items),
                                                          error = std::move(error),
                                                          success = std::move(success)]() mutable {
+    SystraceSection s("UIManager::showPopupMenu");
     if (auto module = m.lock()) {
       module->showPopupMenu(static_cast<int64_t>(reactTag), std::move(items), std::move(error), std::move(success));
     }
@@ -844,6 +869,7 @@ void UIManager::showPopupMenu(
 
 void UIManager::dismissPopupMenu() noexcept {
   m_batchingUIMessageQueue->runOnQueue(Mso::VoidFunctor([m = std::weak_ptr<UIManagerModule>(m_module)]() mutable {
+    SystraceSection s("UIManager::dismissPopupMenu");
     if (auto module = m.lock()) {
       module->dismissPopupMenu();
     }

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -19,10 +19,13 @@
 #include <Utils/PropertyUtils.h>
 #include <Views/ExpressionAnimationStore.h>
 #include <Views/ShadowNodeBase.h>
+#include <cxxreact/SystraceSection.h>
 
 namespace winrt {
 using namespace xaml;
 }
+
+using namespace facebook::react;
 
 namespace Microsoft::ReactNative {
 
@@ -248,7 +251,10 @@ void ViewManagerBase::UpdateProperties(
     }
   }
 
-  OnPropertiesUpdated(nodeToUpdate);
+  {
+    SystraceSection s("ViewManagerBase::OnPropertiesUpdated");
+    OnPropertiesUpdated(nodeToUpdate);
+  }
 }
 
 bool ViewManagerBase::UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -9,6 +9,7 @@
 #include <UI.Xaml.Media.h>
 #include <Utils/PropertyUtils.h>
 #include <Utils/ResourceBrushUtils.h>
+#include <cxxreact/SystraceSection.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.UI.Xaml.Interop.h>
 
@@ -27,6 +28,8 @@ using namespace winrt::Windows::UI::Xaml::Interop;
 using namespace xaml::Media;
 using namespace Windows::Foundation;
 } // namespace winrt
+
+using namespace facebook::react;
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -227,6 +230,7 @@ void ViewPanel::ClipChildren(bool value) {
 }
 
 void ViewPanel::FinalizeProperties() {
+  SystraceSection s("ViewPanel::FinalizeProperties");
   if (!m_propertiesChanged)
     return;
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -19,6 +19,7 @@
 #include <INativeUIManager.h>
 #include <IReactInstance.h>
 
+#include <cxxreact/SystraceSection.h>
 #include <inspectable.h>
 #include <unicode.h>
 #include <winrt/Windows.System.h>
@@ -29,6 +30,8 @@
 // Currently only used for tagging controls in debug
 #include <winrt/Windows.Foundation.h>
 #endif
+
+using namespace facebook::react;
 
 namespace Microsoft::ReactNative {
 
@@ -528,9 +531,11 @@ void ViewViewManager::TryUpdateView(
   //
   // 2. Transfer needed properties from old to new view
   //
-
-  // Transfer properties from old XamlView to the new one
-  TransferProperties(oldXamlView, newXamlView);
+  {
+    SystraceSection s("ViewViewManager::TransferProperties");
+    // Transfer properties from old XamlView to the new one
+    TransferProperties(oldXamlView, newXamlView);
+  }
 
   // Since we transferred properties to the new view we need to make the call to
   // finalize

--- a/vnext/Shared/Threading/BatchingQueueThread.cpp
+++ b/vnext/Shared/Threading/BatchingQueueThread.cpp
@@ -4,8 +4,11 @@
 #include "pch.h"
 #include "Threading/BatchingQueueThread.h"
 #include <cxxreact/Instance.h>
+#include <cxxreact/SystraceSection.h>
 #include <eventWaitHandle/eventWaitHandle.h>
 #include <cassert>
+
+using namespace facebook::react;
 
 namespace Microsoft::ReactNative {
 
@@ -36,7 +39,9 @@ void BatchingQueueCallInvoker::EnsureQueue() noexcept {
 void BatchingQueueCallInvoker::PostBatch() noexcept {
   if (m_taskQueue) {
     m_queueThread->runOnQueue([taskQueue{std::move(m_taskQueue)}]() noexcept {
+      SystraceSection s1("BatchingQueueCallInvoker::PostBatch");
       for (auto &task : *taskQueue) {
+        SystraceSection s2("BatchingQueueCallInvoker::PostBatch::Task");
         task();
         task = nullptr;
       }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Adds a few SystraceSections to improve instrumentation for performance measurements.


### What
This change adds SystraceSections to many relevant UIManager and View calls for more visibility into what work is being done by RN.

Specifically, it instruments the following:
1. Frequent view management APIs for the top-level UIManager and the NativeUIManager (e.g., createView, updateView, manageChildren, etc.). It does not currently measure any context switching from JS to UI thread.
2. Potential hot spots for ViewViewManager, like replacing the ViewPanel with a ViewControl (via ReplaceView, TransferProperties, etc.).
3. Time spent preparing for and executing Yoga layout, including extra XAML layout calls made to prepare the view for Yoga layout (e.g., UpdateExtraLayout and NeedsForceLayout), the call to YGNodeCalculateLayout, and the calls to SetLayoutProps.

## Screenshots
I have not tested what this does in ETW, but here is a screen shot from one of our perf traces using an internal tool at Meta:

<img width="733" alt="image" src="https://user-images.githubusercontent.com/1106239/182406274-5fa72478-0361-45a0-b2ca-a2edf2e87d12.png">

This has a bit of extra detail, as I added a few other traces (e.g., text measurement callbacks, XAML layout calls in MeasureOverride/ArrangeOverride), but most of these get throttled because they are too short and too frequent.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10358)