### PR TITLE
Export OriginPolicy.h to NuGet package

### DIFF
--- a/change/react-native-windows-63ed688a-573c-4dc1-99de-f69d6f650838.json
+++ b/change/react-native-windows-63ed688a-573c-4dc1-99de-f69d6f650838.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove comment",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -56,6 +56,7 @@
     <file src="$nugetroot$\inc\Shared\Modules\I18nModule.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\NativeModuleProvider.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\Networking\IWebSocketResource.h" target="inc"/>
+    <file src="$nugetroot$\inc\Shared\Networking\OriginPolicy.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\RuntimeOptions.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\Tracing.h" target="inc"/>
 

--- a/vnext/Shared/Networking/OriginPolicy.h
+++ b/vnext/Shared/Networking/OriginPolicy.h
@@ -9,7 +9,7 @@ enum class OriginPolicy : size_t {
   None = 0,
   SameOrigin = 1,
   SimpleCrossOriginResourceSharing = 2,
-  CrossOriginResourceSharing = 3, // TODO: Rename as FullCrossOriginResourceSharing?
+  CrossOriginResourceSharing = 3,
 };
 
 } // namespace Microsoft::React::Networking


### PR DESCRIPTION
## Description
Adds OriginPolicy.h to the Desktop NuGet include headers.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
OriginPolicy.h contains the necessary enums to set the app-level HTTP origin policy.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10615)