### PR TITLE
Fix formatting in App.xaml.cs in C# WinAppSDK project template

### DIFF
--- a/change/react-native-windows-4fcaba6c-79ae-484a-a6a8-64fa08ee4c4b.json
+++ b/change/react-native-windows-4fcaba6c-79ae-484a-a6a8-64fa08ee4c4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix formatting in App.xaml.cs in C# WinAppSDK project template",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/cs-app-WinAppSDK/MyApp/App.xaml.cs
+++ b/vnext/template/cs-app-WinAppSDK/MyApp/App.xaml.cs
@@ -30,9 +30,9 @@ namespace {{ namespace }}
     public App()
     {
 #if BUNDLE
-            JavaScriptBundleFile = "index.windows";
-            InstanceSettings.UseWebDebugger = false;
-            InstanceSettings.UseFastRefresh = false;
+      JavaScriptBundleFile = "index.windows";
+      InstanceSettings.UseWebDebugger = false;
+      InstanceSettings.UseFastRefresh = false;
 #else
       JavaScriptBundleFile = "index";
       InstanceSettings.UseWebDebugger = true;


### PR DESCRIPTION
## Description
Minor fix of indentation in App.xaml.cs in C# WinAppSDK project template.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
It seems we don't have an auto formatter for C# code.

### What
Just whitespace change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10604)