### PR TITLE
ReactImage: propagate error messages to JS

### DIFF
--- a/change/react-native-windows-68b9b820-27ca-4ff1-b24f-dd09ca290429.json
+++ b/change/react-native-windows-68b9b820-27ca-4ff1-b24f-dd09ca290429.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ReactImage: propagate error messages to JS",
+  "packageName": "react-native-windows",
+  "email": "ilit@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ImageViewManager.h
@@ -18,7 +18,11 @@ class ImageViewManager : public FrameworkElementViewManager {
       const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   ShadowNode *createShadow() const override;
-  void EmitImageEvent(xaml::Controls::Grid grid, const char *eventName, ReactImageSource &source);
+  void EmitImageEvent(
+      xaml::Controls::Grid grid,
+      const char *eventName,
+      ReactImageSource &source,
+      const winrt::hstring &errorMessage = L"");
   void SetLayoutProps(
       ShadowNodeBase &nodeToUpdate,
       const XamlView &viewToUpdate,

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -27,7 +27,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
   // Events
-  winrt::event_token OnLoadEnd(winrt::Windows::Foundation::EventHandler<bool> const &handler);
+  winrt::event_token OnLoadEnd(winrt::Windows::Foundation::EventHandler<winrt::hstring> const &handler);
   void OnLoadEnd(winrt::event_token const &token) noexcept;
 
   // Public Properties
@@ -63,7 +63,7 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   facebook::react::ImageResizeMode m_resizeMode{facebook::react::ImageResizeMode::Contain};
   winrt::Windows::UI::Color m_tintColor{winrt::Colors::Transparent()};
 
-  winrt::event<winrt::Windows::Foundation::EventHandler<bool>> m_onLoadEndEvent;
+  winrt::event<winrt::Windows::Foundation::EventHandler<winrt::hstring>> m_onLoadEndEvent;
   xaml::FrameworkElement::SizeChanged_revoker m_sizeChangedRevoker;
   xaml::Media::LoadedImageSurface::LoadCompleted_revoker m_surfaceLoadedRevoker;
   xaml::Media::Imaging::BitmapImage::ImageOpened_revoker m_bitmapImageOpened;


### PR DESCRIPTION
## Description
Enriches `nativeEvent` objects received on JS side in Image `onError` callback with error message.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves  #10491

### What
In place of a `bool` flag indicating success use `winrt::hstring` for event payload and populate it with the error message. Empty string (default) indicates success.
Using a string instead of a more descriptive structure to avoid creating a new RT type required by `winrt::EventHandler`.

## Testing
Compared Image page in RNTesterApp before and after the change.
Confirmed the only difference is ErrorHandler section now showing "Failed to load image (E_NETWORK_ERROR)" message.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10492)