### PR TITLE
Fixes bug introduced by pointerEvents change

### DIFF
--- a/change/react-native-windows-6319c12d-1bae-496d-a970-f863834d0d05.json
+++ b/change/react-native-windows-6319c12d-1bae-496d-a970-f863834d0d05.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes bug introduced by pointerEvents change",
+  "packageName": "react-native-windows",
+  "email": "ericroz@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -271,9 +271,11 @@ bool ViewManagerBase::UpdateProperty(
     const auto iter = pointerEventsMap.find(propertyValue.AsString());
     if (iter != pointerEventsMap.end()) {
       nodeToUpdate->m_pointerEvents = iter->second;
-      if (nodeToUpdate->m_pointerEvents == PointerEventsKind::None) {
-        if (const auto uiElement = nodeToUpdate->GetView().try_as<xaml::UIElement>()) {
+      if (const auto uiElement = nodeToUpdate->GetView().try_as<xaml::UIElement>()) {
+        if (nodeToUpdate->m_pointerEvents == PointerEventsKind::None) {
           uiElement.IsHitTestVisible(false);
+        } else {
+          uiElement.ClearValue(xaml::UIElement::IsHitTestVisibleProperty());
         }
       }
     } else {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
The handling for pointerEvents moved from ViewViewManager to ViewManagerBase in #8500 so all views could participate in pointerEvents handling (including Text, etc.). During this move, the code introduced a bug where updates to pointerEvents after pointerEvents is set to `none` are not respected.

Resolves #10493

### What
This adds an else clause to ensure we reset the `IsHitTestVisible` property when a the `pointerEvents` value is not `none`, but still valid.

## Testing
Ran a simple example:
```
function App() {
  const [none, setNone] = useState(false);
  return (
    <>
      <Button title={`Set pointerEvents=\'${none ? 'auto' : 'none'}\'`} onPress={() => setNone(!none)} />
      <View pointerEvents={none ? 'none' : 'box-none'} >
        <View onTouchEnd={() => alert('Pressed!')}>
          <Text>Click here</Text>
        </View>
      </View>
    </>
  );
}
```

Before (doesn't show alert after resetting pointerEvents to 'auto'):

https://user-images.githubusercontent.com/1106239/188284734-1d20ea2d-349f-4d5c-99f0-a3634f877d3a.mp4

After (does show alert after resetting pointerEvents to 'auto'):

https://user-images.githubusercontent.com/1106239/188284624-22eb268d-759d-426e-aa4e-a1abd03060eb.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10498)