### PR TITLE
Use LongLivedObjects for TurboModule callbacks

### DIFF
--- a/change/react-native-windows-74efbb30-e443-4b2f-b4d4-482b9fa56fe5.json
+++ b/change/react-native-windows-74efbb30-e443-4b2f-b4d4-482b9fa56fe5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use LongLivedObjects for TurboModule callbacks",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/LongLivedJsiValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/LongLivedJsiValue.h
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_JSI_LONGLIVEDJSIVALUE_
+#define MICROSOFT_REACTNATIVE_JSI_LONGLIVEDJSIVALUE_
+
+#include <ReactCommon/LongLivedObject.h>
+#include <jsi/jsi.h>
+
+namespace winrt::Microsoft::ReactNative {
+
+// Wrap up JSI Runtime into a LongLivedObject
+struct LongLivedJsiRuntime : facebook::react::LongLivedObject {
+  static std::weak_ptr<LongLivedJsiRuntime> CreateWeak(
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> const &longLivedObjectCollection,
+      facebook::jsi::Runtime &runtime) noexcept {
+    auto value = std::shared_ptr<LongLivedJsiRuntime>(new LongLivedJsiRuntime(longLivedObjectCollection, runtime));
+    longLivedObjectCollection->add(value);
+    return value;
+  }
+
+  facebook::jsi::Runtime &Runtime() {
+    return runtime_;
+  }
+
+ public: // LongLivedObject overrides
+  void allowRelease() override {
+    if (auto longLivedObjectCollection = longLivedObjectCollection_.lock()) {
+      if (longLivedObjectCollection != nullptr) {
+        longLivedObjectCollection->remove(this);
+        return;
+      }
+    }
+    LongLivedObject::allowRelease();
+  }
+
+ protected:
+  LongLivedJsiRuntime(
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> const &longLivedObjectCollection,
+      facebook::jsi::Runtime &runtime)
+      : longLivedObjectCollection_(longLivedObjectCollection), runtime_(runtime) {}
+
+  LongLivedJsiRuntime(LongLivedJsiRuntime const &) = delete;
+
+ private:
+  // Use a weak reference to the collection to avoid reference loops
+  std::weak_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection_;
+  facebook::jsi::Runtime &runtime_;
+};
+
+// Wrap up a JSI Value into a LongLivedObject.
+template <typename TValue>
+struct LongLivedJsiValue : LongLivedJsiRuntime {
+  static std::weak_ptr<LongLivedJsiValue<TValue>> CreateWeak(
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> const &longLivedObjectCollection,
+      facebook::jsi::Runtime &runtime,
+      TValue &&value) noexcept {
+    auto valueWrapper = std::shared_ptr<LongLivedJsiValue<TValue>>(
+        new LongLivedJsiValue<TValue>(longLivedObjectCollection, runtime, std::forward<TValue>(value)));
+    longLivedObjectCollection->add(valueWrapper);
+    return valueWrapper;
+  }
+
+  TValue &Value() {
+    return value_;
+  }
+
+ protected:
+  template <typename TValue2>
+  LongLivedJsiValue(
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> const &longLivedObjectCollection,
+      facebook::jsi::Runtime &runtime,
+      TValue2 &&value)
+      : LongLivedJsiRuntime(longLivedObjectCollection, runtime), value_(std::forward<TValue2>(value)) {}
+
+ private:
+  TValue value_;
+};
+
+using LongLivedJsiFunction = LongLivedJsiValue<facebook::jsi::Function>;
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_JSI_LONGLIVEDJSIVALUE_

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -39,6 +39,7 @@
     <ClInclude Include="$(JSI_SourcePath)\jsi\jsi.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CoreApp.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)DesktopWindowBridge.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\LongLivedJsiValue.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\NodeApiJsiRuntime.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)TurboModuleProvider.h" />
     <ClInclude Include="$(CallInvoker_SourcePath)\ReactCommon\CallInvoker.h" />

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -158,6 +158,9 @@
     </ClInclude>
     <ClInclude Include="$(Bridging_SourcePath)\CallbackWrapper.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CoreApp.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\LongLivedJsiValue.h">
+      <Filter>TurboModule</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="JSI">

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestEventService.h
@@ -12,6 +12,7 @@
 #include <winrt/base.h>
 #include <mutex>
 #include <queue>
+#include <set>
 #include <string_view>
 
 namespace ReactNativeIntegrationTests {
@@ -27,16 +28,12 @@ struct TestEvent {
   JSValue Value;
 };
 
+// Ordered test notifications
 struct TestEventService {
-  // Sets to the service to the initial state.
+  // Sets the service to the initial state.
   static void Initialize() noexcept;
 
-  // Logs new event and notifies the observer to check it.
-  // It blocks current thread until the previous event is observed.
-  //
-  // The expectation is that this method is always called on a thread
-  // different to the one that runs the ObserveEvents method.
-  // We will have a deadlock if this expectation is not met.
+  // Logs new event in the queue and notifies queue observers to check it.
   static void LogEvent(std::string_view eventName, JSValue &&value) noexcept;
 
   // Logs new event for value types that need an explicit call to JSValue constructor.
@@ -45,14 +42,31 @@ struct TestEventService {
     LogEvent(eventName, JSValue{std::forward<TValue>(value)});
   }
 
-  // Blocks current thread and observes all incoming events until we see them all.
+  // Blocks current thread and observes all incoming events in the queue until we see them all.
   static void ObserveEvents(winrt::array_view<const TestEvent> expectedEvents) noexcept;
 
  private:
   static std::mutex s_mutex; // to synchronize access to the fields below
-  static std::condition_variable s_cv; // to notify about new event
+  static std::condition_variable s_cv; // signals about new event
   static std::queue<TestEvent> s_eventQueue; // the event queue
   static bool s_hasNewEvent;
+};
+
+// Unordered test events
+struct TestNotificationService {
+  // Sets the service to the initial state.
+  static void Initialize() noexcept;
+
+  // Set a new notification.
+  static void Set(std::string_view eventName) noexcept;
+
+  // Blocks current thread and waits until expected event appears.
+  static void Wait(std::string_view eventName) noexcept;
+
+ private:
+  static std::mutex s_mutex; // to synchronize access to the fields below
+  static std::condition_variable s_cv; // signals about new event
+  static std::set<std::string, std::less<>> s_events; // a set of events
 };
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -7,7 +7,6 @@
 #include <ReactCommon/TurboModuleUtils.h>
 #include <TurboModuleProvider.h> // It is RNW specific
 #include <dispatchQueue/dispatchQueue.h>
-#include <eventWaitHandle/eventWaitHandle.h>
 #include <future/future.h>
 #include <sstream>
 #include <string>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -7,6 +7,7 @@
 #include <ReactCommon/TurboModuleUtils.h>
 #include <TurboModuleProvider.h> // It is RNW specific
 #include <dispatchQueue/dispatchQueue.h>
+#include <eventWaitHandle/eventWaitHandle.h>
 #include <future/future.h>
 #include <sstream>
 #include <string>
@@ -99,6 +100,12 @@ struct CppTurboModuleSpec : TurboModuleSpec {
       SyncMethod<int(int, int) noexcept>{INDEX(c2), L"addSync"},
       SyncMethod<int(int) noexcept>{INDEX(c2), L"negateSync"},
       SyncMethod<std::string() noexcept>{INDEX(c2), L"sayHelloSync"},
+
+      Method<void(int, Callback<int>) noexcept>{INDEX(c2), L"negateDeferredCallback"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{
+          INDEX(c2),
+          L"negateDeferredTwoCallbacks"},
+      Method<void(int, ReactPromise<int>) noexcept>{INDEX(c2), L"negateDeferredPromise"},
   };
 
   template <class TModule>
@@ -150,6 +157,10 @@ struct CppTurboModuleSpec : TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "addSync", "Generated error message with signatures");
     REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateSync", "Generated error message with signatures");
     REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "sayHelloSync", "Generated error message with signatures");
+
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDeferredCallback", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDeferredTwoCallbacks", "Generated error message with signatures");
+    REACT_SHOW_METHOD_SPEC_ERRORS(INDEX(c3), "negateDeferredPromise", "Generated error message with signatures");
   }
 };
 
@@ -158,7 +169,14 @@ struct CppTurboModule {
   using ModuleSpec = CppTurboModuleSpec;
 
   REACT_INIT(Initialize)
-  void Initialize(ReactContext const & /*reactContext*/) noexcept {}
+  void Initialize(ReactContext const &reactContext) noexcept {
+    m_reactContext = reactContext;
+  }
+
+  REACT_SYNC_METHOD(GetTestName, L"getTestName")
+  hstring GetTestName() noexcept {
+    return m_reactContext.Properties().Get(CppTurboModule::TestName).value();
+  }
 
   REACT_CONSTANT(ConstantString, L"constantString")
   const std::string ConstantString{"myConstantString"};
@@ -475,6 +493,61 @@ struct CppTurboModule {
   std::string SayHelloSync() noexcept {
     return "Hello";
   }
+
+  REACT_METHOD(NegateDeferredCallback, L"negateDeferredCallback")
+  void NegateDeferredCallback(int x, std::function<void(int)> const &resolve) noexcept {
+    TestNotificationService::Set("NegateDeferredCallback called");
+    auto dispatcher = ReactDispatcher(m_reactContext.Properties().Get(TestDispatcher));
+    dispatcher.Post([x, resolve]() noexcept {
+      TestNotificationService::Set("NegateDeferredCallback call started");
+      resolve(-x);
+      TestNotificationService::Set("NegateDeferredCallback call ended");
+    });
+  }
+
+  REACT_METHOD(NegateDeferredTwoCallbacks, L"negateDeferredTwoCallbacks")
+  void NegateDeferredTwoCallbacks(
+      int x,
+      std::function<void(int)> const &resolve,
+      std::function<void(std::string const &)> const &reject) noexcept {
+    TestNotificationService::Set("NegateDeferredTwoCallbacks called");
+    auto dispatcher = ReactDispatcher(m_reactContext.Properties().Get(TestDispatcher));
+    dispatcher.Post([x, resolve, reject]() noexcept {
+      if (x >= 0) {
+        TestNotificationService::Set("NegateDeferredTwoCallbacks resolve started");
+        resolve(-x);
+      } else {
+        TestNotificationService::Set("NegateDeferredTwoCallbacks reject started");
+        reject("Already negative");
+      }
+      TestNotificationService::Set("NegateDeferredTwoCallbacks call ended");
+    });
+  }
+
+  REACT_METHOD(NegateDeferredPromise, L"negateDeferredPromise")
+  void NegateDeferredPromise(int x, React::ReactPromise<int> const &result) noexcept {
+    TestNotificationService::Set("NegateDeferredPromise called");
+    auto dispatcher = ReactDispatcher(m_reactContext.Properties().Get(TestDispatcher));
+    dispatcher.Post([x, result]() noexcept {
+      if (x >= 0) {
+        TestNotificationService::Set("Promise resolve started");
+        result.Resolve(-x);
+      } else {
+        TestNotificationService::Set("Promise reject started");
+        React::ReactError error{};
+        error.Message = "Already negative";
+        result.Reject(std::move(error));
+      }
+      TestNotificationService::Set("Promise call ended");
+    });
+  }
+
+ public:
+  static inline ReactPropertyId<hstring> TestName{L"TurboModuleTests", L"TestName"};
+  static inline ReactPropertyId<IReactDispatcher> TestDispatcher{L"TurboModuleTests", L"TestDispatcher"};
+
+ private:
+  ReactContext m_reactContext;
 };
 
 struct CppTurboModulePackageProvider : winrt::implements<CppTurboModulePackageProvider, IReactPackageProvider> {
@@ -492,6 +565,7 @@ TEST_CLASS (TurboModuleTests) {
 
     auto reactNativeHost = TestReactNativeHostHolder(L"TurboModuleTests", [](ReactNativeHost const &host) noexcept {
       host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+      ReactPropertyBag(host.InstanceSettings().Properties()).Set(CppTurboModule::TestName, L"ExecuteSampleTurboModule");
     });
 
     TestEventService::ObserveEvents({
@@ -560,6 +634,189 @@ TEST_CLASS (TurboModuleTests) {
         TestEvent{"negateSync", -12},
         TestEvent{"sayHelloSync", "Hello"},
     });
+  }
+
+  TEST_METHOD(JSDispatcherAfterInstanceUnload) {
+    TestEventService::Initialize();
+    TestNotificationService::Initialize();
+
+    auto reactNativeHost = TestReactNativeHostHolder(L"TurboModuleTests", [](ReactNativeHost const &host) noexcept {
+      host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+      ReactPropertyBag(host.InstanceSettings().Properties())
+          .Set(CppTurboModule::TestName, L"JSDispatcherAfterInstanceUnload");
+      host.InstanceSettings().InstanceDestroyed(
+          [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+            TestNotificationService::Set("Instance destroyed event");
+          });
+    });
+
+    TestEventService::ObserveEvents({
+        TestEvent{"addSync", 42},
+    });
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // JSDispatcher must not process any callbacks
+    auto jsDispatcher = reactNativeHost.Host()
+                            .InstanceSettings()
+                            .Properties()
+                            .Get(ReactDispatcherHelper::JSDispatcherProperty())
+                            .as<IReactDispatcher>();
+    struct CallbackData {
+      ~CallbackData() {
+        TestNotificationService::Set("CallbackData destroyed");
+      }
+    };
+    bool callbackIsCalled{false};
+    jsDispatcher.Post([&callbackIsCalled, data = std::make_shared<CallbackData>()] { callbackIsCalled = true; });
+    TestNotificationService::Wait("CallbackData destroyed");
+    TestCheck(!callbackIsCalled);
+  }
+
+  TEST_METHOD(DeferCallbackAfterInstanceUnload) {
+    TestNotificationService::Initialize();
+
+    auto testDispatcher = ReactDispatcher(ReactDispatcherHelper::CreateSerialDispatcher());
+    testDispatcher.Post([] { TestNotificationService::Wait("Resume Dispatcher"); });
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"TurboModuleTests", [testDispatcher](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+          auto properties = ReactPropertyBag(host.InstanceSettings().Properties());
+          properties.Set(CppTurboModule::TestName, L"DeferCallbackAfterInstanceUnload");
+          properties.Set(CppTurboModule::TestDispatcher, testDispatcher.Handle());
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+                TestNotificationService::Set("Instance destroyed event");
+              });
+        });
+
+    TestNotificationService::Wait("NegateDeferredCallback called");
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // No crash must happen when the Promise is resolved after RN instance unload.
+    TestNotificationService::Set("Resume Dispatcher");
+    TestNotificationService::Wait("NegateDeferredCallback call started");
+    TestNotificationService::Wait("NegateDeferredCallback call ended");
+  }
+
+  TEST_METHOD(DeferResolveCallbackAfterInstanceUnload) {
+    TestNotificationService::Initialize();
+
+    auto testDispatcher = ReactDispatcher(ReactDispatcherHelper::CreateSerialDispatcher());
+    testDispatcher.Post([] { TestNotificationService::Wait("Resume Dispatcher"); });
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"TurboModuleTests", [testDispatcher](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+          auto properties = ReactPropertyBag(host.InstanceSettings().Properties());
+          properties.Set(CppTurboModule::TestName, L"DeferResolveCallbackAfterInstanceUnload");
+          properties.Set(CppTurboModule::TestDispatcher, testDispatcher.Handle());
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+                TestNotificationService::Set("Instance destroyed event");
+              });
+        });
+
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks called");
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // No crash must happen when the Promise is resolved after RN instance unload.
+    TestNotificationService::Set("Resume Dispatcher");
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks resolve started");
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks call ended");
+  }
+
+  TEST_METHOD(DeferRejectCallbackAfterInstanceUnload) {
+    TestNotificationService::Initialize();
+
+    auto testDispatcher = ReactDispatcher(ReactDispatcherHelper::CreateSerialDispatcher());
+    testDispatcher.Post([] { TestNotificationService::Wait("Resume Dispatcher"); });
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"TurboModuleTests", [testDispatcher](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+          auto properties = ReactPropertyBag(host.InstanceSettings().Properties());
+          properties.Set(CppTurboModule::TestName, L"DeferRejectCallbackAfterInstanceUnload");
+          properties.Set(CppTurboModule::TestDispatcher, testDispatcher.Handle());
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+                TestNotificationService::Set("Instance destroyed event");
+              });
+        });
+
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks called");
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // No crash must happen when the Promise is resolved after RN instance unload.
+    TestNotificationService::Set("Resume Dispatcher");
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks reject started");
+    TestNotificationService::Wait("NegateDeferredTwoCallbacks call ended");
+  }
+
+  TEST_METHOD(DeferPromiseResolveAfterInstanceUnload) {
+    TestNotificationService::Initialize();
+
+    auto testDispatcher = ReactDispatcher(ReactDispatcherHelper::CreateSerialDispatcher());
+    testDispatcher.Post([] { TestNotificationService::Wait("Resume Dispatcher"); });
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"TurboModuleTests", [testDispatcher](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+          auto properties = ReactPropertyBag(host.InstanceSettings().Properties());
+          properties.Set(CppTurboModule::TestName, L"DeferPromiseResolveAfterInstanceUnload");
+          properties.Set(CppTurboModule::TestDispatcher, testDispatcher.Handle());
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+                TestNotificationService::Set("Instance destroyed event");
+              });
+        });
+
+    TestNotificationService::Wait("NegateDeferredPromise called");
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // No crash must happen when the Promise is resolved after RN instance unload.
+    TestNotificationService::Set("Resume Dispatcher");
+    TestNotificationService::Wait("Promise resolve started");
+    TestNotificationService::Wait("Promise call ended");
+  }
+
+  TEST_METHOD(DeferPromiseRejectAfterInstanceUnload) {
+    TestNotificationService::Initialize();
+
+    auto testDispatcher = ReactDispatcher(ReactDispatcherHelper::CreateSerialDispatcher());
+    testDispatcher.Post([] { TestNotificationService::Wait("Resume Dispatcher"); });
+
+    auto reactNativeHost =
+        TestReactNativeHostHolder(L"TurboModuleTests", [testDispatcher](ReactNativeHost const &host) noexcept {
+          host.PackageProviders().Append(winrt::make<CppTurboModulePackageProvider>());
+          auto properties = ReactPropertyBag(host.InstanceSettings().Properties());
+          properties.Set(CppTurboModule::TestName, L"DeferPromiseRejectAfterInstanceUnload");
+          properties.Set(CppTurboModule::TestDispatcher, testDispatcher.Handle());
+          host.InstanceSettings().InstanceDestroyed(
+              [&](IInspectable const & /*sender*/, InstanceDestroyedEventArgs const & /*args*/) {
+                TestNotificationService::Set("Instance destroyed event");
+              });
+        });
+
+    TestNotificationService::Wait("NegateDeferredPromise called");
+
+    reactNativeHost.Host().UnloadInstance();
+    TestNotificationService::Wait("Instance destroyed event");
+
+    // No crash must happen when the Promise is resolved after RN instance unload.
+    TestNotificationService::Set("Resume Dispatcher");
+    TestNotificationService::Wait("Promise reject started");
+    TestNotificationService::Wait("Promise call ended");
   }
 };
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.js
@@ -12,118 +12,134 @@ const promisify2 = fn =>
     res => fn(...args, result => res(result), result => res(result)));
 
 (async function runTests() {
+  const testName = CppTurboModule.getTestName();
   try {
-    const c = CppTurboModule.getConstants();
-    CppTurboModule.logAction("constantString", c.constantString);
-    CppTurboModule.logAction("constantInt", c.constantInt);
-    CppTurboModule.logAction("constantString2", c.constantString2);
-    CppTurboModule.logAction("constantInt2", c.constantInt2);
-    CppTurboModule.logAction("constantString3", c.constantString3);
-    CppTurboModule.logAction("constantInt3", c.constantInt3);
+    if (testName === "ExecuteSampleTurboModule") {
+      const c = CppTurboModule.getConstants();
+      CppTurboModule.logAction("constantString", c.constantString);
+      CppTurboModule.logAction("constantInt", c.constantInt);
+      CppTurboModule.logAction("constantString2", c.constantString2);
+      CppTurboModule.logAction("constantInt2", c.constantInt2);
+      CppTurboModule.logAction("constantString3", c.constantString3);
+      CppTurboModule.logAction("constantInt3", c.constantInt3);
 
-    let result;
-    result = await promisify1(CppTurboModule.add)(2, 8);
-    CppTurboModule.logAction("add", result);
-    result = await promisify1(CppTurboModule.negate)(10);
-    CppTurboModule.logAction("negate", result);
-    result = await promisify1(CppTurboModule.sayHello)();
-    CppTurboModule.logAction("sayHello", result);
+      let result;
+      result = await promisify1(CppTurboModule.add)(2, 8);
+      CppTurboModule.logAction("add", result);
+      result = await promisify1(CppTurboModule.negate)(10);
+      CppTurboModule.logAction("negate", result);
+      result = await promisify1(CppTurboModule.sayHello)();
+      CppTurboModule.logAction("sayHello", result);
 
-    CppTurboModule.sayHello0();
-    CppTurboModule.printPoint({ x: 1, y: 2 });
-    CppTurboModule.printLine({ x: 1, y: 2 }, { x: 3, y: 4 });
+      CppTurboModule.sayHello0();
+      CppTurboModule.printPoint({ x: 1, y: 2 });
+      CppTurboModule.printLine({ x: 1, y: 2 }, { x: 3, y: 4 });
 
-    result = await promisify1(CppTurboModule.addCallback)(7, 8);
-    CppTurboModule.logAction("addCallback", result);
-    result = await promisify1(CppTurboModule.negateCallback)(15);
-    CppTurboModule.logAction("negateCallback", result);
-    result = await promisify1(CppTurboModule.negateAsyncCallback)(16);
-    CppTurboModule.logAction("negateAsyncCallback", result);
-    result = await promisify1(CppTurboModule.negateDispatchQueueCallback)(17);
-    CppTurboModule.logAction("negateDispatchQueueCallback", result);
-    result = await promisify1(CppTurboModule.negateFutureCallback)(18);
-    CppTurboModule.logAction("negateFutureCallback", result);
-    result = await promisify1(CppTurboModule.sayHelloCallback)();
-    CppTurboModule.logAction("sayHelloCallback", result);
+      result = await promisify1(CppTurboModule.addCallback)(7, 8);
+      CppTurboModule.logAction("addCallback", result);
+      result = await promisify1(CppTurboModule.negateCallback)(15);
+      CppTurboModule.logAction("negateCallback", result);
+      result = await promisify1(CppTurboModule.negateAsyncCallback)(16);
+      CppTurboModule.logAction("negateAsyncCallback", result);
+      result = await promisify1(CppTurboModule.negateDispatchQueueCallback)(17);
+      CppTurboModule.logAction("negateDispatchQueueCallback", result);
+      result = await promisify1(CppTurboModule.negateFutureCallback)(18);
+      CppTurboModule.logAction("negateFutureCallback", result);
+      result = await promisify1(CppTurboModule.sayHelloCallback)();
+      CppTurboModule.logAction("sayHelloCallback", result);
 
-    CppTurboModule.callbackZeroArgs(() => CppTurboModule.logAction("callbackZeroArgs", null));
-    CppTurboModule.callbackTwoArgs((x, y) => CppTurboModule.logAction("callbackTwoArgs", { x, y }));
-    CppTurboModule.callbackThreeArgs((x, y, msg) => CppTurboModule.logAction("callbackThreeArgs", { x, y, msg }));
+      CppTurboModule.callbackZeroArgs(() => CppTurboModule.logAction("callbackZeroArgs", null));
+      CppTurboModule.callbackTwoArgs((x, y) => CppTurboModule.logAction("callbackTwoArgs", { x, y }));
+      CppTurboModule.callbackThreeArgs((x, y, msg) => CppTurboModule.logAction("callbackThreeArgs", { x, y, msg }));
 
-    result = await promisify2(CppTurboModule.divideCallbacks)(10, 5);
-    CppTurboModule.logAction("divideCallbacks", result);
-    result = await promisify2(CppTurboModule.divideCallbacks)(10, 0);
-    CppTurboModule.logAction("divideCallbacks.error", result);
-    result = await promisify2(CppTurboModule.negateCallbacks)(10);
-    CppTurboModule.logAction("negateCallbacks", result);
-    result = await promisify2(CppTurboModule.negateCallbacks)(-10);
-    CppTurboModule.logAction("negateCallbacks.error", result);
-    result = await promisify2(CppTurboModule.negateAsyncCallbacks)(10);
-    CppTurboModule.logAction("negateAsyncCallbacks", result);
-    result = await promisify2(CppTurboModule.negateAsyncCallbacks)(-10);
-    CppTurboModule.logAction("negateAsyncCallbacks.error", result);
-    result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(10);
-    CppTurboModule.logAction("negateDispatchQueueCallbacks", result);
-    result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(-10);
-    CppTurboModule.logAction("negateDispatchQueueCallbacks.error", result);
-    result = await promisify2(CppTurboModule.negateFutureCallbacks)(10);
-    CppTurboModule.logAction("negateFutureCallbacks", result);
-    result = await promisify2(CppTurboModule.negateFutureCallbacks)(-10);
-    CppTurboModule.logAction("negateFutureCallbacks.error", result);
-    result = await promisify2(CppTurboModule.resolveSayHelloCallbacks)();
-    CppTurboModule.logAction("resolveSayHelloCallbacks", result);
-    result = await promisify2(CppTurboModule.rejectSayHelloCallbacks)();
-    CppTurboModule.logAction("rejectSayHelloCallbacks.error", result);
+      result = await promisify2(CppTurboModule.divideCallbacks)(10, 5);
+      CppTurboModule.logAction("divideCallbacks", result);
+      result = await promisify2(CppTurboModule.divideCallbacks)(10, 0);
+      CppTurboModule.logAction("divideCallbacks.error", result);
+      result = await promisify2(CppTurboModule.negateCallbacks)(10);
+      CppTurboModule.logAction("negateCallbacks", result);
+      result = await promisify2(CppTurboModule.negateCallbacks)(-10);
+      CppTurboModule.logAction("negateCallbacks.error", result);
+      result = await promisify2(CppTurboModule.negateAsyncCallbacks)(10);
+      CppTurboModule.logAction("negateAsyncCallbacks", result);
+      result = await promisify2(CppTurboModule.negateAsyncCallbacks)(-10);
+      CppTurboModule.logAction("negateAsyncCallbacks.error", result);
+      result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(10);
+      CppTurboModule.logAction("negateDispatchQueueCallbacks", result);
+      result = await promisify2(CppTurboModule.negateDispatchQueueCallbacks)(-10);
+      CppTurboModule.logAction("negateDispatchQueueCallbacks.error", result);
+      result = await promisify2(CppTurboModule.negateFutureCallbacks)(10);
+      CppTurboModule.logAction("negateFutureCallbacks", result);
+      result = await promisify2(CppTurboModule.negateFutureCallbacks)(-10);
+      CppTurboModule.logAction("negateFutureCallbacks.error", result);
+      result = await promisify2(CppTurboModule.resolveSayHelloCallbacks)();
+      CppTurboModule.logAction("resolveSayHelloCallbacks", result);
+      result = await promisify2(CppTurboModule.rejectSayHelloCallbacks)();
+      CppTurboModule.logAction("rejectSayHelloCallbacks.error", result);
 
-    const twoCallbacksZeroArgs = useFirst => CppTurboModule.twoCallbacksZeroArgs(useFirst,
-      () => CppTurboModule.logAction("twoCallbacksZeroArgs1", "success"),
-      () => CppTurboModule.logAction("twoCallbacksZeroArgs2", "failure"));
-    twoCallbacksZeroArgs(true);
-    twoCallbacksZeroArgs(false);
-    const twoCallbacksTwoArgs = useFirst => CppTurboModule.twoCallbacksTwoArgs(useFirst,
-      (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs1", { x, y }),
-      (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs2", { x, y }));
-    twoCallbacksTwoArgs(true);
-    twoCallbacksTwoArgs(false);
-    const twoCallbacksThreeArgs = useFirst => CppTurboModule.twoCallbacksThreeArgs(useFirst,
-      (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs1", { x, y, msg }),
-      (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs2", { x, y, msg }));
-    twoCallbacksThreeArgs(true);
-    twoCallbacksThreeArgs(false);
+      const twoCallbacksZeroArgs = useFirst => CppTurboModule.twoCallbacksZeroArgs(useFirst,
+        () => CppTurboModule.logAction("twoCallbacksZeroArgs1", "success"),
+        () => CppTurboModule.logAction("twoCallbacksZeroArgs2", "failure"));
+      twoCallbacksZeroArgs(true);
+      twoCallbacksZeroArgs(false);
+      const twoCallbacksTwoArgs = useFirst => CppTurboModule.twoCallbacksTwoArgs(useFirst,
+        (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs1", { x, y }),
+        (x, y) => CppTurboModule.logAction("twoCallbacksTwoArgs2", { x, y }));
+      twoCallbacksTwoArgs(true);
+      twoCallbacksTwoArgs(false);
+      const twoCallbacksThreeArgs = useFirst => CppTurboModule.twoCallbacksThreeArgs(useFirst,
+        (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs1", { x, y, msg }),
+        (x, y, msg) => CppTurboModule.logAction("twoCallbacksThreeArgs2", { x, y, msg }));
+      twoCallbacksThreeArgs(true);
+      twoCallbacksThreeArgs(false);
 
-    await CppTurboModule.dividePromise(10, 2)
-      .then(r => CppTurboModule.logAction("dividePromise", r));
-    await CppTurboModule.dividePromise(10, 0)
-      .catch(e => CppTurboModule.logAction("dividePromise.error", e.message));
-    await CppTurboModule.negatePromise(10)
-      .then(r => CppTurboModule.logAction("negatePromise", r));
-    await CppTurboModule.negatePromise(-10)
-      .catch(e => CppTurboModule.logAction("negatePromise.error", e.message));
-    await CppTurboModule.negateAsyncPromise(10)
-      .then(r => CppTurboModule.logAction("negateAsyncPromise", r));
-    await CppTurboModule.negateAsyncPromise(-10)
-      .catch(e => CppTurboModule.logAction("negateAsyncPromise.error", e.message));
-    await CppTurboModule.negateAsyncPromise(10)
-      .then(r => CppTurboModule.logAction("negateDispatchQueuePromise", r));
-    await CppTurboModule.negateAsyncPromise(-10)
-      .catch(e => CppTurboModule.logAction("negateDispatchQueuePromise.error", e.message));
-    await CppTurboModule.negateAsyncPromise(10)
-      .then(r => CppTurboModule.logAction("negateFuturePromise", r));
-    await CppTurboModule.negateAsyncPromise(-10)
-      .catch(e => CppTurboModule.logAction("negateFuturePromise.error", e.message));
-    await CppTurboModule.voidPromise(2)
-      .then(() => CppTurboModule.logAction("voidPromise", "success"));
-    await CppTurboModule.voidPromise(1)
-      .catch(e => CppTurboModule.logAction("voidPromise.error", e.message));
-    await CppTurboModule.resolveSayHelloPromise()
-      .then(r => CppTurboModule.logAction("resolveSayHelloPromise", r));
-    await CppTurboModule.rejectSayHelloPromise()
-      .catch(e => CppTurboModule.logAction("rejectSayHelloPromise", e.message));
+      await CppTurboModule.dividePromise(10, 2)
+        .then(r => CppTurboModule.logAction("dividePromise", r));
+      await CppTurboModule.dividePromise(10, 0)
+        .catch(e => CppTurboModule.logAction("dividePromise.error", e.message));
+      await CppTurboModule.negatePromise(10)
+        .then(r => CppTurboModule.logAction("negatePromise", r));
+      await CppTurboModule.negatePromise(-10)
+        .catch(e => CppTurboModule.logAction("negatePromise.error", e.message));
+      await CppTurboModule.negateAsyncPromise(10)
+        .then(r => CppTurboModule.logAction("negateAsyncPromise", r));
+      await CppTurboModule.negateAsyncPromise(-10)
+        .catch(e => CppTurboModule.logAction("negateAsyncPromise.error", e.message));
+      await CppTurboModule.negateAsyncPromise(10)
+        .then(r => CppTurboModule.logAction("negateDispatchQueuePromise", r));
+      await CppTurboModule.negateAsyncPromise(-10)
+        .catch(e => CppTurboModule.logAction("negateDispatchQueuePromise.error", e.message));
+      await CppTurboModule.negateAsyncPromise(10)
+        .then(r => CppTurboModule.logAction("negateFuturePromise", r));
+      await CppTurboModule.negateAsyncPromise(-10)
+        .catch(e => CppTurboModule.logAction("negateFuturePromise.error", e.message));
+      await CppTurboModule.voidPromise(2)
+        .then(() => CppTurboModule.logAction("voidPromise", "success"));
+      await CppTurboModule.voidPromise(1)
+        .catch(e => CppTurboModule.logAction("voidPromise.error", e.message));
+      await CppTurboModule.resolveSayHelloPromise()
+        .then(r => CppTurboModule.logAction("resolveSayHelloPromise", r));
+      await CppTurboModule.rejectSayHelloPromise()
+        .catch(e => CppTurboModule.logAction("rejectSayHelloPromise", e.message));
 
-    CppTurboModule.logAction("addSync", CppTurboModule.addSync(40, 2));
-    CppTurboModule.logAction("negateSync", CppTurboModule.negateSync(12));
-    CppTurboModule.logAction("sayHelloSync", CppTurboModule.sayHelloSync());
+      CppTurboModule.logAction("addSync", CppTurboModule.addSync(40, 2));
+      CppTurboModule.logAction("negateSync", CppTurboModule.negateSync(12));
+      CppTurboModule.logAction("sayHelloSync", CppTurboModule.sayHelloSync());
+    } else if (testName === "JSDispatcherAfterInstanceUnload") {
+      CppTurboModule.logAction("addSync", CppTurboModule.addSync(40, 2));
+    } else if (testName === "DeferCallbackAfterInstanceUnload") {
+      CppTurboModule.negateDeferredCallback(4, _ => { });
+    } else if (testName === "DeferResolveCallbackAfterInstanceUnload") {
+      CppTurboModule.negateDeferredTwoCallbacks(4, _ => { }, _ => { });
+    } else if (testName === "DeferRejectCallbackAfterInstanceUnload") {
+      CppTurboModule.negateDeferredTwoCallbacks(-4, _ => { }, _ => { });
+    } else if (testName === "DeferPromiseResolveAfterInstanceUnload") {
+      CppTurboModule.negateDeferredPromise(4);
+    } else if (testName === "DeferPromiseRejectAfterInstanceUnload") {
+      CppTurboModule.negateDeferredPromise(-4);
+    }
   } catch (err) {
     CppTurboModule.logAction("Error", err.message);
   }
+
 })();

--- a/vnext/Microsoft.ReactNative/JSDispatcherWriter.cpp
+++ b/vnext/Microsoft.ReactNative/JSDispatcherWriter.cpp
@@ -8,35 +8,57 @@
 
 namespace winrt::Microsoft::ReactNative {
 
+// Special IJSValueWriter that does nothing.
+// We use it instead of JsiWriter when JSI runtime is not available anymore.
+struct JSNoopWriter : winrt::implements<JSNoopWriter, IJSValueWriter> {
+ public: // IJSValueWriter
+  void WriteNull() noexcept;
+  void WriteBoolean(bool value) noexcept;
+  void WriteInt64(int64_t value) noexcept;
+  void WriteDouble(double value) noexcept;
+  void WriteString(const winrt::hstring &value) noexcept;
+  void WriteObjectBegin() noexcept;
+  void WritePropertyName(const winrt::hstring &name) noexcept;
+  void WriteObjectEnd() noexcept;
+  void WriteArrayBegin() noexcept;
+  void WriteArrayEnd() noexcept;
+};
+
 //===========================================================================
 // JSDispatcherWriter implementation
 //===========================================================================
 
 JSDispatcherWriter::JSDispatcherWriter(
     IReactDispatcher const &jsDispatcher,
-    facebook::jsi::Runtime &jsiRuntime) noexcept
-    : m_jsDispatcher(jsDispatcher), m_jsiRuntime(jsiRuntime) {}
+    std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept
+    : m_jsDispatcher(jsDispatcher), m_jsiRuntimeHolder(std::move(jsiRuntimeHolder)) {}
 
 void JSDispatcherWriter::WithResultArgs(
     Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
         handler) noexcept {
   if (m_jsDispatcher.HasThreadAccess()) {
     VerifyElseCrash(!m_dynamicWriter);
-    const facebook::jsi::Value *args{nullptr};
-    size_t argCount{0};
-    m_jsiWriter->AccessResultAsArgs(args, argCount);
-    handler(m_jsiRuntime, args, argCount);
+    if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+      const facebook::jsi::Value *args{nullptr};
+      size_t argCount{0};
+      m_jsiWriter->AccessResultAsArgs(args, argCount);
+      handler(jsiRuntimeHolder->Runtime(), args, argCount);
+      m_jsiWriter = nullptr;
+    }
   } else {
     VerifyElseCrash(!m_jsiWriter);
     folly::dynamic dynValue = m_dynamicWriter->TakeValue();
-    m_jsDispatcher.Post([handler, dynValue, &runtime = m_jsiRuntime]() {
-      VerifyElseCrash(dynValue.isArray());
-      std::vector<facebook::jsi::Value> args;
-      args.reserve(dynValue.size());
-      for (auto const &item : dynValue) {
-        args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+    VerifyElseCrash(dynValue.isArray());
+    m_jsDispatcher.Post([handler, dynValue = std::move(dynValue), weakJsiRuntimeHolder = m_jsiRuntimeHolder]() {
+      if (auto jsiRuntimeHolder = weakJsiRuntimeHolder.lock()) {
+        std::vector<facebook::jsi::Value> args;
+        args.reserve(dynValue.size());
+        auto &runtime = jsiRuntimeHolder->Runtime();
+        for (auto const &item : dynValue) {
+          args.emplace_back(facebook::jsi::valueFromDynamic(runtime, item));
+        }
+        handler(runtime, args.data(), args.size());
       }
-      handler(runtime, args.data(), args.size());
     });
   }
 }
@@ -82,20 +104,36 @@ void JSDispatcherWriter::WriteArrayEnd() noexcept {
 }
 
 IJSValueWriter JSDispatcherWriter::GetWriter() noexcept {
-  if (m_jsDispatcher.HasThreadAccess()) {
-    VerifyElseCrash(!m_dynamicWriter);
-    if (!m_jsiWriter) {
-      m_jsiWriter = winrt::make_self<JsiWriter>(m_jsiRuntime);
-      m_writer = m_jsiWriter.as<IJSValueWriter>();
-    }
-  } else {
-    VerifyElseCrash(!m_jsiWriter);
-    if (!m_dynamicWriter) {
+  if (!m_writer) {
+    if (m_jsDispatcher.HasThreadAccess()) {
+      if (auto jsiRuntimeHolder = m_jsiRuntimeHolder.lock()) {
+        m_jsiWriter = winrt::make_self<JsiWriter>(jsiRuntimeHolder->Runtime());
+        m_writer = m_jsiWriter.as<IJSValueWriter>();
+      } else {
+        m_writer = winrt::make<JSNoopWriter>();
+      }
+    } else {
       m_dynamicWriter = winrt::make_self<DynamicWriter>();
       m_writer = m_dynamicWriter.as<IJSValueWriter>();
     }
   }
+  Debug(VerifyElseCrash(m_dynamicWriter != nullptr || m_jsDispatcher.HasThreadAccess()));
   return m_writer;
 }
+
+//===========================================================================
+// JSNoopWriter implementation
+//===========================================================================
+
+void JSNoopWriter::WriteNull() noexcept {}
+void JSNoopWriter::WriteBoolean(bool /*value*/) noexcept {}
+void JSNoopWriter::WriteInt64(int64_t /*value*/) noexcept {}
+void JSNoopWriter::WriteDouble(double /*value*/) noexcept {}
+void JSNoopWriter::WriteString(const winrt::hstring & /*value*/) noexcept {}
+void JSNoopWriter::WriteObjectBegin() noexcept {}
+void JSNoopWriter::WritePropertyName(const winrt::hstring & /*name*/) noexcept {}
+void JSNoopWriter::WriteObjectEnd() noexcept {}
+void JSNoopWriter::WriteArrayBegin() noexcept {}
+void JSNoopWriter::WriteArrayEnd() noexcept {}
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/JSDispatcherWriter.h
+++ b/vnext/Microsoft.ReactNative/JSDispatcherWriter.h
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 #pragma once
 
+#include <JSI/LongLivedJsiValue.h>
 #include <functional/functor.h>
 #include "DynamicWriter.h"
 #include "JsiWriter.h"
-#include "folly/dynamic.h"
 #include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::Microsoft::ReactNative {
@@ -14,7 +14,9 @@ namespace winrt::Microsoft::ReactNative {
 // In case if writing is done outside of JSDispatcher, it uses DynamicWriter to create
 // folly::dynamic which then is written to JsiWriter in JSDispatcher.
 struct JSDispatcherWriter : winrt::implements<JSDispatcherWriter, IJSValueWriter> {
-  JSDispatcherWriter(IReactDispatcher const &jsDispatcher, facebook::jsi::Runtime &jsiRuntime) noexcept;
+  JSDispatcherWriter(
+      IReactDispatcher const &jsDispatcher,
+      std::weak_ptr<LongLivedJsiRuntime> jsiRuntimeHolder) noexcept;
   void WithResultArgs(Mso::Functor<void(facebook::jsi::Runtime &rt, facebook::jsi::Value const *args, size_t argCount)>
                           handler) noexcept;
 
@@ -35,7 +37,7 @@ struct JSDispatcherWriter : winrt::implements<JSDispatcherWriter, IJSValueWriter
 
  private:
   IReactDispatcher m_jsDispatcher;
-  facebook::jsi::Runtime &m_jsiRuntime;
+  std::weak_ptr<LongLivedJsiRuntime> m_jsiRuntimeHolder;
   winrt::com_ptr<DynamicWriter> m_dynamicWriter;
   winrt::com_ptr<JsiWriter> m_jsiWriter;
   IJSValueWriter m_writer;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -510,6 +510,7 @@ void ReactInstanceWin::Initialize() noexcept {
                 std::move(bundleRootPath), // bundleRootPath
                 std::move(cxxModules),
                 m_options.TurboModuleProvider,
+                m_options.TurboModuleProvider->LongLivedObjectCollection(),
                 std::make_unique<BridgeUIBatchInstanceCallback>(weakThis),
                 m_jsMessageThread.Load(),
                 m_nativeMessageThread.Load(),

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -85,9 +85,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   auto viewManagersProvider = std::make_shared<ViewManagersProvider>();
 #endif
 
-  // LongLivedObjectCollection keeps a list of deferred asynchronous callbacks and promises.
-  auto turboModulesProvider =
-      std::make_shared<TurboModulesProvider>(std::make_shared<facebook::react::LongLivedObjectCollection>());
+  auto turboModulesProvider = std::make_shared<TurboModulesProvider>();
 
   m_packageBuilder = make<ReactPackageBuilder>(
       modulesProvider,

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -85,7 +85,9 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   auto viewManagersProvider = std::make_shared<ViewManagersProvider>();
 #endif
 
-  auto turboModulesProvider = std::make_shared<TurboModulesProvider>();
+  // LongLivedObjectCollection keeps a list of deferred asynchronous callbacks and promises.
+  auto turboModulesProvider =
+      std::make_shared<TurboModulesProvider>(std::make_shared<facebook::react::LongLivedObjectCollection>());
 
   m_packageBuilder = make<ReactPackageBuilder>(
       modulesProvider,

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.cpp
@@ -364,10 +364,6 @@ class TurboModuleImpl : public facebook::react::TurboModule {
   TurboModulesProvider
 -------------------------------------------------------------------------------*/
 
-TurboModulesProvider::TurboModulesProvider(
-    std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection) noexcept
-    : m_longLivedObjectCollection(std::move(longLivedObjectCollection)) {}
-
 std::shared_ptr<facebook::react::TurboModule> TurboModulesProvider::getModule(
     const std::string &moduleName,
     const std::shared_ptr<facebook::react::CallInvoker> &callInvoker) noexcept {

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <ReactCommon/LongLivedObject.h>
 #include <TurboModuleRegistry.h>
 #include "Base/FollyIncludes.h"
 #include "winrt/Microsoft.ReactNative.h"
@@ -20,13 +21,16 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
   std::vector<std::string> getEagerInitModuleNames() noexcept override;
 
  public:
+  TurboModulesProvider(std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection) noexcept;
   void SetReactContext(const IReactContext &reactContext) noexcept;
   void AddModuleProvider(
       winrt::hstring const &moduleName,
       ReactModuleProvider const &moduleProvider,
       bool overwriteExisting) noexcept;
+  std::shared_ptr<facebook::react::LongLivedObjectCollection> const &LongLivedObjectCollection() noexcept;
 
  private:
+  std::shared_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection;
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;
   IReactContext m_reactContext;
 };

--- a/vnext/Microsoft.ReactNative/TurboModulesProvider.h
+++ b/vnext/Microsoft.ReactNative/TurboModulesProvider.h
@@ -21,7 +21,6 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
   std::vector<std::string> getEagerInitModuleNames() noexcept override;
 
  public:
-  TurboModulesProvider(std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection) noexcept;
   void SetReactContext(const IReactContext &reactContext) noexcept;
   void AddModuleProvider(
       winrt::hstring const &moduleName,
@@ -30,7 +29,9 @@ class TurboModulesProvider final : public facebook::react::TurboModuleRegistry {
   std::shared_ptr<facebook::react::LongLivedObjectCollection> const &LongLivedObjectCollection() noexcept;
 
  private:
-  std::shared_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection;
+  // To keep a list of deferred asynchronous callbacks and promises.
+  std::shared_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection{
+      std::make_shared<facebook::react::LongLivedObjectCollection>()};
   std::unordered_map<std::string, ReactModuleProvider> m_moduleProviders;
   IReactContext m_reactContext;
 };

--- a/vnext/Shared/InstanceManager.cpp
+++ b/vnext/Shared/InstanceManager.cpp
@@ -41,6 +41,35 @@ std::shared_ptr<InstanceWrapper> CreateReactInstance(
       std::move(jsBundleBasePath),
       std::move(cxxModules),
       std::move(turboModuleRegistry),
+      nullptr,
+      std::move(callback),
+      std::move(jsQueue),
+      std::move(nativeQueue),
+      std::move(devSettings),
+      GetSharedDevManager());
+
+  return inner;
+}
+
+std::shared_ptr<InstanceWrapper> CreateReactInstance(
+    std::shared_ptr<Instance> &&instance,
+    std::string &&jsBundleBasePath,
+    std::vector<
+        std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
+        &&cxxModules,
+    std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+    std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
+    std::unique_ptr<InstanceCallback> &&callback,
+    std::shared_ptr<MessageQueueThread> jsQueue,
+    std::shared_ptr<MessageQueueThread> nativeQueue,
+    std::shared_ptr<DevSettings> devSettings) noexcept {
+  // Now create the instance
+  std::shared_ptr<InstanceWrapper> inner = InstanceImpl::MakeNoBundle(
+      std::move(instance),
+      std::move(jsBundleBasePath),
+      std::move(cxxModules),
+      std::move(turboModuleRegistry),
+      std::move(longLivedObjectCollection),
       std::move(callback),
       std::move(jsQueue),
       std::move(nativeQueue),

--- a/vnext/Shared/InstanceManager.h
+++ b/vnext/Shared/InstanceManager.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Logging.h>
+#include <ReactCommon/LongLivedObject.h>
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/JSBigString.h>
 #include <map>
@@ -46,6 +47,19 @@ std::shared_ptr<InstanceWrapper> CreateReactInstance(
         std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
         &&cxxModules,
     std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+    std::unique_ptr<InstanceCallback> &&callback,
+    std::shared_ptr<MessageQueueThread> jsQueue,
+    std::shared_ptr<MessageQueueThread> nativeQueue,
+    std::shared_ptr<DevSettings> devSettings) noexcept;
+
+std::shared_ptr<InstanceWrapper> CreateReactInstance(
+    std::shared_ptr<Instance> &&instance,
+    std::string &&jsBundleRelativePath,
+    std::vector<
+        std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
+        &&cxxModules,
+    std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+    std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
     std::unique_ptr<InstanceCallback> &&callback,
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<MessageQueueThread> nativeQueue,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -106,12 +106,17 @@ class OJSIExecutorFactory : public JSExecutorFactory {
     auto turboModuleManager = std::make_shared<TurboModuleManager>(turboModuleRegistry_, jsCallInvoker_);
 
     // TODO: The binding here should also add the proxys that convert cxxmodules into turbomodules
+    // [vmoroz] Note, that we must not use the RN TurboCxxModule.h code because it uses global LongLivedObjectCollection
+    // instance that prevents us from using multiple RN instance in the same process.
     auto binding = [turboModuleManager](const std::string &name) -> std::shared_ptr<TurboModule> {
       return turboModuleManager->getModule(name);
     };
 
     TurboModuleBinding::install(
-        *runtimeHolder_->getRuntime(), std::function(binding), TurboModuleBindingMode::HostObject, nullptr);
+        *runtimeHolder_->getRuntime(),
+        std::function(binding),
+        TurboModuleBindingMode::HostObject,
+        longLivedObjectCollection_);
 
     // init TurboModule
     for (const auto &moduleName : turboModuleManager->getEagerInitModuleNames()) {
@@ -133,17 +138,20 @@ class OJSIExecutorFactory : public JSExecutorFactory {
       std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> runtimeHolder,
       NativeLoggingHook loggingHook,
       std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection,
       bool isProfilingEnabled,
       std::shared_ptr<CallInvoker> jsCallInvoker) noexcept
       : runtimeHolder_{std::move(runtimeHolder)},
         loggingHook_{std::move(loggingHook)},
         turboModuleRegistry_{std::move(turboModuleRegistry)},
+        longLivedObjectCollection_{std::move(longLivedObjectCollection)},
         jsCallInvoker_{std::move(jsCallInvoker)},
         isProfilingEnabled_{isProfilingEnabled} {}
 
  private:
   std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> runtimeHolder_;
   std::shared_ptr<TurboModuleRegistry> turboModuleRegistry_;
+  std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
   std::shared_ptr<CallInvoker> jsCallInvoker_;
   NativeLoggingHook loggingHook_;
   bool isProfilingEnabled_;
@@ -160,6 +168,7 @@ void logMarker(const facebook::react::ReactMarker::ReactMarkerId /*id*/, const c
         std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
         &&cxxModules,
     std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+    std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
     std::unique_ptr<InstanceCallback> &&callback,
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<MessageQueueThread> nativeQueue,
@@ -170,6 +179,7 @@ void logMarker(const facebook::react::ReactMarker::ReactMarkerId /*id*/, const c
       std::move(jsBundleBasePath),
       std::move(cxxModules),
       std::move(turboModuleRegistry),
+      std::move(longLivedObjectCollection),
       std::move(callback),
       std::move(jsQueue),
       std::move(nativeQueue),
@@ -199,6 +209,7 @@ void logMarker(const facebook::react::ReactMarker::ReactMarkerId /*id*/, const c
       std::move(jsBundleBasePath),
       std::move(cxxModules),
       std::move(turboModuleRegistry),
+      nullptr,
       std::move(callback),
       std::move(jsQueue),
       std::move(nativeQueue),
@@ -236,12 +247,14 @@ InstanceImpl::InstanceImpl(
         std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
         &&cxxModules,
     std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+    std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
     std::unique_ptr<InstanceCallback> &&callback,
     std::shared_ptr<MessageQueueThread> jsQueue,
     std::shared_ptr<MessageQueueThread> nativeQueue,
     std::shared_ptr<DevSettings> devSettings,
     std::shared_ptr<IDevSupportManager> devManager)
     : m_turboModuleRegistry(std::move(turboModuleRegistry)),
+      m_longLivedObjectCollection(std::move(longLivedObjectCollection)),
       m_jsThread(std::move(jsQueue)),
       m_nativeQueue(nativeQueue),
       m_jsBundleBasePath(std::move(jsBundleBasePath)),
@@ -302,6 +315,7 @@ InstanceImpl::InstanceImpl(
           m_devSettings->jsiRuntimeHolder,
           m_devSettings->loggingCallback,
           m_turboModuleRegistry,
+          m_longLivedObjectCollection,
           !m_devSettings->useFastRefresh,
           m_innerInstance->getJSCallInvoker());
     } else {
@@ -365,6 +379,7 @@ InstanceImpl::InstanceImpl(
           m_devSettings->jsiRuntimeHolder,
           m_devSettings->loggingCallback,
           m_turboModuleRegistry,
+          m_longLivedObjectCollection,
           !m_devSettings->useFastRefresh,
           m_innerInstance->getJSCallInvoker());
     }

--- a/vnext/Shared/OInstance.h
+++ b/vnext/Shared/OInstance.h
@@ -10,6 +10,7 @@
 #include "InstanceManager.h"
 
 // React Native
+#include <ReactCommon/LongLivedObject.h>
 #include <cxxreact/Instance.h>
 
 // Standard Libriary
@@ -32,6 +33,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
           std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
           &&cxxModules,
       std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
       std::unique_ptr<InstanceCallback> &&callback,
       std::shared_ptr<MessageQueueThread> jsQueue,
       std::shared_ptr<MessageQueueThread> nativeQueue,
@@ -72,19 +74,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
           std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
           &&cxxModules,
       std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
-      std::unique_ptr<InstanceCallback> &&callback,
-      std::shared_ptr<MessageQueueThread> jsQueue,
-      std::shared_ptr<MessageQueueThread> nativeQueue,
-      std::shared_ptr<DevSettings> devSettings,
-      std::shared_ptr<IDevSupportManager> devManager);
-
-  InstanceImpl(
-      std::shared_ptr<Instance> &&instance,
-      std::string &&jsBundleBasePath,
-      std::string &&jsBundleRelativePath,
-      std::vector<
-          std::tuple<std::string, facebook::xplat::module::CxxModule::Provider, std::shared_ptr<MessageQueueThread>>>
-          &&cxxModules,
+      std::shared_ptr<facebook::react::LongLivedObjectCollection> longLivedObjectCollection,
       std::unique_ptr<InstanceCallback> &&callback,
       std::shared_ptr<MessageQueueThread> jsQueue,
       std::shared_ptr<MessageQueueThread> nativeQueue,
@@ -102,6 +92,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
   std::string m_jsBundleBasePath;
   std::shared_ptr<facebook::react::ModuleRegistry> m_moduleRegistry;
   std::shared_ptr<TurboModuleRegistry> m_turboModuleRegistry;
+  std::shared_ptr<facebook::react::LongLivedObjectCollection> m_longLivedObjectCollection;
   std::shared_ptr<MessageQueueThread> m_jsThread;
   std::shared_ptr<MessageQueueThread> m_nativeQueue;
 


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

@acoates-ms has reported an issue with RNW Turbo Module implementation where we see a crash after a RN instance is unloaded. The crash is caused by a JSI `Function` that captured in a lambda used for asynchronous callbacks or in a `Promise`.
We destroy JS engine instance when unloading the RN instance, and the JSI `Function` cannot be safely released anymore.

### What

RN Turbo Modules that wrap up CxxModules use `LongLivedObject` and `LongLivedObjectCollection` as a mechanism to address similar issues. The callbacks are wrapped up into `CallbackWrapper` class inherited from the `LongLivedObject`. The `LongLivedObjectCollection` is cleared when JS engine instance is shut down and it releases all associated `std::shared_ptr<LongLivedObject>` instances, which in turn release all associated JSI values. The deferred callback and Promise lambdas capture `std::weak_ptr<LongLivedObject>`, and do nothing if the weak pointer cannot be "locked" anymore.

The PR uses the same `LongLivedObjectCollection` for RNW Turbo Modules, but it introduces new `LongLivedJsiRuntime` and `LongLivedJsiValue` classes inherited from `LongLivedObject`. They have smaller size and do not use global `LongLivedObjectCollection` instance.

The solution consists of the following parts:
- `JSDispatcherWriter` keeps `std::weak_ptr<LongLivedJsiRuntime>` instead of JSI `Runtime` and does nothing while handling results if the JSI `Runtime` is not available anymore.
- `TurboModulesProvider` is wrapping up JSI `Function` instances into `std::weak_ptr<LongLivedJsiFunction>`. (The `LongLivedJsiFunction` is an alias for `LongLivedJsiValue<jsi::Function>`.) It helps to release all JSI `Function` instances while the JS engine instance is shutting down.
- `ReactNativeHost` creates a new instance of `LongLivedObjectCollection` and passes it to the `TurboModulesProvider`.
- The `InstanceImpl` in `OInstance.h` passes the `LongLivedObjectCollection` instance from `TurboModulesProvider` to the `OJSIExecutorFactory`. The `OJSIExecutorFactory` associates the `LongLivedObjectCollection` instance with a JS engine instance by passing it to the `TurboModuleBinding::install` call.

## Testing

We added new unit tests in `TurboModuleTests.cpp` to check behavior when callbacks and Promises are released after RN instance unload. They are all passing. These tests cause a crash without changes to the `TurboModulesProvider`. 

Also, we added a new test utility class `TestNotificationService` that helps to coordinate setting and waiting for synchronization events. Unlike the `TestEventService` that expects synchronization events to appear in a specified order, the new `TestNotificationService` keeps a set of events and lets the `Wait` function to continue if the set contains an event that it waits for.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10436)