### PR TITLE
Add Regression Test for RNW:9662

### DIFF
--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -239,3 +239,43 @@ test('set, remove breakpoint', async () => {
     await settings.restore();
   }
 });
+
+// Regression test for the fix for RNW:9662 (https://github.com/microsoft/react-native-windows/issues/9662,
+// this test would fail prior to the fix).
+test('reload after continue', async () => {
+  testLog.message(`executing 'pause, resume' test on PID ${pid}`);
+
+  const settings = await PlaygroundDebugSettings.set({
+    webDebugger: false,
+    directDebugging: true,
+    jsEngine: 'Hermes',
+  });
+  try {
+    const isBundleServed0 = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed0);
+
+    const debugTargets = await getDebugTargets();
+    const dbg = new CDPDebugger(debugTargets[0].webSocketDebuggerUrl);
+
+    await dbg.debuggerEnable();
+
+    const pausedEvent = dbg.expectEvent('paused');
+    await dbg.debuggerPause();
+    await pausedEvent;
+
+    const resumedEvent = dbg.expectEvent('resumed');
+    await dbg.debuggerResume();
+    await resumedEvent;
+
+    const isBundleServed1 = metro.isBundleServed('debugTest01');
+
+    // without the fix, this re-load would hang
+    await loadPackage('Samples\\debugTest01', isBundleServed1);
+
+    await dbg.checkOutstandingResponses(3000);
+
+    dbg.close();
+  } finally {
+    await settings.restore();
+  }
+});


### PR DESCRIPTION
## Add Regression Test for RNW:9662

### Type of Change
- add automated test

### Why
- Prevent regression of debugging features

### What
The fix has been pushed to FB RN per https://github.com/facebook/react-native/pull/34342. Until hermes-windows picks up the containing FB ReactCommon version, the fix has been duplicated into hermes-windows as patch per https://github.com/microsoft/hermes-windows/pull/122. 

This change adds an automated test for the fix to RNW.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10523)