### PR TITLE
Limit Yoga layout to relevant root on resize

### DIFF
--- a/change/react-native-windows-f7c98885-c2ec-4944-8d7b-03f0fcc696cc.json
+++ b/change/react-native-windows-f7c98885-c2ec-4944-8d7b-03f0fcc696cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Limit Yoga layout to relevant root on resize",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Perf (non-breaking change which improves performance)

### Why
Recalculation of Yoga layout due to root view size change does not require that we re-run layout on all roots. It also does not require that we invoke UpdateLayout on any new nodes (as a resize operation is independent of a batch of UIManager operations).

### What
This change limits the scope of Yoga calculation and application of Yoga results to XAML views to only the root view that changed size. This optimization primarily impacts apps with multiple windows, but can also benefit any React Native Windows app with multiple roots.

In a future PR, we could also track impacted roots in view manager operations by looking up the rootTag field on the ShadowNode, and only running Yoga layout on windows with actual updates in a given batch.

## Testing
Ran RNTester, window resize still adapts correctly.

https://user-images.githubusercontent.com/1106239/190245420-555c1b14-471a-4866-b04d-cd0fc0aebcde.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10580)