### PR TITLE
Update E2E test app to use latest RNX

### DIFF
--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -20,7 +20,7 @@
     "react": "18.1.0",
     "react-native": "0.0.0-20220714-2051-8af7870c6",
     "react-native-windows": "^0.0.0-canary.545",
-    "react-native-xaml": "^0.0.63"
+    "react-native-xaml": "^0.0.67"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -20,7 +20,7 @@
     "react": "18.1.0",
     "react-native": "0.0.0-20220714-2051-8af7870c6",
     "react-native-windows": "^0.0.0-canary.545",
-    "react-native-xaml": "^0.0.67"
+    "react-native-xaml": "^0.0.68"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
+++ b/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
@@ -20,12 +20,6 @@
         "resolved": "2.7.0",
         "contentHash": "dB4im13tfmMgL/V3Ei+3kD2rUF+/lTxAmR4gjJ45l577eljHfdo/KUrxpq/3I1Vp6e5GCDG1evDaEGuDxypLMg=="
       },
-      "ReactNative.Hermes.Windows": {
-        "type": "Direct",
-        "requested": "[0.12.2, )",
-        "resolved": "0.12.2",
-        "contentHash": "S9AR5puBB7NXhJoBeDj3GBOOX2z3du5gxC/u7rtGb1NaFJxkBX+fEci80ywTT2SYNodticfIxen+FdD2NK4URg=="
-      },
       "XamlTreeDump": {
         "type": "Direct",
         "requested": "[1.0.9, )",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10243,10 +10243,10 @@ react-native-tscodegen@0.68.4:
     nullthrows "1.1.1"
     typescript "^4.1.5"
 
-react-native-xaml@^0.0.63:
-  version "0.0.63"
-  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.63.tgz#9f290faa65eea24077dcd5c95ef4777e7c3a9656"
-  integrity sha512-bkvwmruG26P07bbTs+JfQTubHUTKN36yQ/Zui6CFGKwgDK+4iXfhAIzi2GsloXlkdz2aArE+CofwMC2d1lmRTA==
+react-native-xaml@^0.0.67:
+  version "0.0.67"
+  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.67.tgz#0f93bd84d5e7b67094d4742d0568fceb23110ade"
+  integrity sha512-QQs3/ba9A7aWue99/FftdZ7y7G7nkex1+1WBjY40yv5ShsKW0Ztoh4+aPEgnFUBsbvudva9dO6hZ5CIzxL5/pg==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10243,10 +10243,10 @@ react-native-tscodegen@0.68.4:
     nullthrows "1.1.1"
     typescript "^4.1.5"
 
-react-native-xaml@^0.0.67:
-  version "0.0.67"
-  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.67.tgz#0f93bd84d5e7b67094d4742d0568fceb23110ade"
-  integrity sha512-QQs3/ba9A7aWue99/FftdZ7y7G7nkex1+1WBjY40yv5ShsKW0Ztoh4+aPEgnFUBsbvudva9dO6hZ5CIzxL5/pg==
+react-native-xaml@^0.0.68:
+  version "0.0.68"
+  resolved "https://registry.yarnpkg.com/react-native-xaml/-/react-native-xaml-0.0.68.tgz#f4690260e549f8394a02fad0458a1e0651b77a11"
+  integrity sha512-C28D4mhYe4tSESKb+S/FBUcUTD3LA7uZZdoN0H7JartTYVyNosx6hVcplsnC6a8dEDYm27bpcW4y/tdglC/aJA==
   dependencies:
     "@types/react" "*"
     "@types/react-native" "*"


### PR DESCRIPTION
## Description

This PR updates the E2E test app to use the latest RNX, which among other things uses the ReactTag APIs introduced in #10485.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Want to verify that RNX works with the new APIs and that E2E test passes.

### What
Version bump of RNX to 0.0.68.

## Screenshots

N/A

## Testing

Build and run E2Etest app locally

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10494)