### PR TITLE
Adds LayoutService interface to allow native layout updates

### DIFF
--- a/change/react-native-windows-701f2200-7c68-46ab-9af5-099e1ca8ba0f.json
+++ b/change/react-native-windows-701f2200-7c68-46ab-9af5-099e1ca8ba0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds LayoutService interface to allow native layout updates",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/INativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/INativeUIManager.h
@@ -50,6 +50,7 @@ struct INativeUIManager {
   virtual void UpdateView(ShadowNode &shadowNode, winrt::Microsoft::ReactNative::JSValueObject &props) = 0;
   virtual void onBatchComplete() = 0;
   virtual void ensureInBatch() = 0;
+  virtual bool isInBatch() = 0;
   virtual void measure(
       ShadowNode &shadowNode,
       ShadowNode &shadowRoot,

--- a/vnext/Microsoft.ReactNative/LayoutService.cpp
+++ b/vnext/Microsoft.ReactNative/LayoutService.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "LayoutService.h"
+#include "LayoutService.g.cpp"
+#include <Modules/NativeUIManager.h>
+#include <Modules/PaperUIManagerModule.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+LayoutService::LayoutService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept : m_context(context) {}
+
+/*static*/ winrt::Microsoft::ReactNative::LayoutService LayoutService::FromContext(IReactContext context) {
+  return context.Properties()
+      .Get(LayoutService::LayoutServiceProperty().Handle())
+      .try_as<winrt::Microsoft::ReactNative::LayoutService>();
+}
+
+/*static*/ ReactPropertyId<LayoutService> LayoutService::LayoutServiceProperty() noexcept {
+  static ReactPropertyId<LayoutService> layoutServiceProperty{L"ReactNative.UIManager", L"LayoutService"};
+  return layoutServiceProperty;
+}
+
+void LayoutService::ApplyLayout() noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    uiManager->DoLayout();
+  }
+}
+
+void LayoutService::ApplyLayout(int64_t reactTag) noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    uiManager->ApplyLayout(reactTag);
+  }
+}
+
+void LayoutService::ApplyLayout(int64_t reactTag, float width, float height) noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    uiManager->ApplyLayout(reactTag, width, height);
+  }
+}
+
+bool LayoutService::IsInBatch() noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    return uiManager->isInBatch();
+  }
+
+  return false;
+}
+
+void LayoutService::MarkDirty(int64_t reactTag) noexcept {
+  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+    uiManager->DirtyYogaNode(reactTag);
+  }
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/LayoutService.cpp
+++ b/vnext/Microsoft.ReactNative/LayoutService.cpp
@@ -22,15 +22,9 @@ LayoutService::LayoutService(Mso::CntPtr<Mso::React::IReactContext> &&context) n
   return layoutServiceProperty;
 }
 
-void LayoutService::ApplyLayout() noexcept {
+void LayoutService::ApplyLayoutForAllNodes() noexcept {
   if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
     uiManager->DoLayout();
-  }
-}
-
-void LayoutService::ApplyLayout(int64_t reactTag) noexcept {
-  if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
-    uiManager->ApplyLayout(reactTag);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/LayoutService.h
+++ b/vnext/Microsoft.ReactNative/LayoutService.h
@@ -16,8 +16,7 @@ struct LayoutService : LayoutServiceT<LayoutService> {
   static winrt::Microsoft::ReactNative::LayoutService FromContext(IReactContext context);
   static ReactPropertyId<LayoutService> LayoutServiceProperty() noexcept;
 
-  void ApplyLayout() noexcept;
-  void ApplyLayout(int64_t reactTag) noexcept;
+  void ApplyLayoutForAllNodes() noexcept;
   void ApplyLayout(int64_t reactTag, float width, float height) noexcept;
   bool IsInBatch() noexcept;
   void MarkDirty(int64_t reactTag) noexcept;

--- a/vnext/Microsoft.ReactNative/LayoutService.h
+++ b/vnext/Microsoft.ReactNative/LayoutService.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "LayoutService.g.h"
+#include "INativeUIManager.h"
+#include "ReactHost/React.h"
+#include "ReactPropertyBag.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+struct LayoutService : LayoutServiceT<LayoutService> {
+ public:
+  LayoutService(Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept;
+  static winrt::Microsoft::ReactNative::LayoutService FromContext(IReactContext context);
+  static ReactPropertyId<LayoutService> LayoutServiceProperty() noexcept;
+
+  void ApplyLayout() noexcept;
+  void ApplyLayout(int64_t reactTag) noexcept;
+  void ApplyLayout(int64_t reactTag, float width, float height) noexcept;
+  bool IsInBatch() noexcept;
+  void MarkDirty(int64_t reactTag) noexcept;
+
+ private:
+  Mso::CntPtr<Mso::React::IReactContext> m_context;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+struct LayoutService : LayoutServiceT<LayoutService, implementation::LayoutService> {};
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/LayoutService.idl
+++ b/vnext/Microsoft.ReactNative/LayoutService.idl
@@ -28,10 +28,12 @@ namespace Microsoft.ReactNative
     void ApplyLayout(Int64 reactTag, Single width, Single height);
 
     DOC_STRING(
-      "Determines whether the UIManager is currently processing a batch of node updates."
-      "This is useful for optimizing layout and ensuring that applying layout to a particular "
-      "node will not cause tearing in the rendered UI.")
-    Boolean IsInBatch();
+        "Determines whether the UIManager is currently processing a batch of node updates."
+        "This is useful for optimizing layout and ensuring that applying layout to a particular "
+        "node will not cause tearing in the rendered UI.")
+    Boolean IsInBatch {
+      get;
+    };
 
     DOC_STRING("Mark a particular React node as dirty for Yoga layout.")
     void MarkDirty(Int64 reactTag);

--- a/vnext/Microsoft.ReactNative/LayoutService.idl
+++ b/vnext/Microsoft.ReactNative/LayoutService.idl
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "IReactContext.idl";
+
+#include "NamespaceRedirect.h"
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+  [default_interface]
+  [webhosthidden]
+  DOC_STRING("Provides access to Yoga layout functionality.")
+  runtimeclass LayoutService {
+    DOC_STRING("Use this method to get access to the @LayoutService associated with the @IReactContext.")
+    static LayoutService FromContext(IReactContext context);
+
+    DOC_STRING("Applies layout to all root nodes.")
+    void ApplyLayout();
+
+    DOC_STRING("Applies layout from a given React node.")
+    void ApplyLayout(Int64 reactTag);
+
+    DOC_STRING("Applies layout from a given React node with root layout constraints.")
+    void ApplyLayout(Int64 reactTag, Single width, Single height);
+
+    DOC_STRING(
+      "Determines whether the UIManager is currently processing a batch of node updates."
+      "This is useful for optimizing layout and ensuring that applying layout to a particular "
+      "node will not cause tearing in the rendered UI.")
+    Boolean IsInBatch();
+
+    DOC_STRING("Mark a particular React node as dirty for Yoga layout.")
+    void MarkDirty(Int64 reactTag);
+  }
+} // namespace ReactNative

--- a/vnext/Microsoft.ReactNative/LayoutService.idl
+++ b/vnext/Microsoft.ReactNative/LayoutService.idl
@@ -15,13 +15,16 @@ namespace Microsoft.ReactNative
     DOC_STRING("Use this method to get access to the @LayoutService associated with the @IReactContext.")
     static LayoutService FromContext(IReactContext context);
 
-    DOC_STRING("Applies layout to all root nodes.")
-    void ApplyLayout();
+    DOC_STRING(
+      "Recursively applies layout to all root nodes. This method will trigger "
+      "a Yoga layout operation on roots attached to the React instance and "
+      "apply the layout results to all descendant nodes.")
+    void ApplyLayoutForAllNodes();
 
-    DOC_STRING("Applies layout from a given React node.")
-    void ApplyLayout(Int64 reactTag);
-
-    DOC_STRING("Applies layout from a given React node with root layout constraints.")
+    DOC_STRING(
+      "Recursively applies layout from the given React node with the supplied "
+      "size constraints. This method will trigger a Yoga layout operation on the "
+      "given node and its descendants and apply the layout results to these nodes.")
     void ApplyLayout(Int64 reactTag, Single width, Single height);
 
     DOC_STRING(

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -380,6 +380,10 @@
     <ClInclude Include="Views\VirtualTextViewManager.h" />
     <ClInclude Include="Views\XamlFeatures.h" />
     <ClInclude Include="XamlLoadState.h" />
+    <ClInclude Include="LayoutService.h">
+      <DependentUpon>LayoutService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="XamlUIService.h">
       <DependentUpon>XamlUIService.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -598,6 +602,10 @@
     <ClCompile Include="Views\XamlFeatures.cpp" />
     <ClCompile Include="XamlLoadState.cpp" />
     <ClCompile Include="XamlView.cpp" />
+    <ClCompile Include="LayoutService.cpp">
+      <DependentUpon>LayoutService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="XamlUIService.cpp">
       <DependentUpon>XamlUIService.idl</DependentUpon>
       <SubType>Code</SubType>
@@ -674,6 +682,9 @@
     <Midl Include="Views\cppwinrt\Effects.idl" />
     <Midl Include="Views\cppwinrt\DynamicAutomationPeer.idl" />
     <Midl Include="Views\cppwinrt\ViewPanel.idl" />
+    <Midl Include="LayoutService.idl">
+      <SubType>Designer</SubType>
+    </Midl>
     <Midl Include="XamlUIService.idl">
       <SubType>Designer</SubType>
     </Midl>

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -752,6 +752,7 @@
     <Midl Include="RedBoxHandler.idl" />
     <Midl Include="QuirkSettings.idl" />
     <Midl Include="XamlHelper.idl" />
+    <Midl Include="LayoutService.idl" />
     <Midl Include="XamlUIService.idl" />
     <Midl Include="Views\cppwinrt\AccessibilityAction.idl">
       <Filter>Views\cppwinrt</Filter>

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -253,6 +253,10 @@ void NativeUIManager::ensureInBatch() {
     m_inBatch = true;
 }
 
+bool NativeUIManager::isInBatch() {
+  return m_inBatch;
+}
+
 static float NumberOrDefault(const winrt::Microsoft::ReactNative::JSValue &value, float defaultValue) {
   float result = defaultValue;
 
@@ -877,28 +881,28 @@ void NativeUIManager::DoLayout() {
   auto &rootTags = m_host->GetAllRootTags();
   for (int64_t rootTag : rootTags) {
     ShadowNodeBase &rootShadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(rootTag));
-    if (YGNodeRef rootNode = GetYogaNode(rootTag)) {
-      auto rootElement = rootShadowNode.GetView().as<xaml::FrameworkElement>();
+    const auto rootElement = rootShadowNode.GetView().as<xaml::FrameworkElement>();
+    float actualWidth = static_cast<float>(rootElement.ActualWidth());
+    float actualHeight = static_cast<float>(rootElement.ActualHeight());
+    ApplyLayout(rootTag, actualWidth, actualHeight);
+  }
+}
 
-      float actualWidth = static_cast<float>(rootElement.ActualWidth());
-      float actualHeight = static_cast<float>(rootElement.ActualHeight());
+void NativeUIManager::ApplyLayout(int64_t tag, float width, float height) {
+  if (YGNodeRef rootNode = GetYogaNode(tag)) {
+    SystraceSection s("NativeUIManager::DoLayout::YGNodeCalculateLayout");
+    // We must always run layout in LTR mode, which might seem unintuitive.
+    // We will flip the root of the tree into RTL by forcing the root XAML node's FlowDirection to RightToLeft
+    // which will inherit down the XAML tree, allowing all native controls to pick it up.
+    YGNodeCalculateLayout(rootNode, width, height, YGDirectionLTR);
+  } else {
+    assert(false);
+    return;
+  }
 
-      {
-        SystraceSection s("NativeUIManager::DoLayout::YGNodeCalculateLayout");
-        // We must always run layout in LTR mode, which might seem unintuitive.
-        // We will flip the root of the tree into RTL by forcing the root XAML node's FlowDirection to RightToLeft
-        // which will inherit down the XAML tree, allowing all native controls to pick it up.
-        YGNodeCalculateLayout(rootNode, actualWidth, actualHeight, YGDirectionLTR);
-      }
-    } else {
-      assert(false);
-      return;
-    }
-
-    {
-      SystraceSection s("NativeUIManager::DoLayout::SetLayoutProps");
-      SetLayoutPropsRecursive(rootTag);
-    }
+  {
+    SystraceSection s("NativeUIManager::DoLayout::SetLayoutProps");
+    SetLayoutPropsRecursive(tag);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -56,6 +56,7 @@ class NativeUIManager final : public INativeUIManager {
   void UpdateView(ShadowNode &shadowNode, winrt::Microsoft::ReactNative::JSValueObject &props) override;
   void onBatchComplete() override;
   void ensureInBatch() override;
+  bool isInBatch() override;
   void measure(
       ShadowNode &shadowNode,
       ShadowNode &shadowRoot,
@@ -100,8 +101,10 @@ class NativeUIManager final : public INativeUIManager {
 
   int64_t AddMeasuredRootView(facebook::react::IReactRootView *rootView);
 
- private:
   void DoLayout();
+  void ApplyLayout(int64_t tag, float width = YGUndefined, float height = YGUndefined);
+
+ private:
   void SetLayoutPropsRecursive(int64_t tag);
   YGNodeRef GetYogaNode(int64_t tag) const;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -12,6 +12,7 @@
 #include <appModel.h>
 #include <comUtil/qiCast.h>
 #ifndef CORE_ABI
+#include <LayoutService.h>
 #include <XamlUIService.h>
 #endif
 #include "ReactErrorProvider.h"
@@ -752,6 +753,10 @@ void ReactInstanceWin::InitUIManager() noexcept {
   m_reactContext->Properties().Set(
       implementation::XamlUIService::XamlUIServiceProperty().Handle(),
       winrt::make<implementation::XamlUIService>(m_reactContext));
+
+  m_reactContext->Properties().Set(
+      implementation::LayoutService::LayoutServiceProperty().Handle(),
+      winrt::make<implementation::LayoutService>(m_reactContext));
 }
 #endif
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
In order to enable native layout updates, we need to expose an interface to mark Yoga nodes as dirty, and also to trigger native layout.

Resolves #9988
Towards #7601
Workaround for #9343

### What
While we could just blindly invoke `onBatchComplete` on the NativeUIManager, it is safer to also expose an interface to test whether the UIManager is currently processing a batch of UIManager operations so we can piggy back on the current onBatchComplete call that will occur at the end of a batch if one is in progress. This is also likely to prevent UI tearing. Today, it is unlikely that an call from the UI thread to invoke Yoga and XAML layout will interrupt a batch, if we eventually implement something like eager view creation, this may no longer be the case.

Also, rather than calling `onBatchComplete`, which may have the side-effect of calling UpdateLayout on nodes that specify `NeedsForceLayout`, native UI updates will not involve the creation of new nodes, so we can skip this step, thus the addition of a new API to call YGNodeCalculateLayout for a specific root (and skip layout for other roots where it may not be needed). The LayoutService can also conditionally apply layout to all roots, a specific root with unbound constraints, or a specific root with known constraints.

We will be using this service for a number of features, including re-entrant Yoga layout for views that are self-measuring with React Native descendants dependent on Yoga layout, as well as to work around a text truncation bug caused by Yoga caching to force the Text to re-measure and re-layout when truncation is detected (is narrow use cases).

## Testing
We have used this new LayoutService API in Messenger to implement a native module that dirties some text nodes that get truncated due to a Yoga bug with cached flex basis values. There is no change to core behaviors, I also tested that layout still works correctly in Playground / RNTester.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10671)