### PR TITLE
Remove extra parenthesis in codegen output

### DIFF
--- a/change/@react-native-windows-codegen-082c308f-acca-464f-8f67-243003cacc0b.json
+++ b/change/@react-native-windows-codegen-082c308f-acca-464f-8f67-243003cacc0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove extra paren in codegen output",
+  "packageName": "@react-native-windows/codegen",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e369f6d3-9b6d-4738-912a-65c2f90c9f81.json
+++ b/change/react-native-windows-e369f6d3-9b6d-4738-912a-65c2f90c9f81.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove extra paren in codegen output",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -45,7 +45,7 @@ function getPossibleMethodSignatures(
     funcType.returnTypeAnnotation,
     aliases,
     baseAliasName,
-  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
+  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }`;
 
   const staticsig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
     prop.name
@@ -53,7 +53,7 @@ function getPossibleMethodSignatures(
     funcType.returnTypeAnnotation,
     aliases,
     baseAliasName,
-  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }}`;
+  )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }`;
 
   return [sig, staticsig];
 }

--- a/packages/sample-apps/codegen/NativeMyModuleSpec.g.h
+++ b/packages/sample-apps/codegen/NativeMyModuleSpec.g.h
@@ -53,48 +53,48 @@ struct MyModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "voidFunc",
-          "    REACT_METHOD(voidFunc) void voidFunc() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(voidFunc) static void voidFunc() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(voidFunc) void voidFunc() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(voidFunc) static void voidFunc() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getBool",
-          "    REACT_SYNC_METHOD(getBool) bool getBool(bool arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getBool) static bool getBool(bool arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getBool) bool getBool(bool arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getBool) static bool getBool(bool arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getNumber",
-          "    REACT_SYNC_METHOD(getNumber) double getNumber(double arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getNumber) static double getNumber(double arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getNumber) double getNumber(double arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getNumber) static double getNumber(double arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getString",
-          "    REACT_SYNC_METHOD(getString) std::string getString(std::string arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getString) static std::string getString(std::string arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getString) std::string getString(std::string arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getString) static std::string getString(std::string arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getArray",
-          "    REACT_SYNC_METHOD(getArray) ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getArray) static ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getArray) ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getArray) static ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getObject",
-          "    REACT_SYNC_METHOD(getObject) ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getObject) static ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getObject) ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getObject) static ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "getValue",
-          "    REACT_SYNC_METHOD(getValue) ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getValue) static ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getValue) ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getValue) static ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "getValueWithCallback",
-          "    REACT_METHOD(getValueWithCallback) void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValueWithCallback) static void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValueWithCallback) void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValueWithCallback) static void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "getValueWithPromise",
-          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAccessibilityInfoSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityInfoSpec.g.h
@@ -30,33 +30,33 @@ struct AccessibilityInfoSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "isReduceMotionEnabled",
-          "    REACT_METHOD(isReduceMotionEnabled) void isReduceMotionEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(isReduceMotionEnabled) static void isReduceMotionEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(isReduceMotionEnabled) void isReduceMotionEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(isReduceMotionEnabled) static void isReduceMotionEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "isTouchExplorationEnabled",
-          "    REACT_METHOD(isTouchExplorationEnabled) void isTouchExplorationEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(isTouchExplorationEnabled) static void isTouchExplorationEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(isTouchExplorationEnabled) void isTouchExplorationEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(isTouchExplorationEnabled) static void isTouchExplorationEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "isAccessibilityServiceEnabled",
-          "    REACT_METHOD(isAccessibilityServiceEnabled) void isAccessibilityServiceEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(isAccessibilityServiceEnabled) static void isAccessibilityServiceEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(isAccessibilityServiceEnabled) void isAccessibilityServiceEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(isAccessibilityServiceEnabled) static void isAccessibilityServiceEnabled(std::function<void(bool)> const & onSuccess) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "setAccessibilityFocus",
-          "    REACT_METHOD(setAccessibilityFocus) void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAccessibilityFocus) static void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAccessibilityFocus) void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAccessibilityFocus) static void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "announceForAccessibility",
-          "    REACT_METHOD(announceForAccessibility) void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(announceForAccessibility) static void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(announceForAccessibility) void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(announceForAccessibility) static void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getRecommendedTimeoutMillis",
-          "    REACT_METHOD(getRecommendedTimeoutMillis) void getRecommendedTimeoutMillis(double mSec, std::function<void(double)> const & onSuccess) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getRecommendedTimeoutMillis) static void getRecommendedTimeoutMillis(double mSec, std::function<void(double)> const & onSuccess) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getRecommendedTimeoutMillis) void getRecommendedTimeoutMillis(double mSec, std::function<void(double)> const & onSuccess) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getRecommendedTimeoutMillis) static void getRecommendedTimeoutMillis(double mSec, std::function<void(double)> const & onSuccess) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAccessibilityManagerSpec.g.h
+++ b/vnext/codegen/NativeAccessibilityManagerSpec.g.h
@@ -68,53 +68,53 @@ struct AccessibilityManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getCurrentBoldTextState",
-          "    REACT_METHOD(getCurrentBoldTextState) void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentBoldTextState) static void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentBoldTextState) void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentBoldTextState) static void getCurrentBoldTextState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getCurrentGrayscaleState",
-          "    REACT_METHOD(getCurrentGrayscaleState) void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentGrayscaleState) static void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentGrayscaleState) void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentGrayscaleState) static void getCurrentGrayscaleState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getCurrentInvertColorsState",
-          "    REACT_METHOD(getCurrentInvertColorsState) void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentInvertColorsState) static void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentInvertColorsState) void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentInvertColorsState) static void getCurrentInvertColorsState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getCurrentReduceMotionState",
-          "    REACT_METHOD(getCurrentReduceMotionState) void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentReduceMotionState) static void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentReduceMotionState) void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentReduceMotionState) static void getCurrentReduceMotionState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getCurrentReduceTransparencyState",
-          "    REACT_METHOD(getCurrentReduceTransparencyState) void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentReduceTransparencyState) static void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentReduceTransparencyState) void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentReduceTransparencyState) static void getCurrentReduceTransparencyState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getCurrentVoiceOverState",
-          "    REACT_METHOD(getCurrentVoiceOverState) void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentVoiceOverState) static void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentVoiceOverState) void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentVoiceOverState) static void getCurrentVoiceOverState(std::function<void(bool)> const & onSuccess, std::function<void(::React::JSValue const &)> const & onError) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "setAccessibilityContentSizeMultipliers",
-          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) static void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAccessibilityContentSizeMultipliers) static void setAccessibilityContentSizeMultipliers(AccessibilityManagerSpec_setAccessibilityContentSizeMultipliers_JSMultipliers && JSMultipliers) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "setAccessibilityFocus",
-          "    REACT_METHOD(setAccessibilityFocus) void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAccessibilityFocus) static void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAccessibilityFocus) void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAccessibilityFocus) static void setAccessibilityFocus(double reactTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "announceForAccessibility",
-          "    REACT_METHOD(announceForAccessibility) void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(announceForAccessibility) static void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(announceForAccessibility) void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(announceForAccessibility) static void announceForAccessibility(std::string announcement) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "announceForAccessibilityWithOptions",
-          "    REACT_METHOD(announceForAccessibilityWithOptions) void announceForAccessibilityWithOptions(std::string announcement, AccessibilityManagerSpec_announceForAccessibilityWithOptions_options && options) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(announceForAccessibilityWithOptions) static void announceForAccessibilityWithOptions(std::string announcement, AccessibilityManagerSpec_announceForAccessibilityWithOptions_options && options) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(announceForAccessibilityWithOptions) void announceForAccessibilityWithOptions(std::string announcement, AccessibilityManagerSpec_announceForAccessibilityWithOptions_options && options) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(announceForAccessibilityWithOptions) static void announceForAccessibilityWithOptions(std::string announcement, AccessibilityManagerSpec_announceForAccessibilityWithOptions_options && options) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeActionSheetManagerSpec.g.h
+++ b/vnext/codegen/NativeActionSheetManagerSpec.g.h
@@ -83,18 +83,18 @@ struct ActionSheetManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showActionSheetWithOptions",
-          "    REACT_METHOD(showActionSheetWithOptions) void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showActionSheetWithOptions) static void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showActionSheetWithOptions) void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showActionSheetWithOptions) static void showActionSheetWithOptions(ActionSheetManagerSpec_showActionSheetWithOptions_options && options, std::function<void(double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "showShareActionSheetWithOptions",
-          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showShareActionSheetWithOptions) void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showShareActionSheetWithOptions) static void showShareActionSheetWithOptions(ActionSheetManagerSpec_showShareActionSheetWithOptions_options && options, std::function<void(ActionSheetManagerSpec_showShareActionSheetWithOptions_failureCallback_error const &)> const & failureCallback, std::function<void(bool, std::optional<std::string>)> const & successCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "dismissActionSheet",
-          "    REACT_METHOD(dismissActionSheet) void dismissActionSheet() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dismissActionSheet) static void dismissActionSheet() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dismissActionSheet) void dismissActionSheet() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dismissActionSheet) static void dismissActionSheet() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAlertManagerSpec.g.h
+++ b/vnext/codegen/NativeAlertManagerSpec.g.h
@@ -49,8 +49,8 @@ struct AlertManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "alertWithArgs",
-          "    REACT_METHOD(alertWithArgs) void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(double, std::string)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(double, std::string)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(alertWithArgs) void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(double, std::string)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(alertWithArgs) static void alertWithArgs(AlertManagerSpec_Args && args, std::function<void(double, std::string)> const & callback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAnimatedModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedModuleSpec.g.h
@@ -62,123 +62,123 @@ struct AnimatedModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "startOperationBatch",
-          "    REACT_METHOD(startOperationBatch) void startOperationBatch() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startOperationBatch) static void startOperationBatch() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startOperationBatch) void startOperationBatch() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startOperationBatch) static void startOperationBatch() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "finishOperationBatch",
-          "    REACT_METHOD(finishOperationBatch) void finishOperationBatch() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(finishOperationBatch) static void finishOperationBatch() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(finishOperationBatch) void finishOperationBatch() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(finishOperationBatch) static void finishOperationBatch() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "createAnimatedNode",
-          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateAnimatedNodeConfig",
-          "    REACT_METHOD(updateAnimatedNodeConfig) void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateAnimatedNodeConfig) static void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateAnimatedNodeConfig) void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(updateAnimatedNodeConfig) static void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getValue",
-          "    REACT_METHOD(getValue) void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValue) static void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValue) void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValue) static void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "startListeningToAnimatedNodeValue",
-          "    REACT_METHOD(startListeningToAnimatedNodeValue) void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startListeningToAnimatedNodeValue) static void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startListeningToAnimatedNodeValue) void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startListeningToAnimatedNodeValue) static void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "stopListeningToAnimatedNodeValue",
-          "    REACT_METHOD(stopListeningToAnimatedNodeValue) void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(stopListeningToAnimatedNodeValue) static void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(stopListeningToAnimatedNodeValue) void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(stopListeningToAnimatedNodeValue) static void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "connectAnimatedNodes",
-          "    REACT_METHOD(connectAnimatedNodes) void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connectAnimatedNodes) static void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connectAnimatedNodes) void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(connectAnimatedNodes) static void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "disconnectAnimatedNodes",
-          "    REACT_METHOD(disconnectAnimatedNodes) void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(disconnectAnimatedNodes) static void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(disconnectAnimatedNodes) void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(disconnectAnimatedNodes) static void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "startAnimatingNode",
-          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "stopAnimation",
-          "    REACT_METHOD(stopAnimation) void stopAnimation(double animationId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(stopAnimation) static void stopAnimation(double animationId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(stopAnimation) void stopAnimation(double animationId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(stopAnimation) static void stopAnimation(double animationId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "setAnimatedNodeValue",
-          "    REACT_METHOD(setAnimatedNodeValue) void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAnimatedNodeValue) static void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAnimatedNodeValue) void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAnimatedNodeValue) static void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "setAnimatedNodeOffset",
-          "    REACT_METHOD(setAnimatedNodeOffset) void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAnimatedNodeOffset) static void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAnimatedNodeOffset) void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAnimatedNodeOffset) static void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "flattenAnimatedNodeOffset",
-          "    REACT_METHOD(flattenAnimatedNodeOffset) void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(flattenAnimatedNodeOffset) static void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(flattenAnimatedNodeOffset) void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(flattenAnimatedNodeOffset) static void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "extractAnimatedNodeOffset",
-          "    REACT_METHOD(extractAnimatedNodeOffset) void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(extractAnimatedNodeOffset) static void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(extractAnimatedNodeOffset) void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(extractAnimatedNodeOffset) static void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "connectAnimatedNodeToView",
-          "    REACT_METHOD(connectAnimatedNodeToView) void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connectAnimatedNodeToView) static void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connectAnimatedNodeToView) void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(connectAnimatedNodeToView) static void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           16,
           "disconnectAnimatedNodeFromView",
-          "    REACT_METHOD(disconnectAnimatedNodeFromView) void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(disconnectAnimatedNodeFromView) static void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(disconnectAnimatedNodeFromView) void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(disconnectAnimatedNodeFromView) static void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           17,
           "restoreDefaultValues",
-          "    REACT_METHOD(restoreDefaultValues) void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(restoreDefaultValues) static void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(restoreDefaultValues) void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(restoreDefaultValues) static void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "dropAnimatedNode",
-          "    REACT_METHOD(dropAnimatedNode) void dropAnimatedNode(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dropAnimatedNode) static void dropAnimatedNode(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dropAnimatedNode) void dropAnimatedNode(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dropAnimatedNode) static void dropAnimatedNode(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           20,
           "removeAnimatedEventFromView",
-          "    REACT_METHOD(removeAnimatedEventFromView) void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeAnimatedEventFromView) static void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeAnimatedEventFromView) void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeAnimatedEventFromView) static void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           21,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           22,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "queueAndExecuteBatchedOperations",
-          "    REACT_METHOD(queueAndExecuteBatchedOperations) void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queueAndExecuteBatchedOperations) static void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queueAndExecuteBatchedOperations) void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(queueAndExecuteBatchedOperations) static void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimatedTurboModuleSpec.g.h
@@ -62,123 +62,123 @@ struct AnimatedTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "startOperationBatch",
-          "    REACT_METHOD(startOperationBatch) void startOperationBatch() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startOperationBatch) static void startOperationBatch() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startOperationBatch) void startOperationBatch() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startOperationBatch) static void startOperationBatch() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "finishOperationBatch",
-          "    REACT_METHOD(finishOperationBatch) void finishOperationBatch() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(finishOperationBatch) static void finishOperationBatch() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(finishOperationBatch) void finishOperationBatch() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(finishOperationBatch) static void finishOperationBatch() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "createAnimatedNode",
-          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createAnimatedNode) void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(createAnimatedNode) static void createAnimatedNode(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateAnimatedNodeConfig",
-          "    REACT_METHOD(updateAnimatedNodeConfig) void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateAnimatedNodeConfig) static void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateAnimatedNodeConfig) void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(updateAnimatedNodeConfig) static void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getValue",
-          "    REACT_METHOD(getValue) void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValue) static void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValue) void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValue) static void getValue(double tag, std::function<void(double)> const & saveValueCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "startListeningToAnimatedNodeValue",
-          "    REACT_METHOD(startListeningToAnimatedNodeValue) void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startListeningToAnimatedNodeValue) static void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startListeningToAnimatedNodeValue) void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startListeningToAnimatedNodeValue) static void startListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "stopListeningToAnimatedNodeValue",
-          "    REACT_METHOD(stopListeningToAnimatedNodeValue) void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(stopListeningToAnimatedNodeValue) static void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(stopListeningToAnimatedNodeValue) void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(stopListeningToAnimatedNodeValue) static void stopListeningToAnimatedNodeValue(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "connectAnimatedNodes",
-          "    REACT_METHOD(connectAnimatedNodes) void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connectAnimatedNodes) static void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connectAnimatedNodes) void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(connectAnimatedNodes) static void connectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "disconnectAnimatedNodes",
-          "    REACT_METHOD(disconnectAnimatedNodes) void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(disconnectAnimatedNodes) static void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(disconnectAnimatedNodes) void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(disconnectAnimatedNodes) static void disconnectAnimatedNodes(double parentTag, double childTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "startAnimatingNode",
-          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startAnimatingNode) void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startAnimatingNode) static void startAnimatingNode(double animationId, double nodeTag, ::React::JSValue && config, std::function<void(AnimatedTurboModuleSpec_EndResult const &)> const & endCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "stopAnimation",
-          "    REACT_METHOD(stopAnimation) void stopAnimation(double animationId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(stopAnimation) static void stopAnimation(double animationId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(stopAnimation) void stopAnimation(double animationId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(stopAnimation) static void stopAnimation(double animationId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "setAnimatedNodeValue",
-          "    REACT_METHOD(setAnimatedNodeValue) void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAnimatedNodeValue) static void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAnimatedNodeValue) void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAnimatedNodeValue) static void setAnimatedNodeValue(double nodeTag, double value) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "setAnimatedNodeOffset",
-          "    REACT_METHOD(setAnimatedNodeOffset) void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setAnimatedNodeOffset) static void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setAnimatedNodeOffset) void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setAnimatedNodeOffset) static void setAnimatedNodeOffset(double nodeTag, double offset) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "flattenAnimatedNodeOffset",
-          "    REACT_METHOD(flattenAnimatedNodeOffset) void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(flattenAnimatedNodeOffset) static void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(flattenAnimatedNodeOffset) void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(flattenAnimatedNodeOffset) static void flattenAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "extractAnimatedNodeOffset",
-          "    REACT_METHOD(extractAnimatedNodeOffset) void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(extractAnimatedNodeOffset) static void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(extractAnimatedNodeOffset) void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(extractAnimatedNodeOffset) static void extractAnimatedNodeOffset(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "connectAnimatedNodeToView",
-          "    REACT_METHOD(connectAnimatedNodeToView) void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connectAnimatedNodeToView) static void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connectAnimatedNodeToView) void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(connectAnimatedNodeToView) static void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           16,
           "disconnectAnimatedNodeFromView",
-          "    REACT_METHOD(disconnectAnimatedNodeFromView) void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(disconnectAnimatedNodeFromView) static void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(disconnectAnimatedNodeFromView) void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(disconnectAnimatedNodeFromView) static void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           17,
           "restoreDefaultValues",
-          "    REACT_METHOD(restoreDefaultValues) void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(restoreDefaultValues) static void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(restoreDefaultValues) void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(restoreDefaultValues) static void restoreDefaultValues(double nodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "dropAnimatedNode",
-          "    REACT_METHOD(dropAnimatedNode) void dropAnimatedNode(double tag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dropAnimatedNode) static void dropAnimatedNode(double tag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dropAnimatedNode) void dropAnimatedNode(double tag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dropAnimatedNode) static void dropAnimatedNode(double tag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "addAnimatedEventToView",
-          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addAnimatedEventToView) void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addAnimatedEventToView) static void addAnimatedEventToView(double viewTag, std::string eventName, AnimatedTurboModuleSpec_EventMapping && eventMapping) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           20,
           "removeAnimatedEventFromView",
-          "    REACT_METHOD(removeAnimatedEventFromView) void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeAnimatedEventFromView) static void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeAnimatedEventFromView) void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeAnimatedEventFromView) static void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           21,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           22,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "queueAndExecuteBatchedOperations",
-          "    REACT_METHOD(queueAndExecuteBatchedOperations) void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queueAndExecuteBatchedOperations) static void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queueAndExecuteBatchedOperations) void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(queueAndExecuteBatchedOperations) static void queueAndExecuteBatchedOperations(::React::JSValueArray && operationsAndArgs) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAnimationsDebugModuleSpec.g.h
+++ b/vnext/codegen/NativeAnimationsDebugModuleSpec.g.h
@@ -26,13 +26,13 @@ struct AnimationsDebugModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpe
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "startRecordingFps",
-          "    REACT_METHOD(startRecordingFps) void startRecordingFps() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startRecordingFps) static void startRecordingFps() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startRecordingFps) void startRecordingFps() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startRecordingFps) static void startRecordingFps() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "stopRecordingFps",
-          "    REACT_METHOD(stopRecordingFps) void stopRecordingFps(double animationStopTimeMs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(stopRecordingFps) static void stopRecordingFps(double animationStopTimeMs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(stopRecordingFps) void stopRecordingFps(double animationStopTimeMs) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(stopRecordingFps) static void stopRecordingFps(double animationStopTimeMs) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAppStateSpec.g.h
+++ b/vnext/codegen/NativeAppStateSpec.g.h
@@ -49,18 +49,18 @@ struct AppStateSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getCurrentAppState",
-          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getCurrentAppState) void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getCurrentAppState) static void getCurrentAppState(std::function<void(AppStateSpec_getCurrentAppState_success_appState const &)> const & success, std::function<void(::React::JSValue const &)> const & error) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAppearanceSpec.g.h
+++ b/vnext/codegen/NativeAppearanceSpec.g.h
@@ -27,18 +27,18 @@ struct AppearanceSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getColorScheme",
-          "    REACT_SYNC_METHOD(getColorScheme) std::optional<std::string> getColorScheme() noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getColorScheme) static std::optional<std::string> getColorScheme() noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getColorScheme) std::optional<std::string> getColorScheme() noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getColorScheme) static std::optional<std::string> getColorScheme() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncLocalStorageSpec.g.h
@@ -78,33 +78,33 @@ struct AsyncLocalStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncLocalStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
-          "    REACT_METHOD(clear) void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clear) void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncLocalStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncLocalStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
+++ b/vnext/codegen/NativeAsyncSQLiteDBStorageSpec.g.h
@@ -78,33 +78,33 @@ struct AsyncSQLiteDBStorageSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "multiGet",
-          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiGet) void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiGet) static void multiGet(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiGet_callback_errors_element>>, std::optional<std::vector<std::vector<std::string>>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "multiSet",
-          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiSet) void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiSet) static void multiSet(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiSet_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "multiMerge",
-          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiMerge) void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiMerge) static void multiMerge(std::vector<std::vector<std::string>> const & kvPairs, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiMerge_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "multiRemove",
-          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(multiRemove) void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(multiRemove) static void multiRemove(std::vector<std::string> const & keys, std::function<void(std::optional<std::vector<AsyncSQLiteDBStorageSpec_multiRemove_callback_errors_element>>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clear",
-          "    REACT_METHOD(clear) void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clear) void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clear) static void clear(std::function<void(AsyncSQLiteDBStorageSpec_clear_callback_error const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getAllKeys",
-          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAllKeys) void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getAllKeys) static void getAllKeys(std::function<void(std::optional<AsyncSQLiteDBStorageSpec_getAllKeys_callback_error>, std::optional<std::vector<std::string>>)> const & callback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeBlobModuleSpec.g.h
+++ b/vnext/codegen/NativeBlobModuleSpec.g.h
@@ -48,33 +48,33 @@ struct BlobModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "addNetworkingHandler",
-          "    REACT_METHOD(addNetworkingHandler) void addNetworkingHandler() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addNetworkingHandler) static void addNetworkingHandler() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addNetworkingHandler) void addNetworkingHandler() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addNetworkingHandler) static void addNetworkingHandler() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "addWebSocketHandler",
-          "    REACT_METHOD(addWebSocketHandler) void addWebSocketHandler(double id) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addWebSocketHandler) static void addWebSocketHandler(double id) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addWebSocketHandler) void addWebSocketHandler(double id) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addWebSocketHandler) static void addWebSocketHandler(double id) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "removeWebSocketHandler",
-          "    REACT_METHOD(removeWebSocketHandler) void removeWebSocketHandler(double id) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeWebSocketHandler) static void removeWebSocketHandler(double id) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeWebSocketHandler) void removeWebSocketHandler(double id) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeWebSocketHandler) static void removeWebSocketHandler(double id) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "sendOverSocket",
-          "    REACT_METHOD(sendOverSocket) void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendOverSocket) static void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendOverSocket) void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendOverSocket) static void sendOverSocket(::React::JSValue && blob, double socketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "createFromParts",
-          "    REACT_METHOD(createFromParts) void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createFromParts) static void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createFromParts) void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(createFromParts) static void createFromParts(std::vector<::React::JSValue> const & parts, std::string withId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "release",
-          "    REACT_METHOD(release) void release(std::string blobId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(release) static void release(std::string blobId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(release) void release(std::string blobId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(release) static void release(std::string blobId) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeBugReportingSpec.g.h
+++ b/vnext/codegen/NativeBugReportingSpec.g.h
@@ -27,18 +27,18 @@ struct BugReportingSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "startReportAProblemFlow",
-          "    REACT_METHOD(startReportAProblemFlow) void startReportAProblemFlow() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(startReportAProblemFlow) static void startReportAProblemFlow() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(startReportAProblemFlow) void startReportAProblemFlow() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(startReportAProblemFlow) static void startReportAProblemFlow() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setExtraData",
-          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, ::React::JSValue && extraFiles) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "setCategoryID",
-          "    REACT_METHOD(setCategoryID) void setCategoryID(std::string categoryID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setCategoryID) static void setCategoryID(std::string categoryID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setCategoryID) void setCategoryID(std::string categoryID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setCategoryID) static void setCategoryID(std::string categoryID) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeClipboardSpec.g.h
+++ b/vnext/codegen/NativeClipboardSpec.g.h
@@ -26,13 +26,13 @@ struct ClipboardSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getString",
-          "    REACT_METHOD(getString) void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getString) static void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getString) void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getString) static void getString(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setString",
-          "    REACT_METHOD(setString) void setString(std::string content) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setString) static void setString(std::string content) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setString) void setString(std::string content) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setString) static void setString(std::string content) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDatePickerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDatePickerAndroidSpec.g.h
@@ -25,8 +25,8 @@ struct DatePickerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "open",
-          "    REACT_METHOD(open) void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(open) static void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(open) void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(open) static void open(::React::JSValue && options, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDevLoadingViewSpec.g.h
+++ b/vnext/codegen/NativeDevLoadingViewSpec.g.h
@@ -26,13 +26,13 @@ struct DevLoadingViewSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showMessage",
-          "    REACT_METHOD(showMessage) void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showMessage) static void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showMessage) void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showMessage) static void showMessage(std::string message, std::optional<double> withColor, std::optional<double> withBackgroundColor) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "hide",
-          "    REACT_METHOD(hide) void hide() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(hide) static void hide() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(hide) void hide() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(hide) static void hide() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDevMenuSpec.g.h
+++ b/vnext/codegen/NativeDevMenuSpec.g.h
@@ -29,28 +29,28 @@ struct DevMenuSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "show",
-          "    REACT_METHOD(show) void show() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(show) static void show() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(show) void show() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(show) static void show() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "reload",
-          "    REACT_METHOD(reload) void reload() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reload) static void reload() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reload) void reload() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reload) static void reload() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "debugRemotely",
-          "    REACT_METHOD(debugRemotely) void debugRemotely(bool enableDebug) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(debugRemotely) static void debugRemotely(bool enableDebug) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(debugRemotely) void debugRemotely(bool enableDebug) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(debugRemotely) static void debugRemotely(bool enableDebug) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "setProfilingEnabled",
-          "    REACT_METHOD(setProfilingEnabled) void setProfilingEnabled(bool enabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setProfilingEnabled) static void setProfilingEnabled(bool enabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setProfilingEnabled) void setProfilingEnabled(bool enabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setProfilingEnabled) static void setProfilingEnabled(bool enabled) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "setHotLoadingEnabled",
-          "    REACT_METHOD(setHotLoadingEnabled) void setHotLoadingEnabled(bool enabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setHotLoadingEnabled) static void setHotLoadingEnabled(bool enabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setHotLoadingEnabled) void setHotLoadingEnabled(bool enabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setHotLoadingEnabled) static void setHotLoadingEnabled(bool enabled) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDevSettingsSpec.g.h
+++ b/vnext/codegen/NativeDevSettingsSpec.g.h
@@ -35,58 +35,58 @@ struct DevSettingsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "reload",
-          "    REACT_METHOD(reload) void reload() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reload) static void reload() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reload) void reload() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reload) static void reload() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "reloadWithReason",
-          "    REACT_METHOD(reloadWithReason) void reloadWithReason(std::string reason) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reloadWithReason) static void reloadWithReason(std::string reason) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reloadWithReason) void reloadWithReason(std::string reason) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reloadWithReason) static void reloadWithReason(std::string reason) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "onFastRefresh",
-          "    REACT_METHOD(onFastRefresh) void onFastRefresh() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(onFastRefresh) static void onFastRefresh() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(onFastRefresh) void onFastRefresh() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(onFastRefresh) static void onFastRefresh() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "setHotLoadingEnabled",
-          "    REACT_METHOD(setHotLoadingEnabled) void setHotLoadingEnabled(bool isHotLoadingEnabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setHotLoadingEnabled) static void setHotLoadingEnabled(bool isHotLoadingEnabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setHotLoadingEnabled) void setHotLoadingEnabled(bool isHotLoadingEnabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setHotLoadingEnabled) static void setHotLoadingEnabled(bool isHotLoadingEnabled) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "setIsDebuggingRemotely",
-          "    REACT_METHOD(setIsDebuggingRemotely) void setIsDebuggingRemotely(bool isDebuggingRemotelyEnabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setIsDebuggingRemotely) static void setIsDebuggingRemotely(bool isDebuggingRemotelyEnabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setIsDebuggingRemotely) void setIsDebuggingRemotely(bool isDebuggingRemotelyEnabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setIsDebuggingRemotely) static void setIsDebuggingRemotely(bool isDebuggingRemotelyEnabled) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "setProfilingEnabled",
-          "    REACT_METHOD(setProfilingEnabled) void setProfilingEnabled(bool isProfilingEnabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setProfilingEnabled) static void setProfilingEnabled(bool isProfilingEnabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setProfilingEnabled) void setProfilingEnabled(bool isProfilingEnabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setProfilingEnabled) static void setProfilingEnabled(bool isProfilingEnabled) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "toggleElementInspector",
-          "    REACT_METHOD(toggleElementInspector) void toggleElementInspector() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(toggleElementInspector) static void toggleElementInspector() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(toggleElementInspector) void toggleElementInspector() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(toggleElementInspector) static void toggleElementInspector() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "addMenuItem",
-          "    REACT_METHOD(addMenuItem) void addMenuItem(std::string title) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addMenuItem) static void addMenuItem(std::string title) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addMenuItem) void addMenuItem(std::string title) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addMenuItem) static void addMenuItem(std::string title) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "setIsShakeToShowDevMenuEnabled",
-          "    REACT_METHOD(setIsShakeToShowDevMenuEnabled) void setIsShakeToShowDevMenuEnabled(bool enabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setIsShakeToShowDevMenuEnabled) static void setIsShakeToShowDevMenuEnabled(bool enabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setIsShakeToShowDevMenuEnabled) void setIsShakeToShowDevMenuEnabled(bool enabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setIsShakeToShowDevMenuEnabled) static void setIsShakeToShowDevMenuEnabled(bool enabled) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDevSplitBundleLoaderSpec.g.h
+++ b/vnext/codegen/NativeDevSplitBundleLoaderSpec.g.h
@@ -25,8 +25,8 @@ struct DevSplitBundleLoaderSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "loadBundle",
-          "    REACT_METHOD(loadBundle) void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(loadBundle) static void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(loadBundle) void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(loadBundle) static void loadBundle(std::string bundlePath, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDeviceEventManagerSpec.g.h
+++ b/vnext/codegen/NativeDeviceEventManagerSpec.g.h
@@ -25,8 +25,8 @@ struct DeviceEventManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "invokeDefaultBackPressHandler",
-          "    REACT_METHOD(invokeDefaultBackPressHandler) void invokeDefaultBackPressHandler() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(invokeDefaultBackPressHandler) static void invokeDefaultBackPressHandler() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(invokeDefaultBackPressHandler) void invokeDefaultBackPressHandler() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(invokeDefaultBackPressHandler) static void invokeDefaultBackPressHandler() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerAndroidSpec.g.h
@@ -67,8 +67,8 @@ struct DialogManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showAlert",
-          "    REACT_METHOD(showAlert) void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, double)> const & onAction) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showAlert) static void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, double)> const & onAction) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showAlert) void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, double)> const & onAction) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showAlert) static void showAlert(DialogManagerAndroidSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, double)> const & onAction) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
+++ b/vnext/codegen/NativeDialogManagerWindowsSpec.g.h
@@ -69,8 +69,8 @@ struct DialogManagerWindowsSpec : winrt::Microsoft::ReactNative::TurboModuleSpec
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "showAlert",
-          "    REACT_METHOD(showAlert) void showAlert(DialogManagerWindowsSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, int)> const & onAction) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showAlert) static void showAlert(DialogManagerWindowsSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, int)> const & onAction) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showAlert) void showAlert(DialogManagerWindowsSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, int)> const & onAction) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showAlert) static void showAlert(DialogManagerWindowsSpec_DialogOptions && config, std::function<void(std::string)> const & onError, std::function<void(std::string, int)> const & onAction) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeExceptionsManagerSpec.g.h
+++ b/vnext/codegen/NativeExceptionsManagerSpec.g.h
@@ -63,28 +63,28 @@ struct ExceptionsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "reportFatalException",
-          "    REACT_METHOD(reportFatalException) void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportFatalException) static void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportFatalException) void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reportFatalException) static void reportFatalException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "reportSoftException",
-          "    REACT_METHOD(reportSoftException) void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportSoftException) static void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportSoftException) void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reportSoftException) static void reportSoftException(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "reportException",
-          "    REACT_METHOD(reportException) void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(reportException) static void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(reportException) void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(reportException) static void reportException(ExceptionsManagerSpec_ExceptionData && data) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "updateExceptionMessage",
-          "    REACT_METHOD(updateExceptionMessage) void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateExceptionMessage) static void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateExceptionMessage) void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(updateExceptionMessage) static void updateExceptionMessage(std::string message, std::vector<ExceptionsManagerSpec_StackFrame> const & stack, double exceptionId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "dismissRedbox",
-          "    REACT_METHOD(dismissRedbox) void dismissRedbox() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dismissRedbox) static void dismissRedbox() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dismissRedbox) void dismissRedbox() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dismissRedbox) static void dismissRedbox() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeFileReaderModuleSpec.g.h
+++ b/vnext/codegen/NativeFileReaderModuleSpec.g.h
@@ -26,13 +26,13 @@ struct FileReaderModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "readAsDataURL",
-          "    REACT_METHOD(readAsDataURL) void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(readAsDataURL) static void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(readAsDataURL) void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(readAsDataURL) static void readAsDataURL(::React::JSValue && data, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "readAsText",
-          "    REACT_METHOD(readAsText) void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(readAsText) static void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(readAsText) void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(readAsText) static void readAsText(::React::JSValue && data, std::string encoding, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeFrameRateLoggerSpec.g.h
+++ b/vnext/codegen/NativeFrameRateLoggerSpec.g.h
@@ -36,23 +36,23 @@ struct FrameRateLoggerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setGlobalOptions",
-          "    REACT_METHOD(setGlobalOptions) void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setGlobalOptions) static void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setGlobalOptions) void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setGlobalOptions) static void setGlobalOptions(FrameRateLoggerSpec_setGlobalOptions_options && options) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setContext",
-          "    REACT_METHOD(setContext) void setContext(std::string context) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setContext) static void setContext(std::string context) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setContext) void setContext(std::string context) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setContext) static void setContext(std::string context) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "beginScroll",
-          "    REACT_METHOD(beginScroll) void beginScroll() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(beginScroll) static void beginScroll() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(beginScroll) void beginScroll() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(beginScroll) static void beginScroll() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "endScroll",
-          "    REACT_METHOD(endScroll) void endScroll() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(endScroll) static void endScroll() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(endScroll) void endScroll() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(endScroll) static void endScroll() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
+++ b/vnext/codegen/NativeHeadlessJsTaskSupportSpec.g.h
@@ -26,13 +26,13 @@ struct HeadlessJsTaskSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpe
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "notifyTaskFinished",
-          "    REACT_METHOD(notifyTaskFinished) void notifyTaskFinished(double taskId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(notifyTaskFinished) static void notifyTaskFinished(double taskId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(notifyTaskFinished) void notifyTaskFinished(double taskId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(notifyTaskFinished) static void notifyTaskFinished(double taskId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "notifyTaskRetry",
-          "    REACT_METHOD(notifyTaskRetry) void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(notifyTaskRetry) static void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(notifyTaskRetry) void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(notifyTaskRetry) static void notifyTaskRetry(double taskId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeI18nManagerSpec.g.h
+++ b/vnext/codegen/NativeI18nManagerSpec.g.h
@@ -47,18 +47,18 @@ struct I18nManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "allowRTL",
-          "    REACT_METHOD(allowRTL) void allowRTL(bool allowRTL) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(allowRTL) static void allowRTL(bool allowRTL) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(allowRTL) void allowRTL(bool allowRTL) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(allowRTL) static void allowRTL(bool allowRTL) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "forceRTL",
-          "    REACT_METHOD(forceRTL) void forceRTL(bool forceRTL) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(forceRTL) static void forceRTL(bool forceRTL) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(forceRTL) void forceRTL(bool forceRTL) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(forceRTL) static void forceRTL(bool forceRTL) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "swapLeftAndRightInRTL",
-          "    REACT_METHOD(swapLeftAndRightInRTL) void swapLeftAndRightInRTL(bool flipStyles) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(swapLeftAndRightInRTL) static void swapLeftAndRightInRTL(bool flipStyles) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(swapLeftAndRightInRTL) void swapLeftAndRightInRTL(bool flipStyles) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(swapLeftAndRightInRTL) static void swapLeftAndRightInRTL(bool flipStyles) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImageEditorSpec.g.h
+++ b/vnext/codegen/NativeImageEditorSpec.g.h
@@ -63,8 +63,8 @@ struct ImageEditorSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "cropImage",
-          "    REACT_METHOD(cropImage) void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cropImage) void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(cropImage) static void cropImage(std::string uri, ImageEditorSpec_Options && cropData, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderAndroidSpec.g.h
@@ -29,28 +29,28 @@ struct ImageLoaderAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "abortRequest",
-          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSize",
-          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getSizeWithHeaders",
-          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "prefetchImage",
-          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, double requestId, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImageLoaderIOSSpec.g.h
+++ b/vnext/codegen/NativeImageLoaderIOSSpec.g.h
@@ -29,28 +29,28 @@ struct ImageLoaderIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getSize",
-          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSize) void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getSize) static void getSize(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSizeWithHeaders",
-          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSizeWithHeaders) void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getSizeWithHeaders) static void getSizeWithHeaders(std::string uri, ::React::JSValue && headers, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "prefetchImage",
-          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImage) void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(prefetchImage) static void prefetchImage(std::string uri, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "prefetchImageWithMetadata",
-          "    REACT_METHOD(prefetchImageWithMetadata) void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(prefetchImageWithMetadata) static void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(prefetchImageWithMetadata) void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(prefetchImageWithMetadata) static void prefetchImageWithMetadata(std::string uri, std::string queryRootName, double rootTag, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "queryCache",
-          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(queryCache) void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(queryCache) static void queryCache(std::vector<std::string> const & uris, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImagePickerIOSSpec.g.h
+++ b/vnext/codegen/NativeImagePickerIOSSpec.g.h
@@ -46,33 +46,33 @@ struct ImagePickerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "canRecordVideos",
-          "    REACT_METHOD(canRecordVideos) void canRecordVideos(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canRecordVideos) static void canRecordVideos(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canRecordVideos) void canRecordVideos(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(canRecordVideos) static void canRecordVideos(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "canUseCamera",
-          "    REACT_METHOD(canUseCamera) void canUseCamera(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canUseCamera) static void canUseCamera(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canUseCamera) void canUseCamera(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(canUseCamera) static void canUseCamera(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openCameraDialog",
-          "    REACT_METHOD(openCameraDialog) void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openCameraDialog) static void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openCameraDialog) void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openCameraDialog) static void openCameraDialog(ImagePickerIOSSpec_openCameraDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSelectDialog",
-          "    REACT_METHOD(openSelectDialog) void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSelectDialog) static void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSelectDialog) void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openSelectDialog) static void openSelectDialog(ImagePickerIOSSpec_openSelectDialog_config && config, std::function<void(std::string, double, double)> const & successCallback, std::function<void()> const & cancelCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "clearAllPendingVideos",
-          "    REACT_METHOD(clearAllPendingVideos) void clearAllPendingVideos() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clearAllPendingVideos) static void clearAllPendingVideos() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clearAllPendingVideos) void clearAllPendingVideos() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clearAllPendingVideos) static void clearAllPendingVideos() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "removePendingVideo",
-          "    REACT_METHOD(removePendingVideo) void removePendingVideo(std::string url) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removePendingVideo) static void removePendingVideo(std::string url) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removePendingVideo) void removePendingVideo(std::string url) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removePendingVideo) static void removePendingVideo(std::string url) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImageStoreAndroidSpec.g.h
+++ b/vnext/codegen/NativeImageStoreAndroidSpec.g.h
@@ -25,8 +25,8 @@ struct ImageStoreAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getBase64ForTag",
-          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(std::string)> const & errorCallback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeImageStoreIOSSpec.g.h
+++ b/vnext/codegen/NativeImageStoreIOSSpec.g.h
@@ -40,23 +40,23 @@ struct ImageStoreIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getBase64ForTag",
-          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getBase64ForTag) void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getBase64ForTag) static void getBase64ForTag(std::string uri, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_getBase64ForTag_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "hasImageForTag",
-          "    REACT_METHOD(hasImageForTag) void hasImageForTag(std::string uri, std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(hasImageForTag) static void hasImageForTag(std::string uri, std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(hasImageForTag) void hasImageForTag(std::string uri, std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(hasImageForTag) static void hasImageForTag(std::string uri, std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "removeImageForTag",
-          "    REACT_METHOD(removeImageForTag) void removeImageForTag(std::string uri) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeImageForTag) static void removeImageForTag(std::string uri) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeImageForTag) void removeImageForTag(std::string uri) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeImageForTag) static void removeImageForTag(std::string uri) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "addImageFromBase64",
-          "    REACT_METHOD(addImageFromBase64) void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addImageFromBase64) static void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addImageFromBase64) void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addImageFromBase64) static void addImageFromBase64(std::string base64ImageData, std::function<void(std::string)> const & successCallback, std::function<void(ImageStoreIOSSpec_addImageFromBase64_errorCallback_error const &)> const & errorCallback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeIntentAndroidSpec.g.h
+++ b/vnext/codegen/NativeIntentAndroidSpec.g.h
@@ -29,28 +29,28 @@ struct IntentAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getInitialURL",
-          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "canOpenURL",
-          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openURL",
-          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSettings",
-          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "sendIntent",
-          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendIntent) void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendIntent) static void sendIntent(std::string action, std::optional<::React::JSValueArray> extras, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
+++ b/vnext/codegen/NativeJSCHeapCaptureSpec.g.h
@@ -25,8 +25,8 @@ struct JSCHeapCaptureSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "captureComplete",
-          "    REACT_METHOD(captureComplete) void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(captureComplete) static void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(captureComplete) void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(captureComplete) static void captureComplete(std::string path, std::optional<std::string> error) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
+++ b/vnext/codegen/NativeJSCSamplingProfilerSpec.g.h
@@ -25,8 +25,8 @@ struct JSCSamplingProfilerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "operationComplete",
-          "    REACT_METHOD(operationComplete) void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(operationComplete) static void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(operationComplete) void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(operationComplete) static void operationComplete(double token, std::optional<std::string> result, std::optional<std::string> error) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeJSDevSupportSpec.g.h
+++ b/vnext/codegen/NativeJSDevSupportSpec.g.h
@@ -44,13 +44,13 @@ struct JSDevSupportSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "onSuccess",
-          "    REACT_METHOD(onSuccess) void onSuccess(std::string data) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(onSuccess) static void onSuccess(std::string data) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(onSuccess) void onSuccess(std::string data) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(onSuccess) static void onSuccess(std::string data) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "onFailure",
-          "    REACT_METHOD(onFailure) void onFailure(double errorCode, std::string error) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(onFailure) static void onFailure(double errorCode, std::string error) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(onFailure) void onFailure(double errorCode, std::string error) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(onFailure) static void onFailure(double errorCode, std::string error) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeKeyboardObserverSpec.g.h
+++ b/vnext/codegen/NativeKeyboardObserverSpec.g.h
@@ -26,13 +26,13 @@ struct KeyboardObserverSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeLinkingManagerSpec.g.h
+++ b/vnext/codegen/NativeLinkingManagerSpec.g.h
@@ -30,33 +30,33 @@ struct LinkingManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getInitialURL",
-          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialURL) void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getInitialURL) static void getInitialURL(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "canOpenURL",
-          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(canOpenURL) void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(canOpenURL) static void canOpenURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "openURL",
-          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openURL) void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openURL) static void openURL(std::string url, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "openSettings",
-          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(openSettings) void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(openSettings) static void openSettings(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeLogBoxSpec.g.h
+++ b/vnext/codegen/NativeLogBoxSpec.g.h
@@ -26,13 +26,13 @@ struct LogBoxSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "show",
-          "    REACT_METHOD(show) void show() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(show) static void show() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(show) void show() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(show) static void show() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "hide",
-          "    REACT_METHOD(hide) void hide() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(hide) static void hide() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(hide) void hide() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(hide) static void hide() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeModalManagerSpec.g.h
+++ b/vnext/codegen/NativeModalManagerSpec.g.h
@@ -26,13 +26,13 @@ struct ModalManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeNetworkingAndroidSpec.g.h
+++ b/vnext/codegen/NativeNetworkingAndroidSpec.g.h
@@ -29,28 +29,28 @@ struct NetworkingAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "sendRequest",
-          "    REACT_METHOD(sendRequest) void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendRequest) static void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendRequest) void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendRequest) static void sendRequest(std::string method, std::string url, double requestId, ::React::JSValueArray && headers, ::React::JSValue && data, std::string responseType, bool useIncrementalUpdates, double timeout, bool withCredentials) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "abortRequest",
-          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "clearCookies",
-          "    REACT_METHOD(clearCookies) void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clearCookies) static void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clearCookies) void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clearCookies) static void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeNetworkingIOSSpec.g.h
+++ b/vnext/codegen/NativeNetworkingIOSSpec.g.h
@@ -49,28 +49,28 @@ struct NetworkingIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "sendRequest",
-          "    REACT_METHOD(sendRequest) void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendRequest) static void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendRequest) void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendRequest) static void sendRequest(NetworkingIOSSpec_sendRequest_query && query, std::function<void(double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "abortRequest",
-          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(abortRequest) void abortRequest(double requestId) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(abortRequest) static void abortRequest(double requestId) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "clearCookies",
-          "    REACT_METHOD(clearCookies) void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clearCookies) static void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clearCookies) void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clearCookies) static void clearCookies(std::function<void(bool)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativePermissionsAndroidSpec.g.h
+++ b/vnext/codegen/NativePermissionsAndroidSpec.g.h
@@ -28,23 +28,23 @@ struct PermissionsAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "checkPermission",
-          "    REACT_METHOD(checkPermission) void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(checkPermission) static void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(checkPermission) void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(checkPermission) static void checkPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "requestPermission",
-          "    REACT_METHOD(requestPermission) void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestPermission) static void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestPermission) void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(requestPermission) static void requestPermission(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "shouldShowRequestPermissionRationale",
-          "    REACT_METHOD(shouldShowRequestPermissionRationale) void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(shouldShowRequestPermissionRationale) static void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(shouldShowRequestPermissionRationale) void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(shouldShowRequestPermissionRationale) static void shouldShowRequestPermissionRationale(std::string permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestMultiplePermissions",
-          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestMultiplePermissions) void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(requestMultiplePermissions) static void requestMultiplePermissions(std::vector<std::string> const & permissions, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
+++ b/vnext/codegen/NativePlatformConstantsAndroidSpec.g.h
@@ -73,8 +73,8 @@ struct PlatformConstantsAndroidSpec : winrt::Microsoft::ReactNative::TurboModule
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getAndroidID",
-          "    REACT_SYNC_METHOD(getAndroidID) std::string getAndroidID() noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getAndroidID) static std::string getAndroidID() noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getAndroidID) std::string getAndroidID() noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getAndroidID) static std::string getAndroidID() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
+++ b/vnext/codegen/NativePushNotificationManagerIOSSpec.g.h
@@ -86,93 +86,93 @@ struct PushNotificationManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModu
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "onFinishRemoteNotification",
-          "    REACT_METHOD(onFinishRemoteNotification) void onFinishRemoteNotification(std::string notificationId, std::string fetchResult) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(onFinishRemoteNotification) static void onFinishRemoteNotification(std::string notificationId, std::string fetchResult) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(onFinishRemoteNotification) void onFinishRemoteNotification(std::string notificationId, std::string fetchResult) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(onFinishRemoteNotification) static void onFinishRemoteNotification(std::string notificationId, std::string fetchResult) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setApplicationIconBadgeNumber",
-          "    REACT_METHOD(setApplicationIconBadgeNumber) void setApplicationIconBadgeNumber(double num) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setApplicationIconBadgeNumber) static void setApplicationIconBadgeNumber(double num) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setApplicationIconBadgeNumber) void setApplicationIconBadgeNumber(double num) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setApplicationIconBadgeNumber) static void setApplicationIconBadgeNumber(double num) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getApplicationIconBadgeNumber",
-          "    REACT_METHOD(getApplicationIconBadgeNumber) void getApplicationIconBadgeNumber(std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getApplicationIconBadgeNumber) static void getApplicationIconBadgeNumber(std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getApplicationIconBadgeNumber) void getApplicationIconBadgeNumber(std::function<void(double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getApplicationIconBadgeNumber) static void getApplicationIconBadgeNumber(std::function<void(double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "requestPermissions",
-          "    REACT_METHOD(requestPermissions) void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(requestPermissions) static void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(requestPermissions) void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(requestPermissions) static void requestPermissions(PushNotificationManagerIOSSpec_requestPermissions_permission && permission, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "abandonPermissions",
-          "    REACT_METHOD(abandonPermissions) void abandonPermissions() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(abandonPermissions) static void abandonPermissions() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(abandonPermissions) void abandonPermissions() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(abandonPermissions) static void abandonPermissions() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "checkPermissions",
-          "    REACT_METHOD(checkPermissions) void checkPermissions(std::function<void(PushNotificationManagerIOSSpec_Permissions const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(checkPermissions) static void checkPermissions(std::function<void(PushNotificationManagerIOSSpec_Permissions const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(checkPermissions) void checkPermissions(std::function<void(PushNotificationManagerIOSSpec_Permissions const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(checkPermissions) static void checkPermissions(std::function<void(PushNotificationManagerIOSSpec_Permissions const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "presentLocalNotification",
-          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(presentLocalNotification) void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(presentLocalNotification) static void presentLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "scheduleLocalNotification",
-          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(scheduleLocalNotification) void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(scheduleLocalNotification) static void scheduleLocalNotification(PushNotificationManagerIOSSpec_Notification && notification) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "cancelAllLocalNotifications",
-          "    REACT_METHOD(cancelAllLocalNotifications) void cancelAllLocalNotifications() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cancelAllLocalNotifications) static void cancelAllLocalNotifications() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cancelAllLocalNotifications) void cancelAllLocalNotifications() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(cancelAllLocalNotifications) static void cancelAllLocalNotifications() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "cancelLocalNotifications",
-          "    REACT_METHOD(cancelLocalNotifications) void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cancelLocalNotifications) static void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cancelLocalNotifications) void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(cancelLocalNotifications) static void cancelLocalNotifications(::React::JSValue && userInfo) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "getInitialNotification",
-          "    REACT_METHOD(getInitialNotification) void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getInitialNotification) static void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getInitialNotification) void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getInitialNotification) static void getInitialNotification(::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "getScheduledLocalNotifications",
-          "    REACT_METHOD(getScheduledLocalNotifications) void getScheduledLocalNotifications(std::function<void(PushNotificationManagerIOSSpec_Notification const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getScheduledLocalNotifications) static void getScheduledLocalNotifications(std::function<void(PushNotificationManagerIOSSpec_Notification const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getScheduledLocalNotifications) void getScheduledLocalNotifications(std::function<void(PushNotificationManagerIOSSpec_Notification const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getScheduledLocalNotifications) static void getScheduledLocalNotifications(std::function<void(PushNotificationManagerIOSSpec_Notification const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "removeAllDeliveredNotifications",
-          "    REACT_METHOD(removeAllDeliveredNotifications) void removeAllDeliveredNotifications() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeAllDeliveredNotifications) static void removeAllDeliveredNotifications() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeAllDeliveredNotifications) void removeAllDeliveredNotifications() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeAllDeliveredNotifications) static void removeAllDeliveredNotifications() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "removeDeliveredNotifications",
-          "    REACT_METHOD(removeDeliveredNotifications) void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeDeliveredNotifications) static void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeDeliveredNotifications) void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeDeliveredNotifications) static void removeDeliveredNotifications(std::vector<std::string> const & identifiers) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "getDeliveredNotifications",
-          "    REACT_METHOD(getDeliveredNotifications) void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getDeliveredNotifications) static void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getDeliveredNotifications) void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getDeliveredNotifications) static void getDeliveredNotifications(std::function<void(std::vector<PushNotificationManagerIOSSpec_Notification> const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "getAuthorizationStatus",
-          "    REACT_METHOD(getAuthorizationStatus) void getAuthorizationStatus(std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getAuthorizationStatus) static void getAuthorizationStatus(std::function<void(double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getAuthorizationStatus) void getAuthorizationStatus(std::function<void(double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getAuthorizationStatus) static void getAuthorizationStatus(std::function<void(double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           16,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventType) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventType) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventType) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventType) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           17,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeRedBoxSpec.g.h
+++ b/vnext/codegen/NativeRedBoxSpec.g.h
@@ -26,13 +26,13 @@ struct RedBoxSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setExtraData",
-          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setExtraData) void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setExtraData) static void setExtraData(::React::JSValue && extraData, std::string forIdentifier) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "dismiss",
-          "    REACT_METHOD(dismiss) void dismiss() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dismiss) static void dismiss() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dismiss) void dismiss() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dismiss) static void dismiss() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeSampleTurboModuleSpec.g.h
+++ b/vnext/codegen/NativeSampleTurboModuleSpec.g.h
@@ -55,58 +55,58 @@ struct SampleTurboModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "voidFunc",
-          "    REACT_METHOD(voidFunc) void voidFunc() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(voidFunc) static void voidFunc() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(voidFunc) void voidFunc() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(voidFunc) static void voidFunc() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getBool",
-          "    REACT_SYNC_METHOD(getBool) bool getBool(bool arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getBool) static bool getBool(bool arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getBool) bool getBool(bool arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getBool) static bool getBool(bool arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "getNumber",
-          "    REACT_SYNC_METHOD(getNumber) double getNumber(double arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getNumber) static double getNumber(double arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getNumber) double getNumber(double arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getNumber) static double getNumber(double arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "getString",
-          "    REACT_SYNC_METHOD(getString) std::string getString(std::string arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getString) static std::string getString(std::string arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getString) std::string getString(std::string arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getString) static std::string getString(std::string arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "getArray",
-          "    REACT_SYNC_METHOD(getArray) ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getArray) static ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getArray) ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getArray) static ::React::JSValueArray getArray(::React::JSValueArray && arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "getObject",
-          "    REACT_SYNC_METHOD(getObject) ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getObject) static ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getObject) ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getObject) static ::React::JSValue getObject(::React::JSValue && arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "getUnsafeObject",
-          "    REACT_SYNC_METHOD(getUnsafeObject) ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getUnsafeObject) static ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getUnsafeObject) ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getUnsafeObject) static ::React::JSValue getUnsafeObject(::React::JSValue && arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "getRootTag",
-          "    REACT_SYNC_METHOD(getRootTag) double getRootTag(double arg) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getRootTag) static double getRootTag(double arg) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getRootTag) double getRootTag(double arg) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getRootTag) static double getRootTag(double arg) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "getValue",
-          "    REACT_SYNC_METHOD(getValue) ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getValue) static ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getValue) ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getValue) static ::React::JSValue getValue(double x, std::string y, ::React::JSValue && z) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "getValueWithCallback",
-          "    REACT_METHOD(getValueWithCallback) void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValueWithCallback) static void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValueWithCallback) void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValueWithCallback) static void getValueWithCallback(std::function<void(std::string)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "getValueWithPromise",
-          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getValueWithPromise) void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getValueWithPromise) static void getValueWithPromise(bool error, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeSegmentFetcherSpec.g.h
+++ b/vnext/codegen/NativeSegmentFetcherSpec.g.h
@@ -26,13 +26,13 @@ struct SegmentFetcherSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "fetchSegment",
-          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(fetchSegment) void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(fetchSegment) static void fetchSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getSegment",
-          "    REACT_METHOD(getSegment) void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getSegment) void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getSegment) static void getSegment(double segmentId, ::React::JSValue && options, std::function<void(std::optional<::React::JSValue>, std::optional<std::string>)> const & callback) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeSettingsManagerSpec.g.h
+++ b/vnext/codegen/NativeSettingsManagerSpec.g.h
@@ -42,13 +42,13 @@ struct SettingsManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setValues",
-          "    REACT_METHOD(setValues) void setValues(::React::JSValue && values) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setValues) static void setValues(::React::JSValue && values) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setValues) void setValues(::React::JSValue && values) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setValues) static void setValues(::React::JSValue && values) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "deleteValues",
-          "    REACT_METHOD(deleteValues) void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(deleteValues) static void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(deleteValues) void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(deleteValues) static void deleteValues(std::vector<std::string> const & values) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeShareModuleSpec.g.h
+++ b/vnext/codegen/NativeShareModuleSpec.g.h
@@ -33,8 +33,8 @@ struct ShareModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "share",
-          "    REACT_METHOD(share) void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(share) static void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(share) void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(share) static void share(ShareModuleSpec_share_content && content, std::string dialogTitle, ::React::ReactPromise<::React::JSValue> &&result) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeSoundManagerSpec.g.h
+++ b/vnext/codegen/NativeSoundManagerSpec.g.h
@@ -25,8 +25,8 @@ struct SoundManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "playTouchSound",
-          "    REACT_METHOD(playTouchSound) void playTouchSound() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(playTouchSound) static void playTouchSound() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(playTouchSound) void playTouchSound() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(playTouchSound) static void playTouchSound() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerAndroidSpec.g.h
@@ -46,23 +46,23 @@ struct StatusBarManagerAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleS
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "setColor",
-          "    REACT_METHOD(setColor) void setColor(double color, bool animated) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setColor) static void setColor(double color, bool animated) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setColor) void setColor(double color, bool animated) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setColor) static void setColor(double color, bool animated) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setTranslucent",
-          "    REACT_METHOD(setTranslucent) void setTranslucent(bool translucent) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setTranslucent) static void setTranslucent(bool translucent) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setTranslucent) void setTranslucent(bool translucent) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setTranslucent) static void setTranslucent(bool translucent) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "setStyle",
-          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "setHidden",
-          "    REACT_METHOD(setHidden) void setHidden(bool hidden) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setHidden) static void setHidden(bool hidden) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setHidden) void setHidden(bool hidden) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setHidden) static void setHidden(bool hidden) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
+++ b/vnext/codegen/NativeStatusBarManagerIOSSpec.g.h
@@ -54,33 +54,33 @@ struct StatusBarManagerIOSSpec : winrt::Microsoft::ReactNative::TurboModuleSpec 
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getHeight",
-          "    REACT_METHOD(getHeight) void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(getHeight) static void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(getHeight) void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(getHeight) static void getHeight(std::function<void(StatusBarManagerIOSSpec_getHeight_callback_result const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "setNetworkActivityIndicatorVisible",
-          "    REACT_METHOD(setNetworkActivityIndicatorVisible) void setNetworkActivityIndicatorVisible(bool visible) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setNetworkActivityIndicatorVisible) static void setNetworkActivityIndicatorVisible(bool visible) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setNetworkActivityIndicatorVisible) void setNetworkActivityIndicatorVisible(bool visible) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setNetworkActivityIndicatorVisible) static void setNetworkActivityIndicatorVisible(bool visible) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventType) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventType) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventType) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventType) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "setStyle",
-          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setStyle) void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setStyle) static void setStyle(std::optional<std::string> statusBarStyle, bool animated) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "setHidden",
-          "    REACT_METHOD(setHidden) void setHidden(bool hidden, std::string withAnimation) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setHidden) static void setHidden(bool hidden, std::string withAnimation) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setHidden) void setHidden(bool hidden, std::string withAnimation) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setHidden) static void setHidden(bool hidden, std::string withAnimation) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeTimingSpec.g.h
+++ b/vnext/codegen/NativeTimingSpec.g.h
@@ -27,18 +27,18 @@ struct TimingSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "createTimer",
-          "    REACT_METHOD(createTimer) void createTimer(double callbackID, double duration, double jsSchedulingTime, bool repeats) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createTimer) static void createTimer(double callbackID, double duration, double jsSchedulingTime, bool repeats) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createTimer) void createTimer(double callbackID, double duration, double jsSchedulingTime, bool repeats) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(createTimer) static void createTimer(double callbackID, double duration, double jsSchedulingTime, bool repeats) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "deleteTimer",
-          "    REACT_METHOD(deleteTimer) void deleteTimer(double timerID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(deleteTimer) static void deleteTimer(double timerID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(deleteTimer) void deleteTimer(double timerID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(deleteTimer) static void deleteTimer(double timerID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "setSendIdleEvents",
-          "    REACT_METHOD(setSendIdleEvents) void setSendIdleEvents(bool sendIdleEvents) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setSendIdleEvents) static void setSendIdleEvents(bool sendIdleEvents) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setSendIdleEvents) void setSendIdleEvents(bool sendIdleEvents) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setSendIdleEvents) static void setSendIdleEvents(bool sendIdleEvents) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeToastAndroidSpec.g.h
+++ b/vnext/codegen/NativeToastAndroidSpec.g.h
@@ -51,18 +51,18 @@ struct ToastAndroidSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "show",
-          "    REACT_METHOD(show) void show(std::string message, double duration) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(show) static void show(std::string message, double duration) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(show) void show(std::string message, double duration) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(show) static void show(std::string message, double duration) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "showWithGravity",
-          "    REACT_METHOD(showWithGravity) void showWithGravity(std::string message, double duration, double gravity) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showWithGravity) static void showWithGravity(std::string message, double duration, double gravity) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showWithGravity) void showWithGravity(std::string message, double duration, double gravity) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showWithGravity) static void showWithGravity(std::string message, double duration, double gravity) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "showWithGravityAndOffset",
-          "    REACT_METHOD(showWithGravityAndOffset) void showWithGravityAndOffset(std::string message, double duration, double gravity, double xOffset, double yOffset) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showWithGravityAndOffset) static void showWithGravityAndOffset(std::string message, double duration, double gravity, double xOffset, double yOffset) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showWithGravityAndOffset) void showWithGravityAndOffset(std::string message, double duration, double gravity, double xOffset, double yOffset) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showWithGravityAndOffset) static void showWithGravityAndOffset(std::string message, double duration, double gravity, double xOffset, double yOffset) noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeUIManagerSpec.g.h
+++ b/vnext/codegen/NativeUIManagerSpec.g.h
@@ -49,128 +49,128 @@ struct UIManagerSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "getConstantsForViewManager",
-          "    REACT_SYNC_METHOD(getConstantsForViewManager) ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getConstantsForViewManager) static ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getConstantsForViewManager) ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getConstantsForViewManager) static ::React::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "getDefaultEventTypes",
-          "    REACT_SYNC_METHOD(getDefaultEventTypes) std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(getDefaultEventTypes) static std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(getDefaultEventTypes) std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(getDefaultEventTypes) static std::vector<std::string> getDefaultEventTypes() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "lazilyLoadView",
-          "    REACT_SYNC_METHOD(lazilyLoadView) ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n"
-          "    REACT_SYNC_METHOD(lazilyLoadView) static ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }}\n");
+          "    REACT_SYNC_METHOD(lazilyLoadView) ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }\n"
+          "    REACT_SYNC_METHOD(lazilyLoadView) static ::React::JSValue lazilyLoadView(std::string name) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "createView",
-          "    REACT_METHOD(createView) void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(createView) static void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(createView) void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(createView) static void createView(std::optional<double> reactTag, std::string viewName, double rootTag, ::React::JSValue && props) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "updateView",
-          "    REACT_METHOD(updateView) void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(updateView) static void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(updateView) void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(updateView) static void updateView(double reactTag, std::string viewName, ::React::JSValue && props) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "focus",
-          "    REACT_METHOD(focus) void focus(std::optional<double> reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(focus) static void focus(std::optional<double> reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(focus) void focus(std::optional<double> reactTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(focus) static void focus(std::optional<double> reactTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "blur",
-          "    REACT_METHOD(blur) void blur(std::optional<double> reactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(blur) static void blur(std::optional<double> reactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(blur) void blur(std::optional<double> reactTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(blur) static void blur(std::optional<double> reactTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           7,
           "findSubviewIn",
-          "    REACT_METHOD(findSubviewIn) void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(findSubviewIn) void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(findSubviewIn) static void findSubviewIn(std::optional<double> reactTag, std::vector<double> const & point, std::function<void(double, double, double, double, double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           8,
           "dispatchViewManagerCommand",
-          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dispatchViewManagerCommand) void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dispatchViewManagerCommand) static void dispatchViewManagerCommand(std::optional<double> reactTag, double commandID, std::optional<::React::JSValueArray> commandArgs) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           9,
           "measure",
-          "    REACT_METHOD(measure) void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measure) static void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measure) void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(measure) static void measure(std::optional<double> reactTag, std::function<void(double, double, double, double, double, double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           10,
           "measureInWindow",
-          "    REACT_METHOD(measureInWindow) void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureInWindow) static void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureInWindow) void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(measureInWindow) static void measureInWindow(std::optional<double> reactTag, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           11,
           "viewIsDescendantOf",
-          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(viewIsDescendantOf) void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(viewIsDescendantOf) static void viewIsDescendantOf(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(std::vector<bool> const &)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           12,
           "measureLayout",
-          "    REACT_METHOD(measureLayout) void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayout) static void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayout) void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(measureLayout) static void measureLayout(std::optional<double> reactTag, std::optional<double> ancestorReactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           13,
           "measureLayoutRelativeToParent",
-          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(measureLayoutRelativeToParent) void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(measureLayoutRelativeToParent) static void measureLayoutRelativeToParent(std::optional<double> reactTag, std::function<void(::React::JSValue const &)> const & errorCallback, std::function<void(double, double, double, double)> const & callback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           14,
           "setJSResponder",
-          "    REACT_METHOD(setJSResponder) void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setJSResponder) static void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setJSResponder) void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setJSResponder) static void setJSResponder(std::optional<double> reactTag, bool blockNativeResponder) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           15,
           "clearJSResponder",
-          "    REACT_METHOD(clearJSResponder) void clearJSResponder() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(clearJSResponder) static void clearJSResponder() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(clearJSResponder) void clearJSResponder() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(clearJSResponder) static void clearJSResponder() noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           16,
           "configureNextLayoutAnimation",
-          "    REACT_METHOD(configureNextLayoutAnimation) void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(configureNextLayoutAnimation) static void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(configureNextLayoutAnimation) void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(configureNextLayoutAnimation) static void configureNextLayoutAnimation(::React::JSValue && config, std::function<void()> const & callback, std::function<void(::React::JSValue const &)> const & errorCallback) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           17,
           "removeSubviewsFromContainerWithID",
-          "    REACT_METHOD(removeSubviewsFromContainerWithID) void removeSubviewsFromContainerWithID(double containerID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeSubviewsFromContainerWithID) static void removeSubviewsFromContainerWithID(double containerID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeSubviewsFromContainerWithID) void removeSubviewsFromContainerWithID(double containerID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeSubviewsFromContainerWithID) static void removeSubviewsFromContainerWithID(double containerID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           18,
           "replaceExistingNonRootView",
-          "    REACT_METHOD(replaceExistingNonRootView) void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(replaceExistingNonRootView) static void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(replaceExistingNonRootView) void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(replaceExistingNonRootView) static void replaceExistingNonRootView(std::optional<double> reactTag, std::optional<double> newReactTag) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           19,
           "setChildren",
-          "    REACT_METHOD(setChildren) void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setChildren) static void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setChildren) void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setChildren) static void setChildren(std::optional<double> containerTag, std::vector<double> const & reactTags) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           20,
           "manageChildren",
-          "    REACT_METHOD(manageChildren) void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(manageChildren) static void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(manageChildren) void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(manageChildren) static void manageChildren(std::optional<double> containerTag, std::vector<double> const & moveFromIndices, std::vector<double> const & moveToIndices, std::vector<double> const & addChildReactTags, std::vector<double> const & addAtIndices, std::vector<double> const & removeAtIndices) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           21,
           "setLayoutAnimationEnabledExperimental",
-          "    REACT_METHOD(setLayoutAnimationEnabledExperimental) void setLayoutAnimationEnabledExperimental(bool enabled) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(setLayoutAnimationEnabledExperimental) static void setLayoutAnimationEnabledExperimental(bool enabled) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(setLayoutAnimationEnabledExperimental) void setLayoutAnimationEnabledExperimental(bool enabled) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(setLayoutAnimationEnabledExperimental) static void setLayoutAnimationEnabledExperimental(bool enabled) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           22,
           "sendAccessibilityEvent",
-          "    REACT_METHOD(sendAccessibilityEvent) void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendAccessibilityEvent) static void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendAccessibilityEvent) void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendAccessibilityEvent) static void sendAccessibilityEvent(std::optional<double> reactTag, double eventType) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           23,
           "showPopupMenu",
-          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(showPopupMenu) void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(showPopupMenu) static void showPopupMenu(std::optional<double> reactTag, std::vector<std::string> const & items, std::function<void(::React::JSValue const &)> const & error, std::function<void(std::string, double)> const & success) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           24,
           "dismissPopupMenu",
-          "    REACT_METHOD(dismissPopupMenu) void dismissPopupMenu() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(dismissPopupMenu) static void dismissPopupMenu() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(dismissPopupMenu) void dismissPopupMenu() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(dismissPopupMenu) static void dismissPopupMenu() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeVibrationSpec.g.h
+++ b/vnext/codegen/NativeVibrationSpec.g.h
@@ -27,18 +27,18 @@ struct VibrationSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "vibrate",
-          "    REACT_METHOD(vibrate) void vibrate(double pattern) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(vibrate) static void vibrate(double pattern) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(vibrate) void vibrate(double pattern) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(vibrate) static void vibrate(double pattern) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "vibrateByPattern",
-          "    REACT_METHOD(vibrateByPattern) void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(vibrateByPattern) static void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(vibrateByPattern) void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(vibrateByPattern) static void vibrateByPattern(std::vector<double> const & pattern, double repeat) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "cancel",
-          "    REACT_METHOD(cancel) void cancel() noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(cancel) static void cancel() noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(cancel) void cancel() noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(cancel) static void cancel() noexcept { /* implementation */ }\n");
   }
 };
 

--- a/vnext/codegen/NativeWebSocketModuleSpec.g.h
+++ b/vnext/codegen/NativeWebSocketModuleSpec.g.h
@@ -37,38 +37,38 @@ struct WebSocketModuleSpec : winrt::Microsoft::ReactNative::TurboModuleSpec {
     REACT_SHOW_METHOD_SPEC_ERRORS(
           0,
           "connect",
-          "    REACT_METHOD(connect) void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(connect) void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(connect) static void connect(std::string url, std::optional<std::vector<std::string>> protocols, WebSocketModuleSpec_connect_options && options, double socketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           1,
           "send",
-          "    REACT_METHOD(send) void send(std::string message, double forSocketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(send) static void send(std::string message, double forSocketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(send) void send(std::string message, double forSocketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(send) static void send(std::string message, double forSocketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           2,
           "sendBinary",
-          "    REACT_METHOD(sendBinary) void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(sendBinary) static void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(sendBinary) void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(sendBinary) static void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           3,
           "ping",
-          "    REACT_METHOD(ping) void ping(double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(ping) static void ping(double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(ping) void ping(double socketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(ping) static void ping(double socketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           4,
           "close",
-          "    REACT_METHOD(close) void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(close) static void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(close) void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(close) static void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           5,
           "addListener",
-          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(addListener) static void addListener(std::string eventName) noexcept { /* implementation */ }\n");
     REACT_SHOW_METHOD_SPEC_ERRORS(
           6,
           "removeListeners",
-          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }}\n"
-          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }}\n");
+          "    REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }\n"
+          "    REACT_METHOD(removeListeners) static void removeListeners(double count) noexcept { /* implementation */ }\n");
   }
 };
 


### PR DESCRIPTION
## Description
The strings designed to provide nicer compiler error information have an extra `}` at the end of the sample method implementation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10693)