### PR TITLE
Adds event to listen for quirk settings changes

### DIFF
--- a/change/react-native-windows-a60b678a-aa92-4ee6-9a80-475c8bdcde4c.json
+++ b/change/react-native-windows-a60b678a-aa92-4ee6-9a80-475c8bdcde4c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds event to listen for quirk settings changes",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -13,6 +13,8 @@ namespace winrt::Microsoft::ReactNative::implementation {
 
 QuirkSettings::QuirkSettings() noexcept {}
 
+static event<Windows::Foundation::EventHandler<IReactPropertyName>> s_quirkSettingsChangedEvent;
+
 winrt::Microsoft::ReactNative::ReactPropertyId<bool> MatchAndroidAndIOSStretchBehaviorProperty() noexcept {
   static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
       L"ReactNative.QuirkSettings", L"MatchAndroidAndIOSyStretchBehavior"};
@@ -50,6 +52,7 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
     winrt::Microsoft::ReactNative::ReactPropertyBag properties,
     bool value) noexcept {
   properties.Set(MapWindowDeactivatedToAppStateInactiveProperty(), value);
+  s_quirkSettingsChangedEvent(properties.Handle(), MapWindowDeactivatedToAppStateInactiveProperty().Handle());
 }
 
 #pragma region IDL interface
@@ -58,18 +61,21 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
     winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
     bool value) noexcept {
   SetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag(settings.Properties()), value);
+  s_quirkSettingsChangedEvent(settings.Properties(), MapWindowDeactivatedToAppStateInactiveProperty().Handle());
 }
 
 /*static*/ void QuirkSettings::SetAcceptSelfSigned(
     winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
     bool value) noexcept {
   ReactPropertyBag(settings.Properties()).Set(AcceptSelfSignedCertsProperty(), value);
+  s_quirkSettingsChangedEvent(settings.Properties(), AcceptSelfSignedCertsProperty().Handle());
 }
 
 /*static*/ void QuirkSettings::SetBackHandlerKind(
     winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
     winrt::Microsoft::ReactNative::BackNavigationHandlerKind kind) noexcept {
   ReactPropertyBag(settings.Properties()).Set(EnableBackHandlerKindProperty(), kind);
+  s_quirkSettingsChangedEvent(settings.Properties(), EnableBackHandlerKindProperty().Handle());
 }
 
 /*static*/ void QuirkSettings::SetMapWindowDeactivatedToAppStateInactive(
@@ -96,6 +102,15 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 
 /*static*/ bool QuirkSettings::GetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag properties) noexcept {
   return properties.Get(MapWindowDeactivatedToAppStateInactiveProperty()).value_or(false);
+}
+
+/*static*/ event_token QuirkSettings::QuirkSettingsChanged(
+    Windows::Foundation::EventHandler<IReactPropertyName> const &handler) {
+  return s_quirkSettingsChangedEvent.add(handler);
+}
+
+/*static*/ void QuirkSettings::QuirkSettingsChanged(event_token const &token) noexcept {
+  s_quirkSettingsChangedEvent.remove(token);
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "QuirkSettings.g.h"
+#include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
 #include "ReactPropertyBag.h"
@@ -31,6 +32,9 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       bool value) noexcept;
   static bool GetMapWindowDeactivatedToAppStateInactive(
       winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
+  static event_token QuirkSettingsChanged(Windows::Foundation::EventHandler<IReactPropertyName> const &handler);
+  static void QuirkSettingsChanged(event_token const &token) noexcept;
 
 #pragma region Public API - part of IDL interface
   static void SetMatchAndroidAndIOSStretchBehavior(


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
If we want to set QuirkSettings at runtime, and some component would like to subscribe to those changes, there is currently no mechanism to do that. This adds a winrt::event and a few internal hooks to subscribe to QuirkSettings changes.

### What
The plan is to use this in the PaperUIManager module for experimentation with a few quirk settings, like view flattening or setting `removeChildren` to false when calling `DropView` from `manageChildren`.

## Testing
Usage of this functionality will be added in future PRs. For now, CI is green :).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10585)