### PR TITLE
Isolates the prop changes specific to ViewPanel

### DIFF
--- a/change/react-native-windows-11997fa9-7ef4-40a4-8453-6f65719208df.json
+++ b/change/react-native-windows-11997fa9-7ef4-40a4-8453-6f65719208df.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Isolates the prop changes specific to ViewPanel",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/PropertyUtils.h
@@ -556,9 +556,9 @@ inline bool TryUpdateMouseEvents(
     const std::string &propertyName,
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   if (propertyName == "onMouseEnter")
-    node->m_onMouseEnterRegistered = !propertyValue.IsNull() && propertyValue.AsBoolean();
+    node->m_onMouseEnterRegistered = propertyValue.AsBoolean();
   else if (propertyName == "onMouseLeave")
-    node->m_onMouseLeaveRegistered = !propertyValue.IsNull() && propertyValue.AsBoolean();
+    node->m_onMouseLeaveRegistered = propertyValue.AsBoolean();
   else
     return false;
 

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -45,10 +45,10 @@ enum class ShadowCorners : uint8_t {
 };
 
 struct ShadowNodeLayout {
-  float Left;
-  float Top;
-  float Width;
-  float Height;
+  float Left{0.f};
+  float Top{0.f};
+  float Width{0.f};
+  float Height{0.f};
 };
 
 extern const DECLSPEC_SELECTANY double c_UndefinedEdge = -1;
@@ -135,6 +135,9 @@ struct REACTWINDOWS_EXPORT ShadowNodeBase : public ShadowNode {
   bool m_onLayoutRegistered = false;
   bool m_onMouseEnterRegistered = false;
   bool m_onMouseLeaveRegistered = false;
+
+  // Overflow
+  bool m_overflowHidden = false;
 
   // Pointer events
   PointerEventsKind m_pointerEvents = PointerEventsKind::Auto;

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
@@ -27,14 +27,14 @@ winrt::AutomationPeer ViewControl::OnCreateAutomationPeer() {
   return winrt::make<winrt::Microsoft::ReactNative::implementation::DynamicAutomationPeer>(*this);
 }
 
-winrt::Microsoft::ReactNative::ViewPanel ViewControl::GetPanel() const {
+xaml::Controls::Panel ViewControl::GetPanel() const {
   auto child = Content();
 
   if (auto border = child.try_as<xaml::Controls::Border>()) {
     child = border.Child();
   }
 
-  auto panel = child.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
+  auto panel = child.try_as<xaml::Controls::Panel>();
   assert(panel != nullptr);
 
   return panel;

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.h
@@ -22,7 +22,7 @@ struct ViewControl : ViewControlT<ViewControl> {
 
   xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
-  winrt::Microsoft::ReactNative::ViewPanel GetPanel() const;
+  xaml::Controls::Panel GetPanel() const;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -303,6 +303,9 @@ bool ViewManagerBase::UpdateProperty(
       }
     }
   } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
+  } else if (propertyName == "overflow") {
+    const auto wasClipped = nodeToUpdate->m_overflowHidden;
+    nodeToUpdate->m_overflowHidden = propertyValue.AsString() == "hidden";
   } else {
     return false;
   }
@@ -382,6 +385,16 @@ void ViewManagerBase::SetLayoutProps(
 
   fe.Width(width);
   fe.Height(height);
+
+  // Modifying the `overflow` prop will always result in the Yoga node setting
+  // `YGNodeHasNewLayout`, so we can reliably update the Clip from this method.
+  if (nodeToUpdate.m_overflowHidden) {
+    winrt::RectangleGeometry clipGeometry;
+    clipGeometry.Rect(winrt::Rect(0, 0, width, height));
+    fe.Clip(clipGeometry);
+  } else {
+    fe.ClearValue(xaml::UIElement::ClipProperty());
+  }
 }
 
 YGMeasureFunc ViewManagerBase::GetYogaCustomMeasureFunc() const {

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.cpp
@@ -98,16 +98,6 @@ winrt::AutomationPeer ViewPanel::OnCreateAutomationPeer() {
   return xaml::Controls::Canvas::LeftProperty();
 }
 
-/*static*/ xaml::DependencyProperty ViewPanel::ClipChildrenProperty() {
-  static xaml::DependencyProperty s_clipChildrenProperty = xaml::DependencyProperty::Register(
-      L"ClipChildren",
-      winrt::xaml_typename<bool>(),
-      viewPanelTypeName,
-      winrt::PropertyMetadata(winrt::box_value(false), ViewPanel::VisualPropertyChanged));
-
-  return s_clipChildrenProperty;
-}
-
 /*static*/ void ViewPanel::SetTop(xaml::UIElement const &element, double value) {
   element.SetValue(TopProperty(), winrt::box_value<double>(value));
   InvalidateForArrange(element);
@@ -185,8 +175,6 @@ winrt::Size ViewPanel::ArrangeOverride(winrt::Size finalSize) {
         winrt::Rect(adjustedLeft, adjustedTop, static_cast<float>(childWidth), static_cast<float>(childHeight)));
   }
 
-  UpdateClip(finalSize);
-
   return finalSize;
 }
 
@@ -223,10 +211,6 @@ void ViewPanel::BorderBrush(winrt::Brush const &value) {
 
 void ViewPanel::CornerRadius(xaml::CornerRadius const &value) {
   SetValue(CornerRadiusProperty(), winrt::box_value(value));
-}
-
-void ViewPanel::ClipChildren(bool value) {
-  SetValue(ClipChildrenProperty(), winrt::box_value(value));
 }
 
 void ViewPanel::FinalizeProperties() {
@@ -268,9 +252,6 @@ void ViewPanel::FinalizeProperties() {
   } else if (!displayBorder) {
     scenario = Scenario::NoBorder;
     m_hasOuterBorder = false;
-  } else if (ClipChildren()) {
-    scenario = Scenario::OuterBorder;
-    m_hasOuterBorder = true;
   } else {
     scenario = Scenario::InnerBorder;
     m_hasOuterBorder = false;
@@ -347,17 +328,6 @@ xaml::Controls::Border ViewPanel::GetOuterBorder() {
     return m_border;
   else
     return xaml::Controls::Border(nullptr);
-}
-
-void ViewPanel::UpdateClip(winrt::Size &finalSize) {
-  if (ClipChildren()) {
-    winrt::RectangleGeometry clipGeometry;
-    clipGeometry.Rect(winrt::Rect(0, 0, static_cast<float>(finalSize.Width), static_cast<float>(finalSize.Height)));
-
-    Clip(clipGeometry);
-  } else {
-    Clip(nullptr);
-  }
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewPanel.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewPanel.h
@@ -52,17 +52,11 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
   }
   void CornerRadius(xaml::CornerRadius const &value);
 
-  bool ClipChildren() {
-    return winrt::unbox_value<bool>(GetValue(ClipChildrenProperty()));
-  }
-  void ClipChildren(bool value);
-
   // ViewPanel Properties
   static xaml::DependencyProperty ViewBackgroundProperty();
   static xaml::DependencyProperty BorderThicknessProperty();
   static xaml::DependencyProperty BorderBrushProperty();
   static xaml::DependencyProperty CornerRadiusProperty();
-  static xaml::DependencyProperty ClipChildrenProperty();
 
   // Attached Properties
   static xaml::DependencyProperty TopProperty();
@@ -81,8 +75,6 @@ struct ViewPanel : ViewPanelT<ViewPanel> {
 
  private:
   void Remove(xaml::UIElement element) const;
-
-  void UpdateClip(winrt::Windows::Foundation::Size &finalSize);
 
  private:
   bool m_propertiesChanged{false};

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -425,11 +425,6 @@ bool ViewViewManager::UpdateProperty(
     } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
     } else if (propertyName == "onClick") {
       pViewShadowNode->OnClick(!propertyValue.IsNull() && propertyValue.AsBoolean());
-    } else if (propertyName == "overflow") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
-        bool clipChildren = propertyValue.AsString() == "hidden";
-        pPanel.ClipChildren(clipChildren);
-      }
     } else if (propertyName == "focusable") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
         pViewShadowNode->IsFocusable(propertyValue.AsBoolean());

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -424,27 +424,27 @@ bool ViewViewManager::UpdateProperty(
       UpdateCornerRadiusOnElement(nodeToUpdate, pPanel, maxCornerRadius);
     } else if (TryUpdateMouseEvents(nodeToUpdate, propertyName, propertyValue)) {
     } else if (propertyName == "onClick") {
-      pViewShadowNode->OnClick(!propertyValue.IsNull() && propertyValue.AsBoolean());
+      pViewShadowNode->OnClick(propertyValue.AsBoolean());
     } else if (propertyName == "focusable") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
-        pViewShadowNode->IsFocusable(propertyValue.AsBoolean());
+      pViewShadowNode->IsFocusable(propertyValue.AsBoolean());
     } else if (propertyName == "enableFocusRing") {
-      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean)
-        pViewShadowNode->EnableFocusRing(propertyValue.AsBoolean());
-      else if (propertyValue.IsNull())
-        pViewShadowNode->EnableFocusRing(false);
+      pViewShadowNode->EnableFocusRing(propertyValue.AsBoolean());
     } else if (propertyName == "tabIndex") {
-      auto tabIndex = propertyValue.AsInt64();
-      if (tabIndex == static_cast<int32_t>(tabIndex)) {
-        pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));
-      } else if (propertyValue.IsNull()) {
+      auto resetTabIndex = true;
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64 ||
+          propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double) {
+        const auto tabIndex = propertyValue.AsInt64();
+        if (tabIndex == static_cast<int32_t>(tabIndex)) {
+          pViewShadowNode->TabIndex(static_cast<int32_t>(tabIndex));
+          resetTabIndex = false;
+        }
+      }
+      if (resetTabIndex) {
         pViewShadowNode->TabIndex(std::numeric_limits<std::int32_t>::max());
       }
     } else {
       if (propertyName == "accessible") {
-        if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Boolean) {
-          pViewShadowNode->IsAccessible(propertyValue.AsBoolean());
-        }
+        pViewShadowNode->IsAccessible(propertyValue.AsBoolean());
       }
       ret = Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
     }

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -46,7 +46,7 @@ class ViewShadowNode : public ShadowNodeBase {
   void createView(const winrt::Microsoft::ReactNative::JSValueObject &props) override {
     Super::createView(props);
 
-    auto panel = GetViewPanel();
+    auto panel = GetPanel();
 
     DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(panel, [=]() {
       if (OnClick())
@@ -150,16 +150,16 @@ class ViewShadowNode : public ShadowNodeBase {
           Microsoft::Common::Unicode::Utf16ToUtf8(name.c_str()));
     }
 
-    GetViewPanel().InsertAt(static_cast<uint32_t>(index), view.as<xaml::UIElement>());
+    GetPanel().Children().InsertAt(static_cast<uint32_t>(index), view.as<xaml::UIElement>());
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
     if (indexToRemove == static_cast<uint32_t>(indexToRemove))
-      GetViewPanel().RemoveAt(static_cast<uint32_t>(indexToRemove));
+      GetPanel().Children().RemoveAt(static_cast<uint32_t>(indexToRemove));
   }
 
   void removeAllChildren() override {
-    GetViewPanel().Clear();
+    GetPanel().Children().Clear();
 
     XamlView current = m_view;
 
@@ -183,12 +183,12 @@ class ViewShadowNode : public ShadowNodeBase {
   }
 
   void ReplaceChild(const XamlView &oldChildView, const XamlView &newChildView) override {
-    auto pPanel = GetViewPanel();
+    auto pPanel = GetPanel();
     if (pPanel != nullptr) {
       uint32_t index;
       if (pPanel.Children().IndexOf(oldChildView.as<xaml::UIElement>(), index)) {
-        pPanel.RemoveAt(index);
-        pPanel.InsertAt(index, newChildView.as<xaml::UIElement>());
+        pPanel.Children().RemoveAt(index);
+        pPanel.Children().InsertAt(index, newChildView.as<xaml::UIElement>());
       } else {
         assert(false);
       }
@@ -204,7 +204,7 @@ class ViewShadowNode : public ShadowNodeBase {
     static_cast<FrameworkElementViewManager *>(GetViewManager())->RefreshTransformMatrix(this);
   }
 
-  winrt::Microsoft::ReactNative::ViewPanel GetViewPanel() {
+  xaml::Controls::Panel GetPanel() {
     XamlView current = m_view;
 
     if (IsControl()) {
@@ -219,7 +219,7 @@ class ViewShadowNode : public ShadowNodeBase {
       }
     }
 
-    auto panel = current.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
+    auto panel = current.try_as<xaml::Controls::Panel>();
     assert(panel != nullptr);
 
     return panel;
@@ -399,7 +399,7 @@ bool ViewViewManager::UpdateProperty(
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   auto *pViewShadowNode = static_cast<ViewShadowNode *>(nodeToUpdate);
 
-  auto pPanel = pViewShadowNode->GetViewPanel();
+  auto pPanel = pViewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
   bool ret = true;
   if (pPanel != nullptr) {
     if (TryUpdateBackgroundBrush(pPanel, propertyName, propertyValue)) {
@@ -460,7 +460,7 @@ bool ViewViewManager::UpdateProperty(
 
 void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto *viewShadowNode = static_cast<ViewShadowNode *>(node);
-  auto panel = viewShadowNode->GetViewPanel();
+  auto panel = viewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
 
   if (panel.ReadLocalValue(ViewPanel::ViewBackgroundProperty()) == xaml::DependencyProperty::UnsetValue()) {
     // In XAML, a null background means no hit-test will happen.
@@ -632,7 +632,7 @@ void ViewViewManager::SetLayoutProps(
   // Do this first so that it is setup properly before any events are fired by
   // the Super implementation
   auto *pViewShadowNode = static_cast<ViewShadowNode *>(&nodeToUpdate);
-  auto pPanel = pViewShadowNode->GetViewPanel();
+  auto pPanel = pViewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
   if (pViewShadowNode->IsControl()) {
     pPanel.Width(width);
     pPanel.Height(height);

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.h
@@ -47,6 +47,17 @@ class ViewViewManager : public FrameworkElementViewManager {
 
  private:
   xaml::Media::SolidColorBrush m_transparentBrush{nullptr};
+
+  bool UpdateViewPanelProperty(
+      ViewShadowNode *node,
+      winrt::Microsoft::ReactNative::ViewPanel &panel,
+      const std::string &propertyName,
+      const winrt::Microsoft::ReactNative::JSValue &propertyValue);
+
+  bool UpdatePropertyCore(
+      ViewShadowNode *node,
+      const std::string &propertyName,
+      const winrt::Microsoft::ReactNative::JSValue &propertyValue);
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -15,11 +15,11 @@ namespace Microsoft.ReactNative
 
     // Public Methods
     void InsertAt(UInt32 index, XAML_NAMESPACE.UIElement value);
-      void RemoveAt(UInt32 index);
-      void Clear();
+    void RemoveAt(UInt32 index);
+    void Clear();
 
     void FinalizeProperties();
-      XAML_NAMESPACE.Controls.Border GetOuterBorder();
+    XAML_NAMESPACE.Controls.Border GetOuterBorder();
 
     // Public Properties
     XAML_NAMESPACE.Media.Brush ViewBackground { get; set; };
@@ -51,6 +51,6 @@ namespace Microsoft.ReactNative
   {
     ViewControl();
 
-    ViewPanel GetPanel();
+    XAML_NAMESPACE.Controls.Panel GetPanel();
   }
 }

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -26,14 +26,12 @@ namespace Microsoft.ReactNative
     XAML_NAMESPACE.Thickness BorderThickness { get; set; };
     XAML_NAMESPACE.Media.Brush BorderBrush { get; set; };
     XAML_NAMESPACE.CornerRadius CornerRadius { get; set; };
-    Boolean ClipChildren { get; set; };
 
     // ViewPanel Properties
     static XAML_NAMESPACE.DependencyProperty ViewBackgroundProperty { get; };
     static XAML_NAMESPACE.DependencyProperty BorderThicknessProperty { get; };
     static XAML_NAMESPACE.DependencyProperty BorderBrushProperty { get; };
     static XAML_NAMESPACE.DependencyProperty CornerRadiusProperty { get; };
-    static XAML_NAMESPACE.DependencyProperty ClipChildrenProperty { get; };
 
     // Attached Properties
     static XAML_NAMESPACE.DependencyProperty TopProperty { get; };


### PR DESCRIPTION
## Description

### Why
We're setting up an experiment to use Grid and Canvas instead of ViewPanel. To reduce the number of changes required to support different backing View controls, this commit isolates the changes that are  specific to ViewPanel from those that only apply to the ViewShadowNode.

## Testing

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10779)