### PR TITLE
Skip setting XAML layout when tree is collapsed

### DIFF
--- a/change/react-native-windows-e58e1f46-51d2-4c31-9724-77e523316842.json
+++ b/change/react-native-windows-e58e1f46-51d2-4c31-9724-77e523316842.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Skip setting XAML layout when tree is collapsed",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
@@ -211,14 +211,14 @@ exports[`DisplayNoneTest DisplayNoneEnabledTest 1`] = `
   "Clip": null,
   "CornerRadius": "0,0,0,0",
   "FlowDirection": "LeftToRight",
-  "Height": 0,
+  "Height": 40,
   "HorizontalAlignment": "Stretch",
   "Left": 0,
   "Margin": "0,0,0,0",
-  "Top": 0,
+  "Top": 50,
   "VerticalAlignment": "Stretch",
   "Visibility": "Collapsed",
-  "Width": 0,
+  "Width": 718,
   "XamlType": "Microsoft.ReactNative.ViewPanel",
   "children": [
     {
@@ -229,7 +229,7 @@ exports[`DisplayNoneTest DisplayNoneEnabledTest 1`] = `
       "CornerRadius": "0,0,0,0",
       "FlowDirection": "LeftToRight",
       "Foreground": "#E4000000",
-      "Height": 0,
+      "Height": 40,
       "HorizontalAlignment": "Stretch",
       "Left": 0,
       "Margin": "0,0,0,0",
@@ -238,7 +238,7 @@ exports[`DisplayNoneTest DisplayNoneEnabledTest 1`] = `
       "Top": 0,
       "VerticalAlignment": "Stretch",
       "Visibility": "Visible",
-      "Width": 0,
+      "Width": 718,
       "XamlType": "Windows.UI.Xaml.Controls.TextBox",
       "children": [
         {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -913,12 +913,16 @@ void NativeUIManager::ApplyLayout(int64_t tag, float width, float height) {
   }
 }
 
-void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
+void NativeUIManager::SetLayoutPropsRecursive(int64_t tag, bool isCollapsed) {
   ShadowNodeBase &shadowNode = static_cast<ShadowNodeBase &>(m_host->GetShadowNodeForTag(tag));
+  const auto view = shadowNode.GetView();
+  if (auto yogaNode = GetYogaNode(tag)) {
+    isCollapsed |= YGNodeStyleGetDisplay(yogaNode) == YGDisplay::YGDisplayNone;
+  }
   auto *pViewManager = shadowNode.GetViewManager();
   if (!pViewManager->IsNativeControlWithSelfLayout()) {
     for (const auto child : shadowNode.m_children) {
-      SetLayoutPropsRecursive(child);
+      SetLayoutPropsRecursive(child, isCollapsed);
     }
   }
 
@@ -932,9 +936,10 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag) {
     float top = YGNodeLayoutGetTop(yogaNode);
     float width = YGNodeLayoutGetWidth(yogaNode);
     float height = YGNodeLayoutGetHeight(yogaNode);
-    auto view = shadowNode.GetView();
-    auto pViewManager = shadowNode.GetViewManager();
-    pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+    const auto uiElement = view.try_as<xaml::UIElement>();
+    if (!isCollapsed) {
+      pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
+    }
     if (shadowNode.m_onLayoutRegistered) {
       const auto hasLayoutChanged = !YogaFloatEquals(left, shadowNode.m_layout.Left) ||
           !YogaFloatEquals(top, shadowNode.m_layout.Top) || !YogaFloatEquals(width, shadowNode.m_layout.Width) ||

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -1019,11 +1019,9 @@ void NativeUIManager::measure(
     }
   }
 
-  auto x = 0.f;
-  auto y = 0.f;
+  winrt::Point point{0.f, 0.f};
   if (const auto relativePosition = GetRelativePosition(feView, feRootView)) {
-    x = relativePosition->X;
-    y = relativePosition->Y;
+    point = *relativePosition;
   }
 
   // TODO: The first two params are for the local position. It's unclear what
@@ -1031,8 +1029,8 @@ void NativeUIManager::measure(
   //  Either codify this non-use or determine if and how we can send the needed
   //  data.
   m_context.JSDispatcher().Post(
-      [callback = std::move(callback), x, y, w = node.m_layout.Width, h = node.m_layout.Height]() {
-        callback(0, 0, w, h, x, y);
+      [callback = std::move(callback), point, w = node.m_layout.Width, h = node.m_layout.Height]() {
+        callback(0, 0, w, h, point.X, point.Y);
       });
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -954,26 +954,18 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag, bool isCollapsed) {
   }
 }
 
-winrt::Windows::Foundation::Rect GetRectOfElementInParentCoords(
-    xaml::FrameworkElement element,
-    xaml::UIElement parent) {
+std::optional<winrt::Point> GetRelativePosition(xaml::FrameworkElement element, xaml::UIElement parent) {
   if (parent == nullptr) {
     assert(false);
-    return winrt::Windows::Foundation::Rect();
+    return std::nullopt;
   }
 
-  winrt::Rect anchorRect;
   winrt::Point anchorTopLeft = winrt::Point(0, 0);
 
   winrt::GeneralTransform transform = element.TransformToVisual(parent);
   winrt::Point anchorTopLeftConverted = transform.TransformPoint(anchorTopLeft);
 
-  anchorRect.X = anchorTopLeftConverted.X;
-  anchorRect.Y = anchorTopLeftConverted.Y;
-  anchorRect.Width = (float)element.ActualWidth();
-  anchorRect.Height = (float)element.ActualHeight();
-
-  return anchorRect;
+  return anchorTopLeftConverted;
 }
 
 void NativeUIManager::measure(
@@ -1020,15 +1012,21 @@ void NativeUIManager::measure(
     }
   }
 
-  winrt::Rect rectInParentCoords = GetRectOfElementInParentCoords(feView, feRootView);
+  auto x = 0.f;
+  auto y = 0.f;
+  if (const auto relativePosition = GetRelativePosition(feView, feRootView)) {
+    x = relativePosition->X;
+    y = relativePosition->Y;
+  }
 
   // TODO: The first two params are for the local position. It's unclear what
   // this is exactly, but it is not used anyway.
   //  Either codify this non-use or determine if and how we can send the needed
   //  data.
-  m_context.JSDispatcher().Post([callback = std::move(callback), react = rectInParentCoords]() {
-    callback(0, 0, react.Width, react.Height, react.X, react.Y);
-  });
+  m_context.JSDispatcher().Post(
+      [callback = std::move(callback), x, y, w = node.m_layout.Width, h = node.m_layout.Height]() {
+        callback(0, 0, w, h, x, y);
+      });
 }
 
 void NativeUIManager::measureInWindow(
@@ -1045,7 +1043,7 @@ void NativeUIManager::measureInWindow(
     auto positionInWindow = windowTransform.TransformPoint({0, 0});
 
     m_context.JSDispatcher().Post(
-        [callback = std::move(callback), pos = positionInWindow, w = view.ActualWidth(), h = view.ActualHeight()]() {
+        [callback = std::move(callback), pos = positionInWindow, w = node.m_layout.Width, h = node.m_layout.Height]() {
           callback(pos.X, pos.Y, w, h);
         });
     return;
@@ -1067,8 +1065,8 @@ void NativeUIManager::measureLayout(
     const auto ancenstorElement = ancestor.GetView().as<xaml::FrameworkElement>();
 
     const auto ancestorTransform = targetElement.TransformToVisual(ancenstorElement);
-    const auto width = static_cast<float>(targetElement.ActualWidth());
-    const auto height = static_cast<float>(targetElement.ActualHeight());
+    const auto width = static_cast<float>(target.m_layout.Width);
+    const auto height = static_cast<float>(target.m_layout.Height);
     const auto transformedBounds = ancestorTransform.TransformBounds(winrt::Rect(0, 0, width, height));
 
     m_context.JSDispatcher().Post([callback = std::move(callback), rect = transformedBounds]() {
@@ -1121,15 +1119,21 @@ void NativeUIManager::findSubviewIn(
     }
   }
 
-  if (foundElement == nullptr) {
+  const auto foundNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(foundTag));
+
+  const auto position = GetRelativePosition(foundElement, rootUIView);
+  if (!foundNode || !position) {
     m_context.JSDispatcher().Post([callback = std::move(callback)]() { callback(0, 0, 0, 0, 0); });
     return;
   }
 
   m_context.JSDispatcher().Post(
-      [callback = std::move(callback), foundTag, box = GetRectOfElementInParentCoords(foundElement, rootUIView)]() {
-        callback(static_cast<double>(foundTag), box.X, box.Y, box.Width, box.Height);
-      });
+      [callback = std::move(callback),
+       foundTag,
+       x = position->X,
+       y = position->Y,
+       w = foundNode->m_layout.Width,
+       h = foundNode->m_layout.Height]() { callback(static_cast<double>(foundTag), x, y, w, h); });
 }
 
 void NativeUIManager::focus(int64_t reactTag) {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -937,9 +937,16 @@ void NativeUIManager::SetLayoutPropsRecursive(int64_t tag, bool isCollapsed) {
     float width = YGNodeLayoutGetWidth(yogaNode);
     float height = YGNodeLayoutGetHeight(yogaNode);
     const auto uiElement = view.try_as<xaml::UIElement>();
+
+    // Avoid updating XAML layout in collapsed sub-trees (i.e., for descendants
+    // of Views that set { display: 'none' } in style props). This reduces the
+    // amount of work the XAML layout algorithm needs to do when a sub-tree is
+    // collapsed. There is no effect on what gets rendered to the UI because
+    // React Native Windows sets Visibility to Collapsed for this sub-tree.
     if (!isCollapsed) {
       pViewManager->SetLayoutProps(shadowNode, view, left, top, width, height);
     }
+
     if (shadowNode.m_onLayoutRegistered) {
       const auto hasLayoutChanged = !YogaFloatEquals(left, shadowNode.m_layout.Left) ||
           !YogaFloatEquals(top, shadowNode.m_layout.Top) || !YogaFloatEquals(width, shadowNode.m_layout.Width) ||

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -105,7 +105,7 @@ class NativeUIManager final : public INativeUIManager {
   void ApplyLayout(int64_t tag, float width = YGUndefined, float height = YGUndefined);
 
  private:
-  void SetLayoutPropsRecursive(int64_t tag);
+  void SetLayoutPropsRecursive(int64_t tag, bool isCollapsed = false);
   YGNodeRef GetYogaNode(int64_t tag) const;
 
   winrt::weak_ref<winrt::Microsoft::ReactNative::ReactRootView> GetParentXamlReactControl(int64_t tag) const;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Performance optimization

### Why
When a view tree is collapsed (via `display: 'none'` style setting), there is no need to update the ViewPanel positioning properties (Canvas::TopProperty, Canvas::LeftProperty, FrameworkElement::WidthProperty, and FrameworkElement::HeightProperty), which would in turn trigger invalidate XAML layout for ViewPanels in that tree.

### What
This change ensures we do not update these XAML positioning properties when a view is in the context of a collapsed sub-tree.

## Testing
Ran `display: none` API test in RNTester:

https://user-images.githubusercontent.com/1106239/194947794-bac1a4b9-476c-4b2f-b623-2d475817733e.mp4

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10712)