### PR TITLE
Switch to std::unordered_map for shadow and Yoga nodes

### DIFF
--- a/change/react-native-windows-d7888a84-3523-4fec-9554-362ed0be06ad.json
+++ b/change/react-native-windows-d7888a84-3523-4fec-9554-362ed0be06ad.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Switch to std::unordered_map for shadow and Yoga nodes",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -15,6 +15,7 @@
 #include <nativemodules.h>
 #include <map>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 
 namespace Microsoft::ReactNative {
@@ -112,8 +113,8 @@ class NativeUIManager final : public INativeUIManager {
   YGConfigRef m_yogaConfig;
   bool m_inBatch = false;
 
-  std::map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
-  std::map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;
+  std::unordered_map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
+  std::unordered_map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;
   std::vector<xaml::FrameworkElement::SizeChanged_revoker> m_sizeChangedVector;
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
   std::vector<int64_t> m_extraLayoutNodes;

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.h
@@ -4,7 +4,7 @@
 #pragma once
 #include <Views/PaperShadowNode.h>
 #include <functional/functorref.h>
-#include <map>
+#include <unordered_map>
 
 namespace Microsoft::ReactNative {
 
@@ -36,7 +36,7 @@ struct ShadowNodeRegistry {
 
  private:
   std::unordered_set<int64_t> m_roots;
-  std::map<int64_t, std::unique_ptr<ShadowNode, ShadowNodeDeleter>> m_allNodes;
+  std::unordered_map<int64_t, std::unique_ptr<ShadowNode, ShadowNodeDeleter>> m_allNodes;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Optimization (non-breaking change which improves performance)

### Why
We previously used std::map in ShadowNodeRegistry and NativeUIManager for the storage of shadow nodes (former) and Yoga nodes and context (latter), which has O(log(n)) complexity for insertion, removal, and lookup. The main reason for using std::map over std::unordered_map is when you require ordered enumeration of keys, which none of these maps require.
- Shadow nodes are only enumerated when destroying the UIManagerModule to cleanup by calling `DropView` on the shadow node. Tag indices themselves do not specify much besides creation order, and while children generally have smaller indices than parents in very simple cases, this is not always the case (consider a component that adds a child after some state change, the child index will be larger than its parent). Thus, there is no semantics coupled to the tag value, and no point in enforcing in-order enumeration.
- Yoga nodes are only enumerated for applying Yoga results to views, and the same logic above applies, there is no semantics to tag order, thus no point in enforcing in-order enumeration. #10422 actually changes this behavior to recursively apply Yoga results to children in depth-first order, so there will be no remaining enumerations of Yoga nodes.
- Yoga context values are never enumerated, so an ordered map is not required.

There are two motivations for switching the map type:
1. Effects of logarithmic insertion, removal, and lookup become noticeable in apps with many nodes, like Messenger.
2. We are experimenting with ViewFlattening in the Paper UIManager for RN Windows, which require many more lookups on the ShadowNodeRegistry than are required today.

### What
Changes the map type for storage of shadow nodes, Yoga nodes, and Yoga context to std::unordered_map.

## Testing
RNTester still behaves as expected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10543)