### PR TITLE
Adjust no-hide-descendants Code to Support Touchable

### DIFF
--- a/change/react-native-windows-b2051115-6321-435c-80ff-1897606896ef.json
+++ b/change/react-native-windows-b2051115-6321-435c-80ff-1897606896ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Save State",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -77,7 +77,7 @@ const View: React.AbstractComponent<
 
   // [Windows
   const childrenWithImportantForAccessibility = children => {
-    return React.Children.map(children, child => {
+    const updatedChildren = React.Children.map(children, child => {
       if (React.isValidElement(child)) {
         if (child.props.children) {
           return React.cloneElement(child, {
@@ -92,6 +92,11 @@ const View: React.AbstractComponent<
       }
       return child;
     });
+    if (updatedChildren.length == 1){
+      return updatedChildren[0];
+    }else{
+      return updatedChildren;
+    }
   };
   // Windows]
 

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -92,9 +92,9 @@ const View: React.AbstractComponent<
       }
       return child;
     });
-    if (updatedChildren.length == 1){
+    if (updatedChildren.length == 1) {
       return updatedChildren[0];
-    }else{
+    } else {
       return updatedChildren;
     }
   };


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Touchable components expect to see their children prop as the single child itself and not an array with one child. If array with one child is passed, red box error will fire and no-hide-accessibility will not work for that case.

Note: Native implementation is on its way that will be more performant. This implementation is temporarily in place to meet the end of October deadline for the accessibility pass. 

### What
Check if children array only has one element. If so, return that element. 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10756)