### PR TITLE
Add `accessibilityAccessKey` prop to ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-1b954575-9757-41ff-a990-c4fd5eaca44a.json
+++ b/change/@office-iss-react-native-win32-1b954575-9757-41ff-a990-c4fd5eaca44a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add accessibilityAccessKey to RN win32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
@@ -36,6 +36,7 @@ const UIView = {
   needsOffscreenAlphaCompositing: true,
   style: ReactNativeStyleAttributes,
   // [Windows
+  accessibilityAccessKey: true,
   alwaysShowToolTip: true,
   enableFocusRing: true,
   cursor: true,

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -192,6 +192,11 @@ export type ViewWin32OmitTypes = RN.ViewPropsAndroid &
 export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>, BasePropsWin32 {
   type?: React.ElementType;
   children?: React.ReactNode;
+  /**
+   * An access key to hook up to the UIA_AccessKey_Property.
+   * Access keys are used in keyboard navigation to allow quick navigation to UI in an application.
+   */
+  accessibilityAccessKey?: string;
   accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
   /**
    * Tells a person using a screen reader what kind of annotation they


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Enabling access key functionality for use in RN Win32 per client request. Setting this prop will assign the character passed into the prop to the UIA_AccessKeyProperty and will invoke onPress on the component when that letter is pressed and that component is a visible menu item.

Discussion for RNW happening in #10353 

### What
Adds `accessibilityAccessKey` as a property of `IViewWin32Props`.

## Screenshots
Not a visual change

## Testing
Tested locally by implementing a component that uses onPress. Verified that the character passed in is assigned to the UIA_AccessKeyProperty, and that pressing the access key triggers the menu item.

Changes to the tester cannot happen yet because newer versions of the tester assert on boot, and the tester needs to be updated in order to handle the new property. Once the tester is fixed I'll come back and add tests

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10527)