### PR TITLE
Adds VM interface for custom measurement

### DIFF
--- a/change/react-native-windows-1fc89212-172b-4b76-92ab-0a4511a6e92e.json
+++ b/change/react-native-windows-1fc89212-172b-4b76-92ab-0a4511a6e92e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds VM interface for custom measurement",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -52,7 +52,7 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithCommands{viewManager.try_as<IViewManagerWithCommands>()},
       m_viewManagerWithExportedEventTypeConstants{viewManager.try_as<IViewManagerWithExportedEventTypeConstants>()},
       m_viewManagerRequiresNativeLayout{viewManager.try_as<IViewManagerRequiresNativeLayout>()},
-      m_viewManagerWithNativeLayout{viewManager.try_as<IViewManagerWithNativeLayout>()},
+      m_viewManagerWithMeasure{viewManager.try_as<IViewManagerWithMeasure>()},
       m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()},
       m_viewManagerWithPointerEvents{viewManager.try_as<IViewManagerWithPointerEvents>()},
       m_viewManagerWithDropViewInstance{viewManager.try_as<IViewManagerWithDropViewInstance>()},
@@ -131,7 +131,7 @@ void ABIViewManager::UpdateProperties(
     ::Microsoft::ReactNative::ShadowNodeBase *nodeToUpdate,
     winrt::Microsoft::ReactNative::JSValueObject &props) {
   if ((m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) ||
-      m_viewManagerWithNativeLayout) {
+      m_viewManagerWithMeasure) {
     MarkDirty(nodeToUpdate->m_tag);
   }
 
@@ -232,7 +232,7 @@ void ABIViewManager::ReplaceChild(
 }
 
 YGMeasureFunc ABIViewManager::GetYogaCustomMeasureFunc() const {
-  if (m_viewManagerWithNativeLayout) {
+  if (m_viewManagerWithMeasure) {
     return ABIYogaSelfMeasureTrampoline;
   } else if (m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout()) {
     return ::Microsoft::ReactNative::DefaultYogaSelfMeasureFunc;
@@ -294,12 +294,12 @@ YGSize ABIViewManager::ABIYogaSelfMeasureFunc(
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode) {
-  assert(m_viewManagerWithNativeLayout);
+  assert(m_viewManagerWithMeasure);
   const auto context = reinterpret_cast<::Microsoft::ReactNative::YogaContext *>(YGNodeGetContext(node));
   const auto view = context->view.as<xaml::FrameworkElement>();
   const auto abiWidthMode = ToABIMeasureMode(widthMode);
   const auto abiHeightMode = ToABIMeasureMode(heightMode);
-  const auto abiSize = m_viewManagerWithNativeLayout.Measure(view, width, abiWidthMode, height, abiHeightMode);
+  const auto abiSize = m_viewManagerWithMeasure.Measure(view, width, abiWidthMode, height, abiHeightMode);
   const auto size = ToYGSize(abiSize);
   return size;
 }

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -20,6 +20,13 @@
 
 namespace winrt::Microsoft::ReactNative {
 
+REACTWINDOWS_EXPORT YGSize ABIYogaSelfMeasureTrampoline(
+    YGNodeRef node,
+    float width,
+    YGMeasureMode widthMode,
+    float height,
+    YGMeasureMode heightMode);
+
 class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewManager {
   using Super = ::Microsoft::ReactNative::FrameworkElementViewManager;
 
@@ -78,6 +85,9 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
       float width,
       float height) override;
 
+  YGSize
+  ABIYogaSelfMeasureFunc(YGNodeRef node, float width, YGMeasureMode widthMode, float height, YGMeasureMode heightMode);
+
  protected:
   xaml::DependencyObject CreateViewCore(int64_t, const winrt::Microsoft::ReactNative::JSValueObject &props) override;
 
@@ -90,6 +100,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithExportedEventTypeConstants m_viewManagerWithExportedEventTypeConstants;
   IViewManagerWithChildren m_viewManagerWithChildren;
   IViewManagerRequiresNativeLayout m_viewManagerRequiresNativeLayout;
+  IViewManagerWithNativeLayout m_viewManagerWithNativeLayout;
   IViewManagerWithPointerEvents m_viewManagerWithPointerEvents;
   IViewManagerWithDropViewInstance m_viewManagerWithDropViewInstance;
   IViewManagerWithOnLayout m_viewManagerWithOnLayout;

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -100,7 +100,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithExportedEventTypeConstants m_viewManagerWithExportedEventTypeConstants;
   IViewManagerWithChildren m_viewManagerWithChildren;
   IViewManagerRequiresNativeLayout m_viewManagerRequiresNativeLayout;
-  IViewManagerWithNativeLayout m_viewManagerWithNativeLayout;
+  IViewManagerWithMeasure m_viewManagerWithMeasure;
   IViewManagerWithPointerEvents m_viewManagerWithPointerEvents;
   IViewManagerWithDropViewInstance m_viewManagerWithDropViewInstance;
   IViewManagerWithOnLayout m_viewManagerWithOnLayout;

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -88,7 +88,7 @@ namespace Microsoft.ReactNative
     )
     void OnPointerEvent(Object view, ReactPointerEventArgs args);
   };
-  
+
   [webhosthidden]
   DOC_STRING(
     "Enables view managers to track when views are "
@@ -116,5 +116,46 @@ namespace Microsoft.ReactNative
         "when the final layout has not changed, so this method may be called "
         "without a corresponding `onLayout` event in JavaScript.")
     void OnLayout(XAML_NAMESPACE.FrameworkElement view, Single left, Single top, Single width, Single height);
+  };
+
+  [experimental]
+  DOC_STRING(
+      "An experimental API. It may be removed or changed in a future version. "
+      "Used by @IViewManagerWithNativeLayout for the measurement callback measure mode parameter."
+  )
+  enum YogaMeasureMode {
+    Undefined,
+    Exactly,
+    AtMost,
+  };
+
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+      "An experimental API. It may be removed or changed in a future version. "
+      "Used by @IViewManagerWithNativeLayout for the measurement callback return value."
+  )
+  struct YogaSize {
+    Single Width;
+    Single Height;
+  };
+
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+    "An experimental API. It may be removed or changed in a future version. "
+    "Enables view managers to implement custom Yoga leaf node measurement."
+  )
+  interface IViewManagerWithNativeLayout {
+    DOC_STRING(
+      "An experimental API. It may be removed or changed in a future version. "
+      "Yoga measurement callback for ABI view managers."
+    )
+    YogaSize Measure(
+        XAML_NAMESPACE.FrameworkElement view,
+        Single width,
+        YogaMeasureMode widthMode,
+        Single height,
+        YogaMeasureMode heightMode);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -121,7 +121,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
       "An experimental API. It may be removed or changed in a future version. "
-      "Used by @IViewManagerWithNativeLayout for the measurement callback measure mode parameter."
+      "Used by @IViewManagerWithMeasure for the measurement callback measure mode parameter."
   )
   enum YogaMeasureMode {
     Undefined,
@@ -133,7 +133,7 @@ namespace Microsoft.ReactNative
   [experimental]
   DOC_STRING(
       "An experimental API. It may be removed or changed in a future version. "
-      "Used by @IViewManagerWithNativeLayout for the measurement callback return value."
+      "Used by @IViewManagerWithMeasure for the measurement callback return value."
   )
   struct YogaSize {
     Single Width;
@@ -146,7 +146,7 @@ namespace Microsoft.ReactNative
     "An experimental API. It may be removed or changed in a future version. "
     "Enables view managers to implement custom Yoga leaf node measurement."
   )
-  interface IViewManagerWithNativeLayout {
+  interface IViewManagerWithMeasure {
     DOC_STRING(
       "An experimental API. It may be removed or changed in a future version. "
       "Yoga measurement callback for ABI view managers."

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -794,7 +794,7 @@ void NativeUIManager::CreateView(ShadowNode &shadowNode, React::JSValueObject &p
       if (func != nullptr) {
         YGNodeSetMeasureFunc(yogaNode, func);
 
-        auto context = std::make_unique<Microsoft::ReactNative::YogaContext>(node.GetView());
+        auto context = std::make_unique<Microsoft::ReactNative::YogaContext>(node.GetView(), node.GetViewManager());
         YGNodeSetContext(yogaNode, reinterpret_cast<void *>(context.get()));
 
         m_tagsToYogaContext.emplace(node.m_tag, std::move(context));
@@ -852,7 +852,7 @@ void NativeUIManager::ReplaceView(ShadowNode &shadowNode) {
       YGNodeRef yogaNode = it->second.get();
 
       if (pViewManager->IsNativeControlWithSelfLayout()) {
-        auto context = std::make_unique<YogaContext>(node.GetView());
+        auto context = std::make_unique<YogaContext>(node.GetView(), node.GetViewManager());
         YGNodeSetContext(yogaNode, reinterpret_cast<void *>(context.get()));
 
         m_tagsToYogaContext.erase(node.m_tag);

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -18,12 +18,6 @@ struct IReactInstance;
 struct ShadowNodeBase;
 struct ShadowNode;
 
-struct YogaContext {
-  YogaContext(const XamlView &view_) : view(view_) {}
-
-  XamlView view;
-};
-
 REACTWINDOWS_EXPORT YGSize DefaultYogaSelfMeasureFunc(
     YGNodeRef node,
     float width,
@@ -117,5 +111,12 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
   std::shared_ptr<winrt::Microsoft::ReactNative::BatchingEventEmitter> m_batchingEventEmitter;
 };
 #pragma warning(pop)
+
+struct YogaContext {
+  YogaContext(const XamlView &view_, ViewManagerBase *viewManager_) : view(view_), viewManager(viewManager_) {}
+
+  XamlView view;
+  ViewManagerBase *viewManager;
+};
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
While the default self measure function implemented in ViewManagerBase works in most scenarios, it may not work for all use cases. This change introduces an ABI VM interface to callback when Yoga measurement is being performed.

For example, if we want to implement re-entrant Yoga layout on a "native layout" view we have two options:
1. Something analogous to what was added in #10237, which would require that you invoke Yoga layout from XAML layout via MeasureOverride or ArrangeOverride. The main limitation of this is that recursive layout of children nested in a native layout view will always have their layout delayed by at least one frame because the sequence is:
```
1. Yoga runs from root view and applies updated layout to XAML view
2. XAML runs native layout, invoking MeasureOverride / ArrangeOverride on the native layout view 
3. Yoga is recursively invoked from XAML layout and native layout properties are applied to children
4. XAML renders changes up to native layout view
5. XAML layout runs again with new layout properties from native layout view's children
6. XAML renders changes to native layout view's children
```
2. Alternatively, we can "listen" for native layout changes that are going to occur during the Yoga layout pass via the self-measure callback, update some state on the native layout view's children, and invoke recursive layout on the children before calling `ViewManagerBase::SetLayoutProps` on *any* view. This will allow XAML to render the entire tree in one pass.

This change opens up the opportunity for the second option, though we'll still need one more change to allow children of native layout views to invoke Yoga layout (coming in a future PR).
 
### What
This change adds a new ABI interface for view managers to define a custom measure function.

Since Yoga self measure functions are C-style function pointers, we can't pass instance methods to Yoga. Thus we needed to use a trampoline approach to provide a static method that can subsequently call the appropriate measure instance method on the view manager (that has access to the IViewManagerWithNativeLayout intsance as well). In order to support this, we needed to add a pointer to the view manager to the YogaContext that gets passed back to the measure function.

Adding the VM pointer to YogaContext will add 8 bytes for each Yoga node, which is not great, but YogaContext is only added to Text, TextInput, and any ABI view managers with native layout, so this probably shouldn't be a concern.

## Testing
I added a test native view manager to Playground-win32 and ensured that the measure callback was being invoked and the measurement values it set were being applied to the custom view.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10393)