### PR TITLE
Update autolinking to update project paths in solution files

### DIFF
--- a/change/@react-native-windows-cli-b5c97a05-d431-433f-86bb-1dffed74144b.json
+++ b/change/@react-native-windows-cli-b5c97a05-d431-433f-86bb-1dffed74144b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update autolinking to update project paths in solution files",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
Autolinking needs to inject the paths to modules' native projects into the solution file for the app project, so that those dependencies are built.

However, dependencies are often sourced from `node_modules` paths, which are typically under the control of the package manager being used and the actual path may change. For example, using symlinks to shared caches on disk, etc.

Until now, autolinking only looked for the _exact_ project entry in the solution file, which includes that path. If it wasn't found, it would insert the correct entry.

So if a dev moved the dependency's root folder (say by changing a package manager config) then autolinking would insert the new project entry _in addition_ to the older one, creating a duplicate which would inevitably cause build failures.

Since native project files have both name and GUID identifiers, this PR fixes the problem by instead updating existing project entries with the changed path, rather than inserting a duplicate entry.

Related: #8755

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10386)