### PR TITLE
Explicitly measure relative to the root XAML element

### DIFF
--- a/change/react-native-windows-0f54d4e2-d544-4e6b-b6bb-3f7e6eb6d3e3.json
+++ b/change/react-native-windows-0f54d4e2-d544-4e6b-b6bb-3f7e6eb6d3e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Explicitly measure relative to the root XAML element",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -1012,7 +1012,9 @@ void NativeUIManager::measureInWindow(
   ShadowNodeBase &node = static_cast<ShadowNodeBase &>(shadowNode);
 
   if (auto view = node.GetView().try_as<xaml::FrameworkElement>()) {
-    auto windowTransform = view.TransformToVisual(xaml::Window::Current().Content());
+    // When supplied with nullptr, TransformToVisual will return the position
+    // relative to the root XAML element.
+    auto windowTransform = view.TransformToVisual(nullptr);
     auto positionInWindow = windowTransform.TransformPoint({0, 0});
 
     m_context.JSDispatcher().Post(


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
While not a well supported scenario, multi-window UWP applications might measure relative to the incorrect root XAML view when calling `measureInWindow` if the view is not in the currently activated / foreground window.

I was confused on why `measureInWindow` seemed to work fine in XAML Islands React Native apps, but then realized that `xaml::Window::Current().Content()` returned null in XAML Islands applications, so only UWP apps are impacted.

### What
Previously, `measureInWindow` measured relative to `xaml::Window::Current().Content()`. Calling `TransformToVisual` with a null argument measures relative to the root XAML content, which is equivalent to `xaml::Window::Current().Content()` for the foreground window. The main difference is that this API will now measure correctly for React Native windows that are not in the foreground.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10665)