### PR TITLE
Move v0.69 to Legacy

### DIFF
--- a/change/@office-iss-react-native-win32-e6dfec7d-c0c7-441a-a5ef-8bfc66927b49.json
+++ b/change/@office-iss-react-native-win32-e6dfec7d-c0c7-441a-a5ef-8bfc66927b49.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-354d60b6-89df-4dc2-b5e1-c59a1be8e3ac.json
+++ b/change/@react-native-windows-cli-354d60b6-89df-4dc2-b5e1-c59a1be8e3ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-e80b375d-e72a-4899-a5d9-9177ab839f8d.json
+++ b/change/@react-native-windows-codegen-e80b375d-e72a-4899-a5d9-9177ab839f8d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-22bba5f4-f722-42c9-9993-266502e249a3.json
+++ b/change/@react-native-windows-find-repo-root-22bba5f4-f722-42c9-9993-266502e249a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-6aa01d19-45b9-4eb5-9858-b977d3af2f14.json
+++ b/change/@react-native-windows-fs-6aa01d19-45b9-4eb5-9858-b977d3af2f14.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-44d41335-e8a8-40ae-9694-adf4cd9ae7cb.json
+++ b/change/@react-native-windows-package-utils-44d41335-e8a8-40ae-9694-adf4cd9ae7cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-124ae341-b192-4a88-8116-a3c7f3437ff9.json
+++ b/change/@react-native-windows-telemetry-124ae341-b192-4a88-8116-a3c7f3437ff9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-virtualized-list-7ee6957d-456b-4ff8-84b8-c0834d1afd6e.json
+++ b/change/@react-native-windows-virtualized-list-7ee6957d-456b-4ff8-84b8-c0834d1afd6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "@react-native-windows/virtualized-list",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e2d095c7-4462-46d3-84bf-56e11627f375.json
+++ b/change/react-native-windows-e2d095c7-4462-46d3-84bf-56e11627f375.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.69 to legacy",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -85,7 +85,7 @@
     "react-native": "^0.69.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -70,7 +70,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -52,7 +52,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -37,7 +37,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -35,7 +35,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -51,7 +51,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/virtualized-list/package.json
+++ b/packages/@react-native-windows/virtualized-list/package.json
@@ -33,7 +33,7 @@
     "react-native": "^0.69.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -88,7 +88,7 @@
     "react-native": "^0.69.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.69-stable",
     "gitTags": true,
     "disallowedChangeTypes": [
       "major",


### PR DESCRIPTION
## Description

### Type of Change
- Release Cycle

### Why
Move v0.69 to Legacy

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10517)