### PR TITLE
Enable RCTNetworkingNative as TurboModule (JS only)

### DIFF
--- a/change/@office-iss-react-native-win32-ffa7d3c1-a55b-462d-9195-7911dd08577e.json
+++ b/change/@office-iss-react-native-win32-ffa7d3c1-a55b-462d-9195-7911dd08577e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable RCTNetworkingNative as TurboModule (JS only)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-19db3b6f-e422-479e-baec-0ef3056d5253.json
+++ b/change/react-native-windows-19db3b6f-e422-479e-baec-0ef3056d5253.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable RCTNetworkingNative as TurboModule (JS only)",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Network/RCTNetworking.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Network/RCTNetworking.win32.js
@@ -9,8 +9,7 @@
 'use strict';
 
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
-const RCTNetworkingNative =
-  require('../BatchedBridge/NativeModules').Networking; // [Windows]
+const RCTNetworkingNative = TurboModuleRegistry.getEnforcing('Networking');
 import {type NativeResponseType} from './XMLHttpRequest';
 import convertRequestBody, {type RequestBody} from './convertRequestBody';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';

--- a/vnext/src/Libraries/Network/RCTNetworking.windows.js
+++ b/vnext/src/Libraries/Network/RCTNetworking.windows.js
@@ -9,8 +9,7 @@
 'use strict';
 
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
-const RCTNetworkingNative =
-  require('../BatchedBridge/NativeModules').Networking; // [Windows]
+const RCTNetworkingNative = TurboModuleRegistry.getEnforcing('Networking');
 import {type NativeResponseType} from './XMLHttpRequest';
 import convertRequestBody, {type RequestBody} from './convertRequestBody';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';


### PR DESCRIPTION
- Enable RCTNetworkingNative as TurboModule (JS only)
- Change files

## Description
Allows projecting the native HTTP module as a TurboModule.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
There will be an eventual switch to TurboModules, phasing out CxxModules.

### What
Modifies the JavaScript RCTNetworkingNative to support both TurboModule and CxxModule implementations.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10663)