### PR TITLE
Fix crash creating InstanceSettings on Windows 8.1

### DIFF
--- a/change/react-native-windows-ac0793f7-dae5-4086-850c-2ede09044870.json
+++ b/change/react-native-windows-ac0793f7-dae5-4086-850c-2ede09044870.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix crash creating InstanceSettings on Windows 8.1",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -289,7 +289,12 @@ void UISchedulerWinRT::AwaitTermination() noexcept {
     return queue;
   }
 
-  auto dispatcher = DispatcherQueue::GetForCurrentThread();
+  winrt::Windows::System::DispatcherQueue dispatcher{nullptr};
+  try {
+    dispatcher = DispatcherQueue::GetForCurrentThread();
+  } catch (winrt::hresult_error const &) {
+  }
+
   if (!dispatcher) {
     return queue;
   }

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -289,7 +289,7 @@ void UISchedulerWinRT::AwaitTermination() noexcept {
     return queue;
   }
 
-  winrt::Windows::System::DispatcherQueue dispatcher{nullptr};
+  decltype(DispatcherQueue::GetForCurrentThread()) dispatcher{nullptr};
   try {
     dispatcher = DispatcherQueue::GetForCurrentThread();
   } catch (winrt::hresult_error const &) {


### PR DESCRIPTION
Creating an `InstanceSettings` object on Windows 8.1 crashes when trying to get the current `DispatcherQueue` for the default value of `UIDispatcher`.

In more current versions of windows this call will return null, which is valid if the app explicitly sets the `UIDispatcher` property.  This change treats errors as null, so the app can continue if they provide a `UIDispatcher`.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10471)