### PR TITLE
Fix +1 problem in LocalBundleReader

### DIFF
--- a/change/react-native-windows-d5e1c0c0-cb20-47fd-947a-eb449f7e9677.json
+++ b/change/react-native-windows-d5e1c0c0-cb20-47fd-947a-eb449f7e9677.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix +1 problem in LocalBundleReader",
+  "packageName": "react-native-windows",
+  "email": "aeulitz@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp
@@ -76,14 +76,15 @@ std::future<std::string> LocalBundleReader::LoadBundleAsync(const std::string &b
   auto fileBuffer{co_await winrt::Windows::Storage::FileIO::ReadBufferAsync(file)};
   auto dataReader{winrt::Windows::Storage::Streams::DataReader::FromBuffer(fileBuffer)};
 
-  std::string script(fileBuffer.Length() + 1, '\0');
+  // No need to use length + 1, STL guarantees that string storage is null-terminated.
+  std::string script(fileBuffer.Length(), '\0');
 
   // Construct the array_view to slice into the first fileBuffer.Length bytes.
   // DataReader.ReadBytes will read as many bytes as are present in the
   // array_view. The backing string has fileBuffer.Length() + 1 bytes, without
   // an explicit end it will read 1 byte to many and throw.
   dataReader.ReadBytes(winrt::array_view<uint8_t>{
-      reinterpret_cast<uint8_t *>(&script[0]), reinterpret_cast<uint8_t *>(&script[script.length() - 1])});
+      reinterpret_cast<uint8_t *>(&script[0]), reinterpret_cast<uint8_t *>(&script[script.length()])});
   dataReader.Close();
 
   co_return script;


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
[LocalBundleReader.cpp(79)](https://github.com/microsoft/react-native-windows/blob/main/vnext/Microsoft.ReactNative/Utils/LocalBundleReader.cpp#L79) adds 1 to the file length in an apparent attempt to ensure a null-terminated string (confirmed with @stecrain, the original author). The subsequent code does not adjust the string length to reflect the actual file content length, leading to a JS string that contains a '\0' char. The token scanners of Chakra and Hermes appear to tolerate the '\0' char (perhaps they skip it, or treat it as the end of the JS string, either would work). V8's token scanner, however, reports the '\0' char as an invalid token, causing script parsing to fail with an invalid syntax error.

Resolves [RNW:10655](https://github.com/microsoft/react-native-windows/issues/10655)

### What
Remove problematic (and unnecessary) "... + 1" expressions.

## Testing
- Built UWP Playground app with V8 support (engages LocalBundleReader); generated bundle files with Metro
- Loaded bundle files in the UWP Playground app


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10656)