### PR TITLE
Conditionally include HBC version header

### DIFF
--- a/change/react-native-windows-d4774adb-364c-4bd2-b53b-4a1d54b4e0a4.json
+++ b/change/react-native-windows-d4774adb-364c-4bd2-b53b-4a1d54b4e0a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Conditionally include HBC version header",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -47,7 +47,9 @@
 #include <safeint.h>
 #include "PackagerConnection.h"
 
+#if defined(USE_HERMES) && defined(ENABLE_DEVSERVER_HBCBUNDLES)
 #include <hermes/BytecodeVersion.h>
+#endif
 #include "HermesRuntimeHolder.h"
 
 #if defined(USE_V8)


### PR DESCRIPTION
## Description

### Why
We have preprocessor conditionals that consume the HBC version, so we should only include the header if the value will actually be used.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10729)