### PR TITLE
[0.68] Add Toggle action to accessibilityActionName on ViewWin32 (#10434)

### DIFF
--- a/change/@office-iss-react-native-win32-542f6b5d-16ec-486d-b221-f0c3cf70721e.json
+++ b/change/@office-iss-react-native-win32-542f6b5d-16ec-486d-b221-f0c3cf70721e.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Add Toggle action to accessibilityActionName",
   "packageName": "@office-iss/react-native-win32",
   "email": "krsiler@microsoft.com",

--- a/change/@office-iss-react-native-win32-542f6b5d-16ec-486d-b221-f0c3cf70721e.json
+++ b/change/@office-iss-react-native-win32-542f6b5d-16ec-486d-b221-f0c3cf70721e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Toggle action to accessibilityActionName",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -107,7 +107,8 @@ export type AccessibilityActionName =
   | 'RemoveFromSelection'
   | 'Select'
   | 'Expand'
-  | 'Collapse';
+  | 'Collapse'
+  | 'Toggle';
 
 export type Cursor =
   | 'auto'


### PR DESCRIPTION
Cherry pick PR #10434 

## Description
Add the Toggle action to accessibilityActionName on ViewWin32

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Adding the Toggle action will allow developers to expose the toggle pattern on win32 which is used for accessibility purposes on controls that can be toggled (like a switch). We have support for this functionality natively but have not added it as an action that can be set on ViewWin32.

### What
Added 'Toggle' to the list of strings for accepted names for accessibilityActionName on ViewWin32

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10434)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10463)