### PR TITLE
Use react-native-codegen from react-native instead of from react-native-tscodegen

### DIFF
--- a/change/@react-native-windows-cli-e3847c52-a0ae-4225-ae47-5e0fb5095bd2.json
+++ b/change/@react-native-windows-cli-e3847c52-a0ae-4225-ae47-5e0fb5095bd2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use react-native-codegen from rn, instead of from react-native-tscodegen",
+  "packageName": "@react-native-windows/cli",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-31042724-aa30-4b89-a76d-1131ab4c8448.json
+++ b/change/@react-native-windows-codegen-31042724-aa30-4b89-a76d-1131ab4c8448.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use react-native-codegen from rn, instead of from react-native-tscodegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -65,6 +65,9 @@
     "prettier": "^2.4.1",
     "typescript": "^4.4.4"
   },
+  "peerDependencies": {
+    "react-native": "*"
+  },
   "files": [
     "lib-commonjs",
     "powershell"

--- a/packages/@react-native-windows/codegen/depcheck.config.js
+++ b/packages/@react-native-windows/codegen/depcheck.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  ignoreMatches: [
+    'react-native-codegen', // Resolved dynamically from react-native
+  ]
+}

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -24,7 +24,6 @@
     "chalk": "^4.1.0",
     "globby": "^11.0.4",
     "mustache": "^4.0.1",
-    "react-native-tscodegen": "0.68.4",
     "source-map-support": "^0.5.19",
     "yargs": "^16.2.0"
   },
@@ -41,7 +40,11 @@
     "eslint": "^7.32.0",
     "jest": "^26.6.3",
     "prettier": "^2.4.1",
+    "react-native-tscodegen": "0.68.4",
     "typescript": "^4.4.4"
+  },
+  "peerDependencies": {
+    "react-native": "*"
   },
   "files": [
     "bin.js",

--- a/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {
+import type {
   NativeModuleBaseTypeAnnotation,
   NativeModuleObjectTypeAnnotation,
   NamedShape,

--- a/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasManaging.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {NativeModuleObjectTypeAnnotation} from 'react-native-tscodegen';
+import type {NativeModuleObjectTypeAnnotation} from 'react-native-tscodegen';
 
 let preferredModuleName: string = '';
 

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {SchemaType} from 'react-native-tscodegen';
+import type {SchemaType} from 'react-native-tscodegen';
 import {AliasMap, setPreferredModuleName} from './AliasManaging';
 import {createAliasMap, generateAliases} from './AliasGen';
 import {generateValidateConstants} from './ValidateConstants';

--- a/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateTypeScript.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {
+import type {
   NamedShape,
   NativeModuleBaseTypeAnnotation,
   NativeModuleFunctionTypeAnnotation,

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -6,7 +6,10 @@
 
 'use strict';
 
-import {NativeModuleBaseTypeAnnotation, Nullable} from 'react-native-tscodegen';
+import type {
+  NativeModuleBaseTypeAnnotation,
+  Nullable,
+} from 'react-native-tscodegen';
 import {
   AliasMap,
   getAliasCppName,

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {
+import type {
   NamedShape,
   NativeModuleParamTypeAnnotation,
   Nullable,

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {
+import type {
   NativeModuleReturnTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';

--- a/packages/@react-native-windows/codegen/src/generators/ValidateConstants.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateConstants.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {NativeModuleSchema} from 'react-native-tscodegen';
+import type {NativeModuleSchema} from 'react-native-tscodegen';
 import {AliasMap, getAnonymousAliasCppName} from './AliasManaging';
 
 export function generateValidateConstants(

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {
+import type {
   NativeModuleFunctionTypeAnnotation,
   NativeModulePropertyShape,
   NativeModuleSchema,

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -21,7 +21,10 @@ const rncodegenPath = path.dirname(
   require.resolve('react-native-codegen/package.json', {paths: [rnPath]}),
 );
 const FlowParser = require(path.resolve(rncodegenPath, 'lib/parsers/flow'));
-const TypeScriptParser = require(path.resolve(rncodegenPath, 'lib/parsers/typescript'));
+const TypeScriptParser = require(path.resolve(
+  rncodegenPath,
+  'lib/parsers/typescript',
+));
 
 const schemaValidator = require(path.resolve(
   rncodegenPath,
@@ -125,9 +128,11 @@ function writeMapToFiles(map: Map<string, string>, outputDir: string) {
 export function parseFile(filename: string): SchemaType {
   try {
     const isTypeScript =
-    path.extname(filename) === '.ts' || path.extname(filename) === '.tsx';
+      path.extname(filename) === '.ts' || path.extname(filename) === '.tsx';
 
-    const schema = isTypeScript ? TypeScriptParser.parseFile(filename) : FlowParser.parseFile(filename);
+    const schema = isTypeScript
+      ? TypeScriptParser.parseFile(filename)
+      : FlowParser.parseFile(filename);
     // there will be at most one turbo module per file
     const moduleName = Object.keys(schema.modules)[0];
     if (moduleName) {

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -13,11 +13,18 @@ import {
   generateTypeScript,
   setOptionalTurboModule,
 } from './generators/GenerateTypeScript';
-import {SchemaType} from 'react-native-tscodegen';
-// @ts-ignore
-import {parseFile} from 'react-native-tscodegen/lib/rncodegen/src/parsers/flow';
-// @ts-ignore
-import schemaValidator from 'react-native-tscodegen/lib/rncodegen/src/schemaValidator';
+import type {SchemaType} from 'react-native-tscodegen';
+
+// Load react-native-codegen from react-native
+const rnPath = path.dirname(require.resolve('react-native/package.json'));
+const rncodegenPath = path.dirname(
+  require.resolve('react-native-codegen/package.json', {paths: [rnPath]}),
+);
+const {parseFile} = require(path.resolve(rncodegenPath, 'lib/parsers/flow'));
+const schemaValidator = require(path.resolve(
+  rncodegenPath,
+  'lib/schemaValidator',
+));
 
 interface Options {
   libraryName: string;


### PR DESCRIPTION
react-native-tscodegen has an internal duplication of react-native-codegen. This was largely built before react-native-codegen was properly published.  Now that react-native-codegen is published, we can use the published package directly.

I've switched all our usage of react-native-tscodegen to be for types only.  Hopefully we can look at getting typing information published as part of react-native-codegen in the future to remove the need for react-native-tscodegen entirely.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10667)