### PR TITLE
Enable ABIViewManager to opt out of NeedsForceLayout

### DIFF
--- a/change/react-native-windows-69f1f2d9-b568-4dcc-9074-c70927794d6b.json
+++ b/change/react-native-windows-69f1f2d9-b568-4dcc-9074-c70927794d6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable ABIViewManager to opt out of NeedsForceLayout",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -40,6 +40,7 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithCommands{viewManager.try_as<IViewManagerWithCommands>()},
       m_viewManagerWithExportedEventTypeConstants{viewManager.try_as<IViewManagerWithExportedEventTypeConstants>()},
       m_viewManagerRequiresNativeLayout{viewManager.try_as<IViewManagerRequiresNativeLayout>()},
+      m_viewManagerDisableForceLayout{viewManager.try_as<IViewManagerDisableForceLayout>()},
       m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()},
       m_viewManagerWithPointerEvents{viewManager.try_as<IViewManagerWithPointerEvents>()},
       m_viewManagerWithDropViewInstance{viewManager.try_as<IViewManagerWithDropViewInstance>()} {
@@ -239,7 +240,8 @@ void ABIViewManager::OnDropViewInstance(const ::Microsoft::ReactNative::XamlView
 
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {
   return new ABIShadowNode(
-      m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout());
+      m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout() &&
+      (!m_viewManagerDisableForceLayout || !m_viewManagerDisableForceLayout.DisableForceLayout()));
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -82,6 +82,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithExportedEventTypeConstants m_viewManagerWithExportedEventTypeConstants;
   IViewManagerWithChildren m_viewManagerWithChildren;
   IViewManagerRequiresNativeLayout m_viewManagerRequiresNativeLayout;
+  IViewManagerDisableForceLayout m_viewManagerDisableForceLayout;
   IViewManagerWithPointerEvents m_viewManagerWithPointerEvents;
   IViewManagerWithDropViewInstance m_viewManagerWithDropViewInstance;
 

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -56,6 +56,11 @@ namespace Microsoft.ReactNative
     Boolean RequiresNativeLayout { get; };
   }
 
+  [webhosthidden] DOC_STRING("Enables a view manager to require native layout but not force layout.")
+  interface IViewManagerDisableForceLayout {
+    Boolean DisableForceLayout { get; };
+  }
+
   [webhosthidden]
   DOC_STRING(
     "Enables a view manager to create views whose behavior depend on the the property values passed to the view manager at creation time. "


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
Currently, setting RequiresNativeLayout to true also opts into NeedsForceLayout on the shadow node for ABIViewManager, which makes an extra UpdateLayout call in UIManager. These two features are not necessarily tied together. For example, TextInputViewManager sets both RequiresNativeLayout and NeedsForceLayout, but TextViewManager does not.

We are currently experiencing a crash when being forced to call the extra UpdateLayout call on a custom view manager based on ABIViewManager with an E_FAIL hresult from UIElement::UpdateLayout.

### What
This change adds another interface that allows ABI VMs to opt out of the forced extra UpdateLayout.

## Testing
Confirmed in our app that crash no longer occurs because extra UpdateLayout call here is skipped:
https://github.com/microsoft/react-native-windows/blob/main/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp#L898

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10380)