### PR TITLE
Set Origin HTTP header during CORS

### DIFF
--- a/change/react-native-windows-8769dfac-39b4-4cfc-88ae-91a5456390a2.json
+++ b/change/react-native-windows-8769dfac-39b4-4cfc-88ae-91a5456390a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set Origin HTTP header during CORS",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -759,6 +759,11 @@ ResponseOperation OriginPolicyHttpFilter::SendRequestAsync(HttpRequestMessage co
       ValidatePreflightResponse(coRequest, preflightResponse);
     }
 
+    if (originPolicy == OriginPolicy::SimpleCrossOriginResourceSharing ||
+        originPolicy == OriginPolicy::CrossOriginResourceSharing) {
+      coRequest.Headers().Insert(L"Origin", s_origin.AbsoluteCanonicalUri());
+    }
+
     auto response = co_await m_innerFilter.SendRequestAsync(coRequest);
 
     ValidateResponse(response, originPolicy);


### PR DESCRIPTION
## Description
Sets the `Origin` header when dealing with Simple CORS or Full CORS requests.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
HTTP servers may need the `Origin` header set by the client to properly validate Origin Policy semantics.

Currently, only the CORS preflight request sets this header.

### What
OriginPolicyHttpFilter::SendAsync appends the `Origin` header to both the preflight and main requests before sending.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10700)