### PR TITLE
Add accessibilityLevel as a prop on TextWin32 to set heading level

### DIFF
--- a/change/@office-iss-react-native-win32-14c21e4b-fc70-4934-899a-ba3dd43c88bd.json
+++ b/change/@office-iss-react-native-win32-14c21e4b-fc70-4934-899a-ba3dd43c88bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add accessibilityLevel to BasePropsWin32",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
@@ -28,6 +28,10 @@ const styles = StyleSheet.create({
   listContainer: {
     height: 150,
   },
+  heading: {
+    fontSize: 16,
+    fontWeight: '600'
+  },
 });
 
 interface IFocusableComponentState {
@@ -126,6 +130,17 @@ class ButtonExample extends React.Component<{}, IFocusableComponentState & IExpa
     this.state.expanded ? this._collapse() : this._expand();
   };
 }
+
+const HeadingLevelExample: React.FunctionComponent = () => {
+  return (
+    <ViewWin32>
+      <TextWin32 accessible accessibilityRole="header" accessibilityLevel={1} style={styles.heading}>Paragraph Title</TextWin32>
+      <TextWin32>The above heading level should be heading level 1.</TextWin32>
+      <TextWin32 accessible accessibilityRole="header" style={styles.heading}>Second Paragraph Title</TextWin32>
+      <TextWin32>The above heading has no level set. It should default to heading level 2.</TextWin32>
+    </ViewWin32>
+  );
+};
 
 interface IMultiSelectionExampleState {
   selectedItems: number[];
@@ -476,6 +491,11 @@ export const examples = [
       title: 'Button Example',
       description: 'A button with some basic accessibility props and expand/collapse',
       render: () => <ButtonExample />,
+    },
+    {
+      title: 'Heading Level Example',
+      description: 'A couple text headings with heading level set',
+      render: () => <HeadingLevelExample />,
     },
     {
       title: 'MultiSelection Example',

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
@@ -138,6 +138,10 @@ const HeadingLevelExample: React.FunctionComponent = () => {
       <TextWin32>The above heading level should be heading level 1.</TextWin32>
       <TextWin32 accessible accessibilityRole="header" style={styles.heading}>Second Paragraph Title</TextWin32>
       <TextWin32>The above heading has no level set. It should default to heading level 2.</TextWin32>
+      <TextWin32 accessible accessibilityLevel={1} style={styles.heading}>Third Paragraph Title</TextWin32>
+      <TextWin32>The above heading does not use the "header" role but has a level set. Since the "header" role 
+        is not set, the heading level should be set to none and it will not be read as a header.
+      </TextWin32>
     </ViewWin32>
   );
 };
@@ -494,7 +498,7 @@ export const examples = [
     },
     {
       title: 'Heading Level Example',
-      description: 'A couple text headings with heading level set',
+      description: 'A few text headings with heading level set',
       render: () => <HeadingLevelExample />,
     },
     {

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -178,6 +178,12 @@ export type BasePropsWin32 = {
     * ItemType is used to obtain information about items in a list, tree view, or data grid. For example, an item in a file directory view might be a "Document File" or a "Folder".
     */
    accessibilityItemType?: string;
+
+   /**
+    * Defines the level of an element in a hierarchiacal structure or the heading level of a text element.
+    * Note: accessibilityRole="header" must be used if using this property to define a heading level.
+    */
+    accessibilityLevel?: number;
 };
 
 export type ViewWin32OmitTypes = RN.ViewPropsAndroid &

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/TextNativeComponent.win32.js
@@ -41,6 +41,7 @@ const textViewConfig = {
       //work without being listed.  Any Text-specific events
       // would need to be listed here.
     focusable: true,
+    accessibilityLevel: true,
     // Windows]
   },
   directEventTypes: {


### PR DESCRIPTION
## Description
Add accessibilityLevel as a prop on TextWin32 to set heading level for accessibility purposes.

### Type of Change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Why
On windows, text elements can be defined as a header using `accessibilityRole="header"` but there is no way to define a custom heading level (the current default is 2). This proposal: [RFG Accessibility APIs by necolas](https://github.com/react-native-community/discussions-and-proposals/pull/410/files#diff-0778a9f2187181434c1b3042681941d44513d93af9c5dcbbd1b3e94e329c140cR109) proposes using `accessibilityLevel` as a prop to define text heading levels and hierarchical levels (since it closely aligns with the ARIA level property and is used for the same purpose. See [aria-level](https://www.w3.org/TR/wai-aria-1.2/#aria-level) ). The `accessibilityLevel` prop already exists on ViewWin32 and we need to make it available on TextWin32 in order to define custom heading levels.

### What
Add `accessibilityLevel` to BasePropsWin32 and make it a valid attribute on TextWin32.

## Screenshots
![image](https://user-images.githubusercontent.com/22876140/199541762-d9f946dc-c5f3-495d-8b0b-fef47a401e9d.png)

## Testing
Added a Heading Level Example to the accessibility examples (shown above) and tested locally. Ensured using accessibilityLevel prop in combination with accessibilityRole="header" sets UIA heading level accordingly. Setting no accessibilityLevel with accessibilityRole="header" defaults to heading level 2 like it did before.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10823)