### PR TITLE
Fix reload hang after debugger break-continue

### DIFF
--- a/change/react-native-windows-d730c6a3-e01f-4a1c-b929-c336f548bdb0.json
+++ b/change/react-native-windows-d730c6a3-e01f-4a1c-b929-c336f548bdb0.json
@@ -1,0 +1,10 @@
+{
+  "type": "none",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/react-native-windows-d730c6a3-e01f-4a1c-b929-c336f548bdb0.json
+++ b/change/react-native-windows-d730c6a3-e01f-4a1c-b929-c336f548bdb0.json
@@ -1,10 +1,7 @@
 {
-  "type": "none",
-  "comment": {
-    "title": "",
-    "value": ""
-  },
+  "type": "prerelease",
+  "comment": "Fix reload hang after debugger break and continue",
   "packageName": "react-native-windows",
   "email": "aeulitz@microsoft.com",
-  "dependentChangeType": "none"
+  "dependentChangeType": "patch"
 }

--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -242,7 +242,7 @@ test('set, remove breakpoint', async () => {
 
 // Regression test for the fix for RNW:9662 (https://github.com/microsoft/react-native-windows/issues/9662,
 // this test would fail prior to the fix).
-test.only('reload after continue', async () => {
+test('reload after continue', async () => {
   testLog.message(`executing 'pause, resume' test on PID ${pid}`);
 
   const settings = await PlaygroundDebugSettings.set({

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/hermes/inspector/chrome/ConnectionDemux.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/hermes/inspector/chrome/ConnectionDemux.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ConnectionDemux.h"
+#include "AutoAttachUtils.h"
+#include "Connection.h"
+
+#include <jsinspector/InspectorInterfaces.h>
+
+namespace facebook {
+namespace hermes {
+namespace inspector {
+namespace chrome {
+
+using ::facebook::react::IInspector;
+using ::facebook::react::ILocalConnection;
+using ::facebook::react::IRemoteConnection;
+
+namespace {
+
+class LocalConnection : public ILocalConnection {
+ public:
+  LocalConnection(
+      std::shared_ptr<Connection> conn,
+      std::shared_ptr<std::unordered_set<std::string>> inspectedContexts);
+  ~LocalConnection();
+
+  void sendMessage(std::string message) override;
+  void disconnect() override;
+
+ private:
+  std::shared_ptr<Connection> conn_;
+  std::shared_ptr<std::unordered_set<std::string>> inspectedContexts_;
+};
+
+LocalConnection::LocalConnection(
+    std::shared_ptr<Connection> conn,
+    std::shared_ptr<std::unordered_set<std::string>> inspectedContexts)
+    : conn_(conn), inspectedContexts_(inspectedContexts) {
+  inspectedContexts_->insert(conn->getTitle());
+}
+
+LocalConnection::~LocalConnection() = default;
+
+void LocalConnection::sendMessage(std::string str) {
+  conn_->sendMessage(std::move(str));
+}
+
+void LocalConnection::disconnect() {
+  inspectedContexts_->erase(conn_->getTitle());
+  conn_->disconnect();
+}
+
+} // namespace
+
+ConnectionDemux::ConnectionDemux(facebook::react::IInspector &inspector)
+    : globalInspector_(inspector),
+      inspectedContexts_(std::make_shared<std::unordered_set<std::string>>()) {}
+
+ConnectionDemux::~ConnectionDemux() = default;
+
+int ConnectionDemux::enableDebugging(
+    std::unique_ptr<RuntimeAdapter> adapter,
+    const std::string &title) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // TODO(#22976087): workaround for ComponentScript contexts never being
+  // destroyed.
+  //
+  // After a reload, the old ComponentScript VM instance stays alive. When we
+  // register the new CS VM instance, check for any previous CS VM (via strcmp
+  // of title) and remove them.
+  std::vector<int> pagesToDelete;
+  for (auto it = conns_.begin(); it != conns_.end(); ++it) {
+    if (it->second->getTitle() == title) {
+      pagesToDelete.push_back(it->first);
+    }
+  }
+
+  for (auto pageId : pagesToDelete) {
+    removePage(pageId);
+  }
+
+  // TODO(hypuk): Provide real app and device names.
+  auto waitForDebugger =
+      (inspectedContexts_->find(title) != inspectedContexts_->end()) ||
+      isNetworkInspected(title, "app_name", "device_name");
+
+  return addPage(
+      std::make_shared<Connection>(std::move(adapter), title, waitForDebugger));
+}
+
+void ConnectionDemux::disableDebugging(HermesRuntime &runtime) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  for (auto &it : conns_) {
+    int pageId = it.first;
+    auto &conn = it.second;
+
+    if (&(conn->getRuntime()) == &runtime) {
+      removePage(pageId);
+
+      // must break here. removePage mutates conns_, so range-for iterator is
+      // now invalid.
+      break;
+    }
+  }
+}
+
+int ConnectionDemux::addPage(std::shared_ptr<Connection> conn) {
+  auto connectFunc = [conn, this](std::unique_ptr<IRemoteConnection> remoteConn)
+      -> std::unique_ptr<ILocalConnection> {
+    if (!conn->connect(std::move(remoteConn))) {
+      return nullptr;
+    }
+
+    return std::make_unique<LocalConnection>(conn, inspectedContexts_);
+  };
+
+  int pageId = globalInspector_.addPage(
+      conn->getTitle(), "Hermes", std::move(connectFunc));
+  conns_[pageId] = std::move(conn);
+
+  return pageId;
+}
+
+void ConnectionDemux::removePage(int pageId) {
+  globalInspector_.removePage(pageId);
+
+  auto conn = conns_.at(pageId);
+  std::string title = conn->getTitle();
+  inspectedContexts_->erase(title);
+  conn->disconnect();
+  conns_.erase(pageId);
+}
+
+} // namespace chrome
+} // namespace inspector
+} // namespace hermes
+} // namespace facebook

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -68,6 +68,13 @@
       "baseHash": "86ac95fb195394bc314b2481907026d2568a0c45"
     },
     {
+      "type": "copy",
+      "file": "ReactCommon/TEMP_UntilReactCommonUpdate/hermes/inspector/chrome/ConnectionDemux.cpp",
+      "baseFile": "ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp",
+      "baseHash": "41dc97319f19389ff5af38a70c5c428de83c3ef6",
+      "issue": 10370
+    },
+    {
       "type": "patch",
       "file": "ReactCommon/TEMP_UntilReactCommonUpdate/jsi/jsi/test/testlib.cpp",
       "baseFile": "ReactCommon/jsi/jsi/test/testlib.cpp",

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -68,7 +68,7 @@
       "baseHash": "86ac95fb195394bc314b2481907026d2568a0c45"
     },
     {
-      "type": "copy",
+      "type": "patch",
       "file": "ReactCommon/TEMP_UntilReactCommonUpdate/hermes/inspector/chrome/ConnectionDemux.cpp",
       "baseFile": "ReactCommon/hermes/inspector/chrome/ConnectionDemux.cpp",
       "baseHash": "41dc97319f19389ff5af38a70c5c428de83c3ef6",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
See description in FB PR [34342](https://github.com/facebook/react-native/pull/34342).

Resolves [9662](https://github.com/microsoft/react-native-windows/issues/9662)

### What
Clean up process-wide singleton during instance teardown (see description in FB PR [34342](https://github.com/facebook/react-native/pull/34342))

## Testing
1. Manually tested the change using the Playground app and Chrome Inspect.
2. Added automated (regression-)test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10371)