### PR TITLE
Move ReactTag ABI to XamlHelper

### DIFF
--- a/change/react-native-windows-37139ab0-cad3-4421-9c32-a0b0328c0e6f.json
+++ b/change/react-native-windows-37139ab0-cad3-4421-9c32-a0b0328c0e6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move ReactTag ABI to XamlHelper",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -21,16 +21,16 @@ Windows::UI::Color XamlHelper::ColorFrom(JSValueArgWriter const &valueProvider) 
   return ::Microsoft::ReactNative::ColorFrom(value);
 }
 
-xaml::DependencyProperty XamlUIService::ReactTagProperty() noexcept {
+xaml::DependencyProperty XamlHelper::ReactTagProperty() noexcept {
   return ::Microsoft::ReactNative::ReactTagProperty();
 }
 
 
-int64_t XamlHelper::GetReactTag(xaml::DependencyObject dependencyObject) noexcept {
+int64_t XamlHelper::GetReactTag(xaml::DependencyObject const& dependencyObject) noexcept {
   return ::Microsoft::ReactNative::GetTag(dependencyObject);
 }
 
-void XamlHelper::SetReactTag(xaml::DependencyObject dependencyObject, int64_t tag) noexcept {
+void XamlHelper::SetReactTag(xaml::DependencyObject const& dependencyObject, int64_t tag) noexcept {
   return ::Microsoft::ReactNative::SetTag(dependencyObject, tag);
 }
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -25,12 +25,11 @@ xaml::DependencyProperty XamlHelper::ReactTagProperty() noexcept {
   return ::Microsoft::ReactNative::ReactTagProperty();
 }
 
-
-int64_t XamlHelper::GetReactTag(xaml::DependencyObject const& dependencyObject) noexcept {
+int64_t XamlHelper::GetReactTag(xaml::DependencyObject const &dependencyObject) noexcept {
   return ::Microsoft::ReactNative::GetTag(dependencyObject);
 }
 
-void XamlHelper::SetReactTag(xaml::DependencyObject const& dependencyObject, int64_t tag) noexcept {
+void XamlHelper::SetReactTag(xaml::DependencyObject const &dependencyObject, int64_t tag) noexcept {
   return ::Microsoft::ReactNative::SetTag(dependencyObject, tag);
 }
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -7,6 +7,7 @@
 
 #include <Utils/ValueUtils.h>
 #include "DynamicWriter.h"
+#include "XamlView.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -18,6 +19,19 @@ xaml::Media::Brush XamlHelper::BrushFrom(JSValueArgWriter const &valueProvider) 
 Windows::UI::Color XamlHelper::ColorFrom(JSValueArgWriter const &valueProvider) noexcept {
   auto value = GetFollyDynamicFromValueProvider(valueProvider);
   return ::Microsoft::ReactNative::ColorFrom(value);
+}
+
+xaml::DependencyProperty XamlUIService::ReactTagProperty() noexcept {
+  return ::Microsoft::ReactNative::ReactTagProperty();
+}
+
+
+int64_t XamlHelper::GetReactTag(xaml::DependencyObject dependencyObject) noexcept {
+  return ::Microsoft::ReactNative::GetTag(dependencyObject);
+}
+
+void XamlHelper::SetReactTag(xaml::DependencyObject dependencyObject, int64_t tag) noexcept {
+  return ::Microsoft::ReactNative::SetTag(dependencyObject, tag);
 }
 
 folly::dynamic XamlHelper::GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept {

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -14,8 +14,8 @@ struct XamlHelper : XamlHelperT<XamlHelper> {
   static Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
 
   static xaml::DependencyProperty ReactTagProperty() noexcept;
-  static int64_t GetReactTag(xaml::DependencyObject const& dependencyObject) noexcept;
-  static void SetReactTag(xaml::DependencyObject const& dependencyObject, int64_t tag) noexcept;
+  static int64_t GetReactTag(xaml::DependencyObject const &dependencyObject) noexcept;
+  static void SetReactTag(xaml::DependencyObject const &dependencyObject, int64_t tag) noexcept;
 
   static folly::dynamic GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept;
 };

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -14,8 +14,8 @@ struct XamlHelper : XamlHelperT<XamlHelper> {
   static Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
 
   static xaml::DependencyProperty ReactTagProperty() noexcept;
-  static int64_t GetReactTag(xaml::DependencyObject dependencyObject) noexcept;
-  static void SetReactTag(xaml::DependencyObject dependencyObject, int64_t tag) noexcept;
+  static int64_t GetReactTag(xaml::DependencyObject const& dependencyObject) noexcept;
+  static void SetReactTag(xaml::DependencyObject const& dependencyObject, int64_t tag) noexcept;
 
   static folly::dynamic GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept;
 };

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -13,6 +13,10 @@ struct XamlHelper : XamlHelperT<XamlHelper> {
   static xaml::Media::Brush BrushFrom(JSValueArgWriter const &valueProvider) noexcept;
   static Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
 
+  static xaml::DependencyProperty ReactTagProperty() noexcept;
+  static int64_t GetReactTag(xaml::DependencyObject dependencyObject) noexcept;
+  static void SetReactTag(xaml::DependencyObject dependencyObject, int64_t tag) noexcept;
+
   static folly::dynamic GetFollyDynamicFromValueProvider(JSValueArgWriter const &valueProvider) noexcept;
 };
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.idl
+++ b/vnext/Microsoft.ReactNative/XamlHelper.idl
@@ -17,5 +17,14 @@ namespace Microsoft.ReactNative
 
     DOC_STRING("Returns a Color from @JSValueArgWriter.")
     static Windows.UI.Color ColorFrom(JSValueArgWriter valueProvider);
+
+    DOC_STRING("Returns the attached property where the react tag is stored on a XAML Dependency Object.")
+    static XAML_NAMESPACE.DependencyProperty ReactTagProperty { get; };
+    
+    DOC_STRING("Gets the react tag from a backing XAML element.")
+    static Int64 GetReactTag(XAML_NAMESPACE.DependencyObject dependencyObject);
+
+    DOC_STRING("Sets the react tag for a XAML element.")
+    static void GetReactTag(XAML_NAMESPACE.DependencyObject dependencyObject, Int64 tag);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/XamlHelper.idl
+++ b/vnext/Microsoft.ReactNative/XamlHelper.idl
@@ -25,6 +25,6 @@ namespace Microsoft.ReactNative
     static Int64 GetReactTag(XAML_NAMESPACE.DependencyObject dependencyObject);
 
     DOC_STRING("Sets the react tag for a XAML element.")
-    static void GetReactTag(XAML_NAMESPACE.DependencyObject dependencyObject, Int64 tag);
+    static void SetReactTag(XAML_NAMESPACE.DependencyObject dependencyObject, Int64 tag);
   };
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -15,10 +15,6 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 XamlUIService::XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context(context) {}
 
-xaml::DependencyProperty XamlUIService::ReactTagProperty() noexcept {
-  return ::Microsoft::ReactNative::ReactTagProperty();
-}
-
 xaml::DependencyObject XamlUIService::ElementFromReactTag(int64_t reactTag) noexcept {
   if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
     auto shadowNode = uiManager->getHost()->FindShadowNodeForTag(reactTag);

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -26,10 +26,6 @@ xaml::DependencyObject XamlUIService::ElementFromReactTag(int64_t reactTag) noex
   return nullptr;
 }
 
-int64_t XamlUIService::ReactTagFromElement(xaml::DependencyObject dependencyObject) noexcept {
-  return ::Microsoft::ReactNative::GetTag(dependencyObject);
-}
-
 /*static*/ winrt::Microsoft::ReactNative::XamlUIService XamlUIService::FromContext(IReactContext context) {
   return context.Properties()
       .Get(XamlUIService::XamlUIServiceProperty().Handle())

--- a/vnext/Microsoft.ReactNative/XamlUIService.h
+++ b/vnext/Microsoft.ReactNative/XamlUIService.h
@@ -15,10 +15,6 @@ struct XamlUIService : XamlUIServiceT<XamlUIService> {
   XamlUIService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
   static ReactPropertyId<XamlUIService> XamlUIServiceProperty() noexcept;
 
-  static xaml::DependencyProperty ReactTagProperty() noexcept;
-
-  int64_t ReactTagFromElement(xaml::DependencyObject dependencyObject) noexcept;
-
   xaml::DependencyObject ElementFromReactTag(int64_t reactTag) noexcept;
   static winrt::Microsoft::ReactNative::XamlUIService FromContext(IReactContext context);
   void DispatchEvent(

--- a/vnext/Microsoft.ReactNative/XamlUIService.idl
+++ b/vnext/Microsoft.ReactNative/XamlUIService.idl
@@ -18,14 +18,8 @@ namespace Microsoft.ReactNative
     DOC_STRING("Use this method to get access to the @XamlUIService associated with the @IReactContext.")
     static XamlUIService FromContext(IReactContext context);
 
-    DOC_STRING("Returns the attached property where the react tag is stored on a XAML Dependency Object.")
-    static XAML_NAMESPACE.DependencyProperty ReactTagProperty { get; };
-
     DOC_STRING("Gets the backing XAML element from a react tag.")
     XAML_NAMESPACE.DependencyObject ElementFromReactTag(Int64 reactTag);
-
-    DOC_STRING("Gets the react tag from a backing XAML element.")
-    Int64 ReactTagFromElement(XAML_NAMESPACE.DependencyObject dependencyObject);
 
     DOC_STRING("Dispatches an event to a JS component.")
     void DispatchEvent(XAML_NAMESPACE.FrameworkElement view, String eventName, JSValueArgWriter eventDataArgWriter);


### PR DESCRIPTION
## Description

In #9658 we created a new attached property to store react tags on XAML elements, but put ABI accessors on the XamlUIService, which is attached to a specific ReactContext.

However, these accessors are static and don't need a ReactContext, and in fact there are plenty of places (like RNX serialization) where we don't have (or need) a ReactContext.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
Fix a mistake in #9658.

### What
Moves the new ABI surface into XamHelper, which contains static methods.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10485)