### PR TITLE
Remove unnecessary tree walk in Yoga layout

### DIFF
--- a/change/react-native-windows-6d3b83af-0fc7-4246-ac81-e7e058c82a3b.json
+++ b/change/react-native-windows-6d3b83af-0fc7-4246-ac81-e7e058c82a3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary tree walk in Yoga layout",
+  "packageName": "react-native-windows",
+  "email": "ericroz@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -876,26 +876,6 @@ void NativeUIManager::UpdateView(ShadowNode &shadowNode, winrt::Microsoft::React
   }
 }
 
-void NativeUIManager::UpdateExtraLayout(int64_t tag) {
-  // For nodes that are not self-measure, there may be styles applied that are
-  // applying padding. Here we make sure Yoga knows about that padding so yoga
-  // layout is aware of what rendering intends to do with it.  (net: buttons
-  // with padding shouldn't have clipped content anymore)
-  ShadowNodeBase *shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(tag));
-  if (shadowNode == nullptr)
-    return;
-
-  if (shadowNode->IsExternalLayoutDirty()) {
-    YGNodeRef yogaNode = GetYogaNode(tag);
-    if (yogaNode)
-      shadowNode->DoExtraLayoutPrep(yogaNode);
-  }
-
-  for (int64_t child : shadowNode->m_children) {
-    UpdateExtraLayout(child);
-  }
-}
-
 void NativeUIManager::DoLayout() {
   SystraceSection s("NativeUIManager::DoLayout");
 
@@ -916,11 +896,6 @@ void NativeUIManager::DoLayout() {
 
   auto &rootTags = m_host->GetAllRootTags();
   for (int64_t rootTag : rootTags) {
-    {
-      SystraceSection s("NativeUIManager::DoLayout::UpdateExtraLayout");
-      UpdateExtraLayout(rootTag);
-    }
-
     ShadowNodeBase &rootShadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(rootTag));
     if (YGNodeRef rootNode = GetYogaNode(rootTag)) {
       auto rootElement = rootShadowNode.GetView().as<xaml::FrameworkElement>();

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -102,7 +102,6 @@ class NativeUIManager final : public INativeUIManager {
  private:
   void DoLayout();
   void SetLayoutPropsRecursive(int64_t tag);
-  void UpdateExtraLayout(int64_t tag);
   YGNodeRef GetYogaNode(int64_t tag) const;
 
   winrt::weak_ref<winrt::Microsoft::ReactNative::ReactRootView> GetParentXamlReactControl(int64_t tag) const;

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -103,7 +103,6 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   virtual bool IsExternalLayoutDirty() const {
     return false;
   }
-  virtual void DoExtraLayoutPrep(YGNodeRef /*yogaNode*/) {}
 
   bool HasTransformPS() const {
     return m_transformPS != nullptr;


### PR DESCRIPTION
## Description

### Why
I believe this code is dead code that is no longer needed. It was originally introduced to apply Yoga paddings to ContentControlViewManager from the Polyester folder. However, since then, the approach to handling controls that implement their own padding has changed.

### What
The code that was removed effectively walks all nodes attached to a root node every time the root view size changes or a batch of UI operations completes. Not anymore :).

## Testing
RNTester runs, CI passes :)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10497)