### PR TITLE
[0.69] Allow customers to specify $(CppWinRTVersion)

### DIFF
--- a/change/react-native-windows-79f6563d-c38d-419d-b66a-00820b069c31.json
+++ b/change/react-native-windows-79f6563d-c38d-419d-b66a-00820b069c31.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.69] Allow customers to specify $(CppWinRTVersion)",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
@@ -11,7 +11,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="CppWinRT">
-    <CppWinRTVersion>2.0.211028.7</CppWinRTVersion>
+    <CppWinRTVersion Condition="'$(CppWinRTVersion)' == '' Or $([MSBuild]::VersionLessThan('$(CppWinRTVersion)', '2.0.211028.7'))">2.0.211028.7</CppWinRTVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This PR backports #10793 to 0.69.

* Allow customers to specify $(CppWinRTVersion)

This PR updates our shared prop file where we set the version of $(CppWinRTVersion) to use to only specify it if it's not already specifed by the customer (say in ExperimentalFeatures.props).

* Change files

* Ensure minimum version

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10820)