### PR TITLE
Fixes issue for loading images in Clang builds

### DIFF
--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.cpp
@@ -218,14 +218,16 @@ winrt::fire_and_forget ReactImage::SetBackground(bool fireLoadEndEvent) {
   auto weak_this{get_weak()};
 
   try {
-    memoryStream = co_await GetImageMemoryStreamAsync(source);
+    if (fromStream) {
+      memoryStream = co_await GetImageMemoryStreamAsync(source);
 
-    // Fire failed load event if we're not loading from URI and the memory stream is null.
-    if (fromStream && !memoryStream) {
-      if (auto strong_this{weak_this.get()}) {
-        strong_this->m_onLoadEndEvent(*strong_this, false);
+      // Fire failed load event if we're not loading from URI and the memory stream is null.
+      if (!memoryStream) {
+        if (auto strong_this{weak_this.get()}) {
+          strong_this->m_onLoadEndEvent(*strong_this, false);
+        }
+        co_return;
       }
-      co_return;
     }
   } catch (winrt::hresult_error const &) {
     const auto strong_this{weak_this.get()};


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We recently attempted to upgrade cppwinrt in our app, and noticed that image load failures were occurring. It seems that our combination of cppwinrt and Clang doesn't like when you immediately co_return a nullptr in a coroutine.

### What
To work around this, this change ensures we only call into the coroutine method if necessary (by first checking the `fromStream` boolean).

## Testing
Images typically loaded from a URI source no longer fail to load in our app.

_Optional_: Describe the tests that you ran locally to verify your changes.