### PR TITLE
Always synchronize focusable and accessible props

### DIFF
--- a/change/react-native-windows-9c0c9ca5-333f-4bbb-bd5a-7312b7431160.json
+++ b/change/react-native-windows-9c0c9ca5-333f-4bbb-bd5a-7312b7431160.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Always synchronize focusable and accessible props",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/view.tsx
+++ b/packages/playground/Samples/view.tsx
@@ -11,6 +11,8 @@ export default class Bootstrap extends React.Component<
   {},
   {
     focusable: boolean;
+    accessible: boolean;
+    pressable: boolean;
     hasStyle: boolean;
     hasBorder: boolean;
     radius: boolean;
@@ -23,6 +25,8 @@ export default class Bootstrap extends React.Component<
     super(props);
     this.state = {
       focusable: true,
+      accessible: true,
+      pressable: true,
       hasStyle: true,
       hasBorder: true,
       radius: true,
@@ -96,6 +100,22 @@ export default class Bootstrap extends React.Component<
 
         <View style={{flexDirection: 'row', alignSelf: 'flex-start'}}>
           <Switch
+            onValueChange={value => this.setState({accessible: value})}
+            value={this.state.accessible}
+          />
+          <Text>accessible</Text>
+        </View>
+
+        <View style={{flexDirection: 'row', alignSelf: 'flex-start'}}>
+          <Switch
+            onValueChange={value => this.setState({pressable: value})}
+            value={this.state.pressable}
+          />
+          <Text>pressable</Text>
+        </View>
+
+        <View style={{flexDirection: 'row', alignSelf: 'flex-start'}}>
+          <Switch
             onValueChange={value => this.setState({hasStyle: value})}
             value={this.state.hasStyle}
           />
@@ -155,6 +175,8 @@ export default class Bootstrap extends React.Component<
           }}>
           <View
             focusable={this.state.focusable ? true : false}
+            accessible={this.state.accessible ? true : false}
+            {...{onClick: this.state.pressable}}
             style={
               this.state.hasStyle
                 ? this.state.hasBorder

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -41,6 +41,7 @@ class ViewViewManager : public FrameworkElementViewManager {
 
   XamlView CreateViewCore(int64_t tag, const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void TryUpdateView(ViewShadowNode *viewShadowNode, winrt::Microsoft::ReactNative::ViewPanel &pPanel, bool useControl);
+  void SyncFocusableAndAccessible(ViewShadowNode *viewShadowNode, bool useControl);
 
   xaml::Media::SolidColorBrush EnsureTransparentBrush();
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
If a user disables focusable or accessible only in a particular View update, we will likely not run the logic to keep these values in sync.

Resolves #10687

### What
This changes the behavior to always synchronize these values.

### Test Plan

|focusable|accessible|pressable|expected|actual|
|-|-|-|-|-|
|✅|✅|✅|✅|✅|
|❌|✅|✅|❌|❌|
|✅|❌|✅|❌|❌|
|❌|❌|✅|❌|❌|
|✅|✅|❌|✅|✅|
|❌|✅|❌|✅|✅|
|✅|❌|❌|✅|✅|
|❌|❌|❌|❌|❌|

https://user-images.githubusercontent.com/1106239/194376872-c30fd298-adbb-49e5-ba3d-2b85e3cf6951.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10686)