### PR TITLE
Update to later Mac version, there is a brown-out today before the 9/30 deprecation fo 10.15

### DIFF
--- a/.ado/jobs/macos-tests.yml
+++ b/.ado/jobs/macos-tests.yml
@@ -7,7 +7,7 @@ jobs:
       - template: ../variables/shared.yml
       - name: BUILDSECMON_OPT_IN
         value: true
-    pool: {vmImage: macOS-10.15}
+    pool: {vmImage: macOS-12}
     steps:
       - template: ../templates/checkout-shallow.yml
 


### PR DESCRIPTION
## Description
Update to later mac agent. 10.15 will be deprecated on 9/30.

See: https://github.com/actions/runner-images/issues/5583

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10444)