### PR TITLE
Use `IsNativeControlWithSelfLayout` in ReplaceView

### DIFF
--- a/change/react-native-windows-99b4d0ab-5a17-4781-8844-7bc094e0a18c.json
+++ b/change/react-native-windows-99b4d0ab-5a17-4781-8844-7bc094e0a18c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use `IsNativeControlWithSelfLayout` in ReplaceView",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -843,8 +843,7 @@ void NativeUIManager::ReplaceView(ShadowNode &shadowNode) {
     if (it != m_tagsToYogaNodes.end()) {
       YGNodeRef yogaNode = it->second.get();
 
-      YGMeasureFunc func = pViewManager->GetYogaCustomMeasureFunc();
-      if (func != nullptr) {
+      if (pViewManager->IsNativeControlWithSelfLayout()) {
         auto context = std::make_unique<YogaContext>(node.GetView());
         YGNodeSetContext(yogaNode, reinterpret_cast<void *>(context.get()));
 


### PR DESCRIPTION
Since we strictly speaking don't need to reset the self measure func when swapping out a native view, we can just use the `IsNativeControlWithSelfLayout` check. This internally checks for the a non-null measure function, but may future proof this case if we add additional logic to verify if a node uses self-layout.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10394)