### PR TITLE
Fix warnings for malformed_package_json test file

### DIFF
--- a/.ado/config/CredScanSuppressions.json
+++ b/.ado/config/CredScanSuppressions.json
@@ -4,6 +4,10 @@
         {
             "file": "\\node_modules\\react-native\\template\\android\\app\\debug.keystore",
             "_justification": "Debug secret created and consumed by third-party library"
+        },
+        {
+            "file": "\\node_modules\\resolve\\test\\resolver\\malformed_package_json\\package.json",
+            "_justification": "Explicitly malformed test file"
         }
     ]
 }

--- a/.ado/templates/component-governance.yml
+++ b/.ado/templates/component-governance.yml
@@ -5,3 +5,4 @@ steps:
       alertWarningLevel: Medium
       scanType: 'Register'
       failOnAlert: $(FailCGOnAlert)
+      ignoreDirectories: 'node_modules\resolve\test\resolver\malformed_package_json'


### PR DESCRIPTION
## Description

The `resolver` NPM package includes a malformed `package.json` file for testing, but it causes every one of our compliance tools  to complain since they just assume it's a real NPM package that needs to be parsed.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
I'm tired of seeing all the warnings for this non-package.

Resolves [Add Relevant Issue Here]

### What
Specifies, where possible, that each compliance tool ignore the malformed file.

## Screenshots
N/A

## Testing
N/A

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10753)