### PR TITLE
Fix typo in comment

### DIFF
--- a/change/@office-iss-react-native-win32-447f3ff4-93e5-447e-8956-57f4c3e6c8bc.json
+++ b/change/@office-iss-react-native-win32-447f3ff4-93e5-447e-8956-57f4c3e6c8bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix misspelling",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.Props.ts
@@ -180,7 +180,7 @@ export type BasePropsWin32 = {
    accessibilityItemType?: string;
 
    /**
-    * Defines the level of an element in a hierarchiacal structure or the heading level of a text element.
+    * Defines the level of an element in a hierarchical structure or the heading level of a text element.
     * Note: accessibilityRole="header" must be used if using this property to define a heading level.
     */
     accessibilityLevel?: number;


### PR DESCRIPTION
## Description
Fixes small typo in a comment.

### Type of Change
No change to the package, just fixes typo.

### Why
Typo is being fixed in the backports for the associated change in 0.68, 0.69, and 0.70. Need to fix the typo in the main branch so future branches will have the correct spelling.

### What

## Screenshots

## Testing

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10831)