### PR TITLE
[0.69] [RN Win32] Backport Add `accessibilityAccessKey` prop to ViewWin32 

### DIFF
--- a/change/@office-iss-react-native-win32-1b954575-9757-41ff-a990-c4fd5eaca44a.json
+++ b/change/@office-iss-react-native-win32-1b954575-9757-41ff-a990-c4fd5eaca44a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add accessibilityAccessKey to RN win32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "ruaraki@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@office-iss-react-native-win32-b430ff27-e7bf-4628-bf35-ad7c766db549.json
+++ b/change/@office-iss-react-native-win32-b430ff27-e7bf-4628-bf35-ad7c766db549.json
@@ -1,6 +1,6 @@
 {
-  "type": "prerelease",
-  "comment": "Add accessibilityAccessKey to RN win32",
+  "type": "patch",
+  "comment": "Add `accessibilityAccessKey` prop to ViewWin32 (#10527)",
   "packageName": "@office-iss/react-native-win32",
   "email": "ruaraki@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ReactNativeViewAttributes.win32.js
@@ -36,6 +36,7 @@ const UIView = {
   needsOffscreenAlphaCompositing: true,
   style: ReactNativeStyleAttributes,
   // [Windows
+  accessibilityAccessKey: true,
   enableFocusRing: true,
   cursor: true,
   textStyle: true, // Once we flush out our JS theming story this property will no longer be needed

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -192,6 +192,11 @@ export type ViewWin32OmitTypes = RN.ViewPropsAndroid &
 export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>, BasePropsWin32 {
   type?: React.ElementType;
   children?: React.ReactNode;
+  /**
+   * An access key to hook up to the UIA_AccessKey_Property.
+   * Access keys are used in keyboard navigation to allow quick navigation to UI in an application.
+   */
+  accessibilityAccessKey?: string;
   accessibilityActions?: ReadonlyArray<AccessibilityActionInfo>;
   /**
    * Tells a person using a screen reader what kind of annotation they


### PR DESCRIPTION
Backport of #10527

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10555)