### PR TITLE
Fixes issue with zoom and horizontal scrolling

### DIFF
--- a/change/react-native-windows-b08d7ad3-24e4-4476-a726-1fb58ad0792c.json
+++ b/change/react-native-windows-b08d7ad3-24e4-4476-a726-1fb58ad0792c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issue with zoom and horizontal scrolling",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -90,8 +90,7 @@ void ScrollViewShadowNode::dispatchCommand(
     scrollViewer.ChangeView(x, y, nullptr, !animated /*disableAnimation*/);
   } else if (commandId == ScrollViewCommands::ScrollToEnd) {
     bool animated = commandArgs[0].AsBoolean();
-    bool horiz = scrollViewer.HorizontalScrollMode() == winrt::ScrollMode::Auto;
-    if (horiz)
+    if (m_isHorizontal)
       scrollViewer.ChangeView(scrollViewer.ScrollableWidth(), nullptr, nullptr, !animated /*disableAnimation*/);
     else
       scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr, !animated /*disableAnimation*/);
@@ -490,7 +489,6 @@ XamlView ScrollViewManager::CreateViewCore(int64_t /*tag*/, const winrt::Microso
   scrollViewer.VerticalSnapPointsAlignment(winrt::SnapPointsAlignment::Near);
   scrollViewer.VerticalSnapPointsType(winrt::SnapPointsType::Mandatory);
   scrollViewer.HorizontalSnapPointsType(winrt::SnapPointsType::Mandatory);
-  scrollViewer.HorizontalScrollMode(winrt::ScrollMode::Disabled);
 
   const auto snapPointManager = SnapPointManagingContentControl::Create();
   scrollViewer.Content(*snapPointManager);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #7072, a change was made to always disable horizontal scrolling by default. Prior to this change, apps that enabled vertical scrolling and zoom scale (via maximumZoomScale or minimumZoomScale) could scroll in both directions. 

Resolves #10806

### What
This change reverts the problematic commit from #7072 and puts in a better fix for the scrollToEnd issue.

## Testing
Before:

https://user-images.githubusercontent.com/1106239/198719352-674449f1-3fe8-4739-bbbe-2712f54f7106.mp4

After:

https://user-images.githubusercontent.com/1106239/198719367-156485bb-6e15-4bd1-947d-85257b5f575e.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10807)