### PR TITLE
Move some image functions into separate file

### DIFF
--- a/change/react-native-windows-abb4eabd-b346-47f7-a968-b213177e171f.json
+++ b/change/react-native-windows-abb4eabd-b346-47f7-a968-b213177e171f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move some image functions into separate file",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -555,6 +555,7 @@
     </ClCompile>
     <ClCompile Include="Utils\AccessibilityUtils.cpp" />
     <ClCompile Include="Utils\Helpers.cpp" />
+    <ClCompile Include="Utils\ImageUtils.cpp" />
     <ClCompile Include="Utils\LocalBundleReader.cpp" />
     <ClCompile Include="Utils\ResourceBrushUtils.cpp" />
     <ClCompile Include="Utils\UwpPreparedScriptStore.cpp" />

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -6,7 +6,6 @@
 
 #include <Shared/cdebug.h>
 #include <winrt/Windows.Security.Cryptography.h>
-#include <winrt/Windows.Storage.Streams.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Windows.Web.Http.h>
 

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "ImageUtils.h"
+
+#include <Shared/cdebug.h>
+#include <winrt/Windows.Security.Cryptography.h>
+#include <winrt/Windows.Storage.Streams.h>
+#include <winrt/Windows.Web.Http.Headers.h>
+#include <winrt/Windows.Web.Http.h>
+
+namespace winrt {
+using namespace Windows::Foundation;
+using namespace Windows::Storage::Streams;
+using namespace Windows::Web::Http;
+} // namespace winrt
+
+namespace Microsoft::ReactNative {
+
+winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImageSource source) {
+  try {
+    co_await winrt::resume_background();
+
+    auto httpMethod{source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{winrt::to_hstring(source.method)}};
+
+    winrt::Uri uri{winrt::to_hstring(source.uri)};
+    winrt::HttpRequestMessage request{httpMethod, uri};
+
+    if (!source.headers.empty()) {
+      for (auto &header : source.headers) {
+        if (_stricmp(header.first.c_str(), "authorization") == 0) {
+          request.Headers().TryAppendWithoutValidation(
+              winrt::to_hstring(header.first), winrt::to_hstring(header.second));
+        } else {
+          request.Headers().Append(winrt::to_hstring(header.first), winrt::to_hstring(header.second));
+        }
+      }
+    }
+
+    winrt::HttpClient httpClient;
+    winrt::HttpResponseMessage response{co_await httpClient.SendRequestAsync(request)};
+
+    if (response && response.StatusCode() == winrt::HttpStatusCode::Ok) {
+      winrt::IInputStream inputStream{co_await response.Content().ReadAsInputStreamAsync()};
+      winrt::InMemoryRandomAccessStream memoryStream;
+      co_await winrt::RandomAccessStream::CopyAsync(inputStream, memoryStream);
+      memoryStream.Seek(0);
+
+      co_return memoryStream;
+    }
+  } catch (winrt::hresult_error const &e) {
+    DEBUG_HRESULT_ERROR(e);
+  }
+
+  co_return nullptr;
+}
+
+winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageInlineDataAsync(ReactImageSource source) {
+  size_t start = source.uri.find(',');
+  if (start == std::string::npos || start + 1 > source.uri.length())
+    co_return nullptr;
+
+  try {
+    co_await winrt::resume_background();
+
+    std::string_view base64String(source.uri.c_str() + start + 1, source.uri.length() - start - 1);
+    auto buffer =
+        winrt::Windows::Security::Cryptography::CryptographicBuffer::DecodeFromBase64String(winrt::to_hstring(base64String));
+
+    winrt::InMemoryRandomAccessStream memoryStream;
+    co_await memoryStream.WriteAsync(buffer);
+    memoryStream.Seek(0);
+
+    co_return memoryStream;
+  } catch (winrt::hresult_error const &) {
+    // Base64 decode failed
+  }
+
+  co_return nullptr;
+}
+
+winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageMemoryStreamAsync(ReactImageSource source) {
+  switch (source.sourceType) {
+    case ImageSourceType::Download:
+      co_return co_await GetImageStreamAsync(source);
+    case ImageSourceType::InlineData:
+      co_return co_await GetImageInlineDataAsync(source);
+    default: // ImageSourceType::Uri
+      co_return nullptr;
+  }
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -22,7 +22,8 @@ winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImag
   try {
     co_await winrt::resume_background();
 
-    auto httpMethod{source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{winrt::to_hstring(source.method)}};
+    auto httpMethod{
+        source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{winrt::to_hstring(source.method)}};
 
     winrt::Uri uri{winrt::to_hstring(source.uri)};
     winrt::HttpRequestMessage request{httpMethod, uri};
@@ -65,8 +66,8 @@ winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageInlineDataAsync(React
     co_await winrt::resume_background();
 
     std::string_view base64String(source.uri.c_str() + start + 1, source.uri.length() - start - 1);
-    auto buffer =
-        winrt::Windows::Security::Cryptography::CryptographicBuffer::DecodeFromBase64String(winrt::to_hstring(base64String));
+    auto buffer = winrt::Windows::Security::Cryptography::CryptographicBuffer::DecodeFromBase64String(
+        winrt::to_hstring(base64String));
 
     winrt::InMemoryRandomAccessStream memoryStream;
     co_await memoryStream.WriteAsync(buffer);

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
@@ -8,7 +8,6 @@
 
 namespace Microsoft::ReactNative {
 
-  
 enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2 };
 enum class ImageSourceFormat { Bitmap = 0, Svg = 1 };
 
@@ -33,6 +32,5 @@ winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IR
 
 winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
 GetImageInlineDataAsync(ReactImageSource source);
-
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include <cxxreact/JSBigString.h>
+#include <future>
+#include <string>
+
+namespace Microsoft::ReactNative {
+
+  
+enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2 };
+enum class ImageSourceFormat { Bitmap = 0, Svg = 1 };
+
+struct ReactImageSource {
+  std::string uri;
+  std::string method;
+  std::string bundleRootPath;
+  std::vector<std::pair<std::string, std::string>> headers;
+  double width = 0;
+  double height = 0;
+  double scale = 1.0;
+  bool packagerAsset = false;
+  ImageSourceType sourceType = ImageSourceType::Uri;
+  ImageSourceFormat sourceFormat = ImageSourceFormat::Bitmap;
+};
+
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
+GetImageMemoryStreamAsync(ReactImageSource source);
+
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> GetImageStreamAsync(
+    ReactImageSource source);
+
+winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
+GetImageInlineDataAsync(ReactImageSource source);
+
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.h
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <cxxreact/JSBigString.h>
-#include <future>
+#include <winrt/Windows.Storage.Streams.h>
 #include <string>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -171,16 +171,6 @@ void ReactImage::Source(ReactImageSource source) {
   }
 }
 
-winrt::IAsyncOperation<winrt::IRandomAccessStream> ReactImage::GetImageMemoryStreamAsync(ReactImageSource source) {
-  switch (source.sourceType) {
-    case ImageSourceType::Download:
-      co_return co_await GetImageStreamAsync(source);
-    case ImageSourceType::InlineData:
-      co_return co_await GetImageInlineDataAsync(source);
-    default: // ImageSourceType::Uri
-      co_return nullptr;
-  }
-}
 template <typename TImage>
 std::wstring GetUriFromImage(const TImage &image) {
   return image.UriSource() ? image.UriSource().ToString().c_str() : L"<no Uri available>";
@@ -442,64 +432,4 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   }
 }
 
-winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImageSource source) {
-  try {
-    co_await winrt::resume_background();
-
-    auto httpMethod{source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{Utf8ToUtf16(source.method)}};
-
-    winrt::Uri uri{Utf8ToUtf16(source.uri)};
-    winrt::HttpRequestMessage request{httpMethod, uri};
-
-    if (!source.headers.empty()) {
-      for (auto &header : source.headers) {
-        if (_stricmp(header.first.c_str(), "authorization") == 0) {
-          request.Headers().TryAppendWithoutValidation(Utf8ToUtf16(header.first), Utf8ToUtf16(header.second));
-        } else {
-          request.Headers().Append(Utf8ToUtf16(header.first), Utf8ToUtf16(header.second));
-        }
-      }
-    }
-
-    winrt::HttpClient httpClient;
-    winrt::HttpResponseMessage response{co_await httpClient.SendRequestAsync(request)};
-
-    if (response && response.StatusCode() == winrt::HttpStatusCode::Ok) {
-      winrt::IInputStream inputStream{co_await response.Content().ReadAsInputStreamAsync()};
-      winrt::InMemoryRandomAccessStream memoryStream;
-      co_await winrt::RandomAccessStream::CopyAsync(inputStream, memoryStream);
-      memoryStream.Seek(0);
-
-      co_return memoryStream;
-    }
-  } catch (winrt::hresult_error const &e) {
-    DEBUG_HRESULT_ERROR(e);
-  }
-
-  co_return nullptr;
-}
-
-winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageInlineDataAsync(ReactImageSource source) {
-  size_t start = source.uri.find(',');
-  if (start == std::string::npos || start + 1 > source.uri.length())
-    co_return nullptr;
-
-  try {
-    co_await winrt::resume_background();
-
-    std::string_view base64String(source.uri.c_str() + start + 1, source.uri.length() - start - 1);
-    auto buffer =
-        winrt::Windows::Security::Cryptography::CryptographicBuffer::DecodeFromBase64String(Utf8ToUtf16(base64String));
-
-    winrt::InMemoryRandomAccessStream memoryStream;
-    co_await memoryStream.WriteAsync(buffer);
-    memoryStream.Seek(0);
-
-    co_return memoryStream;
-  } catch (winrt::hresult_error const &) {
-    // Base64 decode failed
-  }
-
-  co_return nullptr;
-}
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -9,25 +9,10 @@
 #include <UI.Xaml.Controls.h>
 
 #include <JSValue.h>
+#include <Utils/ImageUtils.h>
 #include <folly/dynamic.h>
 
 namespace Microsoft::ReactNative {
-
-enum class ImageSourceType { Uri = 0, Download = 1, InlineData = 2 };
-enum class ImageSourceFormat { Bitmap = 0, Svg = 1 };
-
-struct ReactImageSource {
-  std::string uri;
-  std::string method;
-  std::string bundleRootPath;
-  std::vector<std::pair<std::string, std::string>> headers;
-  double width = 0;
-  double height = 0;
-  double scale = 1.0;
-  bool packagerAsset = false;
-  ImageSourceType sourceType = ImageSourceType::Uri;
-  ImageSourceFormat sourceFormat = ImageSourceFormat::Bitmap;
-};
 
 struct ReactImage : xaml::Controls::GridT<ReactImage> {
   using Super = xaml::Controls::GridT<ReactImage>;
@@ -69,8 +54,6 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
  private:
   xaml::Media::Stretch ResizeModeToStretch();
   xaml::Media::Stretch ResizeModeToStretch(winrt::Windows::Foundation::Size size);
-  winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
-  GetImageMemoryStreamAsync(ReactImageSource source);
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
 
   bool m_useCompositionBrush{false};
@@ -90,9 +73,4 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   xaml::Media::Imaging::SvgImageSource::OpenFailed_revoker m_svgImageSourceOpenFailedRevoker;
 };
 
-// Helper functions
-winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> GetImageStreamAsync(
-    ReactImageSource source);
-winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream>
-GetImageInlineDataAsync(ReactImageSource source);
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
Moving a couple of functions out of ReactImage which is tied to Xaml, so it can be shared with non-xaml code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10568)