### PR TITLE
Fix `ReactNotificationService` memory leak in `ExecuteJsi`

### DIFF
--- a/change/react-native-windows-ddcc5f68-cdab-4bae-a2e7-714fdc0de029.json
+++ b/change/react-native-windows-ddcc5f68-cdab-4bae-a2e7-714fdc0de029.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix ReactNotificationService memory leak",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
@@ -42,7 +42,8 @@ struct NotificationTestModule {
         notifyModuleFromApp,
         [subscriptionHolder](IInspectable const & /*sender*/, ReactNotificationArgs<int> const &args) noexcept {
           TestEventService::LogEvent("NotifyModuleFromApp", args.Data());
-          TestEventService::LogEvent("CheckModuleSubscription", args.Subscription() == subscriptionHolder->Subscription);
+          TestEventService::LogEvent(
+              "CheckModuleSubscription", args.Subscription() == subscriptionHolder->Subscription);
 
           // Unsubscribe after the first notification.
           args.Subscription().Unsubscribe();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNotificationServiceTests.cpp
@@ -31,10 +31,18 @@ struct NotificationTestModule {
   void Initialize(ReactContext const &reactContext) noexcept {
     m_reactContext = reactContext;
 
+    // Check that lambda receives correct subscription
+    struct SubscriptionHolder {
+      ReactNotificationSubscription Subscription{nullptr};
+    };
+    auto subscriptionHolder = std::make_shared<SubscriptionHolder>();
+
     // Subscribe to a notification from the app.
-    reactContext.Notifications().Subscribe(
-        notifyModuleFromApp, [](IInspectable const & /*sender*/, ReactNotificationArgs<int> const &args) noexcept {
+    subscriptionHolder->Subscription = reactContext.Notifications().Subscribe(
+        notifyModuleFromApp,
+        [subscriptionHolder](IInspectable const & /*sender*/, ReactNotificationArgs<int> const &args) noexcept {
           TestEventService::LogEvent("NotifyModuleFromApp", args.Data());
+          TestEventService::LogEvent("CheckModuleSubscription", args.Subscription() == subscriptionHolder->Subscription);
 
           // Unsubscribe after the first notification.
           args.Subscription().Unsubscribe();
@@ -301,12 +309,20 @@ TEST_CLASS (ReactNotificationServiceTests) {
         TestReactNativeHostHolder(L"ReactNotificationServiceTests", [](ReactNativeHost const &host) noexcept {
           host.PackageProviders().Append(winrt::make<NotificationTestPackageProvider>());
 
+          // Check that lambda receives correct subscription
+          struct SubscriptionHolder {
+            ReactNotificationSubscription Subscription{nullptr};
+          };
+          auto subscriptionHolder = std::make_shared<SubscriptionHolder>();
+
           // Subscribe to a notification from module to app.
-          ReactNotificationService::Subscribe(
+          subscriptionHolder->Subscription = ReactNotificationService::Subscribe(
               host.InstanceSettings().Notifications(),
               notifyAppFromModule,
-              [](IInspectable const &, ReactNotificationArgs<int> const &args) {
+              [subscriptionHolder](IInspectable const &, ReactNotificationArgs<int> const &args) {
                 TestEventService::LogEvent("NotifyAppFromModule", args.Data());
+                TestEventService::LogEvent(
+                    "CheckAppSubscription", args.Subscription() == subscriptionHolder->Subscription);
 
                 // Send a notification from app to the module.
                 args.Subscription().NotificationService().SendNotification(notifyModuleFromApp, 42);
@@ -319,7 +335,9 @@ TEST_CLASS (ReactNotificationServiceTests) {
     TestEventService::ObserveEvents({
         TestEvent{"Test started", nullptr},
         TestEvent{"NotifyAppFromModule", 15},
+        TestEvent{"CheckAppSubscription", true},
         TestEvent{"NotifyModuleFromApp", 42},
+        TestEvent{"CheckModuleSubscription", true},
         TestEvent{"Test ended", nullptr},
     });
   }

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
@@ -15,7 +15,9 @@ namespace winrt::Microsoft::ReactNative::implementation {
 MSO_GUID(IReactNotificationSubscriptionPrivate, "09437980-3508-4690-930c-7c310e205e6b")
 struct IReactNotificationSubscriptionPrivate : ::IUnknown {
   virtual void SetParent(IReactNotificationSubscription const &parentSubscription) noexcept = 0;
-  virtual void CallHandler(IInspectable const &sender, IInspectable const &data) noexcept = 0;
+  virtual void CallHandler(
+      Windows::Foundation::IInspectable const &sender,
+      Windows::Foundation::IInspectable const &data) noexcept = 0;
 };
 
 // The Notification subscription class.

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
@@ -250,6 +250,9 @@ IReactNotificationSubscription ReactNotificationService::Subscribe(
     IReactPropertyName const &notificationName,
     IReactDispatcher const &dispatcher,
     ReactNotificationHandler const &handler) noexcept {
+  VerifyElseCrashSz(notificationName, "notificationName must be not null");
+  VerifyElseCrashSz(handler, "handler must be not null");
+
   IReactNotificationSubscription subscription =
       make<ReactNotificationSubscription>(m_mutex, get_weak(), notificationName, dispatcher, handler);
   AddSubscription(notificationName, subscription);

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.h
@@ -94,14 +94,16 @@ struct ReactNotificationService : implements<ReactNotificationService, IReactNot
   void AddSubscription(
       IReactPropertyName const &notificationName,
       IReactNotificationSubscription const &subscription) noexcept;
-
-  void AddChildSubscription(
+  void AddSubscriptionToParent(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &subscription) noexcept;
+  void AddSubscriptionFromChild(
       IReactPropertyName const &notificationName,
       IReactNotificationSubscription const &childSubscription) noexcept;
 
  private:
   const IReactNotificationService m_parentNotificationService;
-  std::mutex m_mutex;
+  Mso::RefCountedPtr<std::mutex> m_mutex{Mso::Make_RefCounted<std::mutex>()};
   std::unordered_map<IReactPropertyName, SubscriptionSnapshotPtr> m_subscriptions;
 };
 

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.h
@@ -91,6 +91,14 @@ struct ReactNotificationService : implements<ReactNotificationService, IReactNot
       IReactPropertyName const &notificationName,
       Mso::FunctorRef<SubscriptionSnapshot(SubscriptionSnapshot const &)> const &modifySnapshot);
 
+  void AddSubscription(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &subscription) noexcept;
+
+  void AddChildSubscription(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &childSubscription) noexcept;
+
  private:
   const IReactNotificationService m_parentNotificationService;
   std::mutex m_mutex;
@@ -101,35 +109,6 @@ struct ReactNotificationServiceHelper {
   ReactNotificationServiceHelper() = default;
 
   static IReactNotificationService CreateNotificationService() noexcept;
-};
-
-struct ReactNotificationSubscription : implements<ReactNotificationSubscription, IReactNotificationSubscription> {
-  ReactNotificationSubscription(
-      IReactNotificationSubscription const &parentSubscription,
-      weak_ref<ReactNotificationService> &&notificationService,
-      IReactPropertyName const &notificationName,
-      IReactDispatcher const &dispatcher) noexcept;
-  ReactNotificationSubscription(
-      weak_ref<ReactNotificationService> &&notificationService,
-      IReactPropertyName const &notificationName,
-      IReactDispatcher const &dispatcher,
-      ReactNotificationHandler const &handler) noexcept;
-  ~ReactNotificationSubscription() noexcept;
-
-  IReactNotificationService NotificationService() const noexcept;
-  IReactPropertyName NotificationName() const noexcept;
-  IReactDispatcher Dispatcher() const noexcept;
-  bool IsSubscribed() const noexcept;
-  void Unsubscribe() noexcept;
-  void CallHandler(IInspectable const &sender, IReactNotificationArgs const &args) noexcept;
-
- private:
-  const IReactNotificationSubscription m_parentSubscription{nullptr};
-  const weak_ref<ReactNotificationService> m_notificationService;
-  const IReactPropertyName m_notificationName;
-  const IReactDispatcher m_dispatcher;
-  const ReactNotificationHandler m_handler;
-  std::atomic_bool m_isSubscribed{true};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

@acoates-ms has reported a memory leak issue while using `ExecuteJsi`.
He has found that the issue is caused by `ReactNotificationService` providing a wrong instance of `IReactNotificationSubscription` to the notification handler. As a result, when the handler code calls `Unsubscribe()`, the `ReactNotificationService` keeps another instance of `IReactNotificationSubscription` alive with captured lambda that causes unexpected memory leaks.

### What

The code for the `IReactNotificationService` is changed to ensure that we use correct instance of `IReactNotificationSubscription` in the notification handlers.
To do that we split the `ReactNotificationSubscription` implementation into two different classes: `ReactNotificationSubscription` and `ReactNotificationSubscriptionView`. The new `ReactNotificationSubscriptionView` class does not hold the notification handler delegate and always redirects call to the real `ReactNotificationSubscription` which sets itself to the notification handler arguments.
We also release the notification handler inside of the `Unsubscribe()` method to let it release resources as soon as possible.

## Testing

The `NotificationBetweenAppAndModule` test is modified to check that we use correct `IReactNotificationSubscription` instance in the lambda. All Notification tests are passing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10408)