### PR TITLE
Convert NativeAnimatedModule to TurboModule

### DIFF
--- a/change/react-native-windows-93ed3dff-9f9d-46ac-9b50-1f5024499d6e.json
+++ b/change/react-native-windows-93ed3dff-9f9d-46ac-9b50-1f5024499d6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Convert NativeAnimatedModule to TurboModule",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -7,7 +7,6 @@
 // Modules
 #include <AppModelHelpers.h>
 #include <AsyncStorageModule.h>
-#include <Modules/Animated/NativeAnimatedModule.h>
 #include <Modules/AsyncStorageModuleWin32.h>
 #include <Modules/ClipboardModule.h>
 #include <Modules/NativeUIManager.h>
@@ -57,13 +56,6 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
         [props = context->Properties()]() { return Microsoft::React::CreateFileReaderModule(props); },
         batchingUIMessageQueue);
   }
-
-  // Note: `context` is moved to remove the reference from the current scope.
-  // This should either be the last usage of `context`, or the std::move call should happen later in this method.
-  modules.emplace_back(
-      NativeAnimatedModule::name,
-      [context = std::move(context)]() mutable { return std::make_unique<NativeAnimatedModule>(std::move(context)); },
-      batchingUIMessageQueue);
 
   // AsyncStorageModule doesn't work without package identity (it indirectly depends on
   // Windows.Storage.StorageFile), so check for package identity before adding it.

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.cpp
@@ -10,11 +10,11 @@
 namespace Microsoft::ReactNative {
 AdditionAnimatedNode::AdditionAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  for (const auto &inputNode : config.find(s_inputName).dereference().second) {
-    m_inputNodes.insert(static_cast<int64_t>(inputNode.asDouble()));
+  for (const auto &inputNode : config[s_inputName].AsArray()) {
+    m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AdditionAnimatedNode.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +9,7 @@ class AdditionAnimatedNode final : public ValueAnimatedNode {
  public:
   AdditionAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.cpp
@@ -12,20 +12,19 @@ AnimationDriver::AnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
     const Callback &endCallback,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
-    : m_id(id), m_animatedValueTag(animatedValueTag), m_config(config), m_endCallback(endCallback), m_manager(manager) {
-  m_iterations = [iterations = config.find("iterations"), end = config.items().end()]() {
-    if (iterations != end) {
-      return static_cast<int64_t>(iterations.dereference().second.asDouble());
-    }
-    return static_cast<int64_t>(1);
-  }();
+    : m_id(id),
+      m_animatedValueTag(animatedValueTag),
+      m_config(config.Copy()),
+      m_endCallback(endCallback),
+      m_manager(manager) {
+  m_iterations = config.find("iterations") == config.end() ? 1 : config["iterations"].AsInt64();
 }
 
 void AnimationDriver::DoCallback(bool value) {
   if (m_endCallback) {
-    m_endCallback(std::vector<folly::dynamic>{folly::dynamic::object("finished", value)});
+    m_endCallback(value);
   }
 #ifdef DEBUG
   m_debug_callbackAttempts++;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/AnimationDriver.h
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "NativeAnimatedNodeManager.h"
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
-typedef std::function<void(std::vector<folly::dynamic>)> Callback;
+typedef std::function<void(bool)> Callback;
 
 class ValueAnimatedNode;
 class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
@@ -16,14 +15,14 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
       int64_t id,
       int64_t animatedValueTag,
       const Callback &endCallback,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   virtual ~AnimationDriver();
   void StartAnimation();
   void StopAnimation(bool ignoreCompletedHandlers = false);
 
   virtual std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
-      const folly::dynamic & /*config*/) {
+      const winrt::Microsoft::ReactNative::JSValueObject & /*config*/) {
     return std::make_tuple(nullptr, nullptr);
   };
 
@@ -35,11 +34,11 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
     return m_animatedValueTag;
   }
 
-  inline Callback EndCallback() {
+  inline Callback EndCallback() noexcept {
     return m_endCallback;
   }
 
-  inline folly::dynamic AnimationConfig() {
+  inline const winrt::Microsoft::ReactNative::JSValueObject &AnimationConfig() const noexcept {
     return m_config;
   }
 
@@ -65,7 +64,7 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
   int64_t m_id{0};
   int64_t m_animatedValueTag{};
   int64_t m_iterations{0};
-  folly::dynamic m_config{};
+  winrt::Microsoft::ReactNative::JSValueObject m_config{};
   std::weak_ptr<NativeAnimatedNodeManager> m_manager{};
 
   comp::CompositionAnimation m_animation{nullptr};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.cpp
@@ -9,7 +9,7 @@
 namespace Microsoft::ReactNative {
 
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> CalculatedAnimationDriver::MakeAnimation(
-    const folly::dynamic & /*config*/) {
+    const winrt::Microsoft::ReactNative::JSValueObject & /*config*/) {
   const auto [scopedBatch, animation, easingFunction] = []() {
     const auto compositor = Microsoft::ReactNative::GetCompositor();
     return std::make_tuple(

--- a/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/CalculatedAnimationDriver.h
@@ -13,7 +13,7 @@ class CalculatedAnimationDriver : public AnimationDriver {
   using AnimationDriver::AnimationDriver;
 
   std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
-      const folly::dynamic &config) override;
+      const winrt::Microsoft::ReactNative::JSValueObject &config) override;
 
  protected:
   virtual std::tuple<float, double> GetValueAndVelocityForTime(double time) = 0;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.cpp
@@ -11,12 +11,12 @@ DecayAnimationDriver::DecayAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
     const Callback &endCallback,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : CalculatedAnimationDriver(id, animatedValueTag, endCallback, config, manager) {
-  m_deceleration = config.find(s_decelerationName).dereference().second.asDouble();
+  m_deceleration = config[s_decelerationName].AsDouble();
   assert(m_deceleration > 0);
-  m_velocity = config.find(s_velocityName).dereference().second.asDouble();
+  m_velocity = config[s_velocityName].AsDouble();
 }
 
 std::tuple<float, double> DecayAnimationDriver::GetValueAndVelocityForTime(double time) {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DecayAnimationDriver.h
@@ -13,7 +13,7 @@ class DecayAnimationDriver : public CalculatedAnimationDriver {
       int64_t id,
       int64_t animatedValueTag,
       const Callback &endCallback,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  protected:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.cpp
@@ -9,12 +9,12 @@
 namespace Microsoft::ReactNative {
 DiffClampAnimatedNode::DiffClampAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  m_inputNodeTag = static_cast<int64_t>(config.find(s_inputName).dereference().second.asDouble());
-  m_min = config.find(s_minName).dereference().second.asDouble();
-  m_max = config.find(s_maxName).dereference().second.asDouble();
+  m_inputNodeTag = static_cast<int64_t>(config[s_inputName].AsDouble());
+  m_min = config[s_minName].AsDouble();
+  m_max = config[s_maxName].AsDouble();
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, min = m_min, max = m_max, manager]() {
     const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DiffClampAnimatedNode.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +9,7 @@ class DiffClampAnimatedNode final : public ValueAnimatedNode {
  public:
   DiffClampAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.cpp
@@ -9,14 +9,14 @@
 namespace Microsoft::ReactNative {
 DivisionAnimatedNode::DivisionAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  for (const auto &inputNode : config.find(s_inputName).dereference().second) {
+  for (const auto &inputNode : config[s_inputName].AsArray()) {
     if (m_firstInput == s_firstInputUnset) {
-      m_firstInput = static_cast<int64_t>(inputNode.asDouble());
+      m_firstInput = static_cast<int64_t>(inputNode.AsDouble());
     } else {
-      m_inputNodes.insert(static_cast<int64_t>(inputNode.asDouble()));
+      m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/DivisionAnimatedNode.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +9,7 @@ class DivisionAnimatedNode final : public ValueAnimatedNode {
  public:
   DivisionAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.cpp
@@ -8,12 +8,12 @@
 
 namespace Microsoft::ReactNative {
 EventAnimationDriver::EventAnimationDriver(
-    const folly::dynamic &eventPath,
+    const std::vector<std::string> &eventPath,
     int64_t animatedValueTag,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : m_animatedValueTag(animatedValueTag), m_manager(manager) {
   for (const auto &path : eventPath) {
-    m_eventPath.push_back(path.getString());
+    m_eventPath.push_back(path);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/EventAnimationDriver.h
@@ -11,7 +11,7 @@ class ValueAnimatedNode;
 class EventAnimationDriver {
  public:
   EventAnimationDriver(
-      const folly::dynamic &eventPath,
+      const std::vector<std::string> &eventPath,
       int64_t animatedValueTag,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   ValueAnimatedNode *AnimatedValue();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.cpp
@@ -11,17 +11,17 @@ FrameAnimationDriver::FrameAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
     const Callback &endCallback,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimationDriver(id, animatedValueTag, endCallback, config, manager) {
-  for (const auto &frame : config.find("frames").dereference().second) {
-    m_frames.push_back(frame.asDouble());
+  for (const auto &frame : config["frames"].AsArray()) {
+    m_frames.push_back(frame.AsDouble());
   }
-  m_toValue = config.find("toValue").dereference().second.asDouble();
+  m_toValue = config["toValue"].AsDouble();
 }
 
 std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> FrameAnimationDriver::MakeAnimation(
-    const folly::dynamic & /*config*/) {
+    const winrt::Microsoft::ReactNative::JSValueObject & /*config*/) {
   const auto [scopedBatch, animation] = []() {
     const auto compositor = Microsoft::ReactNative::GetCompositor();
     return std::make_tuple(

--- a/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/FrameAnimationDriver.h
@@ -13,11 +13,11 @@ class FrameAnimationDriver : public AnimationDriver {
       int64_t id,
       int64_t animatedValueTag,
       const Callback &endCallback,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
   std::tuple<comp::CompositionAnimation, comp::CompositionScopedBatch> MakeAnimation(
-      const folly::dynamic &config) override;
+      const winrt::Microsoft::ReactNative::JSValueObject &config) override;
 
   double ToValue() override;
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.cpp
@@ -10,18 +10,18 @@
 namespace Microsoft::ReactNative {
 InterpolationAnimatedNode::InterpolationAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  for (const auto &rangeValue : config.find(s_inputRangeName).dereference().second) {
-    m_inputRanges.push_back(rangeValue.asDouble());
+  for (const auto &rangeValue : config[s_inputRangeName].AsArray()) {
+    m_inputRanges.push_back(rangeValue.AsDouble());
   }
-  for (const auto &rangeValue : config.find(s_outputRangeName).dereference().second) {
-    m_outputRanges.push_back(rangeValue.asDouble());
+  for (const auto &rangeValue : config[s_outputRangeName].AsArray()) {
+    m_outputRanges.push_back(rangeValue.AsDouble());
   }
 
-  m_extrapolateLeft = config.find(s_extrapolateLeftName).dereference().second.asString();
-  m_extrapolateRight = config.find(s_extrapolateRightName).dereference().second.asString();
+  m_extrapolateLeft = config[s_extrapolateLeftName].AsString();
+  m_extrapolateRight = config[s_extrapolateRightName].AsString();
 }
 
 void InterpolationAnimatedNode::Update() {}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/InterpolationAnimatedNode.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -11,7 +10,7 @@ class InterpolationAnimatedNode final : public ValueAnimatedNode {
  public:
   InterpolationAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
   virtual void Update() override;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.cpp
@@ -9,11 +9,11 @@
 namespace Microsoft::ReactNative {
 ModulusAnimatedNode::ModulusAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  m_inputNodeTag = static_cast<int64_t>(config.find(s_inputName).dereference().second.asDouble());
-  m_modulus = static_cast<int64_t>(config.find(s_modulusName).dereference().second.asDouble());
+  m_inputNodeTag = static_cast<int64_t>(config[s_inputName].AsDouble());
+  m_modulus = static_cast<int64_t>(config[s_modulusName].AsDouble());
 
   m_propertySet.StartAnimation(s_valueName, [node = m_inputNodeTag, mod = m_modulus, manager]() {
     const auto anim = Microsoft::ReactNative::GetCompositor().CreateExpressionAnimation();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ModulusAnimatedNode.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
+#include <JSValue.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +10,7 @@ class ModulusAnimatedNode final : public ValueAnimatedNode {
  public:
   ModulusAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.cpp
@@ -9,11 +9,11 @@
 namespace Microsoft::ReactNative {
 MultiplicationAnimatedNode::MultiplicationAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  for (const auto &inputNode : config.find(s_inputName).dereference().second) {
-    m_inputNodes.insert(static_cast<int64_t>(inputNode.asDouble()));
+  for (const auto &inputNode : config[s_inputName].AsArray()) {
+    m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
   }
 
   m_propertySet.StartAnimation(s_valueName, [nodes = m_inputNodes, manager]() {

--- a/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/MultiplicationAnimatedNode.h
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "ValueAnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +9,7 @@ class MultiplicationAnimatedNode final : public ValueAnimatedNode {
  public:
   MultiplicationAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cxxreact/CxxModule.h>
-#include <folly/dynamic.h>
+#include "codegen/NativeAnimatedModuleSpec.g.h"
+
 #include "NativeAnimatedNodeManager.h"
 
 /// <summary>
@@ -53,46 +53,96 @@
 /// <see cref="NativeAnimatedNodeManager"/>.
 /// </remarks>
 namespace Microsoft::ReactNative {
-class NativeAnimatedModule final : public facebook::xplat::module::CxxModule {
- public:
-  NativeAnimatedModule(Mso::CntPtr<Mso::React::IReactContext> &&context);
-  virtual ~NativeAnimatedModule();
 
-  // CxxModule
-  std::string getName() override {
-    return name;
-  };
-  std::map<std::string, folly::dynamic> getConstants() override {
-    return {};
-  };
-  auto getMethods() -> std::vector<Method> override;
+REACT_MODULE(NativeAnimatedModule)
+struct NativeAnimatedModule : std::enable_shared_from_this<NativeAnimatedModule> {
+  // Commented out due to missing implementation of updateAnimatedNodeConfig
+  // using ModuleSpec = ReactNativeSpecs::AnimatedModuleSpec;
 
-  void CreateAnimatedNode(int64_t tag, const folly::dynamic &config);
-  void GetValue(int64_t tag, const Callback &endCallback);
-  void ConnectAnimatedNodeToView(int64_t animatedNodeTag, int64_t viewTag);
-  void DisconnectAnimatedNodeFromView(int64_t animatedNodeTag, int64_t viewTag);
-  void ConnectAnimatedNodes(int64_t parentNodeTag, int64_t childNodeTag);
-  void DisconnectAnimatedNodes(int64_t parentNodeTag, int64_t childNodeTag);
-  void StartAnimatingNode(
-      int64_t animationId,
-      int64_t animatedNodeTag,
-      const folly::dynamic &animationConfig,
-      const Callback &endCallback);
-  void StopAnimation(int64_t animationId);
-  void DropAnimatedNode(int64_t tag);
-  void SetAnimatedNodeValue(int64_t tag, double value);
-  void SetAnimatedNodeOffset(int64_t tag, double offset);
-  void FlattenAnimatedNodeOffset(int64_t tag);
-  void ExtractAnimatedNodeOffset(int64_t tag);
-  void AddAnimatedEventToView(int64_t tag, const std::string &eventName, const folly::dynamic &eventMapping);
-  void RemoveAnimatedEventFromView(int64_t tag, const std::string &eventName, int64_t animatedValueTag);
-  void StartListeningToAnimatedNodeValue(int64_t tag);
-  void StopListeningToAnimatedNodeValue(int64_t tag);
+  REACT_INIT(Initialize)
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  static const char *name;
+  REACT_METHOD(startOperationBatch)
+  void startOperationBatch() noexcept;
+
+  REACT_METHOD(finishOperationBatch)
+  void finishOperationBatch() noexcept;
+
+  REACT_METHOD(createAnimatedNode)
+  void createAnimatedNode(double tag, ::React::JSValue &&config) noexcept;
+
+  // REACT_METHOD(updateAnimatedNodeConfig)
+  // void updateAnimatedNodeConfig(double tag, ::React::JSValue && config) noexcept;
+
+  REACT_METHOD(getValue)
+  void getValue(double tag, std::function<void(double)> const &saveValueCallback) noexcept;
+
+  REACT_METHOD(startListeningToAnimatedNodeValue)
+  void startListeningToAnimatedNodeValue(double tag) noexcept;
+
+  REACT_METHOD(stopListeningToAnimatedNodeValue)
+  void stopListeningToAnimatedNodeValue(double tag) noexcept;
+
+  REACT_METHOD(connectAnimatedNodes)
+  void connectAnimatedNodes(double parentTag, double childTag) noexcept;
+
+  REACT_METHOD(disconnectAnimatedNodes)
+  void disconnectAnimatedNodes(double parentTag, double childTag) noexcept;
+
+  REACT_METHOD(startAnimatingNode)
+  void startAnimatingNode(
+      double animationId,
+      double nodeTag,
+      ::React::JSValue &&config,
+      std::function<void(ReactNativeSpecs::AnimatedModuleSpec_EndResult const &)> const &endCallback) noexcept;
+
+  REACT_METHOD(stopAnimation)
+  void stopAnimation(double animationId) noexcept;
+
+  REACT_METHOD(setAnimatedNodeValue)
+  void setAnimatedNodeValue(double nodeTag, double value) noexcept;
+
+  REACT_METHOD(setAnimatedNodeOffset)
+  void setAnimatedNodeOffset(double nodeTag, double offset) noexcept;
+
+  REACT_METHOD(flattenAnimatedNodeOffset)
+  void flattenAnimatedNodeOffset(double nodeTag) noexcept;
+
+  REACT_METHOD(extractAnimatedNodeOffset)
+  void extractAnimatedNodeOffset(double nodeTag) noexcept;
+
+  REACT_METHOD(connectAnimatedNodeToView)
+  void connectAnimatedNodeToView(double nodeTag, double viewTag) noexcept;
+
+  REACT_METHOD(disconnectAnimatedNodeFromView)
+  void disconnectAnimatedNodeFromView(double nodeTag, double viewTag) noexcept;
+
+  REACT_METHOD(restoreDefaultValues)
+  void restoreDefaultValues(double nodeTag) noexcept;
+
+  REACT_METHOD(dropAnimatedNode)
+  void dropAnimatedNode(double tag) noexcept;
+
+  REACT_METHOD(addAnimatedEventToView)
+  void addAnimatedEventToView(
+      double viewTag,
+      std::string eventName,
+      ReactNativeSpecs::AnimatedModuleSpec_EventMapping &&eventMapping) noexcept;
+
+  REACT_METHOD(removeAnimatedEventFromView)
+  void removeAnimatedEventFromView(double viewTag, std::string eventName, double animatedNodeTag) noexcept;
+
+  REACT_METHOD(addListener)
+  void addListener(std::string eventName) noexcept;
+
+  REACT_METHOD(removeListeners)
+  void removeListeners(double count) noexcept;
+
+  REACT_METHOD(queueAndExecuteBatchedOperations)
+  void queueAndExecuteBatchedOperations(::React::JSValueArray &&operationsAndArgs) noexcept;
 
  private:
-  std::shared_ptr<NativeAnimatedNodeManager> m_nodesManager{};
-  Mso::CntPtr<Mso::React::IReactContext> m_context;
+  std::shared_ptr<NativeAnimatedNodeManager> m_nodesManager{std::make_shared<NativeAnimatedNodeManager>()};
+  winrt::Microsoft::ReactNative::ReactContext m_context;
 };
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.h
@@ -16,6 +16,8 @@
 #include "TransformAnimatedNode.h"
 #include "ValueAnimatedNode.h"
 
+#include "codegen/NativeAnimatedModuleSpec.g.h"
+
 namespace Microsoft::ReactNative {
 /// <summary>
 /// This is the main class that coordinates how native animated JS
@@ -27,7 +29,7 @@ namespace Microsoft::ReactNative {
 ///
 /// </summary>
 
-typedef std::function<void(std::vector<folly::dynamic>)> Callback;
+typedef std::function<void(bool)> EndCallback;
 
 class AnimatedNode;
 class StyleAnimatedNode;
@@ -41,10 +43,10 @@ class NativeAnimatedNodeManager {
  public:
   void CreateAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
-      const Mso::CntPtr<Mso::React::IReactContext> &context,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
+      const winrt::Microsoft::ReactNative::ReactContext &context,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
-  void GetValue(int64_t animatedNodeTag, const Callback &endCallback);
+  void GetValue(int64_t animatedNodeTag, std::function<void(double)> const &endCallback);
   void ConnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag);
   void DisconnectAnimatedNodeToView(int64_t propsNodeTag, int64_t viewTag);
   void ConnectAnimatedNode(int64_t parentNodeTag, int64_t childNodeTag);
@@ -58,15 +60,15 @@ class NativeAnimatedNodeManager {
       int64_t animationId,
       int64_t animatedNodeTag,
       int64_t animatedToValueTag,
-      const folly::dynamic &animationConfig,
-      const Callback &endCallback,
+      const winrt::Microsoft::ReactNative::JSValueObject &animationConfig,
+      const EndCallback &endCallback,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager,
       bool track = true);
   void StartAnimatingNode(
       int64_t animationId,
       int64_t animatedNodeTag,
-      const folly::dynamic &animationConfig,
-      const Callback &endCallback,
+      const winrt::Microsoft::ReactNative::JSValueObject &animationConfig,
+      const EndCallback &endCallback,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   void DropAnimatedNode(int64_t tag);
   void SetAnimatedNodeValue(int64_t tag, double value);
@@ -76,11 +78,11 @@ class NativeAnimatedNodeManager {
   void AddAnimatedEventToView(
       int64_t viewTag,
       const std::string &eventName,
-      const folly::dynamic &eventMapping,
+      const ReactNativeSpecs::AnimatedModuleSpec_EventMapping &eventMapping,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   void RemoveAnimatedEventFromView(int64_t viewTag, const std::string &eventName, int64_t animatedValueTag);
   void ProcessDelayedPropsNodes();
-  void AddDelayedPropsNode(int64_t propsNodeTag, const Mso::CntPtr<Mso::React::IReactContext> &context);
+  void AddDelayedPropsNode(int64_t propsNodeTag, const winrt::Microsoft::ReactNative::ReactContext &context);
 
   AnimatedNode *GetAnimatedNode(int64_t tag);
   ValueAnimatedNode *GetValueAnimatedNode(int64_t tag);

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -15,12 +15,12 @@
 namespace Microsoft::ReactNative {
 PropsAnimatedNode::PropsAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
-    const Mso::CntPtr<Mso::React::IReactContext> &context,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
+    const winrt::Microsoft::ReactNative::ReactContext &context,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager), m_context(context) {
-  for (const auto &entry : config.find("props").dereference().second.items()) {
-    m_propMapping.insert({entry.first.getString(), static_cast<int64_t>(entry.second.asDouble())});
+  for (const auto &entry : config["props"].AsObject()) {
+    m_propMapping.insert({entry.first, static_cast<int64_t>(entry.second.AsDouble())});
   }
   auto compositor = Microsoft::ReactNative::GetCompositor();
   m_subchannelPropertySet = compositor.CreatePropertySet();
@@ -267,7 +267,7 @@ void PropsAnimatedNode::MakeAnimation(int64_t valueNodeTag, FacadeType facadeTyp
 }
 
 Microsoft::ReactNative::ShadowNodeBase *PropsAnimatedNode::GetShadowNodeBase() {
-  if (const auto uiManager = Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
+  if (const auto uiManager = Microsoft::ReactNative::GetNativeUIManager(m_context).lock()) {
     if (const auto nativeUIManagerHost = uiManager->getHost()) {
       return static_cast<Microsoft::ReactNative::ShadowNodeBase *>(
           nativeUIManagerHost->FindShadowNodeForTag(m_connectedViewTag));

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <IReactInstance.h>
 #include <React.h>
+#include <ReactContext.h>
 #include <folly/dynamic.h>
 #include "AnimatedNode.h"
 
@@ -18,8 +19,8 @@ class PropsAnimatedNode final : public AnimatedNode {
  public:
   PropsAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
-      const Mso::CntPtr<Mso::React::IReactContext> &context,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
+      const winrt::Microsoft::ReactNative::ReactContext &context,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   void ConnectToView(int64_t viewTag);
   void DisconnectFromView(int64_t viewTag);
@@ -34,7 +35,7 @@ class PropsAnimatedNode final : public AnimatedNode {
   Microsoft::ReactNative::ShadowNodeBase *GetShadowNodeBase();
   xaml::UIElement GetUIElement();
 
-  Mso::CntPtr<Mso::React::IReactContext> m_context{};
+  winrt::Microsoft::ReactNative::ReactContext m_context;
   std::map<std::string, int64_t> m_propMapping{};
   folly::dynamic m_propMap{};
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.cpp
@@ -12,21 +12,20 @@ SpringAnimationDriver::SpringAnimationDriver(
     int64_t id,
     int64_t animatedValueTag,
     const Callback &endCallback,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager,
-    const folly::dynamic &dynamicToValues)
+    const winrt::Microsoft::ReactNative::JSValueArray &dynamicToValues)
     : CalculatedAnimationDriver(id, animatedValueTag, endCallback, config, manager),
-      m_dynamicToValues(dynamicToValues) {
-  m_springStiffness = config.find(s_springStiffnessParameterName).dereference().second.asDouble();
-  m_springDamping = config.find(s_springDampingParameterName).dereference().second.asDouble();
-  m_springMass = config.find(s_springMassParameterName).dereference().second.asDouble();
-  m_initialVelocity = config.find(s_initialVelocityParameterName).dereference().second.asDouble();
-  m_endValue = config.find(s_endValueParameterName).dereference().second.asDouble();
-  m_restSpeedThreshold = config.find(s_restSpeedThresholdParameterName).dereference().second.asDouble();
-  m_displacementFromRestThreshold =
-      config.find(s_displacementFromRestThresholdParameterName).dereference().second.asDouble();
-  m_overshootClampingEnabled = config.find(s_overshootClampingEnabledParameterName).dereference().second.asBool();
-  m_iterations = static_cast<int>(config.find(s_iterationsParameterName).dereference().second.asDouble());
+      m_dynamicToValues(dynamicToValues.Copy()) {
+  m_springStiffness = config[s_springStiffnessParameterName].AsDouble();
+  m_springDamping = config[s_springDampingParameterName].AsDouble();
+  m_springMass = config[s_springMassParameterName].AsDouble();
+  m_initialVelocity = config[s_initialVelocityParameterName].AsDouble();
+  m_endValue = config[s_endValueParameterName].AsDouble();
+  m_restSpeedThreshold = config[s_restSpeedThresholdParameterName].AsDouble();
+  m_displacementFromRestThreshold = config[s_displacementFromRestThresholdParameterName].AsDouble();
+  m_overshootClampingEnabled = config[s_overshootClampingEnabledParameterName].AsBoolean();
+  m_iterations = static_cast<int>(config[s_iterationsParameterName].AsDouble());
 }
 
 bool SpringAnimationDriver::IsAnimationDone(
@@ -42,7 +41,7 @@ std::tuple<float, double> SpringAnimationDriver::GetValueAndVelocityForTime(doub
   const auto toValue = [this, time]() {
     const auto frameFromTime = static_cast<int>(time * 60.0);
     if (frameFromTime < static_cast<int>(m_dynamicToValues.size())) {
-      return m_startValue + (m_dynamicToValues[frameFromTime].asDouble() * (m_endValue - m_startValue));
+      return m_startValue + (m_dynamicToValues[frameFromTime].AsDouble() * (m_endValue - m_startValue));
     }
     return m_endValue;
   }();

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SpringAnimationDriver.h
@@ -3,7 +3,6 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
 #include "AnimatedNode.h"
 #include "CalculatedAnimationDriver.h"
 
@@ -14,9 +13,10 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
       int64_t id,
       int64_t animatedValueTag,
       const Callback &endCallback,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager,
-      const folly::dynamic &dynamicToValues = folly::dynamic::array());
+      const winrt::Microsoft::ReactNative::JSValueArray &dynamicToValues =
+          winrt::Microsoft::ReactNative::JSValueArray());
 
   double ToValue() override;
 
@@ -37,7 +37,7 @@ class SpringAnimationDriver : public CalculatedAnimationDriver {
   double m_displacementFromRestThreshold{0};
   bool m_overshootClampingEnabled{0};
   int m_iterations{0};
-  folly::dynamic m_dynamicToValues{};
+  winrt::Microsoft::ReactNative::JSValueArray m_dynamicToValues{};
 
   static constexpr std::string_view s_springStiffnessParameterName{"stiffness"};
   static constexpr std::string_view s_springDampingParameterName{"damping"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.cpp
@@ -9,11 +9,11 @@
 namespace Microsoft::ReactNative {
 StyleAnimatedNode::StyleAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
-  for (const auto &entry : config.find(s_styleName).dereference().second.items()) {
-    m_propMapping.insert({entry.first.getString(), static_cast<int64_t>(entry.second.asDouble())});
+  for (const auto &entry : config[s_styleName].AsObject()) {
+    m_propMapping.insert({entry.first, static_cast<int64_t>(entry.second.AsDouble())});
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/StyleAnimatedNode.h
@@ -11,7 +11,7 @@ class StyleAnimatedNode final : public AnimatedNode {
  public:
   StyleAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   void CollectViewUpdates(const folly::dynamic &propsMap);
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.cpp
@@ -9,14 +9,14 @@
 namespace Microsoft::ReactNative {
 SubtractionAnimatedNode::SubtractionAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : ValueAnimatedNode(tag, manager) {
-  for (const auto &inputNode : config.find(s_inputName).dereference().second) {
+  for (const auto &inputNode : config[s_inputName].AsArray()) {
     if (m_firstInput == s_firstInputUnset) {
-      m_firstInput = static_cast<int64_t>(inputNode.asDouble());
+      m_firstInput = static_cast<int64_t>(inputNode.AsDouble());
     } else {
-      m_inputNodes.insert(static_cast<int64_t>(inputNode.asDouble()));
+      m_inputNodes.insert(static_cast<int64_t>(inputNode.AsDouble()));
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/SubtractionAnimatedNode.h
@@ -10,7 +10,7 @@ class SubtractionAnimatedNode final : public ValueAnimatedNode {
  public:
   SubtractionAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
  private:

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.cpp
@@ -9,13 +9,13 @@
 namespace Microsoft::ReactNative {
 TrackingAnimatedNode::TrackingAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
-  m_animationId = static_cast<int64_t>(config.find(s_animationIdName).dereference().second.asDouble());
-  m_toValueId = static_cast<int64_t>(config.find(s_toValueIdName).dereference().second.asDouble());
-  m_valueId = static_cast<int64_t>(config.find(s_valueIdName).dereference().second.asDouble());
-  m_animationConfig = std::move(config.find(s_animationConfigName).dereference().second);
+  m_animationId = static_cast<int64_t>(config[s_animationIdName].AsDouble());
+  m_toValueId = static_cast<int64_t>(config[s_toValueIdName].AsDouble());
+  m_valueId = static_cast<int64_t>(config[s_valueIdName].AsDouble());
+  m_animationConfig = std::move(config[s_animationConfigName].AsObject().Copy());
 
   StartAnimation();
 }
@@ -31,7 +31,7 @@ void TrackingAnimatedNode::StartAnimation() {
       // animationId key in the active animations map in the animation manager.
       strongManager->StopAnimation(m_animationId, true);
       toValueNode->AddActiveTrackingNode(m_tag);
-      m_animationConfig.insert(static_cast<folly::StringPiece>(s_toValueIdName), toValueNode->Value());
+      m_animationConfig[s_toValueIdName] = toValueNode->Value();
       strongManager->StartTrackingAnimatedNode(
           m_animationId, m_valueId, m_toValueId, m_animationConfig, nullptr, strongManager);
     }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TrackingAnimatedNode.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
+#include <JSValue.h>
 #include "AnimatedNode.h"
 
 namespace Microsoft::ReactNative {
@@ -10,7 +10,7 @@ class TrackingAnimatedNode final : public AnimatedNode {
  public:
   TrackingAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
 
   void Update() override;
@@ -21,7 +21,7 @@ class TrackingAnimatedNode final : public AnimatedNode {
   int64_t m_animationId{};
   int64_t m_toValueId{};
   int64_t m_valueId{};
-  folly::dynamic m_animationConfig{};
+  winrt::Microsoft::ReactNative::JSValueObject m_animationConfig;
 
   static constexpr std::string_view s_animationIdName{"animationId"};
   static constexpr std::string_view s_toValueIdName{"toValue"};

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.cpp
@@ -9,17 +9,16 @@
 namespace Microsoft::ReactNative {
 TransformAnimatedNode::TransformAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
-  for (const auto &transform : config.find(s_transformsName).dereference().second) {
-    const auto property = transform.find(s_propertyName).dereference().second.asString();
-    if (transform.find(s_typeName).dereference().second.asString() == s_animatedName) {
-      m_transformConfigs.push_back(TransformConfig{
-          property, static_cast<int64_t>(transform.find(s_nodeTagName).dereference().second.asDouble()), 0});
-    } else {
+  for (const auto &transform : config[s_transformsName].AsArray()) {
+    const auto property = transform[s_propertyName].AsString();
+    if (transform[s_typeName].AsString() == s_animatedName) {
       m_transformConfigs.push_back(
-          TransformConfig{property, s_unsetNodeTag, transform.find(s_valueName).dereference().second.asDouble()});
+          TransformConfig{property, static_cast<int64_t>(transform[s_nodeTagName].AsDouble()), 0});
+    } else {
+      m_transformConfigs.push_back(TransformConfig{property, s_unsetNodeTag, transform[s_valueName].AsDouble()});
     }
   }
 }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/TransformAnimatedNode.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include <folly/dynamic.h>
+#include <JSValue.h>
 #include "AnimatedNode.h"
 #include "FacadeType.h"
 
@@ -18,7 +18,7 @@ class TransformAnimatedNode final : public AnimatedNode {
  public:
   TransformAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   std::unordered_map<FacadeType, int64_t> GetMapping();
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.cpp
@@ -9,16 +9,14 @@
 namespace Microsoft::ReactNative {
 ValueAnimatedNode::ValueAnimatedNode(
     int64_t tag,
-    const folly::dynamic &config,
+    const winrt::Microsoft::ReactNative::JSValueObject &config,
     const std::shared_ptr<NativeAnimatedNodeManager> &manager)
     : AnimatedNode(tag, manager) {
   // TODO: Islands - need to get the XamlView associated with this animation in order to
   // use the compositor Microsoft::ReactNative::GetCompositor(xamlView)
   m_propertySet = Microsoft::ReactNative::GetCompositor().CreatePropertySet();
-  m_propertySet.InsertScalar(
-      s_valueName, static_cast<float>(config.find(s_jsValueName).dereference().second.asDouble()));
-  m_propertySet.InsertScalar(
-      s_offsetName, static_cast<float>(config.find(s_jsOffsetName).dereference().second.asDouble()));
+  m_propertySet.InsertScalar(s_valueName, static_cast<float>(config[s_jsValueName].AsDouble()));
+  m_propertySet.InsertScalar(s_offsetName, static_cast<float>(config[s_jsOffsetName].AsDouble()));
 }
 
 ValueAnimatedNode::ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager)

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <JSValue.h>
 #include <UI.Composition.h>
-#include <folly/dynamic.h>
+#include <unordered_set>
 #include "AnimatedNode.h"
 
 namespace winrt {
@@ -15,7 +16,7 @@ class ValueAnimatedNode : public AnimatedNode {
  public:
   ValueAnimatedNode(
       int64_t tag,
-      const folly::dynamic &config,
+      const winrt::Microsoft::ReactNative::JSValueObject &config,
       const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   ValueAnimatedNode(int64_t tag, const std::shared_ptr<NativeAnimatedNodeManager> &manager);
   double Value();

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -80,6 +80,11 @@ std::weak_ptr<NativeUIManager> GetNativeUIManager(const Mso::React::IReactContex
   return v ? v.Value() : std::weak_ptr<NativeUIManager>{};
 }
 
+std::weak_ptr<NativeUIManager> GetNativeUIManager(const winrt::Microsoft::ReactNative::ReactContext &context) {
+  auto v = context.Properties().Get(NativeUIManagerProperty());
+  return v ? v.Value() : std::weak_ptr<NativeUIManager>{};
+}
+
 class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, public INativeUIManagerHost {
  public:
   UIManagerModule() {}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
@@ -29,6 +29,7 @@ struct UIManagerSettings {
 };
 
 std::weak_ptr<NativeUIManager> GetNativeUIManager(const Mso::React::IReactContext &context);
+std::weak_ptr<NativeUIManager> GetNativeUIManager(const winrt::Microsoft::ReactNative::ReactContext &context);
 
 REACT_MODULE(UIManager)
 struct UIManager final {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -41,6 +41,7 @@
 #ifndef CORE_ABI
 #include "Modules/AccessibilityInfoModule.h"
 #include "Modules/AlertModule.h"
+#include "Modules/Animated/NativeAnimatedModule.h"
 #include "Modules/AppStateModule.h"
 #include "Modules/AppThemeModuleUwp.h"
 #include "Modules/ClipboardModule.h"
@@ -349,6 +350,10 @@ void ReactInstanceWin::LoadModules(
 
   registerTurboModule(
       L"ImageLoader", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::ImageLoader>());
+
+  registerTurboModule(
+      L"NativeAnimatedModule",
+      winrt::Microsoft::ReactNative::MakeModuleProvider<::Microsoft::ReactNative::NativeAnimatedModule>());
 #endif
 
   registerTurboModule(


### PR DESCRIPTION
## Description
Moves `NativeAnimatedModule` off of `CxxModule` and into a TurboModule.  There shouldn't be any functional difference.  The only known difference is that I did implement the newer `queueAndExecuteBatchedOperations` method which is defined in the js file.  -- This function is only called in android.  iOS has an empty implementation.

Another known issue is that by moving over to the codegen spec I found that we are missing an implementation for a new method: `updateAnimatedNodeConfig`.  I didn't want to implement new functionality as part of an already relatively large change, so I left that unimplemented for now - which means this is still not currently verifying against the codegen.  I opened #10731 to track adding the missing functionality.  

## Testing
I ran through all the animation test pages I could find and didn't hit any issues.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10733)