### PR TITLE
Adds view flattening to Paper UIManager

### DIFF
--- a/change/react-native-windows-9ff65cff-6033-4309-b83c-cdf9ebe3e501.json
+++ b/change/react-native-windows-9ff65cff-6033-4309-b83c-cdf9ebe3e501.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds view flattening to Paper UIManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/DisplayNoneTest.test.ts.snap
@@ -211,14 +211,14 @@ Object {
   "Clip": null,
   "CornerRadius": "0,0,0,0",
   "FlowDirection": "LeftToRight",
-  "Height": 0,
+  "Height": 40,
   "HorizontalAlignment": "Stretch",
   "Left": 0,
   "Margin": "0,0,0,0",
-  "Top": 0,
+  "Top": 50,
   "VerticalAlignment": "Stretch",
   "Visibility": "Collapsed",
-  "Width": 0,
+  "Width": 718,
   "XamlType": "Microsoft.ReactNative.ViewPanel",
   "children": Array [
     Object {
@@ -229,7 +229,7 @@ Object {
       "CornerRadius": "0,0,0,0",
       "FlowDirection": "LeftToRight",
       "Foreground": "#E4000000",
-      "Height": 0,
+      "Height": 40,
       "HorizontalAlignment": "Stretch",
       "Left": 0,
       "Margin": "0,0,0,0",
@@ -238,7 +238,7 @@ Object {
       "Top": 0,
       "VerticalAlignment": "Stretch",
       "Visibility": "Visible",
-      "Width": 0,
+      "Width": 718,
       "XamlType": "Windows.UI.Xaml.Controls.TextBox",
       "children": Array [
         Object {

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -373,6 +373,7 @@
     <ClInclude Include="Views\Text\TextVisitors.h" />
     <ClInclude Include="Views\TouchEventHandler.h" />
     <ClInclude Include="Views\ViewControl.h" />
+    <ClInclude Include="Views\ViewFlattening.h" />
     <ClInclude Include="Views\ViewManager.h" />
     <ClInclude Include="Views\ViewManagerBase.h" />
     <ClInclude Include="Views\ViewPanel.h" />
@@ -591,6 +592,7 @@
     <ClCompile Include="Views\Text\TextVisitor.cpp" />
     <ClCompile Include="Views\TouchEventHandler.cpp" />
     <ClCompile Include="Views\ViewControl.cpp" />
+    <ClCompile Include="Views\ViewFlattening.cpp" />
     <ClCompile Include="Views\ViewManagerBase.cpp" />
     <ClCompile Include="Views\ViewPanel.cpp" />
     <ClCompile Include="Views\ViewViewManager.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -336,6 +336,9 @@
     <ClCompile Include="Views\FrameworkElementTransferProperties.cpp" />
     <ClCompile Include="Views\ReactViewInstance.cpp" />
     <ClCompile Include="CoreApp.cpp" />
+    <ClCompile Include="Views\ViewFlattening.cpp">
+      <Filter>Views</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABICxxModule.h" />
@@ -732,6 +735,9 @@
     <ClInclude Include="ReactPointerEventArgs.h" />
     <ClInclude Include="Views\FrameworkElementTransferProperties.h" />
     <ClInclude Include="Views\ReactViewInstance.h" />
+    <ClInclude Include="Views\ViewFlattening.h">
+      <Filter>Views</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="IJSValueReader.idl" />

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -102,7 +102,7 @@ class NativeUIManager final : public INativeUIManager {
 
  private:
   void DoLayout();
-  void SetLayoutPropsRecursive(int64_t tag);
+  void SetLayoutPropsRecursive(int64_t tag, bool isCollapsed = false);
   YGNodeRef GetYogaNode(int64_t tag) const;
 
   winrt::weak_ref<winrt::Microsoft::ReactNative::ReactRootView> GetParentXamlReactControl(int64_t tag) const;

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -30,6 +30,21 @@ struct YogaNodeDeleter {
   }
 };
 
+struct NodeWithOffset {
+  const ShadowNodeBase *node;
+  float offsetX;
+  float offsetY;
+};
+
+enum class SetLayoutModifiers : std::uint_fast8_t {
+  None = 0,
+  IsCollapsed = 1 << 0,
+  IsUnflattening = 1 << 1,
+  LayoutOnlyAncestorUpdated = 1 << 2,
+};
+
+DEFINE_ENUM_FLAG_OPERATORS(SetLayoutModifiers);
+
 typedef std::unique_ptr<YGNode, YogaNodeDeleter> YogaNodePtr;
 
 class NativeUIManager final : public INativeUIManager {
@@ -100,12 +115,21 @@ class NativeUIManager final : public INativeUIManager {
 
   int64_t AddMeasuredRootView(facebook::react::IReactRootView *rootView);
 
+  void UnflattenLayout(int64_t tag);
+
  private:
   void DoLayout();
-  void SetLayoutPropsRecursive(int64_t tag, bool isCollapsed = false);
+  void SetLayoutPropsRecursive(
+      int64_t tag,
+      float offsetX = 0.0f,
+      float offsetY = 0.0f,
+      SetLayoutModifiers modifiers = SetLayoutModifiers::None);
   YGNodeRef GetYogaNode(int64_t tag) const;
 
   winrt::weak_ref<winrt::Microsoft::ReactNative::ReactRootView> GetParentXamlReactControl(int64_t tag) const;
+
+  NodeWithOffset GetNativeParentWithOffset(const ShadowNodeBase *node);
+  std::optional<winrt::Windows::Foundation::Rect> GetRelativeLayout(ShadowNodeBase *target, ShadowNodeBase *ancestor);
 
  private:
   INativeUIManagerHost *m_host = nullptr;

--- a/vnext/Microsoft.ReactNative/QuirkSettings.cpp
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.cpp
@@ -58,6 +58,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   return propId;
 }
 
+winrt::Microsoft::ReactNative::ReactPropertyId<bool> IsViewFlatteningEnabledProperty() noexcept {
+  static winrt::Microsoft::ReactNative::ReactPropertyId<bool> propId{
+      L"ReactNative.QuirkSettings", L"IsViewFlatteningEnabledProperty"};
+  return propId;
+}
+
 /*static*/ void QuirkSettings::SetMapWindowDeactivatedToAppStateInactive(
     winrt::Microsoft::ReactNative::ReactPropertyBag properties,
     bool value) noexcept {
@@ -96,6 +102,12 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
   SetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag(settings.Properties()), value);
 }
 
+/*static*/ void QuirkSettings::SetIsViewFlatteningEnabled(
+    winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+    bool value) noexcept {
+  ReactPropertyBag(settings.Properties()).Set(IsViewFlatteningEnabledProperty(), value);
+}
+
 #pragma endregion IDL interface
 
 /*static*/ bool QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(ReactPropertyBag properties) noexcept {
@@ -118,6 +130,10 @@ winrt::Microsoft::ReactNative::ReactPropertyId<bool> MapWindowDeactivatedToAppSt
 
 /*static*/ bool QuirkSettings::GetMapWindowDeactivatedToAppStateInactive(ReactPropertyBag properties) noexcept {
   return properties.Get(MapWindowDeactivatedToAppStateInactiveProperty()).value_or(false);
+}
+
+/*static*/ bool QuirkSettings::GetIsViewFlatteningEnabled(ReactPropertyBag properties) noexcept {
+  return properties.Get(IsViewFlatteningEnabledProperty()).value_or(false);
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/QuirkSettings.h
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.h
@@ -37,6 +37,8 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
   static bool GetMapWindowDeactivatedToAppStateInactive(
       winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
 
+  static bool GetIsViewFlatteningEnabled(winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
 #pragma region Public API - part of IDL interface
   static void SetMatchAndroidAndIOSStretchBehavior(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
@@ -52,6 +54,10 @@ struct QuirkSettings : QuirkSettingsT<QuirkSettings> {
       winrt::Microsoft::ReactNative::BackNavigationHandlerKind kind) noexcept;
 
   static void SetMapWindowDeactivatedToAppStateInactive(
+      winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
+      bool value) noexcept;
+
+  static void SetIsViewFlatteningEnabled(
       winrt::Microsoft::ReactNative::ReactInstanceSettings settings,
       bool value) noexcept;
 #pragma endregion Public API - part of IDL interface

--- a/vnext/Microsoft.ReactNative/QuirkSettings.idl
+++ b/vnext/Microsoft.ReactNative/QuirkSettings.idl
@@ -53,5 +53,12 @@ namespace Microsoft.ReactNative
       "`inactive` tracks the [Window.Activated Event](https://docs.microsoft.com/uwp/api/windows.ui.core.corewindow.activated) when the window is deactivated.")
     DOC_DEFAULT("false")
     static void SetMapWindowDeactivatedToAppStateInactive(ReactInstanceSettings settings, Boolean value);
+
+    DOC_STRING(
+      "By default `react-native-windows` creates a native view for every native component in the React JS tree. "
+      "Setting this to true enables `react-native-windows` to optimize away some instances of <View> components "
+      "if these instances only use layout props.")
+    DOC_DEFAULT("false")
+    static void SetIsViewFlatteningEnabled(ReactInstanceSettings settings, Boolean value);
   }
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ShadowNodeTypeUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <Views/ShadowNodeBase.h>
+#include <Views/ViewManagerBase.h>
 
 namespace Microsoft::ReactNative {
 
@@ -13,6 +14,10 @@ static inline bool IsNodeType(ShadowNodeBase const *node, wchar_t const *name) {
 
 static inline bool IsTextShadowNode(ShadowNodeBase const *node) {
   return IsNodeType(node, L"RCTText");
+}
+
+static inline bool IsViewShadowNode(ShadowNodeBase const *node) {
+  return IsNodeType(node, L"RCTView");
 }
 
 static inline bool IsVirtualTextShadowNode(ShadowNodeBase const *node) {

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -88,6 +88,12 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
     return false;
   }
 
+  virtual bool IsLayoutOnly() const noexcept {
+    return false;
+  }
+
+  virtual void ForceUnflattened() noexcept {}
+
   void YellowBox(const std::string &message) const noexcept;
   void RedBox(const std::string &message) const noexcept;
 
@@ -141,6 +147,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
 
   // Layout
   ShadowNodeLayout m_layout;
+
+  // Layout only props
+  int64_t m_nativeChildrenCount = 0;
 
   // Support Keyboard
  public:

--- a/vnext/Microsoft.ReactNative/Views/ViewFlattening.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewFlattening.cpp
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "ViewFlattening.h"
+
+#include <JSValue.h>
+#include <QuirkSettings.h>
+#include <Utils/ShadowNodeTypeUtils.h>
+#include <unordered_set>
+
+namespace Microsoft::ReactNative::ViewFlattening {
+
+///
+/// Helpers
+///
+///
+
+void AttachChild(INativeUIManagerHost *host, ShadowNodeBase *child);
+
+void AttachChildren(INativeUIManagerHost *host, ShadowNodeBase *node) {
+  for (auto childTag : node->m_children) {
+    const auto child = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(childTag));
+    assert(child && "All child nodes are assumed to exist.");
+    AttachChild(host, child);
+  }
+}
+
+int64_t AttachNativeDescendants(
+    INativeUIManagerHost *host,
+    ShadowNodeBase *nativeParent,
+    ShadowNodeBase *child,
+    int64_t nativeIndex) {
+  if (!child->IsLayoutOnly()) {
+    nativeParent->AddView(*child, nativeIndex);
+    return 1;
+  } else {
+    auto currentIndex = nativeIndex;
+    for (auto descendantTag : child->m_children) {
+      const auto descendant = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(descendantTag));
+      assert(descendant && "All child nodes are assumed to exist.");
+      currentIndex += AttachNativeDescendants(host, nativeParent, descendant, currentIndex);
+    }
+    return currentIndex - nativeIndex;
+  }
+}
+
+void DetachNativeDescendants(
+    INativeUIManagerHost *host,
+    ShadowNodeBase *nativeParent,
+    ShadowNodeBase *child,
+    int64_t nativeIndex,
+    bool isUnflattening = false) {
+  if (!child->IsLayoutOnly() && !isUnflattening) {
+    nativeParent->RemoveChildAt(nativeIndex);
+  } else {
+    auto currentIndex = nativeIndex;
+    for (auto descendantTag : child->m_children) {
+      const auto descendant = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(descendantTag));
+      assert(descendant && "All child nodes are assumed to exist.");
+      // We don't need to increment the native index, because the nodes are removed in order
+      DetachNativeDescendants(host, nativeParent, descendant, nativeIndex);
+    }
+  }
+}
+
+int64_t GetNativeIndexForChild(INativeUIManagerHost *host, ShadowNodeBase *node, int64_t childTag) {
+  int64_t nativeIndex = 0;
+  for (auto siblingTag : node->m_children) {
+    if (siblingTag == childTag) {
+      break;
+    } else {
+      const auto sibling = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(siblingTag));
+      assert(sibling && "All sibling nodes are assumed to exist.");
+      nativeIndex += sibling->IsLayoutOnly() ? sibling->m_nativeChildrenCount : 1;
+    }
+  }
+
+  return nativeIndex;
+}
+
+struct NodeIndexPair {
+  ShadowNodeBase *node;
+  int64_t index;
+};
+
+std::optional<NodeIndexPair>
+GetNativeParentAndIndex(INativeUIManagerHost *host, ShadowNodeBase *node, int64_t index = 0) {
+  const auto parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(node->m_parent));
+  if (!parent) {
+    return std::nullopt;
+  }
+
+  const auto nativeIndex = GetNativeIndexForChild(host, parent, node->m_tag);
+  // When transitioning a node from layout-only to materialized, we need to
+  // operate as if that parent node is still layout only.
+  if (!parent->IsLayoutOnly()) {
+    return NodeIndexPair{parent, index + nativeIndex};
+  }
+
+  return GetNativeParentAndIndex(host, parent, index + nativeIndex);
+}
+
+void UpdateAncestorNativeChildrenCount(INativeUIManagerHost *host, ShadowNodeBase *child, int64_t nativeChildrenCount) {
+  if (const auto parent = static_cast<ShadowNodeBase *>(host->FindShadowNodeForTag(child->m_parent))) {
+    parent->m_nativeChildrenCount += nativeChildrenCount;
+    if (parent->IsLayoutOnly()) {
+      UpdateAncestorNativeChildrenCount(host, parent, nativeChildrenCount);
+    }
+  }
+}
+
+bool IsViewFlatteningEnabled(ShadowNodeBase *node) {
+  return winrt::Microsoft::ReactNative::implementation::QuirkSettings::GetIsViewFlatteningEnabled(
+      winrt::Microsoft::ReactNative::ReactPropertyBag{node->GetViewManager()->GetReactContext().Properties()});
+}
+
+void AttachChild(INativeUIManagerHost *host, ShadowNodeBase *child) {
+  const auto nativeParentAndIndex = GetNativeParentAndIndex(host, child);
+  // If this node has not yet been attached to a native parent, we can skip
+  // this step. Its native descendants will be attached to a native parent when
+  // an ancestor is attached to a native parent.
+  if (nativeParentAndIndex) {
+    auto nativeParent = nativeParentAndIndex->node;
+    auto nativeIndex = nativeParentAndIndex->index;
+
+    // If attempting to attach a layout only child to a parent is not a View,
+    // we need to materialize the child so it's layout-only children are
+    // positioned correctly.
+    if (child->IsLayoutOnly() && !IsViewShadowNode(nativeParent)) {
+      child->ForceUnflattened();
+      AttachChildren(host, child);
+    }
+
+    AttachNativeDescendants(host, nativeParent, child, nativeIndex);
+  }
+
+  const auto nativeChildrenCount = child->IsLayoutOnly() ? child->m_nativeChildrenCount : 1;
+  UpdateAncestorNativeChildrenCount(host, child, nativeChildrenCount);
+}
+
+void DetachChild(INativeUIManagerHost *host, ShadowNodeBase *child, bool isUnflattening = false) {
+  const auto nativeParentAndIndex = GetNativeParentAndIndex(host, child);
+
+  // If this node has not yet been attached to a native parent, we can skip
+  // this step. Its native descendants are not attached to a native parent.
+  if (nativeParentAndIndex) {
+    auto nativeParent = nativeParentAndIndex->node;
+    auto nativeIndex = nativeParentAndIndex->index;
+    DetachNativeDescendants(host, nativeParent, child, nativeIndex, isUnflattening);
+  }
+
+  const auto nativeChildrenCount = child->IsLayoutOnly() ? child->m_nativeChildrenCount : 1;
+  UpdateAncestorNativeChildrenCount(host, child, nativeChildrenCount * -1);
+}
+
+///
+/// Layout-Only Props
+///
+
+const std::unordered_set<std::string> LayoutOnlyProps{
+    "alignSelf",
+    "alignItems",
+    "flex",
+    "flexBasis",
+    "flexDirection",
+    "flexGrow",
+    "flexShrink",
+    "flexWrap",
+    "justifyContent",
+    "alignContent",
+    "display",
+
+    /* position */
+    "position",
+    "right",
+    "top",
+    "bottom",
+    "left",
+    "start",
+    "end",
+
+    /* dimensions */
+    "width",
+    "height",
+    "minWidth",
+    "maxWidth",
+    "minHeight",
+    "maxHeight",
+
+    /* margins */
+    "margin",
+    "marginVertical",
+    "marginHorizontal",
+    "marginLeft",
+    "marginRight",
+    "marginTop",
+    "marginBottom",
+    "marginStart",
+    "marginEnd",
+
+    /* paddings */
+    "padding",
+    "paddingVertical",
+    "paddingHorizontal",
+    "paddingLeft",
+    "paddingRight",
+    "paddingTop",
+    "paddingBottom",
+    "paddingStart",
+    "paddingEnd",
+};
+
+///
+/// Public Methods
+///
+
+void AddView(IViewFlatteningHost *host, ShadowNodeBase *parent, ShadowNodeBase *child, int64_t index) {
+  if (!host->IsViewFlatteningEnabled()) {
+    parent->AddView(*child, index);
+  } else {
+    AttachChild(host, child);
+  }
+}
+
+bool IsLayoutOnly(ShadowNodeBase *node, winrt::Microsoft::ReactNative::JSValueObject const &props) {
+  if (!IsViewFlatteningEnabled(node)) {
+    return false;
+  }
+
+  if (!IsViewShadowNode(node)) {
+    return false;
+  }
+
+  auto isLayoutOnly = true;
+  for (const auto &pair : props) {
+    const std::string &propertyName = pair.first;
+    const auto &propertyValue = pair.second;
+
+    if (LayoutOnlyProps.find(propertyName) == LayoutOnlyProps.end()) {
+      if (propertyName == "pointerEvents") {
+        const auto pointerEventsValue = propertyValue.AsString();
+        isLayoutOnly = (pointerEventsValue == "auto" || pointerEventsValue == "box-none");
+      } else if (propertyName == "opacity") {
+        isLayoutOnly =
+            (propertyValue.IsNull() ||
+             std::abs(propertyValue.AsDouble() - 1.0) < std::numeric_limits<double>().epsilon());
+      } else if (
+          propertyName == "borderWidth" || propertyName == "borderLeftWidth" || propertyName == "borderTopWidth" ||
+          propertyName == "borderRightWidth" || propertyName == "borderBottomWidth") {
+        isLayoutOnly = propertyValue.AsDouble() < std::numeric_limits<double>().epsilon();
+      } else if (propertyName == "overflow") {
+        isLayoutOnly = (propertyValue.IsNull() || propertyValue.AsString() == "visible");
+      } else if (propertyName == "collapsable") {
+        isLayoutOnly = propertyValue.IsNull() || propertyValue.AsBoolean();
+      } else {
+        isLayoutOnly = false;
+      }
+    }
+
+    if (!isLayoutOnly) {
+      break;
+    }
+  }
+
+  return isLayoutOnly;
+}
+
+void RemoveAllChildren(IViewFlatteningHost *host, ShadowNodeBase *node) {
+  if (!node->IsLayoutOnly()) {
+    node->removeAllChildren();
+  }
+}
+
+void RemoveChildAt(IViewFlatteningHost *host, ShadowNodeBase *parent, ShadowNodeBase *child, int64_t index) {
+  if (!host->IsViewFlatteningEnabled()) {
+    parent->RemoveChildAt(index);
+  } else {
+    DetachChild(host, child);
+  }
+}
+
+void UnflattenNode(IViewFlatteningHost *host, ShadowNodeBase *node) {
+  // Detach all native children
+  DetachChild(host, node, true);
+
+  // Reset native children count, it will be updated again when children are re-attached
+  node->m_nativeChildrenCount = 0;
+
+  // Re-attach all native children
+  AttachChildren(host, node);
+
+  // Attach self
+  AttachChild(host, node);
+
+  // Unflatten layout
+  host->UnflattenLayout(node->m_tag);
+}
+
+} // namespace Microsoft::ReactNative::ViewFlattening

--- a/vnext/Microsoft.ReactNative/Views/ViewFlattening.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewFlattening.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <INativeUIManager.h>
+#include "ShadowNodeBase.h"
+
+namespace winrt::Microsoft::ReactNative {
+struct JSValueObject;
+}
+
+namespace Microsoft::ReactNative::ViewFlattening {
+
+struct IViewFlatteningHost : INativeUIManagerHost {
+  virtual void UnflattenLayout(int64_t tag) = 0;
+  virtual bool IsViewFlatteningEnabled() = 0;
+};
+
+void AddView(IViewFlatteningHost *host, ShadowNodeBase *parent, ShadowNodeBase *child, int64_t index);
+bool IsLayoutOnly(ShadowNodeBase *node, winrt::Microsoft::ReactNative::JSValueObject const &props);
+void RemoveAllChildren(IViewFlatteningHost *host, ShadowNodeBase *node);
+void RemoveChildAt(IViewFlatteningHost *host, ShadowNodeBase *parent, ShadowNodeBase *child, int64_t index);
+void UnflattenNode(IViewFlatteningHost *host, ShadowNodeBase *node);
+
+} // namespace Microsoft::ReactNative::ViewFlattening

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -103,6 +103,7 @@ void ViewManagerBase::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVal
   React::WriteProperty(writer, L"keyUpEvents", L"array");
   React::WriteProperty(writer, L"onMouseEnter", L"function");
   React::WriteProperty(writer, L"onMouseLeave", L"function");
+  React::WriteProperty(writer, L"collapsable", L"boolean");
 }
 
 void ViewManagerBase::GetConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Most react-native apps are littered with views used only for positioning / layout. Creating these controls is a costly in terms of CPU time spent constructing them, adding and removing them from the native XAML tree and time spent running the measure / arrange pass in XAML.

### What
This change implements view flattening to avoid creating native backing views for layout-only nodes.

The core of the implementation is in the set of functions declared in ViewFlattening.h. It abstracts away methods that were previously invoked directly on shadow nodes, and instead performs tree-traversals to find the correct location in the native tree that a given node should be attached or detached.

The rest of the changes are auxiliary:
- ShadowNodeBase adds a virtual method to report whether the node is layout only.
- ShadowNodeBase adds a 64-bit integer to track the number of non-layout only children it manages to avoid recursion into each node any time a view is added, removed, or otherwise re-arranged.
- ViewManagerBase adds the `collapsable` native prop type, which is more-or-less an override flag for forcing materialization of a layout-only view.
- ViewViewManager is updated to avoid creation of a native view if the initial props are layout-only. It also checks the layout-only status when props are updated so it can create the native view if and when it's needed.
- PaperUIManager is where previous native view hierarchy operations were performed directly via ShadowNodes, but are now performed via ViewFlattening functions
- NativeUIManager adds functionality to support setting layout on children of layout only nodes, as well as functionality to re-apply layout when a layout-only node transitions to a materialized view.

## Testing
TBD