### PR TITLE
test for context execution identifier in Debugger.scriptParsed event

### DIFF
--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -294,8 +294,8 @@ test.skip('execution context identifier in Debugger.scriptParsed event', async (
     jsEngine: 'Hermes',
   });
   try {
-    const isBundleServed0 = metro.isBundleServed('debugTest01');
-    await loadPackage('Samples\\debugTest01', isBundleServed0);
+    const isBundleServed = metro.isBundleServed('debugTest01');
+    await loadPackage('Samples\\debugTest01', isBundleServed);
 
     const debugTargets = await getDebugTargets();
     const dbg = new CDPDebugger(debugTargets[0].webSocketDebuggerUrl);


### PR DESCRIPTION
## Test for Context Execution Identifier in Debugger.scriptParsed Event

### Type of Change
- Add new test

### Why
Detect regression with regard to [FB:34639](https://github.com/facebook/react-native/issues/34639).

### What
Automated test verifying context execution identifier in Debugger.scriptParsed CDP event
Actual fix is in [FB:34640](https://github.com/facebook/react-native/pull/34640) and, as a patch, in [HW:131](https://github.com/microsoft/hermes-windows/pull/131/files)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10562)