### PR TITLE
Adds GetReactRootView method to XamlUIService

### DIFF
--- a/change/react-native-windows-58120787-47ec-4a2b-bde5-befd651c528f.json
+++ b/change/react-native-windows-58120787-47ec-4a2b-bde5-befd651c528f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds GetReactRootView method to XamlUIService",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -50,14 +50,17 @@ void XamlUIService::DispatchEvent(
   m_context->CallJSFunction("RCTEventEmitter", "receiveEvent", std::move(params));
 }
 
-xaml::FrameworkElement XamlUIService::GetReactRootElementForView(xaml::FrameworkElement const &view) noexcept {
+winrt::Microsoft::ReactNative::ReactRootView XamlUIService::GetReactRootView(
+    xaml::FrameworkElement const &view) noexcept {
   if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
     const auto reactTag = ::Microsoft::ReactNative::GetTag(view);
     auto shadowNode = uiManager->getHost()->FindParentRootShadowNode(reactTag);
     if (!shadowNode)
       return nullptr;
 
-    return static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(shadowNode)->GetView().as<xaml::FrameworkElement>();
+    return static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(shadowNode)
+        ->GetView()
+        .as<winrt::Microsoft::ReactNative::ReactRootView>();
   }
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -50,6 +50,18 @@ void XamlUIService::DispatchEvent(
   m_context->CallJSFunction("RCTEventEmitter", "receiveEvent", std::move(params));
 }
 
+xaml::FrameworkElement XamlUIService::GetReactRootElementForView(xaml::FrameworkElement const &view) noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    const auto reactTag = ::Microsoft::ReactNative::GetTag(view);
+    auto shadowNode = uiManager->getHost()->FindParentRootShadowNode(reactTag);
+    if (!shadowNode)
+      return nullptr;
+
+    return static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(shadowNode)->GetView().as<xaml::FrameworkElement>();
+  }
+  return nullptr;
+}
+
 /*static*/ ReactPropertyId<XamlUIService> XamlUIService::XamlUIServiceProperty() noexcept {
   static ReactPropertyId<XamlUIService> uiManagerProperty{L"ReactNative.UIManager", L"XamlUIManager"};
   return uiManagerProperty;

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -22,7 +22,7 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       hstring const &eventName,
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
-  xaml::FrameworkElement GetReactRootElementForView(xaml::FrameworkElement const &view) noexcept;
+  winrt::Microsoft::ReactNative::ReactRootView GetReactRootView(xaml::FrameworkElement const &view) noexcept;
 
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static void SetAccessibleRoot(

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -22,6 +22,8 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
       hstring const &eventName,
       JSValueArgWriter const &eventDataArgWriter) noexcept;
 
+  xaml::FrameworkElement GetReactRootElementForView(xaml::FrameworkElement const &view) noexcept;
+
   static void SetXamlRoot(IReactPropertyBag const &properties, xaml::XamlRoot const &xamlRoot) noexcept;
   static void SetAccessibleRoot(
       IReactPropertyBag const &properties,

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "IReactContext.idl";
+import "ReactRootView.idl";
 
 #include "NamespaceRedirect.h"
 #include "DocString.h"
@@ -24,8 +25,8 @@ namespace Microsoft.ReactNative
     DOC_STRING("Dispatches an event to a JS component.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 
-    DOC_STRING("Gets the root view for a given element.")
-    XAML_NAMESPACE.FrameworkElement GetReactRootElementForView(XAML_NAMESPACE.FrameworkElement view);
+    DOC_STRING("Gets the @ReactRootView view for a given element.")
+    ReactRootView GetReactRootView(XAML_NAMESPACE.FrameworkElement view);
 
     DOC_STRING(
       "Sets the @Windows.UI.Xaml.XamlRoot element for the app. "

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -24,6 +24,9 @@ namespace Microsoft.ReactNative
     DOC_STRING("Dispatches an event to a JS component.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);
 
+    DOC_STRING("Gets the root view for a given element.")
+    XAML_NAMESPACE.FrameworkElement GetReactRootElementForView(XAML_NAMESPACE.FrameworkElement view);
+
     DOC_STRING(
       "Sets the @Windows.UI.Xaml.XamlRoot element for the app. "
       "This must be manually provided to the @ReactInstanceSettings object when using XAML Islands "


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### What
We emulate this behavior in our app, it's probably better to expose the core functionality to walk the shadow node tree (rather than using VisualTreeHelpers).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10403)