### PR TITLE
Prevent crash in XAML Islands Flyout

### DIFF
--- a/change/react-native-windows-39bb8fcb-67ab-4f56-adda-ce1fbb820810.json
+++ b/change/react-native-windows-39bb8fcb-67ab-4f56-adda-ce1fbb820810.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent crash in XAML Islands Flyout",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -404,7 +404,9 @@ winrt::Flyout FlyoutShadowNode::GetFlyout() {
 void FlyoutShadowNode::OnShowFlyout() {
   AdjustDefaultFlyoutStyle(50000, 50000);
   if (m_isFlyoutShowOptionsSupported) {
-    if (!m_targetElement && m_targetTag > 0) {
+    if (!m_flyout.XamlRoot()) {
+      LogErrorAndClose("The target view window was closed before flyout could be shown.");
+    } else if (!m_targetElement && m_targetTag > 0) {
       LogErrorAndClose("The target view unmounted before flyout could be shown.");
     } else if (m_targetElement && m_flyout.XamlRoot() != m_targetElement.XamlRoot()) {
       LogErrorAndClose("The target view window lost focus before flyout could be shown.");


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
A recent change to FlyoutViewManager attempts to set the XamlRoot from the NativeUIManager::tryGetXamlRoot function. However, there is a race condition here where the view could be created just after the window was closed (or perhaps even that the window was closed just after the view was created and the weak reference to the XamlRoot on the Flyout resolves to null). When this occurs, attempting to call Flyout::ShowAt results in a crash in XAML Islands applications.

### What
This change ensures that the Flyout has a valid XamlRoot before attempting to show the flyout.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10634)