### PR TITLE
[0.69] backport "Add partial PlatformColor support for Image's tintColor"

### DIFF
--- a/change/react-native-windows-c75e1473-877c-4c26-8953-2b5ba565a734.json
+++ b/change/react-native-windows-c75e1473-877c-4c26-8953-2b5ba565a734.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add PlatformColor support for Image's tintColor",
+  "packageName": "react-native-windows",
+  "email": "agnel@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -5,7 +5,15 @@
  */
 import React from 'react';
 import {Picker} from '@react-native-picker/picker';
-import {AppRegistry, Image, View, Text, Switch, StyleSheet} from 'react-native';
+import {
+  AppRegistry,
+  Image,
+  View,
+  Text,
+  Switch,
+  StyleSheet,
+  PlatformColor,
+} from 'react-native';
 
 const largeImageUri =
   'https://cdn.freebiesupply.com/logos/large/2x/react-logo-png-transparent.png';
@@ -69,9 +77,11 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>ResizeMode</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.selectedResizeMode}
-            onValueChange={value => this.setState({selectedResizeMode: value})}>
+            onValueChange={(value) =>
+              this.setState({selectedResizeMode: value})
+            }>
             <Picker.Item label="cover" value="cover" />
             <Picker.Item label="contain" value="contain" />
             <Picker.Item label="stretch" value="stretch" />
@@ -82,9 +92,9 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Image Source</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.selectedSource}
-            onValueChange={value => this.switchImageUri(value)}>
+            onValueChange={(value) => this.switchImageUri(value)}>
             <Picker.Item label="small" value="small" />
             <Picker.Item label="large" value="large" />
             <Picker.Item label="data" value="data" />
@@ -95,9 +105,9 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Blur Radius</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.blurRadius}
-            onValueChange={value => this.setState({blurRadius: value})}>
+            onValueChange={(value) => this.setState({blurRadius: value})}>
             <Picker.Item label="0" value={0} />
             <Picker.Item label="5" value={5} />
             <Picker.Item label="10" value={10} />
@@ -106,12 +116,13 @@ export default class Bootstrap extends React.Component<
         <View style={styles.rowContainer}>
           <Text style={styles.title}>Tint Color</Text>
           <Picker
-            style={{width: 125}}
+            style={styles.picker}
             selectedValue={this.state.tintColor}
-            onValueChange={value => this.setState({tintColor: value})}>
+            onValueChange={(value) => this.setState({tintColor: value})}>
             <Picker.Item label="None" value="transparent" />
             <Picker.Item label="Purple" value="purple" />
             <Picker.Item label="Green" value="green" />
+            <Picker.Item label="SystemAccentColor" value="platformcolor" />
           </Picker>
         </View>
         <View style={styles.rowContainer}>
@@ -130,7 +141,9 @@ export default class Bootstrap extends React.Component<
             style={[
               styles.image,
               this.state.includeBorder ? styles.imageWithBorder : {},
-              {tintColor: this.state.tintColor},
+              this.state.tintColor === 'platformcolor'
+                ? styles.imageWithPlatformColor
+                : {tintColor: this.state.tintColor},
             ]}
             source={
               this.state.selectedSource === 'svg'
@@ -158,6 +171,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 5,
   },
+  picker: {
+    width: 175,
+  },
   imageContainer: {
     marginTop: 5,
     backgroundColor: 'orange',
@@ -173,6 +189,9 @@ const styles = StyleSheet.create({
     borderWidth: 10,
     borderColor: 'green',
     backgroundColor: 'red',
+  },
+  imageWithPlatformColor: {
+    tintColor: PlatformColor('SystemAccentColor'),
   },
   title: {
     fontWeight: 'bold',

--- a/packages/playground/Samples/image.tsx
+++ b/packages/playground/Samples/image.tsx
@@ -79,9 +79,7 @@ export default class Bootstrap extends React.Component<
           <Picker
             style={styles.picker}
             selectedValue={this.state.selectedResizeMode}
-            onValueChange={(value) =>
-              this.setState({selectedResizeMode: value})
-            }>
+            onValueChange={value => this.setState({selectedResizeMode: value})}>
             <Picker.Item label="cover" value="cover" />
             <Picker.Item label="contain" value="contain" />
             <Picker.Item label="stretch" value="stretch" />
@@ -94,7 +92,7 @@ export default class Bootstrap extends React.Component<
           <Picker
             style={styles.picker}
             selectedValue={this.state.selectedSource}
-            onValueChange={(value) => this.switchImageUri(value)}>
+            onValueChange={value => this.switchImageUri(value)}>
             <Picker.Item label="small" value="small" />
             <Picker.Item label="large" value="large" />
             <Picker.Item label="data" value="data" />
@@ -107,7 +105,7 @@ export default class Bootstrap extends React.Component<
           <Picker
             style={styles.picker}
             selectedValue={this.state.blurRadius}
-            onValueChange={(value) => this.setState({blurRadius: value})}>
+            onValueChange={value => this.setState({blurRadius: value})}>
             <Picker.Item label="0" value={0} />
             <Picker.Item label="5" value={5} />
             <Picker.Item label="10" value={10} />
@@ -118,7 +116,7 @@ export default class Bootstrap extends React.Component<
           <Picker
             style={styles.picker}
             selectedValue={this.state.tintColor}
-            onValueChange={(value) => this.setState({tintColor: value})}>
+            onValueChange={value => this.setState({tintColor: value})}>
             <Picker.Item label="None" value="transparent" />
             <Picker.Item label="Purple" value="purple" />
             <Picker.Item label="Green" value="green" />

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -118,17 +118,21 @@ struct BrushCache {
       return RegisterBrush(resourceName, brush);
     }
 
-    winrt::IInspectable resource{winrt::Application::Current().Resources().Lookup(winrt::box_value(resourceName))};
+    const auto appResources{winrt::Application::Current().Resources()};
+    const auto boxedResourceName{winrt::box_value(resourceName)};
+    if (appResources.HasKey(boxedResourceName)) {
+      winrt::IInspectable resource{appResources.Lookup(boxedResourceName)};
 
-    if (auto brush = resource.try_as<xaml::Media::Brush>()) {
-      return RegisterBrush(resourceName, brush);
-    } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
-      auto brush = xaml::Media::SolidColorBrush(color.value());
-      return RegisterBrush(resourceName, brush);
+      if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+        return RegisterBrush(resourceName, brush);
+      } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+        auto brush = xaml::Media::SolidColorBrush(color.value());
+        return RegisterBrush(resourceName, brush);
+      }
     }
 
     assert(false && "Resource is not a Color or Brush");
-    return nullptr;
+    return xaml::Media::SolidColorBrush(winrt::Colors::Transparent());;
   }
 
   xaml::Media::Brush RegisterBrush(winrt::hstring resourceName, const xaml::Media::Brush &brush) {

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -132,7 +132,8 @@ struct BrushCache {
     }
 
     assert(false && "Resource is not a Color or Brush");
-    return xaml::Media::SolidColorBrush(winrt::Colors::Transparent());;
+    return xaml::Media::SolidColorBrush(winrt::Colors::Transparent());
+    ;
   }
 
   xaml::Media::Brush RegisterBrush(winrt::hstring resourceName, const xaml::Media::Brush &brush) {

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.cpp
@@ -143,7 +143,7 @@ bool ImageViewManager::UpdateProperty(
   } else if (propertyName == "tintColor") {
     const auto isValidColorValue = IsValidColorValue(propertyValue);
     if (isValidColorValue || propertyValue.IsNull()) {
-      const auto color = isValidColorValue ? ColorFrom(propertyValue) : winrt::Colors::Transparent();
+      const auto color = isValidColorValue ? SolidColorBrushFrom(propertyValue).Color() : winrt::Colors::Transparent();
       reactImage->TintColor(color);
     }
     // Override default accessibility behavior


### PR DESCRIPTION
## Description
backport: https://github.com/microsoft/react-native-windows/pull/10192

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Internal Request

## Testing
Added example from original PR, and confirmed it fixes the issue. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10391)