### PR TITLE
Apply fast text optimization to multiple runs

### DIFF
--- a/change/react-native-windows-a5d81eea-50b4-4029-80b1-944768616ecf.json
+++ b/change/react-native-windows-a5d81eea-50b4-4029-80b1-944768616ecf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Apply fast text optimization to multiple runs",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Text/TextPropertyChangedParentVisitor.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextPropertyChangedParentVisitor.cpp
@@ -40,13 +40,7 @@ void TextPropertyChangedParentVisitor::VisitText(ShadowNodeBase *node) {
       }
     }
 
-    // Update fast text content
-    if (!m_isNested && node->m_children.size() == 1) {
-      if (const auto childNode = GetShadowNode(node->m_children[0])) {
-        const auto run = static_cast<ShadowNodeBase *>(childNode)->GetView().as<winrt::Run>();
-        element.Text(run.Text());
-      }
-    }
+    TextViewManager::UpdateOptimizedText(node);
   }
 
   // Refresh text highlighters

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.h
@@ -29,6 +29,8 @@ class TextViewManager : public FrameworkElementViewManager {
 
   static void UpdateTextHighlighters(ShadowNodeBase *node, bool highlightAdded);
 
+  static void UpdateOptimizedText(ShadowNodeBase *node);
+
   static void SetDescendantPressable(ShadowNodeBase *node);
 
   static TextTransform GetTextTransformValue(ShadowNodeBase *node);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Perf fix (non-breaking change which improves performance)

### Why
Currently, the fast text optimization is only applied for Text nodes with a single run child. If you have text like the following:
```
<Text>Count: {count}</Text>
```
This will create two inline children.

### What
We can instead validate that the Text node has only runs for children, and concatenate the context of the runs together to keep using the optimized text path (setting the xaml::TextBlock::TextProperty).

## Testing
Checked around with Text examples in Playground - behavior unchanged. Also verified that updating RawTextNode "text" props trigger updates to the optimized text when necessary.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10811)