### PR TITLE
Retain ViewControl even if not needed

### DIFF
--- a/change/react-native-windows-43b865f3-ecf6-4b36-942e-daa4809097c9.json
+++ b/change/react-native-windows-43b865f3-ecf6-4b36-942e-daa4809097c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Retain ViewControl even if not needed",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -504,6 +504,13 @@ void ViewViewManager::TryUpdateView(
   if (isControl == useControl && hadOuterBorder == hasOuterBorder)
     return;
 
+  // This short-circuits if we are already a control and no longer need to be.
+  // Chances are if something was a control at one point in time, it will need
+  // to be a control again, so it is an over-optimization to remove the control
+  // wrapper.
+  if (!useControl && isControl)
+    return;
+
   //
   // 1. Ensure we have the new 'root' and do the child replacement
   //      This is first to ensure that we can re-parent the Border or ViewPanel

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -477,9 +477,10 @@ void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
     // keep it around, so not adding that code (yet).
   }
 
+  // If component is already ViewControl, it should be ViewControl.
   // If component is focusable, it should be a ViewControl.
   // If component is a View with accessible set to true, the component should be focusable, thus we need a ViewControl.
-  bool shouldBeControl =
+  bool shouldBeControl = viewShadowNode->IsControl() ||
       (viewShadowNode->IsFocusable() || (viewShadowNode->IsAccessible() && !viewShadowNode->OnClick()));
   if (auto view = viewShadowNode->GetView().try_as<xaml::UIElement>()) {
     // If we have DynamicAutomationProperties, we need a ViewControl with a
@@ -502,13 +503,6 @@ void ViewViewManager::TryUpdateView(
 
   // This short-circuits all of the update code when we have the same hierarchy
   if (isControl == useControl && hadOuterBorder == hasOuterBorder)
-    return;
-
-  // This short-circuits if we are already a control and no longer need to be.
-  // Chances are if something was a control at one point in time, it will need
-  // to be a control again, so it is an over-optimization to remove the control
-  // wrapper.
-  if (!useControl && isControl)
     return;
 
   //
@@ -537,7 +531,7 @@ void ViewViewManager::TryUpdateView(
   }
 
   // Clean up child of Control if needed
-  if (isControl && (!useControl || (hasOuterBorder != hadOuterBorder))) {
+  if (isControl && hasOuterBorder != hadOuterBorder) {
     pViewShadowNode->GetControl().Content(nullptr);
   }
 


### PR DESCRIPTION
## Description

### Why
Chances are, if an app needs a ViewControl for focusability or accessibility properties, it will need the ViewControl again in the future.

### What
This change avoids removal of the ViewControl when a <View> transitions from focusable/accessible to not focusable.

## Testing
Ran a simple test in Playground, confirmed that the ContentControl wrapper is stable and switching in and out of focusable still works as expected.

https://user-images.githubusercontent.com/1106239/192593997-c414840c-719f-4af1-933f-756ce81eb0c6.mp4

https://user-images.githubusercontent.com/1106239/194339044-6a3b0a6a-d508-4e26-ac90-11788407caf1.mp4

Added `accessible` example. Please note, there are two bugs in the main branch today, one of which is fixed by this:
1. If the control is both `focusable` and `accessible` and then `accessible` is disabled, Narrator can get out of sync with keyboard focus. This issue is present both before and after this change. cc @chiaramooney 
2. If the control was neither `focusable` nor `accessible`, and only `accessible` is enabled, the control also becomes `focusable`. This issue is only present before this change, and I'm not sure whether it's expected behavior. cc @chiaramooney.

https://user-images.githubusercontent.com/1106239/194344585-d53ac028-40f1-4026-b036-43c3579c9d63.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10641)