### PR TITLE
Fabric: TextInput caret is incorrect size

### DIFF
--- a/change/react-native-windows-4e282efb-fc79-4999-8d71-dd5b68a36f92.json
+++ b/change/react-native-windows-4e282efb-fc79-4999-8d71-dd5b68a36f92.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "getClientReact returns incorrect bottom value",
+  "comment": "Fabric: TextInput caret is incorrect size",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-4e282efb-fc79-4999-8d71-dd5b68a36f92.json
+++ b/change/react-native-windows-4e282efb-fc79-4999-8d71-dd5b68a36f92.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "getClientReact returns incorrect bottom value",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -78,7 +78,7 @@ RECT CompositionBaseComponentView::getClientRect() const noexcept {
   rc.left += static_cast<LONG>(m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor);
   rc.top += static_cast<LONG>(m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor);
   rc.right = rc.left + static_cast<LONG>(m_layoutMetrics.frame.size.width * m_layoutMetrics.pointScaleFactor);
-  rc.bottom = rc.left + static_cast<LONG>(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
+  rc.bottom = rc.top + static_cast<LONG>(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
   return rc;
 }
 


### PR DESCRIPTION
## Description
The rect being provided to RichEdit was incorrect, which was causing RichEdit to provide the wrong size for the caret.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10692)