### PR TITLE
ADO: Change full checkout `persistCredentials` default back to `false`

### DIFF
--- a/.ado/integrate-rn.yaml
+++ b/.ado/integrate-rn.yaml
@@ -24,8 +24,6 @@ jobs:
     steps:
       - template: templates/checkout-full.yml
 
-      - template: templates/configure-git.yml
-
       - template: templates/prepare-js-env.yml
 
       - script: git checkout -b integrate-${{ parameters.reactNativeVersion }} origin/main

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -333,8 +333,8 @@ jobs:
 
             steps:
               - template: ../templates/checkout-full.yml
-
-              - template: ../templates/configure-git.yml
+                parameters:
+                  persistCredentials: false # We don't need git creds in this job
 
               - template: ../templates/prepare-js-env.yml
 

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - template: ../templates/checkout-full.yml
+        parameters:
+          persistCredentials: true # Git creds needed for beachball
 
       - powershell: gci env:/BUILD_*
         displayName: Show build information

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -56,7 +56,7 @@ jobs:
 
       - template: templates/checkout-full.yml
         parameters:
-          persistCredentials: false # We're going to use rnbot's credentials to publish
+          persistCredentials: false # We're going to use rnbot's git creds to publish
 
       - powershell: gci env:/BUILD_*
         displayName: Show build information  

--- a/.ado/templates/checkout-full.yml
+++ b/.ado/templates/checkout-full.yml
@@ -4,7 +4,7 @@
 parameters:
   - name: persistCredentials
     type: boolean
-    default: true
+    default: false # Make callers explicitly request credentials if they need them
 
 steps:
   - checkout: self


### PR DESCRIPTION
## Description

A change in beachball behavior means we need to make sure we have (the right) credentials ready to run beachball commands in our various ADO pipelines.

I made some temporary workarounds to unblock pipelines:

- [Add persistCredentials: true to checkout](https://github.com/microsoft/react-native-windows/commit/ba5b0080a6121f5e2562e91752411d521cf7d19b)
- [Update publish.yml to not set credentials until after running credscan](https://github.com/microsoft/react-native-windows/commit/19ef0684655a119ae2dffdd0ecbd91d6bf77f63e)
- [Parameterize persistCredentials, default to true](https://github.com/microsoft/react-native-windows/commit/462407c4e4c9c4c11779d9699b168e0643cd5392)
- [Update publish.yml to not persist credentials](https://github.com/microsoft/react-native-windows/commit/8f607832651023cf24b3a36dd9dc7e6ca859e83d)

This PR updates our pipelines to use the most appropriate credentials for the tasks they need to run.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

The temporary workarounds made **all** "full checkouts" in ADO persist the credentials used to checkout the repo, but that will override using any other credentials later in the pipeline.

In the case of publish, we actually need rnbot's admin credentials, so the publish pipeline reverts to the previous behavior of no longer persisting creds at checkout and instead configuring for rnbot's creds.

However, many other tasks do trivial/temporary local repo operations using rnbot's credentials. This is an unnecessary (and potentially risky) elevation that we shouldn't do anymore.

### What

This PR sets "full checkouts" back to not persisting credentials by default, because most tasks don't need them. Then, in the places where we do need credentials for later git/beachball commands, we choose from this prioritized list:

1. If possible, set `persistCredentials` to `true`, and use the (less-powerful) credentials
2. Otherwise, and only if the tasks require it, continue using rnbot's credentials

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10553)