### PR TITLE
Move required PackageRestore properties into shared property sheets

### DIFF
--- a/change/react-native-windows-4368402e-1685-4f6d-8750-48801eb76e19.json
+++ b/change/react-native-windows-4368402e-1685-4f6d-8750-48801eb76e19.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move required PackageRestore properties into shared property sheets",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
+++ b/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
@@ -25,9 +25,6 @@
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>

--- a/packages/integration-test-app/windows/InteropTestModuleCS/InteropTestModuleCS.csproj
+++ b/packages/integration-test-app/windows/InteropTestModuleCS/InteropTestModuleCS.csproj
@@ -23,9 +23,6 @@
     <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>

--- a/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
+++ b/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
@@ -13,11 +13,6 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
-    <AssetTargetFallback>$(AssetTargetFallback);uap10.0.16299</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
     <ConsumeCSharpModules Condition="'$(ConsumeCSharpModules)' == ''">true</ConsumeCSharpModules>

--- a/packages/playground/CoreApp/CoreApp.vcxproj
+++ b/packages/playground/CoreApp/CoreApp.vcxproj
@@ -18,19 +18,6 @@
     <RunAutolinkCheck>false</RunAutolinkCheck>
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-    <!--
-      Avoid Visual Studio error message:
-      "The project '$(MSBuildProjectName)' ran into a problem during the last operation: The value of the
-      'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '$(Configuration)|$(Platform)' configuration are both
-      empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors. You may
-      need to reload the solution after fixing the problem."
-    -->
-    <TargetFrameworkMoniker>native,Version=v0.0</TargetFrameworkMoniker>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\External\Microsoft.ReactNative.WindowsSdk.Default.props" />
   <ImportGroup Label="ReactNativeWindowsPropertySheets">

--- a/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
+++ b/packages/sample-apps/windows/SampleAppCPP/SampleAppCpp.vcxproj
@@ -13,11 +13,6 @@
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
-    <AssetTargetFallback>$(AssetTargetFallback);uap10.0.16299</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Label="ReactNativeWindowsProps">
     <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
     <ConsumeCSharpModules Condition="'$(ConsumeCSharpModules)' == ''">true</ConsumeCSharpModules>

--- a/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
@@ -24,9 +24,6 @@
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>

--- a/packages/sample-apps/windows/SampleLibraryCS/SampleLibraryCS.csproj
+++ b/packages/sample-apps/windows/SampleLibraryCS/SampleLibraryCS.csproj
@@ -23,9 +23,6 @@
     <EnableTypeInfoReflection>false</EnableTypeInfoReflection>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/Microsoft.ReactNative.Managed.UnitTests.csproj
@@ -19,9 +19,6 @@
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">$(VisualStudioVersion)</UnitTestPlatformVersion>
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
@@ -88,6 +85,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
+  <Import Project="..\PropertySheets\NuGet.CSharp.props" />
   <Import Project="..\PropertySheets\WinUI.props" />
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
+++ b/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
@@ -25,9 +25,6 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <!-- Missing XML comment for publicly visible type or member -->
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
@@ -80,6 +77,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
+  <Import Project="..\PropertySheets\NuGet.CSharp.props" />
   <Import Project="..\PropertySheets\WinUI.props" />
   <ItemGroup>
     <Compile Include="AttributedViewManager.cs" />

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -9,10 +9,7 @@
     <CsWinRTGeneratedFilesDir>$(OutDir)</CsWinRTGeneratedFilesDir>
   </PropertyGroup>
 
-  <PropertyGroup Label="NuGet">
-    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
+  <Import Project="..\PropertySheets\NuGet.CSharp.props" />
 
   <ItemGroup>
     <None Remove="nuget\Microsoft.ReactNative.WindowsAppSDK.nuspec" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.props
@@ -37,15 +37,6 @@
     <HermesNoDLLCopy Condition="'$(UseHermes)' != 'true'">true</HermesNoDLLCopy>
   </PropertyGroup>
 
-  <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.props -->
-  <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
-    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
-    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</RestoreUseStaticGraphEvaluation>
-
-    <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-  </PropertyGroup>
-
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NewAPIDeclarations.props" />
 
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Generated\PackageVersion.g.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpApp.props
@@ -20,5 +20,6 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Appx.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Autolink.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.CSharp.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CSharpLib.props
@@ -13,4 +13,5 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.CSharp.props" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppApp.props
@@ -16,6 +16,7 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Appx.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Autolink.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.Cpp.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\CppAppConsumeCSharpModule.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Uwp.CppLib.props
@@ -17,6 +17,7 @@
     <GenerateLibraryLayout>false</GenerateLibraryLayout>
   </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Uwp.Common.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.Cpp.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\PackageVersionDefinitions.props" />
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.WinAppSDK.CSharpApp.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.WinAppSDK.CSharpApp.props
@@ -22,5 +22,6 @@
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.WinAppSDK.Common.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Appx.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\Autolink.props" />
+  <Import Project="$(ReactNativeWindowsDir)\PropertySheets\NuGet.CSharp.props" />
   <Import Project="$(ReactNativeWindowsDir)\PropertySheets\WinUI.props" />
 </Project>

--- a/vnext/PropertySheets/NuGet.CSharp.props
+++ b/vnext/PropertySheets/NuGet.CSharp.props
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT License.
+
+  Defines NuGet-related properties for C# projects using PackageReference.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="NuGet">
+    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
+    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
+  </PropertyGroup>
+  
+</Project>

--- a/vnext/PropertySheets/NuGet.Cpp.props
+++ b/vnext/PropertySheets/NuGet.Cpp.props
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT License.
+
+  Defines NuGet-related properties for C++ projects using PackageReference.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="NuGet">
+    <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.props -->
+    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
+    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</RestoreUseStaticGraphEvaluation>
+
+    <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
+    <ResolveNuGetPackages>false</ResolveNuGetPackages>
+
+    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
+    <AssetTargetFallback>$(AssetTargetFallback);uap10.0.16299</AssetTargetFallback>
+
+    <!--
+      Avoid Visual Studio error message:
+      "The project '$(MSBuildProjectName)' ran into a problem during the last operation: The value of the
+      'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '$(Configuration)|$(Platform)' configuration are both
+      empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors. You may
+      need to reload the solution after fixing the problem."
+    -->
+    <TargetFrameworkMoniker>native,Version=v0.0</TargetFrameworkMoniker>
+  </PropertyGroup>
+
+</Project>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -17,21 +17,7 @@
     <EnableWinRtLeanAndMean Condition="'$(EnableWinRtLeanAndMean)' == ''">true</EnableWinRtLeanAndMean>
   </PropertyGroup>
 
-  <PropertyGroup Label="NuGet">
-    <ResolveNuGetPackages>false</ResolveNuGetPackages>
-
-    <!-- https://github.com/NuGet/Home/issues/10511#issuecomment-778400668 -->
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-
-    <!--
-      Avoid Visual Studio error message:
-      "The project '$(MSBuildProjectName)' ran into a problem during the last operation: The value of the
-      'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '$(Configuration)|$(Platform)' configuration are both
-      empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors. You may
-      need to reload the solution after fixing the problem."
-    -->
-    <TargetFrameworkMoniker>native,Version=v0.0</TargetFrameworkMoniker>
-  </PropertyGroup>
+  <Import Project="$(MSBuildThisFileDirectory)NuGet.Cpp.props" />
 
   <PropertyGroup Label="Desktop">
     <!-- See https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt -->

--- a/vnext/template/cs-app/proj/MyApp.csproj
+++ b/vnext/template/cs-app/proj/MyApp.csproj
@@ -25,9 +25,6 @@
     <AppxGeneratePrisForPortableLibrariesEnabled>false</AppxGeneratePrisForPortableLibrariesEnabled>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>

--- a/vnext/template/cs-lib/proj/MyLib.csproj
+++ b/vnext/template/cs-lib/proj/MyLib.csproj
@@ -24,9 +24,6 @@
     <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Label="NuGet">
-    <AssetTargetFallback>$(AssetTargetFallback);native</AssetTargetFallback>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>


### PR DESCRIPTION
## Description

The switch to PackageRestore sprinkled required properties in each
individual app/lib file, rather than putting it into the shared
property sheets so customers could benefit.

This means that app customers must add the correct properties to their
app projects when upgrading to 0.68+, and that native modules that don't
do the equivalent will also just stop working.

Resolves #10538

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)