### PR TITLE
Add Agent ES exemption file for compliance pipeline

### DIFF
--- a/.ado/config/AgentES.Exemptions.json
+++ b/.ado/config/AgentES.Exemptions.json
@@ -1,0 +1,11 @@
+{
+    "Application": "AgentES v1.0.0.0",
+    "Description": "This file is manually authored.",
+    "Excluded Directories": [
+        {
+            "Path": "node_modules",
+            "Justification": "NPM packages"
+        }
+    ],
+    "Banned File Exemptions": []
+}

--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -6,22 +6,6 @@ parameters:
   default: false
 
 steps:
-  - task: NuGetToolInstaller@1
-    inputs:
-      versionSpec: ">=5.8.0"
-  
-  - task: NuGetAuthenticate@1
-  
-  # AgentES Task (https://aka.ms/UES)
-  # Installs and runs the "Agent ES" tool, which scans the source code for banned file types.
-  - powershell: |
-      & nuget.exe install AgentES -FallbackSource https://microsoft.pkgs.visualstudio.com/_packaging/Undocked.Shell.Services/nuget/v3/index.json
-      $AgentESPath = (Get-ChildItem -Path AgentES* -Filter AgentES.exe -Recurse | %{$_.FullName})
-      & "$AgentESPath" $env:BUILD_SOURCESDIRECTORY -e:$env:BUILD_SOURCESDIRECTORY\.ado\config\AgentES.Exemptions.json -b
-    displayName: "⚖️ AgentES - Scan of Repository for UES Policy Violations"
-    workingDirectory: $(Agent.BuildDirectory)
-    continueOnError: ${{ parameters.complianceWarnOnly }}
-
   # PoliCheck Build Task (https://aka.ms/gdn-azdo-policheck)
   # Scans the text of source code, comments, and content for terminology that could be sensitive for legal, cultural, or geopolitical reasons.
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2

--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -10,6 +10,8 @@ steps:
     inputs:
       versionSpec: ">=5.8.0"
   
+  - task: NuGetAuthenticate@1
+  
   # AgentES Task (https://aka.ms/UES)
   # Installs and runs the "Agent ES" tool, which scans the source code for banned file types.
   - powershell: |

--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -6,6 +6,10 @@ parameters:
   default: false
 
 steps:
+  - task: NuGetToolInstaller@1
+    inputs:
+      versionSpec: ">=5.8.0"
+  
   # AgentES Task (https://aka.ms/UES)
   # Installs and runs the "Agent ES" tool, which scans the source code for banned file types.
   - powershell: |

--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -6,6 +6,16 @@ parameters:
   default: false
 
 steps:
+  # AgentES Task (https://aka.ms/UES)
+  # Installs and runs the "Agent ES" tool, which scans the source code for banned file types.
+  - powershell: |
+      & nuget.exe install AgentES -FallbackSource https://microsoft.pkgs.visualstudio.com/_packaging/Undocked.Shell.Services/nuget/v3/index.json
+      $AgentESPath = (Get-ChildItem -Path AgentES* -Filter AgentES.exe -Recurse | %{$_.FullName})
+      & "$AgentESPath" $env:BUILD_SOURCESDIRECTORY -e:$env:BUILD_SOURCESDIRECTORY\.ado\config\AgentES.Exemptions.json -b
+    displayName: "⚖️ AgentES - Scan of Repository for UES Policy Violations"
+    workingDirectory: $(Agent.BuildDirectory)
+    continueOnError: ${{ parameters.complianceWarnOnly }}
+
   # PoliCheck Build Task (https://aka.ms/gdn-azdo-policheck)
   # Scans the text of source code, comments, and content for terminology that could be sensitive for legal, cultural, or geopolitical reasons.
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2


### PR DESCRIPTION
## Description

Adds the Agent ES exemptions file.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why

The AgentES tool must be ran to determine if any banned file types are present in the repo.

Closes #10147

### What

Adds a new task to the `run-compliance.yml` file to download the AgentES NuGet package and run the tool with our exemption file.

## Screenshots
N/A

## Testing
Ran steps manually locally.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10592)