### PR TITLE
Remove incorrect `typename` keyword in helpers.h function template

### DIFF
--- a/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
+++ b/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
@@ -5,6 +5,6 @@
     "value": ""
   },
   "packageName": "react-native-windows",
-  "email": "vmorozov@microsoft.com",
+  "email": "45952631+JonCavesMSFT@users.noreply.github.com",
   "dependentChangeType": "patch"
 }

--- a/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
+++ b/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
@@ -1,0 +1,10 @@
+{
+  "type": "prerelease",
+  "comment": {
+    "title": "",
+    "value": ""
+  },
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
+++ b/change/react-native-windows-8d7cf1e8-5491-4630-bf74-b2e4f942cf70.json
@@ -1,9 +1,6 @@
 {
   "type": "prerelease",
-  "comment": {
-    "title": "",
-    "value": ""
-  },
+  "comment": "Remove incorrect typename keyword in helpers.h function template",
   "packageName": "react-native-windows",
   "email": "45952631+JonCavesMSFT@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -18,7 +18,7 @@ struct ReactId {
 };
 
 template <typename T>
-inline typename T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
+inline T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());
 }
 


### PR DESCRIPTION
Remove unnecessary 'typename' as recent builds of MSVC compiler will emit an error

## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The code contained an unnecessary 'typename' keyword which is flagged as an error by recent builds of the MSVC compiler

### What
Remove 'typename' keyword


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10373)