### PR TITLE
Fix bad fix for size_t -> int truncation from RN merge

### DIFF
--- a/change/react-native-windows-53cbb9fa-9565-4dfe-a5f9-3740f353a469.json
+++ b/change/react-native-windows-53cbb9fa-9565-4dfe-a5f9-3740f353a469.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad fix for size_t -> int truncation from RN merge",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/core/LayoutableShadowNode.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/core/LayoutableShadowNode.cpp
@@ -27,15 +27,15 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
   auto transformedFrames = LayoutableSmallVector<Rect>{size};
   auto transformation = Transform::Identity();
 
-  for (size_t i = size - 1; i >= 0; --i) { // changed from int to size_t, make PR upstream
+  for (size_t i = size; i > 0; --i) { // use size_t instead of int, and modify loop to avoid underflow, make PR upstream (Note changes to all uses of i in loop)
     auto currentShadowNode =
-        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
+        traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i - 1));
     auto currentFrame = currentShadowNode->getLayoutMetrics().frame;
 
     if (policy.includeTransform) {
       if (Transform::isVerticalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         currentFrame.origin.y =
             parentShadowNode->getLayoutMetrics().frame.size.height -
             currentFrame.size.height - currentFrame.origin.y;
@@ -43,15 +43,15 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
 
       if (Transform::isHorizontalInversion(transformation)) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         currentFrame.origin.x =
             parentShadowNode->getLayoutMetrics().frame.size.width -
             currentFrame.size.width - currentFrame.origin.x;
       }
 
-      if (i != size - 1) {
+      if (i != size) {
         auto parentShadowNode =
-            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i + 1));
+            traitCast<LayoutableShadowNode const *>(shadowNodeList.at(i));
         auto contentOritinOffset = parentShadowNode->getContentOriginOffset();
         if (Transform::isVerticalInversion(transformation)) {
           contentOritinOffset.y = -contentOritinOffset.y;
@@ -65,7 +65,7 @@ static LayoutableSmallVector<Rect> calculateTransformedFrames(
       transformation = transformation * currentShadowNode->getTransform();
     }
 
-    transformedFrames[i] = currentFrame;
+    transformedFrames[i - 1] = currentFrame;
   }
 
   return transformedFrames;


### PR DESCRIPTION
## Description
There was a fix made by the last RN integration that caused a loop to underflow and then attempt to index a very large number into an index.  This results in numerous crashes in fabric.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10688)