### PR TITLE
Refactor the onLayout event for view flattening

### DIFF
--- a/change/react-native-windows-377f2770-0169-4a24-add1-e9ae515c1038.json
+++ b/change/react-native-windows-377f2770-0169-4a24-add1-e9ae515c1038.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor the onLayout event for view flattening",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -34,6 +34,11 @@ static YogaNodePtr make_yoga_node(YGConfigRef config) {
   return result;
 }
 
+static inline bool YogaFloatEquals(float x, float y) {
+  // Epsilon value of 0.0001f is taken from the YGFloatsEqual method in Yoga.
+  return std::fabs(x - y) < 0.0001f;
+};
+
 #if defined(_DEBUG)
 static int YogaLog(
     const YGConfigRef /*config*/,
@@ -943,6 +948,17 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
     auto view = shadowNode.GetView();
     auto pViewManager = shadowNode.GetViewManager();
     pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+    if (shadowNode.m_onLayoutRegistered) {
+      const auto hasLayoutChanged = !YogaFloatEquals(left, shadowNode.m_layout.Left) ||
+          !YogaFloatEquals(top, shadowNode.m_layout.Top) || !YogaFloatEquals(width, shadowNode.m_layout.Width) ||
+          !YogaFloatEquals(height, shadowNode.m_layout.Height);
+      if (hasLayoutChanged) {
+        React::JSValueObject layout{{"x", left}, {"y", top}, {"height", height}, {"width", width}};
+        React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
+        pViewManager->DispatchCoalescingEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
+      }
+    }
+    shadowNode.m_layout = {left, top, width, height};
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -44,6 +44,13 @@ enum class ShadowCorners : uint8_t {
   CountCorners
 };
 
+struct ShadowNodeLayout {
+  float Left;
+  float Top;
+  float Width;
+  float Height;
+};
+
 extern const DECLSPEC_SELECTANY double c_UndefinedEdge = -1;
 #define INIT_UNDEFINED_EDGES                                                                              \
   {                                                                                                       \
@@ -131,6 +138,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
 
   // Pointer events
   PointerEventsKind m_pointerEvents = PointerEventsKind::Auto;
+
+  // Layout
+  ShadowNodeLayout m_layout;
 
   // Support Keyboard
  public:

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -358,25 +358,12 @@ void ViewManagerBase::SetLayoutProps(
   }
   auto fe = element.as<xaml::FrameworkElement>();
 
-  const bool layoutHasChanged = left != ViewPanel::GetLeft(element) || top != ViewPanel::GetTop(element) ||
-      width != fe.Width() || height != fe.Height();
-
   // Set Position & Size Properties
   ViewPanel::SetLeft(element, left);
   ViewPanel::SetTop(element, top);
 
   fe.Width(width);
   fe.Height(height);
-
-  // Fire Events
-  if (layoutHasChanged && nodeToUpdate.m_onLayoutRegistered) {
-    int64_t tag = GetTag(viewToUpdate);
-    React::JSValueObject layout{{"x", left}, {"y", top}, {"height", height}, {"width", width}};
-
-    React::JSValueObject eventData{{"target", tag}, {"layout", std::move(layout)}};
-
-    m_batchingEventEmitter->DispatchCoalescingEvent(tag, L"topLayout", MakeJSValueWriter(std::move(eventData)));
-  }
 }
 
 YGMeasureFunc ViewManagerBase::GetYogaCustomMeasureFunc() const {
@@ -412,6 +399,13 @@ void ViewManagerBase::DispatchEvent(
     winrt::hstring &&eventName,
     const React::JSValueArgWriter &eventDataWriter) const noexcept {
   m_batchingEventEmitter->DispatchEvent(viewTag, std::move(eventName), eventDataWriter);
+}
+
+void ViewManagerBase::DispatchCoalescingEvent(
+    int64_t viewTag,
+    winrt::hstring &&eventName,
+    const React::JSValueArgWriter &eventDataWriter) const noexcept {
+  m_batchingEventEmitter->DispatchCoalescingEvent(viewTag, std::move(eventName), eventDataWriter);
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -90,6 +90,10 @@ class REACTWINDOWS_EXPORT ViewManagerBase : public IViewManager {
       int64_t viewTag,
       winrt::hstring &&eventName,
       const winrt::Microsoft::ReactNative::JSValueArgWriter &eventDataWriter) const noexcept;
+  void DispatchCoalescingEvent(
+      int64_t viewTag,
+      winrt::hstring &&eventName,
+      const winrt::Microsoft::ReactNative::JSValueArgWriter &eventDataWriter) const noexcept;
 
   virtual void TransferProperties(const XamlView &oldView, const XamlView &newView);
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
We are working on an implementation of view flattening for the Paper UIManager in react-native-windows. Since not all nodes are materialized into native components, the backing store for previous layout data cannot be the native component itself. Also, the actual top/left values that get applied to a particular view will not equal the values computed by Yoga (they will be offset by the cumulative left and top values of any flattening parents).

### What

This change adds 4 bytes to the ShadowNode to store the latest layout constraints computed by Yoga and lifts the `onLayout` event to the NativeUIManager, so that even if a view is flattened, it can still emit `onLayout` events.

## Testing
Ran RNTester > VirtualizedList examples. VirtualizedList is the core component that is most dependent on the `onLayout` event. Since it behaves the same, it's most probable that the onLayout events have not been broken.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10658)