### PR TITLE
Reduce frequency of arrange invalidation for ViewPanel

### DIFF
--- a/change/react-native-windows-6070865d-4422-4418-9a80-e5d2db74ace8.json
+++ b/change/react-native-windows-6070865d-4422-4418-9a80-e5d2db74ace8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Reduce frequency of arrange invalidation for ViewPanel",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -89,6 +89,11 @@ YGSize DefaultYogaSelfMeasureFunc(
   return desiredSize;
 }
 
+static inline bool YogaDoubleEquals(double x, double y) {
+  // Epsilon value of 0.0001 is taken from the YGDoubleEqual method in Yoga.
+  return std::fabs(x - y) < 0.0001;
+};
+
 ViewManagerBase::ViewManagerBase(const Mso::React::IReactContext &context)
     : m_context(&context),
       m_batchingEventEmitter{std::make_shared<React::BatchingEventEmitter>(Mso::CntPtr(&context))} {}
@@ -377,8 +382,12 @@ void ViewManagerBase::SetLayoutProps(
   auto fe = element.as<xaml::FrameworkElement>();
 
   // Set Position & Size Properties
-  ViewPanel::SetLeft(element, left);
-  ViewPanel::SetTop(element, top);
+  if (!YogaDoubleEquals(ViewPanel::GetLeft(element), left)) {
+    ViewPanel::SetLeft(element, left);
+  }
+  if (!YogaDoubleEquals(ViewPanel::GetTop(element), top)) {
+    ViewPanel::SetTop(element, top);
+  }
 
   fe.Width(width);
   fe.Height(height);

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -109,11 +109,13 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
 }
 
 /*static*/ void ViewPanel::SetTop(xaml::UIElement const &element, double value) {
+  const auto oldValue = GetTop(element);
   element.SetValue(TopProperty(), winrt::box_value<double>(value));
   InvalidateForArrange(element);
 }
 
 /*static*/ void ViewPanel::SetLeft(xaml::UIElement const &element, double value) {
+  const auto oldValue = GetLeft(element);
   element.SetValue(LeftProperty(), winrt::box_value<double>(value));
   InvalidateForArrange(element);
 }


### PR DESCRIPTION



This change should allow us to only invalidate the XAML parent when Yoga layout has actually changed.

## Description

### Type of Change
_Erase all that don't apply._
- Perf optimization

### Why
We spend a non-trivial amount of time in ArrangeOverride for ViewPanel. The Top and Left properties are set any time a Yoga node has a new layout, which is not always when the actual layout value has changed (e.g., only the width or height may have changed, or perhaps a descendant value layout has updated, which often marks the parent as having a new layout when nothing has actually changed).

### What
ViewPanel top and left props are set from Yoga results. For better or worse, float values in Yoga are treated as equal if the difference is less than 0.0001. As such, it's safe for us to only invalidate the parent when the values are not equal with an epsilon of 0.0001.

## Testing
No change in RNTester behavior.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10714)