### PR TITLE
Enables direct debugging by default in Playground-win32

### DIFF
--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -65,7 +65,7 @@ struct WindowData {
 
   bool m_useWebDebugger{false};
   bool m_fastRefreshEnabled{true};
-  bool m_useDirectDebugger{false};
+  bool m_useDirectDebugger{true};
   bool m_breakOnNextLine{false};
   uint16_t m_debuggerPort{defaultDebuggerPort};
   xaml::ElementTheme m_theme{xaml::ElementTheme::Default};


### PR DESCRIPTION
## Description

### Why
Previously, in #10263, we disabled the default option to use web debugging. This change simply flips the bit for direct debugging, which was the original intention of #10263 (just overlooked).

### Tests

<img width="236" alt="image" src="https://user-images.githubusercontent.com/1106239/196459534-379ac4ab-444f-4822-b315-9375eb8e3a49.png">

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10762)