### PR TITLE
Upgrade to Windows App SDK 1.1.4

### DIFF
--- a/change/@react-native-windows-cli-e5211ab6-1bb2-437a-a8b1-d9e7b4aa7905.json
+++ b/change/@react-native-windows-cli-e5211ab6-1bb2-437a-a8b1-d9e7b4aa7905.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade to Windows App SDK 1.1.4",
+  "packageName": "@react-native-windows/cli",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-26f93a0e-6a5b-4670-b543-0f3d222a2ee5.json
+++ b/change/react-native-windows-26f93a0e-6a5b-4670-b543-0f3d222a2ee5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Upgrade to Windows App SDK 1.1.4",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/autolink.test.ts
@@ -295,7 +295,7 @@ test('ensureXAMLDialect - useWinUI3=true in react-native.config.js, useWinUI3=fa
   // example packages.config:
   // <packages>
   //   <package id="SuperPkg" version="42"/>
-  //   <package id="Microsoft.WindowsAppSDK" version="1.0.0" targetFramework="native"/>
+  //   <package id="Microsoft.WindowsAppSDK" version="1.1.4" targetFramework="native"/>
   // </packages>
   //
   expect(al.packagesConfig).toContain('Microsoft.WindowsAppSDK');
@@ -332,7 +332,7 @@ test('ensureXAMLDialect - useWinUI3=false in react-native.config.js, useWinUI3=t
   // example packages.config:
   // <packages>
   //   <package id="SuperPkg" version="42"/>
-  //   <package id="Microsoft.WindowsAppSDK" version="1.0.0" targetFramework="native"/>
+  //   <package id="Microsoft.WindowsAppSDK" version="1.1.4" targetFramework="native"/>
   // </packages>
   //
   expect(al.packagesConfig).not.toContain('Microsoft.WindowsAppSDK');
@@ -369,7 +369,7 @@ test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=tru
   // example packages.config:
   // <packages>
   //   <package id="SuperPkg" version="42"/>
-  //   <package id="Microsoft.WindowsAppSDK" version="1.0.0" targetFramework="native"/>
+  //   <package id="Microsoft.WindowsAppSDK" version="1.1.4" targetFramework="native"/>
   // </packages>
   //
   expect(al.packagesConfig).toContain('Microsoft.WindowsAppSDK');
@@ -405,7 +405,7 @@ test('ensureXAMLDialect - useWinUI3 not in react-native.config.js, useWinUI3=fal
   // example packages.config:
   // <packages>
   //   <package id="SuperPkg" version="42"/>
-  //   <package id="Microsoft.WindowsAppSDK" version="1.0.0" targetFramework="native"/>
+  //   <package id="Microsoft.WindowsAppSDK" version="1.1.4" targetFramework="native"/>
   // </packages>
   //
   expect(al.packagesConfig).not.toContain('Microsoft.WindowsAppSDK');

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -545,7 +545,7 @@ function getWinAppSDKPackages(nugetVersion: string): NugetPackage[] {
 
   winAppSDKPackages.push({
     id: 'Microsoft.WindowsAppSDK',
-    version: '1.0.0',
+    version: '1.1.4',
   });
 
   return winAppSDKPackages;

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -20,11 +20,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
   </ItemGroup>
   <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.18" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.18" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.24" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.24" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="WinUI3 versioning">
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.0.0</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.1.4</WinUI3Version>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">


### PR DESCRIPTION
## Description

Upgrade Windows App SDK from 1.0.0 to 1.1.4 (latest stable).

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Windows App SDK has had several releases since 1.0 with [many bug fixes](https://docs.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel). 

### What
Changes the CLI, WinUI.props Property Sheet, and Microsoft.ReactNative.WindowsAppSDK.csproj to use Windows App SDK version 1.1.4.

## Testing
The only way I verified this is by confirming that Microsoft.ReactNative.WindowsAppSDK.sln still builds. I'm not sure if there's a way to use the CLI within the repo to confirm a new RNW project using WinAppSDK will run properly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10570)