### PR TITLE
Fix "Encountered two children with the same key" warning

### DIFF
--- a/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
+++ b/packages/@react-native-windows/tester/src/js/utils/RNTesterList.windows.js
@@ -253,11 +253,6 @@ const APIs: Array<RNTesterModuleInfo> = [
     module: require('../examples/Keyboard/KeyboardExample').default,
   },
   {
-    key: 'W3C PointerEvents',
-    category: 'Experimental',
-    module: require('../examples/Experimental/W3CPointerEventsExample').default,
-  },
-  {
     key: 'KeyboardExample',
     module: require('../examples-win/Keyboard/KeyboardExample'),
   },


### PR DESCRIPTION
## Description
When enabling `ReactNativeFeatureFlags.shouldEmitW3CPointerEvents` RNTester produces a warning: **Encountered two children with the same key, `APIS:W3C PointerEvents`.**  This is due to the windows fork of RNTesterList having an additional copy of the W3C PointerEvents test page. 

### What
Keeping the `W3C PointerEvents` entry from core, and removing the extra one in the .windows fork.

## Testing
Boot RNTester with `ReactNativeFeatureFlags.shouldEmitW3CPointerEvents` set.  No longer see the warning.