### PR TITLE
Adding support for ImageSource on windows #10614

### DIFF
--- a/change/react-native-windows-970e4edd-52b3-420e-94e4-d1d323d5b4f2.json
+++ b/change/react-native-windows-970e4edd-52b3-420e-94e4-d1d323d5b4f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adding support for ImageSource on windows",
+  "packageName": "react-native-windows",
+  "email": "helewxdong@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -106,6 +106,9 @@ void ABIViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValu
         case ViewManagerPropertyType::Function:
           writer.WriteString(L"function");
           break;
+        case ViewManagerPropertyType::ImageSource:
+          writer.WriteString(L"ImageSource");
+        break;
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/IViewManagerCore.idl
+++ b/vnext/Microsoft.ReactNative/IViewManagerCore.idl
@@ -19,6 +19,7 @@ namespace Microsoft.ReactNative
     Map,
     Color,
     Function,
+    ImageSource,
   };
 
   [webhosthidden]


### PR DESCRIPTION
## Description
Added ImageSource support to ViewManagerPropertType, meaning ImageSource will be a valid prop in Windows

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Ensures that Windows has similar behavior to iOS and Android

Resolves #10614

## Testing
I modified EmojiGridViewManager to expose using ImageSource.
Errors before the changes stating that ImageSource is not supported:

<img width="794" alt="Screen Shot 2022-10-21 at 9 14 33 AM" src="https://user-images.githubusercontent.com/33271708/197287812-610e6f2c-eb17-4d6c-b947-f9c467062c88.png">

Emojis working as normal after changes, showing support for ImageSource:

https://user-images.githubusercontent.com/33271708/197287935-2177d38a-0889-4d89-8372-cc9b2c7ae64f.mov