### PR TITLE
Update WindowsAppSDK versions to latest

### DIFF
--- a/change/@react-native-windows-cli-e884393e-295e-43ea-b50c-dce70f71a176.json
+++ b/change/@react-native-windows-cli-e884393e-295e-43ea-b50c-dce70f71a176.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Align WindowsAppSDK Target Windows version with UWP",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-e884393e-295e-43ea-b50c-dce70f71a176.json
+++ b/change/@react-native-windows-cli-e884393e-295e-43ea-b50c-dce70f71a176.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Align WindowsAppSDK Target Windows version with UWP",
+  "comment": "Update WindowsAppSDK versions to latest",
   "packageName": "@react-native-windows/cli",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
+++ b/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Try to update WindowsAppSDK to 19041",
+  "comment": "Align WindowsAppSDK Target Windows version with UWP",
   "packageName": "react-native-windows",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
+++ b/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Align WindowsAppSDK Target Windows version with UWP",
+  "comment": "Update WindowsAppSDK versions to latest",
   "packageName": "react-native-windows",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
+++ b/change/react-native-windows-90e2cc65-5baa-4b5c-9bf9-0cdfe54e132a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Try to update WindowsAppSDK to 19041",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -545,7 +545,7 @@ function getWinAppSDKPackages(nugetVersion: string): NugetPackage[] {
 
   winAppSDKPackages.push({
     id: 'Microsoft.WindowsAppSDK',
-    version: '1.0.0',
+    version: '1.1.4',
   });
 
   return winAppSDKPackages;

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup Condition="'$(SolutionName)'=='Microsoft.ReactNative.WindowsAppSDK'">
     <UseWinUI3>true</UseWinUI3>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows10.0.18362.0</TargetFramework>
+    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
     <Platforms>x64</Platforms>
   </PropertyGroup>
 
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.18362.18" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.18362.18" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.27" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.27" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.3.5" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.6.5" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
   </ItemGroup>
-  <ItemGroup>
+  <!-- <ItemGroup>
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.26" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.26" />
-  </ItemGroup>
+  </ItemGroup> -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="1.6.5" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.4" />
   </ItemGroup>
-  <!-- <ItemGroup>
+  <ItemGroup>
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.26" />
     <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.26" />
-  </ItemGroup> -->
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
+++ b/vnext/Microsoft.ReactNative.WindowsAppSDK/Microsoft.ReactNative.WindowsAppSDK.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.27" />
-    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.27" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.26" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.26" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)\..\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj" />

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="WinUI3 versioning">
     <!-- This value is also used by the CLI, see /packages/@react-native-windows/generate-windows -->
-    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.0.0</WinUI3Version>
+    <WinUI3Version Condition="'$(WinUI3Version)'==''">1.1.4</WinUI3Version>
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI2x versioning">

--- a/vnext/template/cs-app-WinAppSDK/proj/MyApp.csproj
+++ b/vnext/template/cs-app-WinAppSDK/proj/MyApp.csproj
@@ -33,6 +33,10 @@
     <SDKReference Include="Microsoft.VCLibs, Version=14.0" />
   </ItemGroup>
   <ItemGroup>
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" RuntimeFrameworkVersion="10.0.19041.26" />
+    <FrameworkReference Update="Microsoft.Windows.SDK.NET.Ref" TargetingPackVersion="10.0.19041.26" />
+  </ItemGroup>
+  <ItemGroup>
     {{#csNugetPackages}}
     <PackageReference Include="{{ id }}">
       <Version>{{ version }}</Version>


### PR DESCRIPTION
## Description

This PR updates the following versions for the `Microsoft.ReactNative.WindowsAppSDK` project and the template for apps built agsinst it:

* Upgrade `WindowsTargetPlatformVersion` / `Microsoft.WindowsSDK` to 10.0.19041 from 10.0.18362
* Upgrade `WinUI3` / `Microsoft.WindowsAppSDK` to 1.1.4 from 1.0.0

### Type of Change
_Erase all that don't apply._
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why

Building the `Microsoft.ReactNative.WindowsAppSDK` project with the `WindowsTargetPlatformVersion` at 10.0.18362 means all of the dependencies (like `Microsoft.ReactNative`) also build targeting that version, which causes multiple warnings by the MIDL compiler. Updating to 10.0.19041 aligns WindowsAppSDK with the standard UWP projects.

To make that upgrade/alignment happen, the `Microsoft.WindowsAppSDK` also needed to be bumped.

### What
Updated versions in project files, including the WinAppSDK app template.

## Screenshots
N/A

## Testing
N/A

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10771)