### PR TITLE
Move timing native module to TurboModule

### DIFF
--- a/change/react-native-windows-7cf8ea6f-f155-4b6f-a4f8-06bbe79b671b.json
+++ b/change/react-native-windows-7cf8ea6f-f155-4b6f-a4f8-06bbe79b671b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move timing native module to TurboModule",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -60,11 +60,6 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
         batchingUIMessageQueue);
   }
 
-  modules.emplace_back(
-      "Timing",
-      [batchingUIMessageQueue]() { return facebook::react::CreateTimingModule(batchingUIMessageQueue); },
-      batchingUIMessageQueue);
-
   // Note: `context` is moved to remove the reference from the current scope.
   // This should either be the last usage of `context`, or the std::move call should happen later in this method.
   modules.emplace_back(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -54,6 +54,7 @@
 #include "Modules/LogBoxModule.h"
 #include "Modules/NativeUIManager.h"
 #include "Modules/PaperUIManagerModule.h"
+#include "Modules/TimingModule.h"
 #endif
 #include "Modules/ReactRootViewTagGenerator.h"
 
@@ -358,6 +359,8 @@ void ReactInstanceWin::LoadModules(
       L"LinkingManager",
       winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::LinkingManager>());
 
+  registerTurboModule(
+      L"Timing", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Timing>());
 #endif
 }
 


### PR DESCRIPTION
## Description
This moves the existing Timing module to be a TurboModule.  It continues to use the same queue and logic as before, so should run the same way.  This allows the module to use a codegen'd spec, and will allow future changes to use the property bag to toggle different behaviors.  (Fabric will want to use something other than xaml rendering callback)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10674)