### PR TITLE
Avoid batching create view operations

### DIFF
--- a/change/react-native-windows-14dc008b-ae56-4cd9-b6ff-2fc6a6188aaf.json
+++ b/change/react-native-windows-14dc008b-ae56-4cd9-b6ff-2fc6a6188aaf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds QuirkSetting for non-batched create view",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
@@ -22,9 +22,11 @@ class NativeUIManager;
 struct UIManagerSettings {
   UIManagerSettings(
       const std::shared_ptr<facebook::react::MessageQueueThread> batchingUIMessageQueue,
+      const std::shared_ptr<facebook::react::MessageQueueThread> uiMessageQueue,
       std::vector<std::unique_ptr<IViewManager>> &&viewManagers);
   UIManagerSettings(UIManagerSettings const &) = delete;
   const std::shared_ptr<facebook::react::MessageQueueThread> batchingUIMessageQueue;
+  const std::shared_ptr<facebook::react::MessageQueueThread> uiMessageQueue;
   std::vector<std::unique_ptr<IViewManager>> viewManagers;
 };
 
@@ -175,6 +177,7 @@ struct UIManager final {
 
  private:
   std::shared_ptr<facebook::react::MessageQueueThread> m_batchingUIMessageQueue;
+  std::shared_ptr<facebook::react::MessageQueueThread> m_uiMessageQueue;
   std::shared_ptr<UIManagerModule> m_module;
   winrt::Microsoft::ReactNative::ReactContext m_context;
 };

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -789,8 +789,8 @@ void ReactInstanceWin::InitUIManager() noexcept {
 
   Microsoft::ReactNative::AddStandardViewManagers(viewManagers, *m_reactContext);
 
-  auto uiManagerSettings =
-      std::make_unique<Microsoft::ReactNative::UIManagerSettings>(m_batchingUIThread, std::move(viewManagers));
+  auto uiManagerSettings = std::make_unique<Microsoft::ReactNative::UIManagerSettings>(
+      m_batchingUIThread, m_uiMessageThread.Load(), std::move(viewManagers));
   Microsoft::ReactNative::UIManager::SetSettings(m_reactContext->Properties(), std::move(uiManagerSettings));
 
   m_reactContext->Properties().Set(


### PR DESCRIPTION
## Description

### Why

iOS and Android each have their own approach to create view components immediately when the `UIManager.createView` operation is invoked. On Android, the `createView` operations are aggregated in a separate batch and allowed to run for half a frame. On iOS, the `createView` operations always immediately create the native view when the UIManager module method is called.

On Windows, we have been adding the `createView` operation to the batch of operations that invoke when the batch is completed, missing an opportunity to better utilize the UI thread while the JS thread is still busy doing work.

### What
Passes the non-batched UI thread queue to the UIManager and uses that queue for `createView` operations.

Please note, this should not create any UI tearing, as the operations to mount the created views in the native XAML tree are still only performed on batch completion.

## Testing
We ran an experiment for this on Messenger with some significant results. Time-to-rendered-content (TTRC) for important scenarios like thread switching improved by more than 8%, cold start latencies improved by ~1%, overall memory usage improved by a small margin, and TTRC for message sends also improved by about 3%.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10602)