### PR TITLE
Make AddTurboModule a non-experimental API

### DIFF
--- a/change/react-native-windows-e21dad36-9fab-4c18-b6ea-440dc068dc72.json
+++ b/change/react-native-windows-e21dad36-9fab-4c18-b6ea-440dc068dc72.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make AddTurboModule a non-experimental API",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
+++ b/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
@@ -7,9 +7,12 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::integrationtest::implementation {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  // We do not use TurboModules for the TestModule, since the integration tests are specifically targetting NativeModules NOT TurboModules
-  // Ex: https://github.com/facebook/react-native/blob/153aedce413ef73f5e026abdfcf1346a37cec219/IntegrationTests/AppEventsTest.js#L16
-  AddAttributedModules(packageBuilder, false); 
+  // We do not use TurboModules for the TestModule, since the integration tests are specifically targetting
+  // NativeModules NOT TurboModules.
+  //
+  // See here for an example usage of NativeModules.TestModule:
+  // https://github.com/facebook/react-native/blob/153aedce413ef73f5e026abdfcf1346a37cec219/IntegrationTests/AppEventsTest.js#L16
+  AddAttributedModules(packageBuilder, false);
 }
 
 } // namespace winrt::integrationtest::implementation

--- a/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
+++ b/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
@@ -7,7 +7,9 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::integrationtest::implementation {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  AddAttributedModules(packageBuilder, true);
+  // We do not use TurboModules for the TestModule, since the integration tests are specifically targetting NativeModules NOT TurboModules
+  // Ex: https://github.com/facebook/react-native/blob/153aedce413ef73f5e026abdfcf1346a37cec219/IntegrationTests/AppEventsTest.js#L16
+  AddAttributedModules(packageBuilder, false); 
 }
 
 } // namespace winrt::integrationtest::implementation

--- a/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
+++ b/packages/integration-test-app/windows/integrationtest/ReactPackageProvider.cpp
@@ -7,7 +7,7 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::integrationtest::implementation {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  AddAttributedModules(packageBuilder);
+  AddAttributedModules(packageBuilder, true);
 }
 
 } // namespace winrt::integrationtest::implementation

--- a/packages/playground/CoreApp/App.cpp
+++ b/packages/playground/CoreApp/App.cpp
@@ -28,7 +28,7 @@ struct LogBox {
 struct ThisAppPackageProvider
     : winrt::implements<ThisAppPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
   void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept {
-    winrt::Microsoft::ReactNative::AddAttributedModules(packageBuilder);
+    winrt::Microsoft::ReactNative::AddAttributedModules(packageBuilder, true);
   }
 };
 

--- a/packages/playground/windows/playground/ReactPackageProvider.cpp
+++ b/packages/playground/windows/playground/ReactPackageProvider.cpp
@@ -10,7 +10,7 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::playground::implementation {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  AddAttributedModules(packageBuilder);
+  AddAttributedModules(packageBuilder, true);
 }
 
 } // namespace winrt::playground::implementation

--- a/packages/sample-apps/index.windows.js
+++ b/packages/sample-apps/index.windows.js
@@ -16,15 +16,18 @@ import {
   Linking,
 } from 'react-native';
 
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeEventEmitter, TurboModuleRegistry } from 'react-native';
 
 import {MyComp} from './myComp';
 
 import {default as MyModule} from './NativeMyModule';
 
+const SampleModuleCS = TurboModuleRegistry.get('SampleModuleCS');
+const SampleModuleCpp = TurboModuleRegistry.get('SampleModuleCpp');
+
 // Creating event emitters
-const SampleModuleCSEmitter = new NativeEventEmitter(NativeModules.SampleModuleCS);
-const SampleModuleCppEmitter = new NativeEventEmitter(NativeModules.SampleModuleCpp);
+const SampleModuleCSEmitter = new NativeEventEmitter(SampleModuleCS);
+const SampleModuleCppEmitter = new NativeEventEmitter(SampleModuleCpp);
 
 const CustomUserControlCS = requireNativeComponent('CustomUserControlCS');
 const CustomUserControlCpp = requireNativeComponent('CustomUserControlCpp');
@@ -34,7 +37,7 @@ const CircleCpp = requireNativeComponent('CircleCpp');
 
 var log = function(result) {
   console.log(result);
-  NativeModules.DebugConsole.Log('' + result);
+  TurboModuleRegistry.get('DebugConsole').Log('' + result);
 };
 
 var getCallback = function(prefix) {
@@ -117,98 +120,98 @@ class SampleApp extends Component {
 
     // SampleModuleCS constants
 
-    log(`SampleModuleCS.NumberConstant: ${NativeModules.SampleModuleCS.NumberConstant}`);
-    log(`SampleModuleCS.StringConstant: ${NativeModules.SampleModuleCS.StringConstant}`);
+    log(`SampleModuleCS.NumberConstant: ${SampleModuleCS.NumberConstant}`);
+    log(`SampleModuleCS.StringConstant: ${SampleModuleCS.StringConstant}`);
 
-    log(`SampleModuleCS.NumberConstantViaProvider: ${NativeModules.SampleModuleCS.NumberConstantViaProvider}`);
-    log(`SampleModuleCS.StringConstantViaProvider: ${NativeModules.SampleModuleCS.StringConstantViaProvider}`);
+    log(`SampleModuleCS.NumberConstantViaProvider: ${SampleModuleCS.NumberConstantViaProvider}`);
+    log(`SampleModuleCS.StringConstantViaProvider: ${SampleModuleCS.StringConstantViaProvider}`);
 
     // SampleModuleCS method calls
 
-    NativeModules.SampleModuleCS.VoidMethod();
+    SampleModuleCS.VoidMethod();
 
-    NativeModules.SampleModuleCS.VoidMethodWithArgs(numberArg);
+    SampleModuleCS.VoidMethodWithArgs(numberArg);
 
-    NativeModules.SampleModuleCS.ReturnMethod(getCallback('SampleModuleCS.ReturnMethod => '));
+    SampleModuleCS.ReturnMethod(getCallback('SampleModuleCS.ReturnMethod => '));
 
-    NativeModules.SampleModuleCS.ReturnMethodWithArgs(numberArg, getCallback('SampleModuleCS.ReturnMethodWithArgs => '));
+    SampleModuleCS.ReturnMethodWithArgs(numberArg, getCallback('SampleModuleCS.ReturnMethodWithArgs => '));
 
-    NativeModules.SampleModuleCS.ExplicitCallbackMethod(getCallback('SampleModuleCS.ExplicitCallbackMethod => '));
+    SampleModuleCS.ExplicitCallbackMethod(getCallback('SampleModuleCS.ExplicitCallbackMethod => '));
 
-    NativeModules.SampleModuleCS.ExplicitCallbackMethodWithArgs(numberArg, getCallback('SampleModuleCS.ExplicitCallbackMethodWithArgs => '));
+    SampleModuleCS.ExplicitCallbackMethodWithArgs(numberArg, getCallback('SampleModuleCS.ExplicitCallbackMethodWithArgs => '));
 
-    NativeModules.SampleModuleCS.TwoCallbacksMethod(/*shouldSucceed:*/true,
+    SampleModuleCS.TwoCallbacksMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCS.TwoCallbacksMethod success => '),
       getCallback('SampleModuleCS.TwoCallbacksMethod fail => '));
 
-    NativeModules.SampleModuleCS.TwoCallbacksMethod(/*shouldSucceed:*/false,
+    SampleModuleCS.TwoCallbacksMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCS.TwoCallbacksMethod success => '),
       getCallback('SampleModuleCS.TwoCallbacksMethod fail => '));
 
-    NativeModules.SampleModuleCS.TwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
+    SampleModuleCS.TwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCS.TwoCallbacksAsyncMethod success => '),
       getCallback('SampleModuleCS.TwoCallbacksAsyncMethod fail => '));
 
-    NativeModules.SampleModuleCS.TwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
+    SampleModuleCS.TwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCS.TwoCallbacksAsyncMethod success => '),
       getCallback('SampleModuleCS.TwoCallbacksAsyncMethod fail => '));
 
-    NativeModules.SampleModuleCS.ReverseTwoCallbacksMethod(/*shouldSucceed:*/true,
+    SampleModuleCS.ReverseTwoCallbacksMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCS.ReverseTwoCallbacksMethod fail => '),
       getCallback('SampleModuleCS.ReverseTwoCallbacksMethod success => '));
 
-    NativeModules.SampleModuleCS.ReverseTwoCallbacksMethod(/*shouldSucceed:*/false,
+    SampleModuleCS.ReverseTwoCallbacksMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCS.ReverseTwoCallbacksMethod fail => '),
       getCallback('SampleModuleCS.ReverseTwoCallbacksMethod success => '));
 
-    NativeModules.SampleModuleCS.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
+    SampleModuleCS.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCS.ReverseTwoCallbacksAsyncMethod fail => '),
       getCallback('SampleModuleCS.ReverseTwoCallbacksAsyncMethod success => '));
 
-    NativeModules.SampleModuleCS.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
+    SampleModuleCS.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCS.ReverseTwoCallbacksAsyncMethod fail => '),
       getCallback('SampleModuleCS.ReverseTwoCallbacksAsyncMethod success => '));
 
-    var promise1 = NativeModules.SampleModuleCS.ExplicitPromiseMethod();
+    var promise1 = SampleModuleCS.ExplicitPromiseMethod();
     promise1.then(getCallback('SampleModuleCS.ExplicitPromiseMethod then => ')).catch(getErrorCallback('SampleModuleCS.ExplicitPromiseMethod catch => '));
 
-    var promise2 = NativeModules.SampleModuleCS.ExplicitPromiseMethodWithArgs(numberArg);
+    var promise2 = SampleModuleCS.ExplicitPromiseMethodWithArgs(numberArg);
     promise2.then(getCallback('SampleModuleCS.ExplicitPromiseMethodWithArgs then => ')).catch(getErrorCallback('SampleModuleCS.ExplicitPromiseMethodWithArgs catch => '));
 
-    var promise3 = NativeModules.SampleModuleCS.NegateAsyncPromise(5);
+    var promise3 = SampleModuleCS.NegateAsyncPromise(5);
     promise3.then(getCallback('SampleModuleCS.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCS.NegateAsyncPromise catch => '));
 
-    var promise4 = NativeModules.SampleModuleCS.NegateAsyncPromise(-5);
+    var promise4 = SampleModuleCS.NegateAsyncPromise(-5);
     promise4.then(getCallback('SampleModuleCS.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCS.NegateAsyncPromise catch => '));
 
-    NativeModules.SampleModuleCS.callDistanceFunction({x: 22, y: 23}, {x: 55, y: 65});
+    SampleModuleCS.callDistanceFunction({x: 22, y: 23}, {x: 55, y: 65});
 
-    NativeModules.SampleModuleCS.TaskNoArgs()
+    SampleModuleCS.TaskNoArgs()
       .then(getCallback('SampleModuleCS.TaskNoArgs then => '))
       .catch(getErrorCallback('SampleModuleCS.TaskNoArgs catch => '));
 
-    NativeModules.SampleModuleCS.TaskTwoArgs(11, 200)
+    SampleModuleCS.TaskTwoArgs(11, 200)
       .then(getCallback('SampleModuleCS.TaskTwoArgs then => '))
       .catch(getErrorCallback('SampleModuleCS.TaskTwoArgs catch => '));
 
-    NativeModules.SampleModuleCS.TaskOfTNoArgs()
+    SampleModuleCS.TaskOfTNoArgs()
       .then(getCallback('SampleModuleCS.TaskOfTNoArgs then => '))
       .catch(getErrorCallback('SampleModuleCS.TaskOfTNoArgs catch => '));
 
-    NativeModules.SampleModuleCS.TaskOfTTwoArgs(11, 200)
+    SampleModuleCS.TaskOfTTwoArgs(11, 200)
       .then(getCallback('SampleModuleCS.TaskOfTTwoArgs then => '))
       .catch(getErrorCallback('SampleModuleCS.TaskOfTTwoArgs catch => '));
 
-    NativeModules.SampleModuleCS.EmitJSEvent1(43);
-    NativeModules.SampleModuleCS.EmitJSEvent2(8, 52);
-    NativeModules.SampleModuleCS.EmitJSEvent3(15, 79);
-    NativeModules.SampleModuleCS.EmitJSEventArg0();
-    NativeModules.SampleModuleCS.EmitJSEventArg1(7);
-    NativeModules.SampleModuleCS.EmitJSEventArg2(42, 15);
+    SampleModuleCS.EmitJSEvent1(43);
+    SampleModuleCS.EmitJSEvent2(8, 52);
+    SampleModuleCS.EmitJSEvent3(15, 79);
+    SampleModuleCS.EmitJSEventArg0();
+    SampleModuleCS.EmitJSEventArg1(7);
+    SampleModuleCS.EmitJSEventArg2(42, 15);
 
     //TODO: make sync method accessible only in non-web debugger scenarios
-    //log('SampleModuleCS.SyncReturnMethod => ' + NativeModules.SampleModuleCS.SyncReturnMethod());
-    //log('SampleModuleCS.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCS.SyncReturnMethodWithArgs(numberArg));
+    //log('SampleModuleCS.SyncReturnMethod => ' + SampleModuleCS.SyncReturnMethod());
+    //log('SampleModuleCS.SyncReturnMethodWithArgs => ' + SampleModuleCS.SyncReturnMethodWithArgs(numberArg));
   }
 
   onPressSampleModuleCpp() {
@@ -218,82 +221,82 @@ class SampleApp extends Component {
 
     // SampleModuleCpp constants
 
-    log(`SampleModuleCpp.NumberConstant: ${NativeModules.SampleModuleCpp.NumberConstant}`);
-    log(`SampleModuleCpp.StringConstant: ${NativeModules.SampleModuleCpp.StringConstant}`);
+    log(`SampleModuleCpp.NumberConstant: ${SampleModuleCpp.NumberConstant}`);
+    log(`SampleModuleCpp.StringConstant: ${SampleModuleCpp.StringConstant}`);
 
-    log(`SampleModuleCpp.NumberConstantViaProvider: ${NativeModules.SampleModuleCpp.NumberConstantViaProvider}`);
-    log(`SampleModuleCpp.StringConstantViaProvider: ${NativeModules.SampleModuleCpp.StringConstantViaProvider}`);
+    log(`SampleModuleCpp.NumberConstantViaProvider: ${SampleModuleCpp.NumberConstantViaProvider}`);
+    log(`SampleModuleCpp.StringConstantViaProvider: ${SampleModuleCpp.StringConstantViaProvider}`);
 
     // SampleModuleCpp method calls
 
-    NativeModules.SampleModuleCpp.VoidMethod();
+    SampleModuleCpp.VoidMethod();
 
-    NativeModules.SampleModuleCpp.VoidMethodWithArgs(numberArg);
+    SampleModuleCpp.VoidMethodWithArgs(numberArg);
 
-    NativeModules.SampleModuleCpp.ReturnMethod(getCallback('SampleModuleCpp.ReturnMethod => '));
+    SampleModuleCpp.ReturnMethod(getCallback('SampleModuleCpp.ReturnMethod => '));
 
-    NativeModules.SampleModuleCpp.ReturnMethodWithArgs(numberArg, getCallback('SampleModuleCpp.ReturnMethodWithArgs => '));
+    SampleModuleCpp.ReturnMethodWithArgs(numberArg, getCallback('SampleModuleCpp.ReturnMethodWithArgs => '));
 
-    NativeModules.SampleModuleCpp.ExplicitCallbackMethod(getCallback('SampleModuleCpp.ExplicitCallbackMethod => '));
+    SampleModuleCpp.ExplicitCallbackMethod(getCallback('SampleModuleCpp.ExplicitCallbackMethod => '));
 
-    NativeModules.SampleModuleCpp.ExplicitCallbackMethodWithArgs(numberArg, getCallback('SampleModuleCpp.ExplicitCallbackMethodWithArgs => '));
+    SampleModuleCpp.ExplicitCallbackMethodWithArgs(numberArg, getCallback('SampleModuleCpp.ExplicitCallbackMethodWithArgs => '));
 
-    NativeModules.SampleModuleCpp.TwoCallbacksMethod(/*shouldSucceed:*/true,
+    SampleModuleCpp.TwoCallbacksMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCpp.TwoCallbacksMethod success => '),
       getCallback('SampleModuleCpp.TwoCallbacksMethod fail => '));
 
-    NativeModules.SampleModuleCpp.TwoCallbacksMethod(/*shouldSucceed:*/false,
+    SampleModuleCpp.TwoCallbacksMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCpp.TwoCallbacksMethod success => '),
       getCallback('SampleModuleCpp.TwoCallbacksMethod fail => '));
 
-    NativeModules.SampleModuleCpp.TwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
+    SampleModuleCpp.TwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCpp.TwoCallbacksAsyncMethod success => '),
       getCallback('SampleModuleCpp.TwoCallbacksAsyncMethod fail => '));
 
-    NativeModules.SampleModuleCpp.TwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
+    SampleModuleCpp.TwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCpp.TwoCallbacksAsyncMethod success => '),
       getCallback('SampleModuleCpp.TwoCallbacksAsyncMethod fail => '));
 
-    NativeModules.SampleModuleCpp.ReverseTwoCallbacksMethod(/*shouldSucceed:*/true,
+    SampleModuleCpp.ReverseTwoCallbacksMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCpp.ReverseTwoCallbacksMethod fail => '),
       getCallback('SampleModuleCpp.ReverseTwoCallbacksMethod success => '));
 
-    NativeModules.SampleModuleCpp.ReverseTwoCallbacksMethod(/*shouldSucceed:*/false,
+    SampleModuleCpp.ReverseTwoCallbacksMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCpp.ReverseTwoCallbacksMethod fail => '),
       getCallback('SampleModuleCpp.ReverseTwoCallbacksMethod success => '));
 
-    NativeModules.SampleModuleCpp.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
+    SampleModuleCpp.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/true,
       getCallback('SampleModuleCpp.ReverseTwoCallbacksAsyncMethod fail => '),
       getCallback('SampleModuleCpp.ReverseTwoCallbacksAsyncMethod success => '));
 
-    NativeModules.SampleModuleCpp.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
+    SampleModuleCpp.ReverseTwoCallbacksAsyncMethod(/*shouldSucceed:*/false,
       getCallback('SampleModuleCpp.ReverseTwoCallbacksAsyncMethod fail => '),
       getCallback('SampleModuleCpp.ReverseTwoCallbacksAsyncMethod success => '));
 
-    var promise1 = NativeModules.SampleModuleCpp.ExplicitPromiseMethod();
+    var promise1 = SampleModuleCpp.ExplicitPromiseMethod();
     promise1.then(getCallback('SampleModuleCpp.ExplicitPromiseMethod then => ')).catch(getErrorCallback('SampleModuleCpp.ExplicitPromiseMethod catch => '));
 
-    var promise2 = NativeModules.SampleModuleCpp.ExplicitPromiseMethodWithArgs(numberArg);
+    var promise2 = SampleModuleCpp.ExplicitPromiseMethodWithArgs(numberArg);
     promise2.then(getCallback('SampleModuleCpp.ExplicitPromiseMethodWithArgs then => ')).catch(getErrorCallback('SampleModuleCpp.ExplicitPromiseMethodWithArgs catch => '));
 
-    var promise3 = NativeModules.SampleModuleCpp.NegateAsyncPromise(5);
+    var promise3 = SampleModuleCpp.NegateAsyncPromise(5);
     promise3.then(getCallback('SampleModuleCpp.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCpp.NegateAsyncPromise catch => '));
 
-    var promise4 = NativeModules.SampleModuleCpp.NegateAsyncPromise(-5);
+    var promise4 = SampleModuleCpp.NegateAsyncPromise(-5);
     promise4.then(getCallback('SampleModuleCpp.NegateAsyncPromise then => ')).catch(getErrorCallback('SampleModuleCpp.NegateAsyncPromise catch => '));
 
-    NativeModules.SampleModuleCpp.callDistanceFunction({x: 2, y: 3}, {x: 5, y: 6});
+    SampleModuleCpp.callDistanceFunction({x: 2, y: 3}, {x: 5, y: 6});
 
-    NativeModules.SampleModuleCpp.EmitJSEvent1(42);
-    NativeModules.SampleModuleCpp.EmitJSEvent2(7, 51);
-    NativeModules.SampleModuleCpp.EmitJSEvent3(14, 78);
-    NativeModules.SampleModuleCpp.EmitJSEventArg0();
-    NativeModules.SampleModuleCpp.EmitJSEventArg1(7);
-    NativeModules.SampleModuleCpp.EmitJSEventArg2(42, 15);
+    SampleModuleCpp.EmitJSEvent1(42);
+    SampleModuleCpp.EmitJSEvent2(7, 51);
+    SampleModuleCpp.EmitJSEvent3(14, 78);
+    SampleModuleCpp.EmitJSEventArg0();
+    SampleModuleCpp.EmitJSEventArg1(7);
+    SampleModuleCpp.EmitJSEventArg2(42, 15);
 
     //TODO: make sync method accessible only in non-web debugger scenarios
-    //log('SampleModuleCpp.SyncReturnMethod => ' + NativeModules.SampleModuleCpp.SyncReturnMethod());
-    //log('SampleModuleCpp.SyncReturnMethodWithArgs => ' + NativeModules.SampleModuleCpp.SyncReturnMethodWithArgs(numberArg));
+    //log('SampleModuleCpp.SyncReturnMethod => ' + SampleModuleCpp.SyncReturnMethod());
+    //log('SampleModuleCpp.SyncReturnMethodWithArgs => ' + SampleModuleCpp.SyncReturnMethodWithArgs(numberArg));
   }
 
   onPressCustomUserControlCS() {
@@ -334,12 +337,12 @@ class SampleApp extends Component {
 
   onReloadSampleModuleCS() {
     log('SampleApp.onReloadSampleModuleCS()');
-    NativeModules.SampleModuleCS.ReloadInstance();
+    SampleModuleCS.ReloadInstance();
   }
 
   onReloadSampleModuleCpp() {
     log('SampleApp.onReloadSampleModuleCpp()');
-    NativeModules.SampleModuleCpp.ReloadInstance();
+    SampleModuleCpp.ReloadInstance();
   }
 
   render() {
@@ -356,8 +359,8 @@ class SampleApp extends Component {
 
         <Button onPress={() => { MyModule.voidFunc(); }} title="Call MyModule tests"/>
 
-        <Button onPress={() => { this.onPressSampleModuleCS(); }} title="Call SampleModuleCS!" disabled={NativeModules.SampleModuleCS == null} />
-        <Button onPress={() => { this.onPressSampleModuleCpp(); }} title="Call SampleModuleCpp!" disabled={NativeModules.SampleModuleCpp == null} />
+        <Button onPress={() => { this.onPressSampleModuleCS(); }} title="Call SampleModuleCS!" disabled={SampleModuleCS == null} />
+        <Button onPress={() => { this.onPressSampleModuleCpp(); }} title="Call SampleModuleCpp!" disabled={SampleModuleCpp == null} />
 
         <CustomUserControlCS style={styles.customcontrol} label="CustomUserControlCS!" ref={(ref) => { this._CustomUserControlCSRef = ref; }} onLabelChanged={(evt) => { this.onLabelChangedCustomUserControlCS(evt); }} />
         <Button onPress={() => { this.onPressCustomUserControlCS(); }} title="Call CustomUserControlCS Commands!" />
@@ -365,8 +368,8 @@ class SampleApp extends Component {
         <CustomUserControlCpp style={styles.customcontrol} label="CustomUserControlCpp!" ref={(ref) => { this._CustomUserControlCppRef = ref; }} onLabelChanged={(evt) => { this.onLabelChangedCustomUserControlCpp(evt); }} />
         <Button onPress={() => { this.onPressCustomUserControlCpp(); }} title="Call CustomUserControlCpp Commands!" />
 
-        <Button onPress={() => { this.onReloadSampleModuleCS(); }} title="Reload from SampleModuleCS" disabled={NativeModules.SampleModuleCS == null} />
-        <Button onPress={() => { this.onReloadSampleModuleCpp(); }} title="Reload from SampleModuleCpp" disabled={NativeModules.SampleModuleCpp == null} />
+        <Button onPress={() => { this.onReloadSampleModuleCS(); }} title="Reload from SampleModuleCS" disabled={SampleModuleCS == null} />
+        <Button onPress={() => { this.onReloadSampleModuleCpp(); }} title="Reload from SampleModuleCpp" disabled={SampleModuleCpp == null} />
 
         <CircleCS style={styles.circle}>
           <View style={styles.box}>

--- a/packages/sample-apps/index.windows.js
+++ b/packages/sample-apps/index.windows.js
@@ -59,14 +59,14 @@ var getErrorCallback = function(prefix) {
 };
 
 // To demo JS function calls we define a class and then register it as a callable module
-class SampleModuleCpp {
+class SampleModuleCppModule {
   calcDistance(point1, point2) {
     log('SampleApp.calcDistance()');
     const distance = Math.hypot(point1.x - point2.x, point1.y - point2.y);
     log(`Distance between (${point1.x}, ${point1.y}) and (${point2.x}, ${point2.y}) is ${distance}`);
   }
 }
-global.__fbBatchedBridge.registerLazyCallableModule('SampleModuleCpp', () => new SampleModuleCpp());
+global.__fbBatchedBridge.registerLazyCallableModule('SampleModuleCpp', () => new SampleModuleCppModule());
 
 class SampleApp extends Component {
   componentDidMount() {

--- a/packages/sample-apps/windows/SampleAppCPP/ReactPackageProvider.cpp
+++ b/packages/sample-apps/windows/SampleAppCPP/ReactPackageProvider.cpp
@@ -15,7 +15,7 @@ namespace winrt::SampleAppCpp::implementation {
 //===========================================================================
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  AddAttributedModules(packageBuilder);
+  AddAttributedModules(packageBuilder, true);
 }
 
 } // namespace winrt::SampleAppCpp::implementation

--- a/packages/sample-apps/windows/SampleLibraryCPP/ReactPackageProvider.cpp
+++ b/packages/sample-apps/windows/SampleLibraryCPP/ReactPackageProvider.cpp
@@ -18,7 +18,7 @@ using namespace winrt::Microsoft::ReactNative;
 namespace winrt::SampleLibraryCpp::implementation {
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-  AddAttributedModules(packageBuilder);
+  AddAttributedModules(packageBuilder, true);
 
   packageBuilder.AddModule(L"MyModule", MakeTurboModuleProvider<::SampleLibraryCpp::MyModule>());
   packageBuilder.AddViewManager(

--- a/vnext/Desktop/ABI/TestController.cpp
+++ b/vnext/Desktop/ABI/TestController.cpp
@@ -91,7 +91,7 @@ msrn::IReactModuleBuilder TestController::CreateReactModuleBuilder(msrn::IReactC
 msrn::IReactPackageBuilder TestController::CreateReactPackageBuilder() {
   auto nativeModulesProvider = std::make_shared<msrn::NativeModulesProvider>();
   auto turboModulesProvider = std::make_shared<msrn::TurboModulesProvider>();
-  return make<msrn::ReactPackageBuilder>(nativeModulesProvider, turboModulesProvider);
+  return make<msrn::ReactPackageBuilder>(nativeModulesProvider, turboModulesProvider, true);
 }
 
 msrn::IRedBoxErrorFrameInfo

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.cpp
@@ -15,16 +15,26 @@ ModuleRegistration::ModuleRegistration(wchar_t const *moduleName) noexcept : m_m
   s_head = this;
 }
 
-void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept {
+void AddAttributedModules(IReactPackageBuilder const &packageBuilder, bool useTurboModules) noexcept {
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
-    packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
+    if (useTurboModules)
+      packageBuilder.AddTurboModule(reg->ModuleName(), reg->MakeModuleProvider());
+    else
+      packageBuilder.AddModule(reg->ModuleName(), reg->MakeModuleProvider());
   }
 }
 
-bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept {
+bool TryAddAttributedModule(
+    IReactPackageBuilder const &packageBuilder,
+    std::wstring_view moduleName,
+    bool useTurboModule) noexcept {
   for (auto const *reg = ModuleRegistration::Head(); reg != nullptr; reg = reg->Next()) {
     if (moduleName == reg->ModuleName()) {
-      packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());
+      if (useTurboModule) {
+        packageBuilder.AddTurboModule(moduleName, reg->MakeModuleProvider());
+      } else {
+        packageBuilder.AddModule(moduleName, reg->MakeModuleProvider());
+      }
       return true;
     }
   }

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -100,8 +100,11 @@ struct ModuleRegistration {
   static const ModuleRegistration *s_head;
 };
 
-void AddAttributedModules(IReactPackageBuilder const &packageBuilder) noexcept;
+void AddAttributedModules(IReactPackageBuilder const &packageBuilder, bool useTurboModules = false) noexcept;
 
-bool TryAddAttributedModule(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) noexcept;
+bool TryAddAttributedModule(
+    IReactPackageBuilder const &packageBuilder,
+    std::wstring_view moduleName,
+    bool useTurboModules = false) noexcept;
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
@@ -17,8 +17,7 @@ template <
     typename TTurboModule,
     std::enable_if_t<std::is_base_of_v<::facebook::react::TurboModule, TTurboModule>, int> = 0>
 void AddTurboModuleProvider(IReactPackageBuilder const &packageBuilder, std::wstring_view moduleName) {
-  auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
-  experimental.AddTurboModule(
+  packageBuilder.AddTurboModule(
       moduleName, [](IReactModuleBuilder const &moduleBuilder) noexcept -> winrt::Windows::Foundation::IInspectable {
         IJsiHostObject abiTurboModule{nullptr};
         // We expect the initializer to be called immediately for TurboModules

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactNativeHostTests.js
@@ -1,15 +1,15 @@
-import { NativeModules } from 'react-native';
+import { TurboModuleRegistry } from 'react-native';
 
 class TestHostModuleFunctions {
     addValues(a, b) {
-        NativeModules.TestHostModule.returnResult(a + b);
+      TurboModuleRegistry.get('TestHostModule').returnResult(a + b);
     }
 }
 
 // Accessing TestHostModule has a side effect of initializing global.__fbBatchedBridge
-if (NativeModules.TestHostModule) {
+if (TurboModuleRegistry.get('TestHostModule')) {
   global.__fbBatchedBridge.registerLazyCallableModule('TestHostModuleFunctions', () => new TestHostModuleFunctions());
 
   // Start running tests.
-  NativeModules.TestHostModule.startTests();
+  TurboModuleRegistry.get('TestHostModule').startTests();
 }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -551,8 +551,7 @@ struct CppTurboModule {
 
 struct CppTurboModulePackageProvider : winrt::implements<CppTurboModulePackageProvider, IReactPackageProvider> {
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
-    auto experimental = packageBuilder.as<IReactPackageBuilderExperimental>();
-    experimental.AddTurboModule(L"CppTurboModule", MakeTurboModuleProvider<CppTurboModule>());
+    packageBuilder.AddTurboModule(L"CppTurboModule", MakeTurboModuleProvider<CppTurboModule>());
   }
 };
 

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -26,18 +26,15 @@ namespace Microsoft.ReactNative
     DOC_STRING("Adds a custom native module. See @ReactModuleProvider.")
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
 
+    DOC_STRING("Adds a custom native module. See @ReactModuleProvider. This will register the"
+    "module as a TurboModule unless the application is running using WebDebbugging, in which"
+    "case it will revert to a legacy NativeModule.\n"
+    "NOTE: TurboModules using JSI directly will not run correctly while using WebDebugging")
+    void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
+
 #ifndef CORE_ABI
     DOC_STRING("Adds a custom view manager. See @ReactViewManagerProvider.")
     void AddViewManager(String viewManagerName, ReactViewManagerProvider viewManagerProvider);
 #endif
-  }
-
-  [webhosthidden]
-  [experimental]
-  DOC_STRING("Experimental extensions to the @IReactPackageBuilder.")
-  interface IReactPackageBuilderExperimental requires IReactPackageBuilder
-  {
-    DOC_STRING("Adds a custom TurboModule that directly uses the JS Engine API (JSI).")
-    void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactPackageBuilder.idl
@@ -27,9 +27,9 @@ namespace Microsoft.ReactNative
     void AddModule(String moduleName, ReactModuleProvider moduleProvider);
 
     DOC_STRING("Adds a custom native module. See @ReactModuleProvider. This will register the"
-    "module as a TurboModule unless the application is running using WebDebbugging, in which"
-    "case it will revert to a legacy NativeModule.\n"
-    "NOTE: TurboModules using JSI directly will not run correctly while using WebDebugging")
+    "module as a TurboModule unless the application is running using @ReactInstanceSettings.UseWebDebugger,"
+    "in which case it will revert to a legacy NativeModule.\n"
+    "NOTE: TurboModules using JSI directly will not run correctly while using @ReactInstanceSettings.UseWebDebugger")
     void AddTurboModule(String moduleName, ReactModuleProvider moduleProvider);
 
 #ifndef CORE_ABI

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -92,7 +92,8 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
 #ifndef CORE_ABI
       viewManagersProvider,
 #endif
-      turboModulesProvider);
+      turboModulesProvider,
+      m_instanceSettings.UseWebDebugger());
 
   if (auto packageProviders = InstanceSettings().PackageProviders()) {
     for (auto const &packageProvider : packageProviders) {

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.cpp
@@ -15,12 +15,14 @@ ReactPackageBuilder::ReactPackageBuilder(
 #ifndef CORE_ABI
     std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
 #endif
-    std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept
+    std::shared_ptr<TurboModulesProvider> const &turboModulesProvider,
+    bool isWebDebugging) noexcept
     : m_modulesProvider{modulesProvider},
 #ifndef CORE_ABI
       m_viewManagersProvider{viewManagersProvider},
 #endif
-      m_turboModulesProvider{turboModulesProvider} {
+      m_turboModulesProvider{turboModulesProvider},
+      m_isWebDebugging{isWebDebugging} {
 }
 
 void ReactPackageBuilder::AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept {
@@ -38,7 +40,10 @@ void ReactPackageBuilder::AddViewManager(
 void ReactPackageBuilder::AddTurboModule(
     hstring const &moduleName,
     ReactModuleProvider const &moduleProvider) noexcept {
-  m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
+  if (m_isWebDebugging)
+    m_modulesProvider->AddModuleProvider(moduleName, moduleProvider);
+  else
+    m_turboModulesProvider->AddModuleProvider(moduleName, moduleProvider, true);
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -18,7 +18,7 @@ struct ReactPackageBuilder : winrt::implements<ReactPackageBuilder, IReactPackag
       std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
 #endif
       std::shared_ptr<TurboModulesProvider> const &turboModulesProvider,
-      bool useTurboModulesByDefault) noexcept;
+      bool isWebDebugging) noexcept;
 
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;

--- a/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
+++ b/vnext/Microsoft.ReactNative/ReactPackageBuilder.h
@@ -11,14 +11,14 @@
 
 namespace winrt::Microsoft::ReactNative {
 
-struct ReactPackageBuilder
-    : winrt::implements<ReactPackageBuilder, IReactPackageBuilder, IReactPackageBuilderExperimental> {
+struct ReactPackageBuilder : winrt::implements<ReactPackageBuilder, IReactPackageBuilder> {
   ReactPackageBuilder(
       std::shared_ptr<NativeModulesProvider> const &modulesProvider,
 #ifndef CORE_ABI
       std::shared_ptr<ViewManagersProvider> const &viewManagersProvider,
 #endif
-      std::shared_ptr<TurboModulesProvider> const &turboModulesProvider) noexcept;
+      std::shared_ptr<TurboModulesProvider> const &turboModulesProvider,
+      bool useTurboModulesByDefault) noexcept;
 
  public: // IReactPackageBuilder
   void AddModule(hstring const &moduleName, ReactModuleProvider const &moduleProvider) noexcept;
@@ -33,6 +33,7 @@ struct ReactPackageBuilder
   std::shared_ptr<ViewManagersProvider> m_viewManagersProvider;
 #endif
   std::shared_ptr<TurboModulesProvider> m_turboModulesProvider;
+  const bool m_isWebDebugging;
 };
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/template/cpp-app/src/ReactPackageProvider.cpp
+++ b/vnext/template/cpp-app/src/ReactPackageProvider.cpp
@@ -9,7 +9,7 @@ namespace winrt::{{ namespaceCpp }}::implementation
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
 {
-    AddAttributedModules(packageBuilder);
+    AddAttributedModules(packageBuilder, true);
 }
 
 } // namespace winrt::{{ namespaceCpp }}::implementation

--- a/vnext/template/cpp-lib/src/ReactPackageProvider.cpp
+++ b/vnext/template/cpp-lib/src/ReactPackageProvider.cpp
@@ -13,7 +13,7 @@ namespace winrt::{{ namespaceCpp }}::implementation
 
 void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept
 {
-    AddAttributedModules(packageBuilder);
+    AddAttributedModules(packageBuilder, true);
 }
 
 } // namespace winrt::{{ namespaceCpp }}::implementation


### PR DESCRIPTION
## Description
We've had TurboModule support for a while, but its always involved using an experimental API.  Its also not been easy to use with `AddAttributedModules`.

This moves the current `AddTurboModule` api from `IReactPackageBuilderExperimental` to `IReactPackageBuilder` and adds an optional parameter to  `AddAttributedModules` which can be used to specify that the attributed modules should use TurboModules.

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Why
The new architecture is moving towards TurboModules, and this will enable much easier transition to TurboModules.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10489)