### PR TITLE
Fix skew transforms for string values

### DIFF
--- a/change/react-native-windows-7381bba4-15a0-458e-82c9-63951b1129c8.json
+++ b/change/react-native-windows-7381bba4-15a0-458e-82c9-63951b1129c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix skew transforms for string values",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -235,12 +235,12 @@ bool FrameworkElementViewManager::UpdateProperty(
                 MultiplyInto(
                     transformMatrix,
                     winrt::Windows::Foundation::Numerics::float4x4(
-                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(innerValue.AsSingle(), 0.f)));
+                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(ToRadians(innerValue), 0.f)));
               } else if (transformType == "skewY") {
                 MultiplyInto(
                     transformMatrix,
                     winrt::Windows::Foundation::Numerics::float4x4(
-                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(0.f, innerValue.AsSingle())));
+                        winrt::Windows::Foundation::Numerics::make_float3x2_skew(0.f, ToRadians(innerValue))));
               }
             }
           }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #9798, we added functionality to update transform props directly without first converting those props into a transform matrix in JS. This change did not account for string values of skewX and skewY.

Resolves #10364

### What
Skew transforms can be specified in degrees (via string) rather than explicit float values. Ensure we call `ToRadians` before attempting to create the skew matrices.

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

https://user-images.githubusercontent.com/1106239/182689785-1fdaf726-d69e-470c-b54a-76acf24326ac.mp4





###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10365)