### PR TITLE
Fix hardware back events

### DIFF
--- a/change/react-native-windows-647ad113-7678-43e1-9f59-aed8eb42737d.json
+++ b/change/react-native-windows-647ad113-7678-43e1-9f59-aed8eb42737d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix typo in TouchHandler.cpp which broke hardware back button events",
+  "packageName": "react-native-windows",
+  "email": "jahiggin@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.cpp
@@ -427,7 +427,7 @@ bool TouchEventHandler::DispatchBackEvent() {
     return false;
 
   BatchingEmitter().EmitJSEvent(
-      L"RCTDeviceEventEmitter", L"emit", winrt::Microsoft::ReactNative::MakeJSValueArgWriter(L"hardwardBackPress"));
+      L"RCTDeviceEventEmitter", L"emit", winrt::Microsoft::ReactNative::MakeJSValueArgWriter(L"hardwareBackPress"));
 
   return true;
 }


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fixes a typo that was causing hardware back button event subscriptions to not fire in JS.

Resolves #10742 

### What
Fixed typo "hardward" -> "hardware"

Tested locally in our app by applying this change as a patch to our node_modules via `npx patch-package`

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10743)