### PR TITLE
[0.69] Fix `ReactNotificationService` memory leak in `ExecuteJsi` (#10408)

### DIFF
--- a/change/react-native-windows-ddcc5f68-cdab-4bae-a2e7-714fdc0de029.json
+++ b/change/react-native-windows-ddcc5f68-cdab-4bae-a2e7-714fdc0de029.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix ReactNotificationService memory leak",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.h
@@ -91,9 +91,19 @@ struct ReactNotificationService : implements<ReactNotificationService, IReactNot
       IReactPropertyName const &notificationName,
       Mso::FunctorRef<SubscriptionSnapshot(SubscriptionSnapshot const &)> const &modifySnapshot);
 
+  void AddSubscription(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &subscription) noexcept;
+  void AddSubscriptionToParent(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &subscription) noexcept;
+  void AddSubscriptionFromChild(
+      IReactPropertyName const &notificationName,
+      IReactNotificationSubscription const &childSubscription) noexcept;
+
  private:
   const IReactNotificationService m_parentNotificationService;
-  std::mutex m_mutex;
+  Mso::RefCountedPtr<std::mutex> m_mutex{Mso::Make_RefCounted<std::mutex>()};
   std::unordered_map<IReactPropertyName, SubscriptionSnapshotPtr> m_subscriptions;
 };
 
@@ -101,35 +111,6 @@ struct ReactNotificationServiceHelper {
   ReactNotificationServiceHelper() = default;
 
   static IReactNotificationService CreateNotificationService() noexcept;
-};
-
-struct ReactNotificationSubscription : implements<ReactNotificationSubscription, IReactNotificationSubscription> {
-  ReactNotificationSubscription(
-      IReactNotificationSubscription const &parentSubscription,
-      weak_ref<ReactNotificationService> &&notificationService,
-      IReactPropertyName const &notificationName,
-      IReactDispatcher const &dispatcher) noexcept;
-  ReactNotificationSubscription(
-      weak_ref<ReactNotificationService> &&notificationService,
-      IReactPropertyName const &notificationName,
-      IReactDispatcher const &dispatcher,
-      ReactNotificationHandler const &handler) noexcept;
-  ~ReactNotificationSubscription() noexcept;
-
-  IReactNotificationService NotificationService() const noexcept;
-  IReactPropertyName NotificationName() const noexcept;
-  IReactDispatcher Dispatcher() const noexcept;
-  bool IsSubscribed() const noexcept;
-  void Unsubscribe() noexcept;
-  void CallHandler(IInspectable const &sender, IReactNotificationArgs const &args) noexcept;
-
- private:
-  const IReactNotificationSubscription m_parentSubscription{nullptr};
-  const weak_ref<ReactNotificationService> m_notificationService;
-  const IReactPropertyName m_notificationName;
-  const IReactDispatcher m_dispatcher;
-  const ReactNotificationHandler m_handler;
-  std::atomic_bool m_isSubscribed{true};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation


### PR DESCRIPTION
Cherry pick #10408. Original PR description:

## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

@acoates-ms has reported a memory leak issue while using `ExecuteJsi`.
He has found that the issue is caused by `ReactNotificationService` providing a wrong instance of `IReactNotificationSubscription` to the notification handler. As a result, when the handler code calls `Unsubscribe()`, the `ReactNotificationService` keeps another instance of `IReactNotificationSubscription` alive with captured lambda that causes unexpected memory leaks.

### What

The code for the `IReactNotificationService` is changed to ensure that we use correct instance of `IReactNotificationSubscription` in the notification handlers.
To do that we split the `ReactNotificationSubscription` implementation into two different classes: `ReactNotificationSubscription` and `ReactNotificationSubscriptionView`. The new `ReactNotificationSubscriptionView` class does not hold the notification handler delegate and always redirects call to the real `ReactNotificationSubscription` which sets itself to the notification handler arguments.
We also release the notification handler inside of the `Unsubscribe()` method to let it release resources as soon as possible.

## Testing

The `NotificationBetweenAppAndModule` test is modified to check that we use correct `IReactNotificationSubscription` instance in the lambda. All Notification tests are passing.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10416)