### PR TITLE
[0.66] Add new prop alwaysShowToolTip to ViewWin32 (#10381)

### DIFF
--- a/change/@office-iss-react-native-win32-7fce2b29-0c20-4c4f-b2c6-8c4e7001f7cd.json
+++ b/change/@office-iss-react-native-win32-7fce2b29-0c20-4c4f-b2c6-8c4e7001f7cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add new prop alwaysShowToolTip to ViewWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
@@ -35,6 +35,7 @@ const UIView = {
   needsOffscreenAlphaCompositing: true,
   style: ReactNativeStyleAttributes,
   // [Windows
+  alwaysShowToolTip: true,
   enableFocusRing: true,
   cursor: true,
   textStyle: true, // Once we flush out our JS theming story this property will no longer be needed

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -218,6 +218,10 @@ export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>,
   animationClass?: string;
   focusable?: boolean;
   enableFocusRing?: boolean;
+  /*
+  * overrides the default behavior of some components that do not show a tooltip. i.e. components in a menu
+  */
+  alwaysShowToolTip?: boolean;
 
   /**
    * The onBlur event occurs when an element loses focus.  The opposite of onBlur is onFocus.  Note that in React


### PR DESCRIPTION
* add new prop alwaysShowToolTip to ViewWin32

* Change files

* Change files

## Description
Adding the `alwaysShowToolTip` prop for RNWin32's View.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To keep native behavior where certain components are tagged to not show tooltips while giving clients the flexibility to use JS to override this behavior and show tooltips if necessary.

This change will be backported back to 0.66 so that it can be consumed by Office.

### What
Added `alwaysShowToolTip` prop to the typing for ViewWin32. Also added `alwaysShowToolTip` to the list of `validAttributes`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10381)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10425)