### PR TITLE
Do not use xaml rendering callback in non-xaml apps

### DIFF
--- a/change/react-native-windows-a86ad746-4da6-4d3b-86d7-8b4f05cdf352.json
+++ b/change/react-native-windows-a86ad746-4da6-4d3b-86d7-8b4f05cdf352.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not use xaml rendering callback in non-xaml apps",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -9,6 +9,7 @@
 #include <InstanceManager.h>
 #include <UI.Xaml.Media.h>
 #include <Utils/ValueUtils.h>
+#include <XamlUtils.h>
 
 #include <unknwnbase.h>
 
@@ -72,6 +73,7 @@ bool TimerQueue::IsEmpty() {
 
 void Timing::Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   m_context = reactContext;
+  m_usePostForRendering = !xaml::TryGetCurrentApplication();
 }
 
 void Timing::OnTick() {
@@ -94,6 +96,8 @@ void Timing::OnTick() {
 
   if (m_timerQueue.IsEmpty()) {
     StopTicks();
+  } else if (m_usePostForRendering && m_usingRendering && emittedAnimationFrame) {
+    PostRenderFrame(); // Repost
   } else if (!m_usingRendering || !emittedAnimationFrame) {
     // If we're using a rendering callback, check if any animation frame
     // requests were emitted in this tick. If not, start the dispatcher timer.
@@ -122,10 +126,25 @@ winrt::dispatching::DispatcherQueueTimer Timing::EnsureDispatcherTimer() {
   return m_dispatcherQueueTimer;
 }
 
+void Timing::PostRenderFrame() noexcept {
+  assert(m_usePostForRendering);
+  m_usingRendering = true;
+  m_context.UIDispatcher().Post([wkThis = std::weak_ptr(this->shared_from_this())]() {
+      if (auto pThis = wkThis.lock()) {
+        pThis->m_usingRendering = false;
+        pThis->OnTick();
+      }
+    });
+}
+
 void Timing::StartRendering() {
   if (m_dispatcherQueueTimer)
     m_dispatcherQueueTimer.Stop();
 
+  if (m_usePostForRendering) {
+    PostRenderFrame();
+    return;
+  }
   m_rendering.revoke();
   m_usingRendering = true;
   m_rendering = xaml::Media::CompositionTarget::Rendering(

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.cpp
@@ -130,11 +130,11 @@ void Timing::PostRenderFrame() noexcept {
   assert(m_usePostForRendering);
   m_usingRendering = true;
   m_context.UIDispatcher().Post([wkThis = std::weak_ptr(this->shared_from_this())]() {
-      if (auto pThis = wkThis.lock()) {
-        pThis->m_usingRendering = false;
-        pThis->OnTick();
-      }
-    });
+    if (auto pThis = wkThis.lock()) {
+      pThis->m_usingRendering = false;
+      pThis->OnTick();
+    }
+  });
 }
 
 void Timing::StartRendering() {

--- a/vnext/Microsoft.ReactNative/Modules/TimingModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/TimingModule.h
@@ -73,6 +73,7 @@ struct Timing : public std::enable_shared_from_this<Timing> {
   void OnTick();
   winrt::dispatching::DispatcherQueueTimer EnsureDispatcherTimer();
   void StartRendering();
+  void PostRenderFrame() noexcept;
   void StartDispatcherTimer();
   void StopTicks();
 
@@ -81,6 +82,7 @@ struct Timing : public std::enable_shared_from_this<Timing> {
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
   winrt::dispatching::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
   bool m_usingRendering{false};
+  bool m_usePostForRendering{false};
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description
In fabric it'll be possible to run RNW without using XAML, at which point we cannot use the CompositionTarget::Rendering event.  

### Why
This unblocks the usage of various timers in fabric with no xaml - such as the composition playground app.

### What
Instead of using the Rendering event, the timers will be fired based on a dispatch queue post call.

## Testing
The Timing test page in RNTester would previously crash in the composition playground app.  Now all the buttons pass.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10800)