### PR TITLE
Fix Deploy Error for Apps that Contain Spaces in Path

### DIFF
--- a/change/@react-native-windows-cli-512117e3-b225-422d-aac1-f69efa3a70cb.json
+++ b/change/@react-native-windows-cli-512117e3-b225-422d-aac1-f69efa3a70cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Deploy Bug for App Paths Containing Spaces",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -181,7 +181,7 @@ function getWindowsStoreAppUtils(options: RunWindowsOptions) {
     'WindowsStoreAppUtils.ps1',
   );
   execSync(
-    `${powershell} -NoProfile Unblock-File "'${windowsStoreAppUtilsPath}'"`,
+    `${powershell} -NoProfile Unblock-File '${windowsStoreAppUtilsPath}'`,
   );
   popd();
   return windowsStoreAppUtilsPath;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -180,8 +180,9 @@ function getWindowsStoreAppUtils(options: RunWindowsOptions) {
     'powershell',
     'WindowsStoreAppUtils.ps1',
   );
+  //execSync(`"${windowsStoreAppUtilsPath}" -replace ' ', '` '`,);
   execSync(
-    `${powershell} -NoProfile Unblock-File "${windowsStoreAppUtilsPath}"`,
+    `${powershell} -NoProfile Unblock-File "'${windowsStoreAppUtilsPath}'"`,
   );
   popd();
   return windowsStoreAppUtilsPath;

--- a/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/deploy.ts
@@ -180,7 +180,6 @@ function getWindowsStoreAppUtils(options: RunWindowsOptions) {
     'powershell',
     'WindowsStoreAppUtils.ps1',
   );
-  //execSync(`"${windowsStoreAppUtilsPath}" -replace ' ', '` '`,);
   execSync(
     `${powershell} -NoProfile Unblock-File "'${windowsStoreAppUtilsPath}'"`,
   );


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Apps that contain spaces in their path fail to deploy after running `npx react-native run-windows`. Path name incorrectly sent to Powershell, as space has not been escaped correctly.

Resolves #10001

## Testing
Validated in a stand alone app. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10402)