### PR TITLE
Fabric: fix zorder issues

### DIFF
--- a/change/react-native-windows-f017b5c1-bf44-4a8f-b996-203d619e5329.json
+++ b/change/react-native-windows-f017b5c1-bf44-4a8f-b996-203d619e5329.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: fix zorder issues",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -245,8 +245,8 @@ struct CompSpriteVisual : winrt::Microsoft::ReactNative::Composition::implementa
   void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
     auto containerChildren = m_visual.Children();
     auto compVisual = winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerVisual(visual);
-    if (index == 0 || containerChildren.Count() == 0) {
-      containerChildren.InsertAtTop(compVisual);
+    if (index == 0) {
+      containerChildren.InsertAtBottom(compVisual);
       return;
     }
     auto insertAfter = containerChildren.First();


### PR DESCRIPTION
Error in the insert logic was causing visuals to be inserted in the wrong order.  This causes visuals to show up with the wrong zorder.

One obvious effect of this is the yellowbox warning banner would disappear behind the app content.  But also easily visible in the zorder view test page in RNTester.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10653)