### PR TITLE
Deletes irrelevant TODO from NativeUIManager

### DIFF
--- a/change/react-native-windows-e25a11c7-0495-427c-a391-bf0597daa183.json
+++ b/change/react-native-windows-e25a11c7-0495-427c-a391-bf0597daa183.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Deletes irrelevant TODO from NativeUIManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -202,25 +202,6 @@ int64_t NativeUIManager::AddMeasuredRootView(facebook::react::IReactRootView *ro
 
   m_host->RegisterRootView(rootView, tag, width, height);
 
-  // TODO: call UpdateRootNodeSize when ReactRootView size changes
-  /*var resizeCount = 0;
-  rootView.SetOnSizeChangedListener((sender, args) =>
-  {
-  var currentCount = ++resizeCount;
-  var newWidth = args.NewSize.Width;
-  var newHeight = args.NewSize.Height;
-
-  Context.RunOnNativeModulesQueueThread(() =>
-  {
-  if (currentCount == resizeCount)
-  {
-  Context.AssertOnNativeModulesQueueThread();
-  _uiImplementation.UpdateRootNodeSize(tag, newWidth, newHeight,
-  _eventDispatcher);
-  }
-  });
-  });*/
-
   return tag;
 }
 


### PR DESCRIPTION
This TODO in NativeUIManager was a reminder to set up size changed events for the root view to update layout. This must have been fixed already but the TODO was never removed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10642)