### PR TITLE
Remove extra accessibilityLevel prop from ViewWin32

### DIFF
--- a/change/@office-iss-react-native-win32-385acbc9-f9c6-40e3-8c13-3e5f6fc1778d.json
+++ b/change/@office-iss-react-native-win32-385acbc9-f9c6-40e3-8c13-3e5f6fc1778d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove duplicate accessibilityLevel prop",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -218,7 +218,6 @@ export interface IViewWin32Props extends Omit<RN.ViewProps, ViewWin32OmitTypes>,
   *
   */
   accessibilityDescription?: string;
-  accessibilityLevel?: number;
   accessibilityPositionInSet?: number;
 
   accessibilitySetSize?: number;


### PR DESCRIPTION
## Description
Removes extra accessibilityLevel prop from ViewWin32 which I forgot to remove from IViewWin32Props when it was moved to BasePropsWin32 in #10823.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
No need for accessibilityLevel to be defined in two places.

### What
Removes accessibilityLevel prop from IViewWin32Props since it's defined in BasePropsWin32.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Manually tested existing test case scenarios in the RN Tester App locally.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10824)