### PR TITLE
Fixes event ordering for `onLayout`

### DIFF
--- a/change/react-native-windows-8d316c11-9ba7-4e64-a2e0-2f7066ebcc70.json
+++ b/change/react-native-windows-8d316c11-9ba7-4e64-a2e0-2f7066ebcc70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes event ordering for `onLayout`",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -948,9 +948,12 @@ void NativeUIManager::DoLayout() {
 }
 
 void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
-  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
-  for (const auto child : shadowNode.m_children) {
-    SetLayoutPropsRecursive(child);
+  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));\
+  auto *pViewManager = shadowNode.GetViewManager();
+  if (!pViewManager->IsNativeControlWithSelfLayout()) {
+    for (const auto child : shadowNode.m_children) {
+      SetLayoutPropsRecursive(child);
+    }
   }
 
   const auto tagToYogaNode = m_tagsToYogaNodes.find(tag);

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -940,12 +940,14 @@ void NativeUIManager::DoLayout() {
       return;
     }
 
-    SetLayoutPropsRecursive(rootTag);
+    {
+      SystraceSection s("NativeUIManager::DoLayout::SetLayoutProps");
+      SetLayoutPropsRecursive(rootTag);
+    }
   }
 }
 
 void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
-  SystraceSection s("NativeUIManager::DoLayout::SetLayoutProps");
   ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
   for (const auto child : shadowNode.m_children) {
     SetLayoutPropsRecursive(child);

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -952,18 +952,18 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
   }
 
   const auto tagToYogaNode = m_tagsToYogaNodes.find(tag);
-  if (tagToYogaNode != m_tagsToYogaNodes.end()) {
-    YGNodeRef yogaNode = tagToYogaNode->second.get();
-    if (YGNodeGetHasNewLayout(yogaNode)) {
-      YGNodeSetHasNewLayout(yogaNode, false);
-      float left = YGNodeLayoutGetLeft(yogaNode);
-      float top = YGNodeLayoutGetTop(yogaNode);
-      float width = YGNodeLayoutGetWidth(yogaNode);
-      float height = YGNodeLayoutGetHeight(yogaNode);
-      auto view = shadowNode.GetView();
-      auto pViewManager = shadowNode.GetViewManager();
-      pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
-    }
+  if (auto yogaNode = GetYogaNode(tag)) {
+    if (!YGNodeGetHasNewLayout(yogaNode))
+      return;
+    YGNodeSetHasNewLayout(yogaNode, false);
+
+    float left = YGNodeLayoutGetLeft(yogaNode);
+    float top = YGNodeLayoutGetTop(yogaNode);
+    float width = YGNodeLayoutGetWidth(yogaNode);
+    float height = YGNodeLayoutGetHeight(yogaNode);
+    auto view = shadowNode.GetView();
+    auto pViewManager = shadowNode.GetViewManager();
+    pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -948,7 +948,7 @@ void NativeUIManager::DoLayout() {
 }
 
 void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
-  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));\
+  ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
   auto *pViewManager = shadowNode.GetViewManager();
   if (!pViewManager->IsNativeControlWithSelfLayout()) {
     for (const auto child : shadowNode.m_children) {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -101,6 +101,7 @@ class NativeUIManager final : public INativeUIManager {
 
  private:
   void DoLayout();
+  void SetLayoutPropsRecursive(int64_t tag);
   void UpdateExtraLayout(int64_t tag);
   YGNodeRef GetYogaNode(int64_t tag) const;
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Other platforms fire `onLayout` depth first. Windows should do the same. Also, once we upgrade to React 18, it is a common case that React commits will create nodes that are not yet attached to any root (and thus do not participate in the Yoga layout for that batch / commit). This means that, in the current approach for updating layout, we would fire `onLayout` events with `NaN` values for width and height.

Resolves #10421


### What
This changes switches from iterating over all Yoga nodes to update layout on each UIManager batch to recursively updating layout from the root shadow node. The effect is that we fire events depth first and we only attempt to update layout on nodes that have participated in Yoga layout (because they are descendants of some root).

This also likely fixes a bug in our app we were seeing where attempt to transfer an explicit NaN Width/Height property when replacing a ViewPanel with a ViewControl or Border (for relevant prop implementations) would occasionally throw an exception.

## Testing
Ran RNTester, everything still seems to work as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10422)