### PR TITLE
Fabric: Stop using timers to run EventBeat

### DIFF
--- a/change/react-native-windows-e19002f6-ebe4-4bba-be43-0bed11a149b6.json
+++ b/change/react-native-windows-e19002f6-ebe4-4bba-be43-0bed11a149b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: Stop using timers to run eventbeat",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -54,8 +54,6 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
   CreateDesktopWindowTarget(m_hwnd);
   CreateCompositionRoot();
 
-  EnsureTarget();
-
   m_compRootView.InitialProps(std::move(m_initialPropsWriter));
   m_compRootView.ComponentName(std::move(m_componentName));
   m_compRootView.ReactNativeHost(std::move(m_reactNativeHost));
@@ -135,7 +133,6 @@ void CompositionHwndHost::ReactNativeHost(ReactNative::ReactNativeHost const &va
   } else {
     m_reactNativeHost = value;
   }
-  EnsureTarget();
 }
 
 winrt::Windows::UI::Composition::Compositor CompositionHwndHost::Compositor() const noexcept {
@@ -145,18 +142,6 @@ winrt::Windows::UI::Composition::Compositor CompositionHwndHost::Compositor() co
 
   return winrt::Microsoft::ReactNative::Composition::implementation::CompositionContextHelper::InnerCompositor(
       compositionContext);
-}
-
-void CompositionHwndHost::EnsureTarget() noexcept {
-  if (!ReactNativeHost() || !m_hwnd) {
-    return;
-  }
-
-  winrt::Microsoft::ReactNative::ReactPropertyBag propBag(ReactNativeHost().InstanceSettings().Properties());
-  propBag.Set(
-      winrt::Microsoft::ReactNative::ReactPropertyId<winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget>(
-          L"CompCoreDispatcher"),
-      Target());
 }
 
 winrt::hstring CompositionHwndHost::ComponentName() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
@@ -39,7 +39,6 @@ struct CompositionHwndHost : CompositionHwndHostT<CompositionHwndHost> {
   winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget Target() const noexcept;
   winrt::Windows::UI::Composition::Compositor Compositor() const noexcept;
 
-  void EnsureTarget() noexcept;
   void CreateDesktopWindowTarget(HWND window);
   void CreateCompositionRoot();
   void UpdateSize() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -73,7 +73,7 @@ class AsyncEventBeat final : public facebook::react::EventBeat {
     isRequested_ = false;
     m_isBeatCallbackScheduled = true;
 
-    m_runtimeExecutor([this, ownerBox = ownerBox_, f = m_frame](jsi::Runtime &runtime) {
+    m_runtimeExecutor([this, ownerBox = ownerBox_](jsi::Runtime &runtime) {
       auto owner = ownerBox->owner.lock();
       if (!owner) {
         return;
@@ -90,7 +90,7 @@ class AsyncEventBeat final : public facebook::react::EventBeat {
     bool alreadyRequested = isRequested_;
     EventBeat::request();
     if (!alreadyRequested) {
-      m_context.UIDispatcher().Post([this, ownerBox = ownerBox_, f = m_frame]() {
+      m_context.UIDispatcher().Post([this, ownerBox = ownerBox_]() {
         auto owner = ownerBox->owner.lock();
         if (!owner) {
           return;


### PR DESCRIPTION
## Description
Some ugly stop gap code was being used to continually trigger the fabric `EventBeat` objects.  This switches the code away from using an always running timer, to using the dispatch queue.

### Why
Running a timer would cause the CPU to spin so it was in efficient, while at the same time also made some events take up to a second to fire when they should happen right away.

## Testing
Clicking around RNTester.  Generally, when this code was wrong events wouldn't fire and pointer events wouldn't do anything.
