### PR TITLE
Set User-Agent header in Origin Policy filter

### DIFF
--- a/change/react-native-windows-a912b218-3e03-4b76-8b54-d9cd603a29c0.json
+++ b/change/react-native-windows-a912b218-3e03-4b76-8b54-d9cd603a29c0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set User-Agent header in Origin Policy filter",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -640,8 +640,6 @@ void OriginPolicyHttpFilter::ValidateResponse(HttpResponseMessage const &respons
 }
 
 ResponseOperation OriginPolicyHttpFilter::SendPreflightAsync(HttpRequestMessage const &request) const {
-  // TODO: Inject user agent?
-
   auto coRequest = request;
 
   HttpRequestMessage preflightRequest;
@@ -759,17 +757,6 @@ ResponseOperation OriginPolicyHttpFilter::SendRequestAsync(HttpRequestMessage co
       }
 
       ValidatePreflightResponse(coRequest, preflightResponse);
-    }
-
-    // Set User-Agent after validating request and preflight.
-    auto userAgent = GetRuntimeOptionString("Http.UserAgent");
-    if (userAgent.size() > 0) {
-      coRequest.Headers().Append(L"User-Agent", to_hstring(userAgent));
-    }
-
-    if (originPolicy == OriginPolicy::SimpleCrossOriginResourceSharing ||
-        originPolicy == OriginPolicy::CrossOriginResourceSharing) {
-      coRequest.Headers().Insert(L"Origin", s_origin.AbsoluteCanonicalUri());
     }
 
     auto response = co_await m_innerFilter.SendRequestAsync(coRequest);

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -761,6 +761,17 @@ ResponseOperation OriginPolicyHttpFilter::SendRequestAsync(HttpRequestMessage co
       ValidatePreflightResponse(coRequest, preflightResponse);
     }
 
+    // Set User-Agent after validating request and preflight.
+    auto userAgent = GetRuntimeOptionString("Http.UserAgent");
+    if (userAgent.size() > 0) {
+      coRequest.Headers().Append(L"User-Agent", to_hstring(userAgent));
+    }
+
+    if (originPolicy == OriginPolicy::SimpleCrossOriginResourceSharing ||
+        originPolicy == OriginPolicy::CrossOriginResourceSharing) {
+      coRequest.Headers().Insert(L"Origin", s_origin.AbsoluteCanonicalUri());
+    }
+
     auto response = co_await m_innerFilter.SendRequestAsync(coRequest);
 
     ValidateResponse(response, originPolicy);

--- a/vnext/Shared/Networking/RedirectHttpFilter.cpp
+++ b/vnext/Shared/Networking/RedirectHttpFilter.cpp
@@ -5,6 +5,8 @@
 
 #include "RedirectHttpFilter.h"
 
+// React Native Windows
+#include <CppRuntimeOptions.h>
 #include "WinRTTypes.h"
 
 // Windows API
@@ -211,6 +213,13 @@ ResponseOperation RedirectHttpFilter::SendRequestAsync(HttpRequestMessage const 
   method = coRequest.Method();
 
   do {
+    // Set User-Agent
+    // See https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+    auto userAgent = GetRuntimeOptionString("Http.UserAgent");
+    if (userAgent.size() > 0) {
+      coRequest.Headers().Append(L"User-Agent", winrt::to_hstring(userAgent));
+    }
+
     // Send subsequent requests through the filter that doesn't have the credentials included in the first request
     response =
         co_await (redirectCount > 0 ? m_innerFilterWithNoCredentials : m_innerFilter).SendRequestAsync(coRequest);

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -152,6 +152,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\RedirectHttpFilter.cpp">
       <Filter>Source Files\Networking</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobModule.cpp">
+      <Filter>Source Files\Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -456,6 +459,15 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IRedirectEventSource.h">
       <Filter>Header Files\Networking</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobModule.h">
+      <Filter>Header Files\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\IWebSocketModuleProxy.h">
+      <Filter>Header Files\Modules</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\IWebSocketModuleContentHandler.h">
+      <Filter>Header Files\Modules</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
Sets the User-Agent header in RedirectHttpFilter::SendRequestAsync.


### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Some HTTP endpoints may require the User-Agent header to be set to return a successful response (i.e. `200: OK`).
Example: `GET https://api.github.com/repos/microsoft/react-native-windows`
If the request has no `User-Agent` header, the result is `403: Forbidden`.

The User-Agent should be settable via native code by the consuming app, and not only passed from the JavaScript layer on which HTTP headers may not be directly settable.

### What
Retrieves the runtime option string `Http.UserAgent` and appends it to an HTTP request right before sending it.

### Introduced Runtime Options
- `Http.UserAgent` Used to set the `User-Agent` header for all HTTP requests via native code.

Note, this header should always be set **after** Origin Policy eventual request validation because `User-Agent` is not considered a "Simple CORS". This prevents false negatives during such request validation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10695)