### PR TITLE
Move @react-native/rntester dependency to devDependencies

### DIFF
--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -11,7 +11,6 @@
     "validate-overrides": "react-native-platform-override validate"
   },
   "dependencies": {
-    "@react-native/tester": "0.0.1",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5"
   },
@@ -23,6 +22,7 @@
     "react-native-xaml": "^0.0.50"
   },
   "devDependencies": {
+    "@react-native/tester": "0.0.1",
     "@rnw-scripts/babel-react-native-config": "0.0.0",
     "@rnw-scripts/eslint-config": "1.1.14",
     "@rnw-scripts/just-task": "2.2.6",


### PR DESCRIPTION


## Description

### Why
We only use the @react-native/rntester dependency to copy code in the lage build task. We're working on an e2e testing capability that requires us to publish the code for @react-native-windows, and we can only do so by removing this actual dependency.

## Testing
Ran:
```
> yarn
> yarn --cwd packages\playground
```
Ran playground and confirmed that RNTester still loads correctly.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10727)