### PR TITLE
Fix WinUI 3 crash when using keyboard due to KeyboardEventHandler using unsupported class

### DIFF
--- a/change/react-native-windows-27063fbb-4174-416f-87e8-24c77ce8c128.json
+++ b/change/react-native-windows-27063fbb-4174-416f-87e8-24c77ce8c128.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix WinUI 3 crash when using keyboard due to KeyboardEventHandler using unsupported class",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -650,8 +650,7 @@ bool KeyboardHelper::IsModifiedKeyLocked(
 #else
   auto const &keyState = coreWindow.GetKeyState(virtualKey);
 #endif // USE_WINUI3
-  return (keyState & winrt::CoreVirtualKeyStates::Locked) ==
-      winrt::CoreVirtualKeyStates::Locked;
+  return (keyState & winrt::CoreVirtualKeyStates::Locked) == winrt::CoreVirtualKeyStates::Locked;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -10,6 +10,10 @@
 #include "Utils/PropertyHandlerUtils.h"
 #include "Views/KeyboardEventHandler.h"
 
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Input.h>
+#endif
+
 using namespace std::placeholders;
 
 static constexpr auto ALT_KEY = "altKey";
@@ -630,13 +634,23 @@ std::string KeyboardHelper::CodeFromVirtualKey(winrt::Windows::System::VirtualKe
 bool KeyboardHelper::IsModifiedKeyPressed(
     winrt::CoreWindow const &coreWindow,
     winrt::Windows::System::VirtualKey virtualKey) {
-  return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
+#ifdef USE_WINUI3
+  auto const &keyState = winrt::Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(virtualKey);
+#else
+  auto const &keyState = coreWindow.GetKeyState(virtualKey);
+#endif // USE_WINUI3
+  return (keyState & winrt::CoreVirtualKeyStates::Down) == winrt::CoreVirtualKeyStates::Down;
 }
 
 bool KeyboardHelper::IsModifiedKeyLocked(
     winrt::CoreWindow const &coreWindow,
     winrt::Windows::System::VirtualKey virtualKey) {
-  return (coreWindow.GetKeyState(virtualKey) & winrt::CoreVirtualKeyStates::Locked) ==
+#ifdef USE_WINUI3
+  auto const &keyState = winrt::Microsoft::UI::Input::InputKeyboardSource::GetKeyStateForCurrentThread(virtualKey);
+#else
+  auto const &keyState = coreWindow.GetKeyState(virtualKey);
+#endif // USE_WINUI3
+  return (keyState & winrt::CoreVirtualKeyStates::Locked) ==
       winrt::CoreVirtualKeyStates::Locked;
 }
 


### PR DESCRIPTION
## Description
[Per WinAppSDK the CoreWindow class is unsupported](https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/desktop-to-uwp-supported-api#core-unsupported-classes). It's used in KeyboardEventHandler for calling GetKeyState, which the docs provide an alternative:
> Instead of the [GetKeyState](https://docs.microsoft.com/en-us/uwp/api/windows.ui.core.corewindow.getkeystate) method, use the [InputKeyboardSource.GetKeyStateForCurrentThread](https://docs.microsoft.com/en-us/windows/windows-app-sdk/api/winrt/microsoft.ui.input.inputkeyboardsource.getkeystateforcurrentthread) method provided by WinUI 3 instead.

This PR makes that change.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #8063

## Screenshots
Before (crashes):
![image](https://user-images.githubusercontent.com/359157/190793624-dcdfc1c9-7b28-420c-846a-b1e64adeb38c.png)

After (no crash):
![image](https://user-images.githubusercontent.com/359157/190816016-ede04c77-b2f9-42fb-815f-c206f4da15ed.png)


## Testing
To test, launch WinUI 3 app with RNW and press any key.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10598)