### PR TITLE
Disabling JS Systrace temporarily

### DIFF
--- a/change/react-native-windows-53b610f4-ce56-47e2-b384-708de4a35fb4.json
+++ b/change/react-native-windows-53b610f4-ce56-47e2-b384-708de4a35fb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Disabling JS Systrace until it is stabilized",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -30,7 +30,7 @@
     <ENABLE_ETW_TRACING Condition="'$(ENABLE_ETW_TRACING)' == ''">true</ENABLE_ETW_TRACING>
 
     <!-- Enables routing Systrace events from JavaScript code to our ETW provider -->
-    <ENABLE_JS_SYSTRACE_TO_ETW Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)' == ''">true</ENABLE_JS_SYSTRACE_TO_ETW>
+    <ENABLE_JS_SYSTRACE_TO_ETW Condition="'$(ENABLE_JS_SYSTRACE_TO_ETW)' == ''">false</ENABLE_JS_SYSTRACE_TO_ETW>
   </PropertyGroup>
 
   <PropertyGroup Label="ExternalDependencies">


### PR DESCRIPTION


## Description

This change is disabling Systrace signals from Javascript code.
In 0.68, Systrace APIs are getting called with wrong parameters which is causing load failures when enabled.
In the main branch, the Systrace initialization is already disabled: https://github.com/facebook/react-native/blob/main/Libraries/Core/InitializeCore.js


### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Why
Office Commenting fails to load with Metro bundler in dev mode. This change fixes it.
This is happening because the Systrace calls from JS are not well maintained and is almost deprecated. JS Systrace is not
enabled by default in platforms other than Windows. 
And the JS Systrace is completely disabled in the fb RN repo : the Systrace initialization is already disabled: https://github.com/facebook/react-native/blob/main/Libraries/Core/InitializeCore.js

### What
Disable Systrace logging from JS.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Verified that the Office commenting and UWP playground app launches after this change.
ETW traces will not contain Systrace logging from JS. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10751)