### PR TITLE
Mitigate MSB4011 warning for importing ExperimentalFeatures.props 

### DIFF
--- a/change/@react-native-windows-cli-72a84946-f9a2-4c32-9ab3-b7502b3cddaa.json
+++ b/change/@react-native-windows-cli-72a84946-f9a2-4c32-9ab3-b7502b3cddaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Mitigate MSB4011 warning for importing ExperimentalFeatures.props",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e5fed6cf-085b-4951-9594-acb92c1fc660.json
+++ b/change/react-native-windows-e5fed6cf-085b-4951-9594-acb92c1fc660.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Mitigate MSB4011 warning for importing ExperimentalFeatures.props",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
+++ b/packages/@react-native-windows/cli/src/e2etest/__snapshots__/projectConfig.test.ts.snap
@@ -29,6 +29,7 @@ Object {
 exports[`projectConfig - SimpleCSharpApp (Ignore react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -48,6 +49,7 @@ Object {
 exports[`projectConfig - SimpleCSharpApp (Use react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -67,6 +69,7 @@ Object {
 exports[`projectConfig - SimpleCppApp (Ignore react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -86,6 +89,7 @@ Object {
 exports[`projectConfig - SimpleCppApp (Use react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -105,6 +109,7 @@ Object {
 exports[`projectConfig - WithExperimentalNuget (Ignore react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "true",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -124,6 +129,7 @@ Object {
 exports[`projectConfig - WithExperimentalNuget (Use react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "true",
     "UseHermes": "false",
     "UseWinUI3": "false",
@@ -143,6 +149,7 @@ Object {
 exports[`projectConfig - WithHermes (Ignore react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "true",
     "UseWinUI3": "false",
@@ -162,6 +169,7 @@ Object {
 exports[`projectConfig - WithHermes (Use react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "true",
     "UseWinUI3": "false",
@@ -217,6 +225,7 @@ Object {
 exports[`projectConfig - WithWinUI3 (Ignore react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "true",
@@ -236,6 +245,7 @@ Object {
 exports[`projectConfig - WithWinUI3 (Use react-native.config.js) 1`] = `
 Object {
   "experimentalFeatures": Object {
+    "ReactExperimentalFeaturesSet": "true",
     "UseExperimentalNuget": "false",
     "UseHermes": "false",
     "UseWinUI3": "true",
@@ -287,6 +297,8 @@ exports[`useWinUI3=true in react-native.config.js, UseWinUI3=false in Experiment
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
     <UseExperimentalNuget>false</UseExperimentalNuget>
+
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   
   </PropertyGroup>
 
@@ -329,6 +341,8 @@ exports[`useWinUI3=true in react-native.config.js, UseWinUI3=false in Experiment
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
     <UseExperimentalNuget>false</UseExperimentalNuget>
+
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   
   </PropertyGroup>
 

--- a/packages/e2e-test-app/windows/ExperimentalFeatures.props
+++ b/packages/e2e-test-app/windows/ExperimentalFeatures.props
@@ -3,8 +3,8 @@
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseHermes>false</UseHermes>
-    
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/packages/e2e-test-app/windows/ExperimentalFeatures.props
+++ b/packages/e2e-test-app/windows/ExperimentalFeatures.props
@@ -3,6 +3,8 @@
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseHermes>false</UseHermes>
+    
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/packages/integration-test-app/windows/ExperimentalFeatures.props
+++ b/packages/integration-test-app/windows/ExperimentalFeatures.props
@@ -4,7 +4,7 @@
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseHermes>false</UseHermes>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/packages/integration-test-app/windows/ExperimentalFeatures.props
+++ b/packages/integration-test-app/windows/ExperimentalFeatures.props
@@ -3,6 +3,8 @@
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseHermes>false</UseHermes>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/packages/playground/CoreApp/ExperimentalFeatures.props
+++ b/packages/playground/CoreApp/ExperimentalFeatures.props
@@ -5,5 +5,7 @@
     <UseHermes>true</UseHermes>
     <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   </PropertyGroup>
 </Project>

--- a/packages/playground/CoreApp/ExperimentalFeatures.props
+++ b/packages/playground/CoreApp/ExperimentalFeatures.props
@@ -6,6 +6,6 @@
     <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 </Project>

--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -5,6 +5,8 @@
     <UseHermes>true</UseHermes>
     <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   </PropertyGroup>
 
   <PropertyGroup Label="Unpackaged playground-win32" Condition="'$(SolutionName)'=='playground-win32' OR '$(SolutionName)'=='playground-composition'">

--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -6,7 +6,7 @@
     <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 
   <PropertyGroup Label="Unpackaged playground-win32" Condition="'$(SolutionName)'=='playground-win32' OR '$(SolutionName)'=='playground-composition'">

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -6,4 +6,7 @@
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
   </PropertyGroup>
+  <PropertyGroup>
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+  </PropertyGroup>
 </Project>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -7,6 +7,6 @@
     <UseFabric>false</UseFabric>
   </PropertyGroup>
   <PropertyGroup>
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 </Project>

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -24,11 +24,6 @@
           "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
-      "boost": {
-        "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -58,27 +53,12 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
-      },
-      "Microsoft.UI.Xaml": {
-        "type": "Transitive",
-        "resolved": "2.7.0",
-        "contentHash": "dB4im13tfmMgL/V3Ei+3kD2rUF+/lTxAmR4gjJ45l577eljHfdo/KUrxpq/3I1Vp6e5GCDG1evDaEGuDxypLMg=="
-      },
-      "Microsoft.Windows.CppWinRT": {
-        "type": "Transitive",
-        "resolved": "2.0.211028.7",
-        "contentHash": "JBGI0c3WLoU6aYJRy9Qo0MLDQfObEp+d4nrhR95iyzf7+HOgjRunHDp/6eGFREd7xq3OI1mll9ecJrMfzBvlyg=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22000.194",
-        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -87,11 +67,6 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
-      },
-      "ReactNative.Hermes.Windows": {
-        "type": "Transitive",
-        "resolved": "0.70.0",
-        "contentHash": "nh9F1wAhkndqfHG/hrS+ezesunlGhCr32pASEEAkQenn8Ou4dUwjmt0c7aT3pONl9itZ1bF9GWbpXJ7t6AsS+Q=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -160,38 +135,8 @@
         "resolved": "2.2.9",
         "contentHash": "qF6RRZKaflI+LR1YODNyWYjq5YoX8IJ2wx5y8O+AW2xO+1t/Q6Mm+jQ38zJbWnmXbrcOqUYofn7Y3/KC6lTLBQ=="
       },
-      "common": {
-        "type": "Project"
-      },
-      "fmt": {
-        "type": "Project"
-      },
-      "folly": {
-        "type": "Project",
-        "dependencies": {
-          "boost": "[1.76.0, )",
-          "fmt": "[1.0.0, )"
-        }
-      },
       "microsoft.reactnative": {
-        "type": "Project",
-        "dependencies": {
-          "Common": "[1.0.0, )",
-          "Folly": "[1.0.0, )",
-          "Microsoft.UI.Xaml": "[2.7.0, )",
-          "Microsoft.Windows.CppWinRT": "[2.0.211028.7, )",
-          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
-          "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.70.0, )",
-          "boost": "[1.76.0, )"
-        }
-      },
-      "reactcommon": {
-        "type": "Project",
-        "dependencies": {
-          "Folly": "[1.0.0, )",
-          "boost": "[1.76.0, )"
-        }
+        "type": "Project"
       }
     },
     "UAP,Version=v10.0.16299/win10-arm": {

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
+  <Target Name="EnsureExperimentalFeaturesSetTarget" BeforeTargets="PrepareForBuild" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props') And '$(ExperimentalFeaturesSet)' != 'true'">
+    <Warning Text="Property 'ExperimentalFeaturesSet' not set. Please specify &lt;ExperimentalFeaturesSet&gt;true&lt;/ExperimentalFeaturesSet>&gt; in '$(SolutionDir)\ExperimentalFeatures.props' to prevent the MSB4011 warnings." />
+  </Target>
+
+  <ImportGroup Condition="'$(ExperimentalFeaturesSet)' != 'true'">
+    <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
+  </ImportGroup>
 
   <PropertyGroup>
     <JsEnginePropsDefined>true</JsEnginePropsDefined>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="EnsureExperimentalFeaturesSetTarget" BeforeTargets="PrepareForBuild" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props') And '$(ExperimentalFeaturesSet)' != 'true'">
-    <Warning Text="Property 'ExperimentalFeaturesSet' not set. Please specify &lt;ExperimentalFeaturesSet&gt;true&lt;/ExperimentalFeaturesSet>&gt; in '$(SolutionDir)\ExperimentalFeatures.props' to prevent the MSB4011 warnings." />
+  <Target Name="EnsureReactExperimentalFeaturesSetTarget" BeforeTargets="PrepareForBuild" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props') And '$(ReactExperimentalFeaturesSet)' != 'true'">
+    <Warning Text="Property 'ReactExperimentalFeaturesSet' not set. Please specify &lt;ReactExperimentalFeaturesSet&gt;true&lt;/ReactExperimentalFeaturesSet>&gt; in '$(SolutionDir)\ExperimentalFeatures.props' to prevent the MSB4011 warnings." />
   </Target>
 
-  <ImportGroup Condition="'$(ExperimentalFeaturesSet)' != 'true'">
+  <ImportGroup Condition="'$(ReactExperimentalFeaturesSet)' != 'true'">
     <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
   </ImportGroup>
 

--- a/vnext/template/cs-app-WinAppSDK/proj/ExperimentalFeatures.props
+++ b/vnext/template/cs-app-WinAppSDK/proj/ExperimentalFeatures.props
@@ -18,7 +18,7 @@
     -->
     <UseHermes>false</UseHermes>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/vnext/template/cs-app-WinAppSDK/proj/ExperimentalFeatures.props
+++ b/vnext/template/cs-app-WinAppSDK/proj/ExperimentalFeatures.props
@@ -2,7 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
-    
     <!--
       Changes compilation to assume use of WinUI 3 instead of System XAML.
       Requires creation of new project.
@@ -18,6 +17,8 @@
       See https://microsoft.github.io/react-native-windows/docs/0.64/hermes
     -->
     <UseHermes>false</UseHermes>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   </PropertyGroup>
 
 </Project>

--- a/vnext/template/shared-app/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-app/proj/ExperimentalFeatures.props
@@ -32,6 +32,8 @@
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
     <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   
   </PropertyGroup>
 

--- a/vnext/template/shared-app/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-app/proj/ExperimentalFeatures.props
@@ -33,7 +33,7 @@
     -->
     <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   
   </PropertyGroup>
 

--- a/vnext/template/shared-lib/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-lib/proj/ExperimentalFeatures.props
@@ -32,6 +32,8 @@
       See https://microsoft.github.io/react-native-windows/docs/nuget
     -->
     <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
+
+    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
   
   </PropertyGroup>
 

--- a/vnext/template/shared-lib/proj/ExperimentalFeatures.props
+++ b/vnext/template/shared-lib/proj/ExperimentalFeatures.props
@@ -33,7 +33,7 @@
     -->
     <UseExperimentalNuget>{{useExperimentalNuget}}</UseExperimentalNuget>
 
-    <ExperimentalFeaturesSet>true</ExperimentalFeaturesSet>
+    <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

This PR fixes the `MSB4011` warning when `JSEngine.props` tries to import `ExperimentalFeatures.props` a second time. The expectation is that all RNW projects (app or module) import the `ExperimentalFeatures.props` file (located next to the VS solution) at the very top of each project file, so all RNW-related projects are in sync with respect to the state of any Experimental Features.

However, older RNW apps/module templates did not include this import, hence `JSEngine.props`'s workaround to import it. Unfortunately, MSBuild:

* Doesn't like project files to be imported twice, so it gives the `MSB4011` warning
* Doesn't provide any built-in way to detect if a project file has already been imported
* Doesn't allow you to suppress this particular warning completely

The best solution is to set a property in the imported file and check for that property before attempting to import the file.

This PR adds an `ReactExperimentalFeaturesSet` property to all in-repo and new template `ExperimentalFeatures.props` files, and changes `JSEngine.props` to both check for it before importing and throw a new warning so let existing projects know about the new property and how to resolve all of the warnings.

TLDR: After this PR has been merged, adding

```xml
<ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
```

to your `ExperimentalFeatures.props` file will get rid these annoying MSB4011 warnings.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Honestly, I'm tired of this warning spamming my CI logs and obfuscating real issues.

Resolves my sanity

### What
See above.

## Screenshots
N/A

## Testing
Verified warning no longer appears for in-repo apps, and removing the property causes both the old and new warnings to appear.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10767)