### PR TITLE
Allow ABIViewManagers to use `overflow: hidden`

### DIFF
--- a/change/react-native-windows-145b5e26-99fe-403f-9bb5-8e41695aac40.json
+++ b/change/react-native-windows-145b5e26-99fe-403f-9bb5-8e41695aac40.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow ABIViewManagers to use `overflow: hidden`",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementTransferProperties.cpp
@@ -46,6 +46,7 @@ void TransferFrameworkElementProperties(const xaml::DependencyObject &oldView, c
   TransferProperty(oldView, newView, xaml::FrameworkElement::MaxHeightProperty());
   TransferProperty(oldView, newView, xaml::FrameworkElement::FlowDirectionProperty());
   TransferProperty(oldView, newView, xaml::Controls::Canvas::ZIndexProperty());
+  TransferProperty(oldView, newView, xaml::UIElement::ClipProperty());
 
   const auto oldUI = oldView.as<xaml::UIElement>();
   const auto left = winrt::Microsoft::ReactNative::ViewPanel::GetLeft(oldUI);

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -45,10 +45,10 @@ enum class ShadowCorners : uint8_t {
 };
 
 struct ShadowNodeLayout {
-  float Left;
-  float Top;
-  float Width;
-  float Height;
+  float Left{0.f};
+  float Top{0.f};
+  float Width{0.f};
+  float Height{0.f};
 };
 
 extern const DECLSPEC_SELECTANY double c_UndefinedEdge = -1;
@@ -135,6 +135,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   bool m_onLayoutRegistered = false;
   bool m_onMouseEnterRegistered = false;
   bool m_onMouseLeaveRegistered = false;
+
+  // Overflow
+  bool m_overflowHidden = false;
 
   // Pointer events
   PointerEventsKind m_pointerEvents = PointerEventsKind::Auto;

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -303,6 +303,8 @@ bool ViewManagerBase::UpdateProperty(
       }
     }
   } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
+  } else if (propertyName == "overflow") {
+    nodeToUpdate->m_overflowHidden = propertyValue.AsString() == "hidden";
   } else {
     return false;
   }
@@ -382,6 +384,16 @@ void ViewManagerBase::SetLayoutProps(
 
   fe.Width(width);
   fe.Height(height);
+
+  // Modifying the `overflow` prop will always result in the Yoga node setting
+  // `YGNodeHasNewLayout`, so we can reliably update the Clip from this method.
+  if (nodeToUpdate.m_overflowHidden) {
+    winrt::RectangleGeometry clipGeometry;
+    clipGeometry.Rect(winrt::Rect(0, 0, width, height));
+    fe.Clip(clipGeometry);
+  } else {
+    fe.ClearValue(xaml::UIElement::ClipProperty());
+  }
 }
 
 YGMeasureFunc ViewManagerBase::GetYogaCustomMeasureFunc() const {

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -98,16 +98,6 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return xaml::Controls::Canvas::LeftProperty();
 }
 
-/*static*/ xaml::DependencyProperty ViewPanel::ClipChildrenProperty() {
-  static xaml::DependencyProperty s_clipChildrenProperty = xaml::DependencyProperty::Register(
-      L"ClipChildren",
-      winrt::xaml_typename<bool>(),
-      viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::box_value(false), ViewPanel::VisualPropertyChanged));
-
-  return s_clipChildrenProperty;
-}
-
 /*static*/ void ViewPanel::SetTop(xaml::UIElement const &element, double value) {
   element.SetValue(TopProperty(), winrt::box_value<double>(value));
   InvalidateForArrange(element);
@@ -185,8 +175,6 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
         winrt::Rect(adjustedLeft, adjustedTop, static_cast<float>(childWidth), static_cast<float>(childHeight)));
   }
 
-  UpdateClip(finalSize);
-
   return finalSize;
 }
 
@@ -223,10 +211,6 @@ void ViewPanel::BorderBrush(winrt::Brush const &value) {
 
 void ViewPanel::CornerRadius(xaml::CornerRadius const &value) {
   SetValue(CornerRadiusProperty(), winrt::box_value(value));
-}
-
-void ViewPanel::ClipChildren(bool value) {
-  SetValue(ClipChildrenProperty(), winrt::box_value(value));
 }
 
 void ViewPanel::FinalizeProperties() {
@@ -268,9 +252,6 @@ void ViewPanel::FinalizeProperties() {
   } else if (!displayBorder) {
     scenario = Scenario::NoBorder;
     m_hasOuterBorder = false;
-  } else if (ClipChildren()) {
-    scenario = Scenario::OuterBorder;
-    m_hasOuterBorder = true;
   } else {
     scenario = Scenario::InnerBorder;
     m_hasOuterBorder = false;
@@ -347,17 +328,6 @@ xaml::Controls::Border ViewPanel::GetOuterBorder() {
     return m_border;
   else
     return xaml::Controls::Border(nullptr);
-}
-
-void ViewPanel::UpdateClip(winrt::Size &finalSize) {
-  if (ClipChildren()) {
-    winrt::RectangleGeometry clipGeometry;
-    clipGeometry.Rect(winrt::Rect(0, 0, static_cast<float>(finalSize.Width), static_cast<float>(finalSize.Height)));
-
-    Clip(clipGeometry);
-  } else {
-    Clip(nullptr);
-  }
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -52,17 +52,11 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   }
   void CornerRadius(xaml::CornerRadius const &value);
 
-  bool ClipChildren() {
-    return winrt::unbox_value<bool>(GetValue(ClipChildrenProperty()));
-  }
-  void ClipChildren(bool value);
-
   // ViewPanel Properties
   static xaml::DependencyProperty ViewBackgroundProperty();
   static xaml::DependencyProperty BorderThicknessProperty();
   static xaml::DependencyProperty BorderBrushProperty();
   static xaml::DependencyProperty CornerRadiusProperty();
-  static xaml::DependencyProperty ClipChildrenProperty();
 
   // Attached Properties
   static xaml::DependencyProperty TopProperty();
@@ -81,8 +75,6 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
 
  private:
   void Remove(xaml::UIElement element) const;
-
-  void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
 
  private:
   bool m_propertiesChanged{false};

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -425,11 +425,6 @@ bool ViewViewManager::UpdateProperty(
     } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
     } else if (propertyName == "onClick") {
       pViewShadowNode->OnClick(propertyValue.AsBoolean());
-    } else if (propertyName == "overflow") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        bool clipChildren = propertyValue.AsString() == "hidden";
-        pPanel.ClipChildren(clipChildren);
-      }
     } else if (propertyName == "focusable") {
       pViewShadowNode->IsFocusable(propertyValue.AsBoolean());
     } else if (propertyName == "enableFocusRing") {

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -26,14 +26,12 @@ namespace Microsoft.ReactNative
     XAML_NAMESPACE.Thickness BorderThickness { get; set; };
     XAML_NAMESPACE.Media.Brush BorderBrush { get; set; };
     XAML_NAMESPACE.CornerRadius CornerRadius { get; set; };
-    Boolean ClipChildren { get; set; };
 
     // ViewPanel Properties
     static XAML_NAMESPACE.DependencyProperty ViewBackgroundProperty { get; };
     static XAML_NAMESPACE.DependencyProperty BorderThicknessProperty { get; };
     static XAML_NAMESPACE.DependencyProperty BorderBrushProperty { get; };
     static XAML_NAMESPACE.DependencyProperty CornerRadiusProperty { get; };
-    static XAML_NAMESPACE.DependencyProperty ClipChildrenProperty { get; };
 
     // Attached Properties
     static XAML_NAMESPACE.DependencyProperty TopProperty { get; };


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Currently, `overflow: hidden` is only implemented on `<View>`, but any node should be allowed to use this style.

### What
This moves the logic to handle clipping to ViewManagerBase. This change also removes the Clip related properties from ViewPanel, forcing a breaking change (because ViewPanel is exposed through the ABI).

## Testing

RNTester `overflow: 'hidden'`:
<img width="218" alt="image" src="https://user-images.githubusercontent.com/1106239/195150765-04af305e-495c-4d60-911a-2cb376e2b272.png">

Test app:

https://user-images.githubusercontent.com/1106239/195151620-ad0ff0df-449f-4950-9f08-18ec6a323450.mp4

Please note, prior to this change, there was also a bug where, after being enabled, disabling the clip did not work correctly because the Clip property was only applied in ArrangeOverride.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10717)