### PR TITLE
Adds QuirkSetting to use YGExperimentalFeatureWebFlexBasis

### DIFF
--- a/change/react-native-windows-81766dee-43b9-4551-9a83-d2cc2e6b1f03.json
+++ b/change/react-native-windows-81766dee-43b9-4551-9a83-d2cc2e6b1f03.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds QuirkSetting to use YGExperimentalFeatureWebFlexBasis",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -145,6 +145,8 @@ XamlView NativeUIManager::reactPeerOrContainerFrom(xaml::FrameworkElement fe) {
 NativeUIManager::NativeUIManager(winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : m_context(reactContext) {
   m_yogaConfig = YGConfigNew();
+  if (React::implementation::QuirkSettings::GetUseWebFlexBasisBehavior(m_context.Properties()))
+    YGConfigSetExperimentalFeatureEnabled(m_yogaConfig, YGExperimentalFeatureWebFlexBasis, true);
   if (React::implementation::QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(m_context.Properties()))
     YGConfigSetUseLegacyStretchBehaviour(m_yogaConfig, true);
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -25,6 +25,18 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MatchAndroidAndIOSStretchBe
   properties.Set(MatchAndroidAndIOSStretchBehaviorProperty(), value);
 }
 
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> UseWebFlexBasisBehaviorProperty() noexcept {
+  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"UseWebFlexBasisBehavior"};
+  return propId;
+}
+
+/*static*/ void QuirkSettings::SetUseWebFlexBasisBehavior(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    bool value) noexcept {
+  properties.Set(UseWebFlexBasisBehaviorProperty(), value);
+}
+
 winrt::Microsoft::ReactNative::ReactPropertyId<bool> AcceptSelfSignedCertsProperty() noexcept {
   winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
       L"ReactNative.QuirkSettings", L"Networking.AcceptSelfSigned"};
@@ -60,6 +72,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   SetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag(settings.Properties()), value);
 }
 
+/*static*/ void QuirkSettings::SetUseWebFlexBasisBehavior(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
+  SetUseWebFlexBasisBehavior(ReactPropertyBag(settings.Properties()), value);
+}
+
 /*static*/ void QuirkSettings::SetAcceptSelfSigned(
     winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
     bool value) noexcept {
@@ -81,6 +99,10 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
+  return properties.Get(MatchAndroidAndIOSStretchBehaviorProperty()).value_or(true);
+}
+
+/*static*/ bool QuirkSettings::GetUseWebFlexBasisBehavior(ReactPropertyBag properties) noexcept {
   return properties.Get(MatchAndroidAndIOSStretchBehaviorProperty()).value_or(true);
 }
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -103,7 +103,7 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 }
 
 /*static*/ bool QuirkSettings::GetUseWebFlexBasisBehavior(ReactPropertyBag properties) noexcept {
-  return properties.Get(MatchAndroidAndIOSStretchBehaviorProperty()).value_or(true);
+  return properties.Get(UseWebFlexBasisBehaviorProperty()).value_or(false);
 }
 
 /*static*/ bool QuirkSettings::GetAcceptSelfSigned(ReactPropertyBag properties) noexcept {

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -20,6 +20,11 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       bool value) noexcept;
   static bool GetMatchAndroidAndIOSStretchBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
+  static void SetUseWebFlexBasisBehavior(
+      winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+      bool value) noexcept;
+  static bool GetUseWebFlexBasisBehavior(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
   static bool GetAcceptSelfSigned(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
   static winrt::Microsoft::ReactNative::BackNavigationHandlerKind GetBackHandlerKind(
       winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
@@ -34,6 +39,10 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
 
 #pragma region Public API - part of IDL interface
   static void SetMatchAndroidAndIOSStretchBehavior(
+      winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+      bool value) noexcept;
+
+  static void SetUseWebFlexBasisBehavior(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
       bool value) noexcept;
 

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -30,6 +30,13 @@ namespace Microsoft.ReactNative
     DOC_DEFAULT("true")
     static void SetMatchAndroidAndIOSStretchBehavior(ReactInstanceSettings settings, Boolean value);
 
+    DOC_STRING(
+        "There is a chance that cached flex basis values can cause text truncation in some re-layout scenarios. "
+        "Enabling [Yoga](https://github.com/facebook/yoga)'s experimental web flex basis behavior fixes this issue, "
+        "however using it may result in perfomance regressions due to additional layout passes.")
+    DOC_DEFAULT("false")
+    static void SetUseWebFlexBasisBehavior(ReactInstanceSettings settings, Boolean value);
+
     DOC_STRING("Runtime setting allowing Networking (HTTP, WebSocket) connections to skip certificate validation.")
     static void SetAcceptSelfSigned(ReactInstanceSettings settings, Boolean value);
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
By default, Yoga will cache flex basis values to avoid expensive recomputation. However, there are some scenarios, particularly when resizing the window, where cached layout values from Yoga combined with cached flex basis values can produce incorrect results.

Resolves #9343

### What
This change adds a new QuirkSetting to opt-in to the YGExperimentalFeatureWebFlexBasis option in Yoga for apps where re-use of this cached flex basis value is problematic. We'll keep this opt-in for now, as it is likely to impact performance of Yoga layout.

## Testing
CI is green. Results of opting into this QuirkSetting may vary in different apps both w.r.t. to performance and potentially layout results.
