### PR TITLE
Change Accessible/Focusable Relationship to Default to 

### DIFF
--- a/change/react-native-windows-46b530e4-8447-414b-9761-43c03e7088da.json
+++ b/change/react-native-windows-46b530e4-8447-414b-9761-43c03e7088da.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Alter Accessibility Protocol",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -129,6 +129,10 @@ void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     xaml::Automation::AutomationProperties::SetAccessibilityView(
         control, xaml::Automation::Peers::AccessibilityView::Content);
     control.IsEnabled(true);
+    node->YellowBox(
+        "Values for accessible and focusable prop do not match. In Windows, keyboard "
+        "focus and accessibility focus move together. If you wish to disable focus for "
+        "this component, set both accessible and focusable to false.");
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -125,9 +125,10 @@ void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto control(node->GetView().as<xaml::Controls::Control>());
 
   if (IsAccessible() != IsFocusable()) {
-    control.IsTabStop(false);
+    control.IsTabStop(true);
     xaml::Automation::AutomationProperties::SetAccessibilityView(
-        control, xaml::Automation::Peers::AccessibilityView::Raw);
+        control, xaml::Automation::Peers::AccessibilityView::Content);
+    control.IsEnabled(true);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -124,6 +124,8 @@ void ControlViewManager::SetLayoutProps(
 void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto control(node->GetView().as<xaml::Controls::Control>());
 
+  // If developer specifies either the accessible and focusable prop to be false
+  // remove accessibility and keyboard focus for component.
   if (IsAccessible() != IsFocusable()) {
     control.IsTabStop(false);
     xaml::Automation::AutomationProperties::SetAccessibilityView(

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -125,14 +125,10 @@ void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto control(node->GetView().as<xaml::Controls::Control>());
 
   if (IsAccessible() != IsFocusable()) {
-    control.IsTabStop(true);
+    control.IsTabStop(false);
     xaml::Automation::AutomationProperties::SetAccessibilityView(
-        control, xaml::Automation::Peers::AccessibilityView::Content);
-    control.IsEnabled(true);
-    node->YellowBox(
-        "Values for accessible and focusable prop do not match. In Windows, keyboard "
-        "focus and accessibility focus move together. If you wish to disable focus for "
-        "this component, set both accessible and focusable to false.");
+        control, xaml::Automation::Peers::AccessibilityView::Raw);
+    control.IsEnabled(false);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -477,7 +477,7 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     // keep it around, so not adding that code (yet).
   }
 
-  bool shouldBeControl = viewShadowNode->IsFocusable();
+  bool shouldBeControl = (viewShadowNode->IsFocusable() || viewShadowNode->IsAccessible());
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
     // DynamicAutomationPeer
@@ -601,9 +601,9 @@ void ViewViewManager::TryUpdateView(
     pViewShadowNode->GetControl().Content(visualRoot);
 
   if (useControl && pViewShadowNode->IsAccessible() != pViewShadowNode->IsFocusable()) {
-    pViewShadowNode->GetControl().IsTabStop(false);
+    pViewShadowNode->GetControl().IsTabStop(true);
     xaml::Automation::AutomationProperties::SetAccessibilityView(
-        pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Raw);
+        pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Content);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -477,7 +477,7 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     // keep it around, so not adding that code (yet).
   }
 
-  bool shouldBeControl = (viewShadowNode->IsFocusable() || viewShadowNode->IsAccessible());
+  bool shouldBeControl = (viewShadowNode->IsFocusable() || (viewShadowNode->IsAccessible() && !viewShadowNode->OnClick()));
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
     // DynamicAutomationPeer
@@ -601,12 +601,15 @@ void ViewViewManager::TryUpdateView(
     pViewShadowNode->GetControl().Content(visualRoot);
 
   if (useControl && pViewShadowNode->IsAccessible() != pViewShadowNode->IsFocusable()) {
-    pViewShadowNode->GetControl().IsTabStop(true);
-    xaml::Automation::AutomationProperties::SetAccessibilityView(
-        pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Content);
-    pViewShadowNode->YellowBox("Values for accessible and focusable prop do not match. In Windows, keyboard"
-                               "focus and accessibility focus move together. If you wish to disable focus for"
-                               " this component, set both accessible and focusable to false.");
+    if (!pViewShadowNode->OnClick()) {
+      pViewShadowNode->GetControl().IsTabStop(true);
+      xaml::Automation::AutomationProperties::SetAccessibilityView(
+          pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Content);
+    } else {
+      pViewShadowNode->GetControl().IsTabStop(false);
+      xaml::Automation::AutomationProperties::SetAccessibilityView(
+          pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Raw);
+    }
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -477,7 +477,8 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     // keep it around, so not adding that code (yet).
   }
 
-  bool shouldBeControl = (viewShadowNode->IsFocusable() || (viewShadowNode->IsAccessible() && !viewShadowNode->OnClick()));
+  bool shouldBeControl =
+      (viewShadowNode->IsFocusable() || (viewShadowNode->IsAccessible() && !viewShadowNode->OnClick()));
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
     // DynamicAutomationPeer

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -477,6 +477,8 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     // keep it around, so not adding that code (yet).
   }
 
+  // If component is focusable, it should be a ViewControl.
+  // If component is a View with accessible set to true, the component should be focusable, thus we need a ViewControl.
   bool shouldBeControl =
       (viewShadowNode->IsFocusable() || (viewShadowNode->IsAccessible() && !viewShadowNode->OnClick()));
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
@@ -601,6 +603,10 @@ void ViewViewManager::TryUpdateView(
   if (useControl)
     pViewShadowNode->GetControl().Content(visualRoot);
 
+  // If developer specifies either the accessible and focusable prop to be false
+  // remove accessibility and keyboard focus for component. Exception is made
+  // for case where a View with undefined onPress is specified, where
+  // component gains accessibility focus when either the accessible and focusable prop are true.
   if (useControl && pViewShadowNode->IsAccessible() != pViewShadowNode->IsFocusable()) {
     if (!pViewShadowNode->OnClick()) {
       pViewShadowNode->GetControl().IsTabStop(true);

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -604,6 +604,9 @@ void ViewViewManager::TryUpdateView(
     pViewShadowNode->GetControl().IsTabStop(true);
     xaml::Automation::AutomationProperties::SetAccessibilityView(
         pViewShadowNode->GetControl(), xaml::Automation::Peers::AccessibilityView::Content);
+    pViewShadowNode->YellowBox("Values for accessible and focusable prop do not match. In Windows, keyboard"
+                               "focus and accessibility focus move together. If you wish to disable focus for"
+                               " this component, set both accessible and focusable to false.");
   }
 }
 


### PR DESCRIPTION
## Description

### Type of Change
- Functionality change

### Why
Following change to accessible/focusable prop relationship in #9840, request from partner to adjust logic in order to reduce number of code edits needed. 

#9840 was needed in order to bring RNW up to Windows accessibility standards. In Windows accessibility focus and keyboard focus are the same. RNW should not allow developers to remove elements from the UIA while they still remain keyboard focusable. 

### What
Originally, the PR set the behavior to be if either accessible or focusable was set to false the control should not be focusable or accessible. The logic is now if either accessible or focusable is set to true the control should be focusable and accessible. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10569)