### PR TITLE
Add `$schema` to `cgmanifest.json` codegen

### DIFF
--- a/change/react-native-windows-1f809f69-c2e9-49d5-bea5-706b281f03ff.json
+++ b/change/react-native-windows-1f809f69-c2e9-49d5-bea5-706b281f03ff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "\"Add `$schema` to `cgmanifest.json` codegen\"",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -291,6 +291,7 @@
   <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFolly" Inputs="$(FollyZipFile)" Outputs="$(CGManifestFile)">
     <PropertyGroup>
       <CGManifestText>{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
     "Registrations": [
         {
             "Component": {

--- a/vnext/Folly/cgmanifest.json
+++ b/vnext/Folly/cgmanifest.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
-  "Registrations": [
-    {
-      "Component": {
-        "Type": "git",
-        "Git": {
-          "RepositoryUrl": "https://github.com/facebook/folly",
-          "CommitHash": "4baba28200d7446c870e96f3cdbeb492f54625d0"
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "git",
+                "Git": {
+                  "RepositoryUrl": "https://github.com/facebook/folly",
+                  "CommitHash": "4baba28200d7446c870e96f3cdbeb492f54625d0"
+                }
+            },
+            "DevelopmentDependency": false
         }
-      },
-      "DevelopmentDependency": false
-    }
-  ]
+    ]
 }

--- a/vnext/fmt/cgmanifest.json
+++ b/vnext/fmt/cgmanifest.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
     "Registrations": [
         {
             "Component": {

--- a/vnext/fmt/fmt.vcxproj
+++ b/vnext/fmt/fmt.vcxproj
@@ -120,6 +120,7 @@
   <Target Name="WriteCGManifest" BeforeTargets="PrepareForBuild" DependsOnTargets="DownloadFmt" Inputs="$(FmtZipFile)" Outputs="$(CGManifestFile)">
     <PropertyGroup>
       <CGManifestText>{
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
     "Registrations": [
         {
             "Component": {


### PR DESCRIPTION
## Description

This PR correctly implements the fix attempted in #10474, by updating the code-gen of our `cgmanifest.json` files, rather than the output.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The change to add a `$schema` field to the `cgmanifest.json` files, while righteous, was applied to generated files, and to only one of those present in our repo. This means the changes will be lost during the next build.

### What

Updated and re-ran the code-gen to add the `$schema` field.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10495)