### PR TITLE
upgrade managed codegen project to .net 6

### DIFF
--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -20,6 +20,9 @@ jobs:
       - powershell: gci env:/BUILD_*
         displayName: Show build information
 
+      - powershell: dotnet --info
+        displayName: show dotnet information
+
       - template: ../templates/compute-beachball-branch-name.yml
 
       - template: ../templates/strict-yarn-install.yml

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -70,6 +70,9 @@
 
                 - template: ../templates/apply-published-version-vars.yml
 
+                - powershell: dotnet --info
+                  displayName: show dotnet information
+
                 - template: ../templates/msbuild-sln.yml
                   parameters:
                     solutionDir: vnext

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -76,6 +76,12 @@
                 - powershell: $env:PATH
                   displayName: show PATH
 
+                - task: UseDotNet@2
+                  displayName: Use .net 6
+                  inputs:
+                    packageType: 'sdk'
+                    version: '6.0.x'
+
                 - template: ../templates/msbuild-sln.yml
                   parameters:
                     solutionDir: vnext

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -73,6 +73,9 @@
                 - powershell: dotnet --info
                   displayName: show dotnet information
 
+                - powershell: $env:PATH
+                  displayName: show PATH
+
                 - template: ../templates/msbuild-sln.yml
                   parameters:
                     solutionDir: vnext

--- a/.ado/windows-vs-pr.yml
+++ b/.ado/windows-vs-pr.yml
@@ -16,13 +16,13 @@ parameters:
     default:
       Small:
         name: rnw-pool-2
-        demands: ImageOverride -equals rnw-img-node16
+        demands: ImageOverride -equals rnw-img-test
       Medium:
         name: rnw-pool-4
-        demands: ImageOverride -equals rnw-img-node16
+        demands: ImageOverride -equals rnw-img-test
       Large:
         name: rnw-pool-8
-        demands: ImageOverride -equals rnw-img-node16
+        demands: ImageOverride -equals rnw-img-test
 
 stages:
   - template: stages.yml

--- a/change/react-native-windows-b98775ae-73f9-4222-933a-cb7bd1f5b800.json
+++ b/change/react-native-windows-b98775ae-73f9-4222-933a-cb7bd1f5b800.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "upgrade managed codegen project to .net 6",
+  "packageName": "react-native-windows",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/App.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/App.cs
@@ -111,7 +111,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 }
 
                 // Ensure output directory
-                Directory.CreateDirectory(Path.GetDirectoryName(path));
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
 
                 await File.WriteAllTextAsync(path, contents, m_cancellationToken);
 

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/CodeAnalyzer.cs
@@ -280,12 +280,12 @@ namespace Microsoft.ReactNative.Managed.CodeGen
                 string? moduleName = null;
                 string? eventEmitterName = null;
 
-                if (attr.ConstructorArguments.Length > 0)
+                if (attr!.ConstructorArguments.Length > 0)
                 {
                     moduleName = attr.ConstructorArguments[0].Value as string;
                 }
 
-                foreach (var namedArgument in attr.NamedArguments)
+                foreach (var namedArgument in attr!.NamedArguments)
                 {
                     switch (namedArgument.Key)
                     {
@@ -374,7 +374,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             if (TryFindAttribute(method, attributeType, out var attr))
             {
                 string? name = null;
-                if (attr.ConstructorArguments.Length > 0)
+                if (attr!.ConstructorArguments.Length > 0)
                 {
                     name = attr.ConstructorArguments[0].Value as string;
                 }
@@ -599,7 +599,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             if (TryFindAttribute(symbol, ReactTypes.ReactConstantAttribute, out var attr))
             {
                 string? name = null;
-                if (attr.ConstructorArguments.Length > 0)
+                if (attr!.ConstructorArguments.Length > 0)
                 {
                     name = attr.ConstructorArguments[0].Value as string;
                 }
@@ -697,7 +697,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             {
                 name = null;
                 callbackContextName = null;
-                if (attr.ConstructorArguments.Length > 0)
+                if (attr!.ConstructorArguments.Length > 0)
                 {
                     name = attr.ConstructorArguments[0].Value as string;
                 }
@@ -813,7 +813,7 @@ namespace Microsoft.ReactNative.Managed.CodeGen
             }
         }
 
-        private bool TryFindAttribute(ISymbol symbol, INamedTypeSymbol attributeType, out AttributeData attr)
+        private bool TryFindAttribute(ISymbol symbol, INamedTypeSymbol attributeType, out AttributeData? attr)
         {
             attr = symbol.GetAttributes().FirstOrDefault(potentialMatch => potentialMatch.AttributeClass != null && potentialMatch.AttributeClass.Equals(attributeType, SymbolEqualityComparer.Default));
             return attr != null;

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Platforms>x64;x86;ARM;ARM64</Platforms>
+    <TargetFramework>netcoreapp6</TargetFramework>
+    <Platforms>x64;x86;ARM64</Platforms>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
 
     <Platform>x64</Platform>


### PR DESCRIPTION
## Description
Upgrades the .net codegen project (currently using out-of-support .net core 3.1), to .net 6.

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
Upgrade from no-longer-supported version of .net

Resolves #5146



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10541)