### PR TITLE
Adds test native module project for Playground

### DIFF
--- a/packages/playground/Samples/nativeLayout.tsx
+++ b/packages/playground/Samples/nativeLayout.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ */
+import React from 'react';
+import {AppRegistry, requireNativeComponent} from 'react-native';
+
+const GridView: any = requireNativeComponent('PlaygroundGridView');
+const GridItemView: any = requireNativeComponent('PlaygroundGridItemView');
+
+function Bootstrap() {
+  return (
+    <GridView
+      style={{width: 200, height: 200}}
+      columns={['*', '*']}
+      rows={['*', '*']}>
+      <GridItemView gridRow={0} gridColumn={0} style={{backgroundColor: 'red'}} />
+      <GridItemView gridRow={0} gridColumn={1} style={{backgroundColor: 'green'}} />
+      <GridItemView gridRow={1} gridColumn={0} style={{backgroundColor: 'blue'}} />
+      <GridItemView gridRow={1} gridColumn={1} style={{backgroundColor: 'yellow'}} />
+    </GridView>
+  );
+}
+
+AppRegistry.registerComponent('Bootstrap', () => Bootstrap);

--- a/packages/playground/Samples/nativeLayout.tsx
+++ b/packages/playground/Samples/nativeLayout.tsx
@@ -4,7 +4,7 @@
  * @format
  */
 import React from 'react';
-import {AppRegistry, requireNativeComponent} from 'react-native';
+import {AppRegistry, View, Text, requireNativeComponent} from 'react-native';
 
 const GridView: any = requireNativeComponent('PlaygroundGridView');
 const GridItemView: any = requireNativeComponent('PlaygroundGridItemView');
@@ -15,10 +15,26 @@ function Bootstrap() {
       style={{width: 200, height: 200}}
       columns={['*', '*']}
       rows={['*', '*']}>
-      <GridItemView gridRow={0} gridColumn={0} style={{backgroundColor: 'red'}} />
-      <GridItemView gridRow={0} gridColumn={1} style={{backgroundColor: 'green'}} />
-      <GridItemView gridRow={1} gridColumn={0} style={{backgroundColor: 'blue'}} />
-      <GridItemView gridRow={1} gridColumn={1} style={{backgroundColor: 'yellow'}} />
+      <GridItemView gridRow={0} gridColumn={0}>
+        <View style={{backgroundColor: '#F25022', justifyContent: 'center', alignItems: 'center'}}>
+          <Text>1</Text>
+        </View>
+      </GridItemView>
+      <GridItemView gridRow={0} gridColumn={1}>
+        <View style={{backgroundColor: '#7FBA00', justifyContent: 'center', alignItems: 'center'}}>
+          <Text>2</Text>
+        </View>
+      </GridItemView>
+      <GridItemView gridRow={1} gridColumn={0}>
+        <View style={{backgroundColor: '#00A4EF', justifyContent: 'center', alignItems: 'center'}}>
+          <Text>3</Text>
+        </View>
+      </GridItemView>
+      <GridItemView gridRow={1} gridColumn={1}>
+        <View style={{backgroundColor: '#FFB900', justifyContent: 'center', alignItems: 'center'}}>
+          <Text>4</Text>
+        </View>
+      </GridItemView>
     </GridView>
   );
 }

--- a/packages/playground/Samples/nativeLayout.tsx
+++ b/packages/playground/Samples/nativeLayout.tsx
@@ -16,22 +16,42 @@ function Bootstrap() {
       columns={['*', '*']}
       rows={['*', '*']}>
       <GridItemView gridRow={0} gridColumn={0}>
-        <View style={{backgroundColor: '#F25022', justifyContent: 'center', alignItems: 'center'}}>
+        <View
+          style={{
+            backgroundColor: '#F25022',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
           <Text>1</Text>
         </View>
       </GridItemView>
       <GridItemView gridRow={0} gridColumn={1}>
-        <View style={{backgroundColor: '#7FBA00', justifyContent: 'center', alignItems: 'center'}}>
+        <View
+          style={{
+            backgroundColor: '#7FBA00',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
           <Text>2</Text>
         </View>
       </GridItemView>
       <GridItemView gridRow={1} gridColumn={0}>
-        <View style={{backgroundColor: '#00A4EF', justifyContent: 'center', alignItems: 'center'}}>
+        <View
+          style={{
+            backgroundColor: '#00A4EF',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
           <Text>3</Text>
         </View>
       </GridItemView>
       <GridItemView gridRow={1} gridColumn={1}>
-        <View style={{backgroundColor: '#FFB900', justifyContent: 'center', alignItems: 'center'}}>
+        <View
+          style={{
+            backgroundColor: '#FFB900',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}>
           <Text>4</Text>
         </View>
       </GridItemView>

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemView.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemView.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "GridItemView.h"
+#include "GridItemView.g.cpp"
+
+namespace winrt {
+using namespace Microsoft::ReactNative;
+using namespace Windows::Foundation;
+using namespace xaml;
+using namespace xaml::Controls;
+} // namespace winrt
+
+namespace winrt::PlaygroundNativeModules::implementation {
+
+winrt::Size GridItemView::ArrangeOverride(winrt::Size availableSize) {
+  const auto desiredSize = Super::ArrangeOverride(availableSize);
+  if (Children().Size() > 0) {
+    if (const auto child = Children().GetAt(0).try_as<xaml::FrameworkElement>()) {
+      const auto reactTag = React::XamlHelper::GetReactTag(child);
+      if (reactTag != -1) {
+        React::LayoutService::FromContext(m_reactContext)
+            .ApplyLayout(reactTag, desiredSize.Width, desiredSize.Height);
+      }
+    }
+  }
+  return desiredSize;
+}
+
+} // namespace winrt::PlaygroundNativeModules::implementation

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemView.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemView.cpp
@@ -20,8 +20,7 @@ winrt::Size GridItemView::ArrangeOverride(winrt::Size availableSize) {
     if (const auto child = Children().GetAt(0).try_as<xaml::FrameworkElement>()) {
       const auto reactTag = React::XamlHelper::GetReactTag(child);
       if (reactTag != -1) {
-        React::LayoutService::FromContext(m_reactContext)
-            .ApplyLayout(reactTag, desiredSize.Width, desiredSize.Height);
+        React::LayoutService::FromContext(m_reactContext).ApplyLayout(reactTag, desiredSize.Width, desiredSize.Height);
       }
     }
   }

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemView.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemView.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "GridItemView.g.h"
+#include "NativeModules.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::PlaygroundNativeModules::implementation {
+
+class GridItemView : public GridItemViewT<GridItemView> {
+ using Super = GridItemViewT<GridItemView>;
+ public:
+  GridItemView(Microsoft::ReactNative::IReactContext const &reactContext) : m_reactContext{reactContext} {}
+  virtual winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size availableSize);
+ private:
+  Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
+};
+} // namespace winrt::ReactNativePicker::implementation
+
+namespace winrt::PlaygroundNativeModules::factory_implementation {
+struct GridItemView : GridItemViewT<GridItemView, implementation::GridItemView> {};
+} // namespace winrt::PlaygroundNativeModules::factory_implementation

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemView.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemView.h
@@ -10,14 +10,16 @@
 namespace winrt::PlaygroundNativeModules::implementation {
 
 class GridItemView : public GridItemViewT<GridItemView> {
- using Super = GridItemViewT<GridItemView>;
+  using Super = GridItemViewT<GridItemView>;
+
  public:
   GridItemView(Microsoft::ReactNative::IReactContext const &reactContext) : m_reactContext{reactContext} {}
   virtual winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size availableSize);
+
  private:
   Microsoft::ReactNative::IReactContext m_reactContext{nullptr};
 };
-} // namespace winrt::ReactNativePicker::implementation
+} // namespace winrt::PlaygroundNativeModules::implementation
 
 namespace winrt::PlaygroundNativeModules::factory_implementation {
 struct GridItemView : GridItemViewT<GridItemView, implementation::GridItemView> {};

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemView.idl
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemView.idl
@@ -1,0 +1,9 @@
+#include <NamespaceRedirect.h>
+
+namespace PlaygroundNativeModules {
+
+[default_interface]
+runtimeclass GridItemView : XAML_NAMESPACE.Controls.Grid {
+  GridItemView(Microsoft.ReactNative.IReactContext context);
+};
+} // namespace PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "GridItemViewManager.h"
+#include "JSValueXaml.h"
+
+namespace winrt {
+  using namespace Windows::Foundation::Collections;
+} // namespace winrt
+
+namespace winrt::PlaygroundNativeModules {
+
+winrt::hstring GridItemViewManager::Name() noexcept {
+  return L"PlaygroundGridItemView";
+}
+
+xaml::FrameworkElement GridItemViewManager::CreateView() noexcept {
+  return xaml::Controls::Grid();
+}
+
+void GridItemViewManager::AddView(
+    xaml::FrameworkElement const &parent,
+    xaml::UIElement const &child,
+    int64_t index) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().InsertAt(static_cast<uint32_t>(index), child);
+  }
+}
+
+void GridItemViewManager::RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().Clear();
+  }
+}
+
+void GridItemViewManager::RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().RemoveAt(static_cast<uint32_t>(index));
+  }
+}
+
+void GridItemViewManager::ReplaceChild(
+    xaml::FrameworkElement const &parent,
+    xaml::UIElement const &oldChild,
+    xaml::UIElement const &newChild) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    uint32_t index;
+    if (grid.Children().IndexOf(oldChild, index)) {
+      grid.Children().RemoveAt(index);
+      grid.Children().InsertAt(index, newChild);
+    }
+  }
+}
+
+winrt::IMapView<winrt::hstring, React::ViewManagerPropertyType> GridItemViewManager::NativeProps() noexcept {
+  auto nativeProps = winrt::single_threaded_map<winrt::hstring, React::ViewManagerPropertyType>();
+  nativeProps.Insert(L"gridRow", React::ViewManagerPropertyType::Number);
+  nativeProps.Insert(L"gridColumn", React::ViewManagerPropertyType::Number);
+  return nativeProps.GetView();
+}
+
+void GridItemViewManager::UpdateProperties(
+    xaml::FrameworkElement const &view,
+    winrt::Microsoft::ReactNative::IJSValueReader const &propertyMapReader) noexcept {
+  React::JSValueObject propertyMap = React::JSValueObject::ReadFrom(propertyMapReader);
+  for (const auto &pair : propertyMap) {
+    const auto &propertyName = winrt::to_hstring(pair.first);
+    const auto &propertyValue = pair.second;
+
+    if (propertyName == L"gridRow") {
+      xaml::Controls::Grid::SetRow(view, propertyValue.AsInt32());
+    } else if (propertyName == L"gridColumn") {
+      xaml::Controls::Grid::SetColumn(view, propertyValue.AsInt32());
+    } else if (propertyName == L"backgroundColor") {
+      view.as<xaml::Controls::Grid>().Background(propertyValue.To<xaml::Media::Brush>());
+    }
+  }
+}
+
+} // namespace winrt::PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+#include "GridItemView.h"
 #include "GridItemViewManager.h"
+#include "JSValue.h"
 #include "JSValueXaml.h"
 
 namespace winrt {
@@ -16,7 +18,15 @@ winrt::hstring GridItemViewManager::Name() noexcept {
 }
 
 xaml::FrameworkElement GridItemViewManager::CreateView() noexcept {
-  return xaml::Controls::Grid();
+  return winrt::PlaygroundNativeModules::GridItemView(m_reactContext.Handle());
+}
+
+React::IReactContext GridItemViewManager::ReactContext() noexcept {
+  return m_reactContext.Handle();
+}
+
+void GridItemViewManager::ReactContext(React::IReactContext reactContext) noexcept {
+  m_reactContext = reactContext;
 }
 
 void GridItemViewManager::AddView(
@@ -24,7 +34,11 @@ void GridItemViewManager::AddView(
     xaml::UIElement const &child,
     int64_t index) noexcept {
   if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
-    grid.Children().InsertAt(static_cast<uint32_t>(index), child);
+    if (grid.Children().Size() > 0 || index != 0) {
+      m_reactContext.CallJSFunction(L"RCTLog", L"logToConsole", "warn", "GridItem only supports one child.");  
+    } else {
+      grid.Children().InsertAt(static_cast<uint32_t>(index), child);
+    }
   }
 }
 
@@ -36,7 +50,9 @@ void GridItemViewManager::RemoveAllChildren(xaml::FrameworkElement const &parent
 
 void GridItemViewManager::RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept {
   if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
-    grid.Children().RemoveAt(static_cast<uint32_t>(index));
+    if (index == 0) {
+      grid.Children().RemoveAt(static_cast<uint32_t>(index));
+    }
   }
 }
 

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.cpp
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include "GridItemView.h"
 #include "GridItemViewManager.h"
+#include "GridItemView.h"
 #include "JSValue.h"
 #include "JSValueXaml.h"
 
 namespace winrt {
-  using namespace Windows::Foundation::Collections;
+using namespace Windows::Foundation::Collections;
 } // namespace winrt
 
 namespace winrt::PlaygroundNativeModules {
@@ -35,7 +35,7 @@ void GridItemViewManager::AddView(
     int64_t index) noexcept {
   if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
     if (grid.Children().Size() > 0 || index != 0) {
-      m_reactContext.CallJSFunction(L"RCTLog", L"logToConsole", "warn", "GridItem only supports one child.");  
+      m_reactContext.CallJSFunction(L"RCTLog", L"logToConsole", "warn", "GridItem only supports one child.");
     } else {
       grid.Children().InsertAt(static_cast<uint32_t>(index), child);
     }

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "winrt/Microsoft.ReactNative.h"
+#include "NativeModules.h"
+
+namespace winrt::PlaygroundNativeModules {
+
+class GridItemViewManager : public winrt::implements<GridItemViewManager,
+                                                     React::IViewManager,
+                                                     React::IViewManagerWithChildren,
+                                                     React::IViewManagerWithNativeProperties,
+                                                     React::IViewManagerRequiresNativeLayout> {
+ public:
+  // IViewManager
+  winrt::hstring Name() noexcept;
+
+  xaml::FrameworkElement CreateView() noexcept;
+
+  // IViewManagerWithChildren
+  void AddView(
+      xaml::FrameworkElement const &parent,
+      xaml::UIElement const &child,
+      int64_t index) noexcept;
+  void RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept;
+  void RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept;
+  void ReplaceChild(
+      xaml::FrameworkElement const &parent,
+      xaml::UIElement const &oldChild,
+      xaml::UIElement const &newChild) noexcept;
+
+  // IViewManagerWithNativeProperties
+  winrt::Windows::Foundation::Collections::
+      IMapView<winrt::hstring, React::ViewManagerPropertyType>
+      NativeProps() noexcept;
+
+  void UpdateProperties(
+      xaml::FrameworkElement const &view,
+      React::IJSValueReader const &propertyMapReader) noexcept;
+
+  // IViewManagerRequiresNativeLayout
+  bool RequiresNativeLayout() const noexcept {
+    return true;
+  }
+};
+
+} // namespace facebook::archon

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
@@ -9,6 +9,7 @@ namespace winrt::PlaygroundNativeModules {
 
 class GridItemViewManager : public winrt::implements<GridItemViewManager,
                                                      React::IViewManager,
+                                                     React::IViewManagerWithReactContext,
                                                      React::IViewManagerWithChildren,
                                                      React::IViewManagerWithNativeProperties,
                                                      React::IViewManagerRequiresNativeLayout> {
@@ -17,6 +18,10 @@ class GridItemViewManager : public winrt::implements<GridItemViewManager,
   winrt::hstring Name() noexcept;
 
   xaml::FrameworkElement CreateView() noexcept;
+
+  // IViewManagerWithReactContext
+  React::IReactContext ReactContext() noexcept;
+  void ReactContext(React::IReactContext reactContext) noexcept;
 
   // IViewManagerWithChildren
   void AddView(
@@ -43,6 +48,9 @@ class GridItemViewManager : public winrt::implements<GridItemViewManager,
   bool RequiresNativeLayout() const noexcept {
     return true;
   }
+
+ private:
+  winrt::Microsoft::ReactNative::ReactContext m_reactContext{nullptr};
 };
 
 } // namespace facebook::archon

--- a/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridItemViewManager.h
@@ -2,17 +2,18 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "winrt/Microsoft.ReactNative.h"
 #include "NativeModules.h"
+#include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::PlaygroundNativeModules {
 
-class GridItemViewManager : public winrt::implements<GridItemViewManager,
-                                                     React::IViewManager,
-                                                     React::IViewManagerWithReactContext,
-                                                     React::IViewManagerWithChildren,
-                                                     React::IViewManagerWithNativeProperties,
-                                                     React::IViewManagerRequiresNativeLayout> {
+class GridItemViewManager : public winrt::implements<
+                                GridItemViewManager,
+                                React::IViewManager,
+                                React::IViewManagerWithReactContext,
+                                React::IViewManagerWithChildren,
+                                React::IViewManagerWithNativeProperties,
+                                React::IViewManagerRequiresNativeLayout> {
  public:
   // IViewManager
   winrt::hstring Name() noexcept;
@@ -24,10 +25,7 @@ class GridItemViewManager : public winrt::implements<GridItemViewManager,
   void ReactContext(React::IReactContext reactContext) noexcept;
 
   // IViewManagerWithChildren
-  void AddView(
-      xaml::FrameworkElement const &parent,
-      xaml::UIElement const &child,
-      int64_t index) noexcept;
+  void AddView(xaml::FrameworkElement const &parent, xaml::UIElement const &child, int64_t index) noexcept;
   void RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept;
   void RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept;
   void ReplaceChild(
@@ -36,13 +34,10 @@ class GridItemViewManager : public winrt::implements<GridItemViewManager,
       xaml::UIElement const &newChild) noexcept;
 
   // IViewManagerWithNativeProperties
-  winrt::Windows::Foundation::Collections::
-      IMapView<winrt::hstring, React::ViewManagerPropertyType>
-      NativeProps() noexcept;
+  winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, React::ViewManagerPropertyType>
+  NativeProps() noexcept;
 
-  void UpdateProperties(
-      xaml::FrameworkElement const &view,
-      React::IJSValueReader const &propertyMapReader) noexcept;
+  void UpdateProperties(xaml::FrameworkElement const &view, React::IJSValueReader const &propertyMapReader) noexcept;
 
   // IViewManagerRequiresNativeLayout
   bool RequiresNativeLayout() const noexcept {
@@ -53,4 +48,4 @@ class GridItemViewManager : public winrt::implements<GridItemViewManager,
   winrt::Microsoft::ReactNative::ReactContext m_reactContext{nullptr};
 };
 
-} // namespace facebook::archon
+} // namespace winrt::PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/GridViewManager.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridViewManager.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "GridViewManager.h"
+
+namespace winrt::PlaygroundNativeModules {
+
+winrt::hstring GridViewManager::Name() noexcept {
+  return L"PlaygroundGridView";
+}
+
+xaml::FrameworkElement GridViewManager::CreateView() noexcept {
+  return xaml::Controls::Grid();
+}
+
+void GridViewManager::AddView(
+    xaml::FrameworkElement const &parent,
+    xaml::UIElement const &child,
+    int64_t index) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().InsertAt(static_cast<uint32_t>(index), child);
+  }
+}
+
+void GridViewManager::RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().Clear();
+  }
+}
+
+void GridViewManager::RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    grid.Children().RemoveAt(static_cast<uint32_t>(index));
+  }
+}
+
+void GridViewManager::ReplaceChild(
+    xaml::FrameworkElement const &parent,
+    xaml::UIElement const &oldChild,
+    xaml::UIElement const &newChild) noexcept {
+  if (auto const &grid = parent.try_as<xaml::Controls::Grid>()) {
+    uint32_t index;
+    if (grid.Children().IndexOf(oldChild, index)) {
+      grid.Children().RemoveAt(index);
+      grid.Children().InsertAt(index, newChild);
+    }
+  }
+}
+
+winrt::IMapView<winrt::hstring, React::ViewManagerPropertyType>
+GridViewManager::NativeProps() noexcept {
+  auto nativeProps = winrt::single_threaded_map<winrt::hstring, React::ViewManagerPropertyType>();
+  nativeProps.Insert(L"rows", React::ViewManagerPropertyType::Array);
+  nativeProps.Insert(L"columns", React::ViewManagerPropertyType::Array);
+  return nativeProps.GetView();
+}
+
+xaml::GridLength GetGridLength(const winrt::Microsoft::ReactNative::JSValue &v) {
+  if (v.Type() == React::JSValueType::Double || v.Type() == React::JSValueType::Int64) {
+    return xaml::GridLengthHelper::FromValueAndType(v.AsDouble(), xaml::GridUnitType::Pixel);
+  } else if (v.Type() == React::JSValueType::String) {
+    auto str = v.AsString();
+    double units = 1;
+    xaml::GridUnitType unitType = xaml::GridUnitType::Pixel;
+    if (str.back() == '*') {
+      unitType = xaml::GridUnitType::Star;
+      str.pop_back();
+      if (str.length() > 0) {
+        units = std::stod(str);
+      }
+    } else if (str == "auto") {
+      unitType = xaml::GridUnitType::Auto;
+    } else {
+      units = std::stod(str);
+    }
+    return xaml::GridLengthHelper::FromValueAndType(units, unitType);
+  }
+  return xaml::GridLengthHelper::FromValueAndType(1, xaml::GridUnitType::Auto);
+}
+
+void GridViewManager::UpdateProperties(
+    xaml::FrameworkElement const &view,
+    winrt::Microsoft::ReactNative::IJSValueReader const &propertyMapReader) noexcept {
+  React::JSValueObject propertyMap = React::JSValueObject::ReadFrom(propertyMapReader);
+  for (const auto &pair : propertyMap) {
+    const auto &propertyName = winrt::to_hstring(pair.first);
+    const auto &propertyValue = pair.second;
+
+    if (propertyName == L"rows") {
+      const auto grid = view.as<xaml::Controls::Grid>();
+      for (const auto &row : propertyValue.AsArray()) {
+        xaml::Controls::RowDefinition rowDefinition{};
+        rowDefinition.Height(GetGridLength(row));
+        grid.RowDefinitions().Append(rowDefinition);
+      }
+    } else if (propertyName == L"columns") {
+      const auto grid = view.as<xaml::Controls::Grid>();
+      for (const auto &column : propertyValue.AsArray()) {
+        xaml::Controls::ColumnDefinition columnDefinition{};
+        columnDefinition.Width(GetGridLength(column));
+        grid.ColumnDefinitions().Append(columnDefinition);
+      }
+    }
+  }
+}
+
+
+} // namespace facebook::archon

--- a/packages/playground/windows/PlaygroundNativeModules/GridViewManager.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/GridViewManager.cpp
@@ -48,8 +48,7 @@ void GridViewManager::ReplaceChild(
   }
 }
 
-winrt::IMapView<winrt::hstring, React::ViewManagerPropertyType>
-GridViewManager::NativeProps() noexcept {
+winrt::IMapView<winrt::hstring, React::ViewManagerPropertyType> GridViewManager::NativeProps() noexcept {
   auto nativeProps = winrt::single_threaded_map<winrt::hstring, React::ViewManagerPropertyType>();
   nativeProps.Insert(L"rows", React::ViewManagerPropertyType::Array);
   nativeProps.Insert(L"columns", React::ViewManagerPropertyType::Array);
@@ -105,5 +104,4 @@ void GridViewManager::UpdateProperties(
   }
 }
 
-
-} // namespace facebook::archon
+} // namespace winrt::PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/GridViewManager.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridViewManager.h
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "winrt/Microsoft.ReactNative.h"
+#include "NativeModules.h"
+
+namespace winrt::PlaygroundNativeModules {
+
+class GridViewManager : public winrt::implements<GridViewManager,
+                                                 React::IViewManager,
+                                                 React::IViewManagerWithChildren,
+                                                 React::IViewManagerWithNativeProperties,
+                                                 React::IViewManagerRequiresNativeLayout> {
+ public:
+  // IViewManager
+  winrt::hstring Name() noexcept;
+
+  xaml::FrameworkElement CreateView() noexcept;
+
+  // IViewManagerWithChildren
+  void AddView(
+      xaml::FrameworkElement const &parent, xaml::UIElement const &child,
+      int64_t index) noexcept;
+  void RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept;
+  void RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept;
+  void ReplaceChild(
+      xaml::FrameworkElement const &parent,
+      xaml::UIElement const &oldChild,
+      xaml::UIElement const &newChild) noexcept;
+
+  // IViewManagerWithNativeProperties
+  winrt::Windows::Foundation::Collections::
+      IMapView<winrt::hstring, React::ViewManagerPropertyType>
+      NativeProps() noexcept;
+
+  void UpdateProperties(
+      xaml::FrameworkElement const &view,
+      React::IJSValueReader const &propertyMapReader) noexcept;
+
+  // IViewManagerRequiresNativeLayout
+  bool RequiresNativeLayout() const noexcept {
+    return true;
+  }
+};
+
+} // namespace winrt::PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/GridViewManager.h
+++ b/packages/playground/windows/PlaygroundNativeModules/GridViewManager.h
@@ -2,16 +2,17 @@
 // Licensed under the MIT License.
 
 #pragma once
-#include "winrt/Microsoft.ReactNative.h"
 #include "NativeModules.h"
+#include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::PlaygroundNativeModules {
 
-class GridViewManager : public winrt::implements<GridViewManager,
-                                                 React::IViewManager,
-                                                 React::IViewManagerWithChildren,
-                                                 React::IViewManagerWithNativeProperties,
-                                                 React::IViewManagerRequiresNativeLayout> {
+class GridViewManager : public winrt::implements<
+                            GridViewManager,
+                            React::IViewManager,
+                            React::IViewManagerWithChildren,
+                            React::IViewManagerWithNativeProperties,
+                            React::IViewManagerRequiresNativeLayout> {
  public:
   // IViewManager
   winrt::hstring Name() noexcept;
@@ -19,9 +20,7 @@ class GridViewManager : public winrt::implements<GridViewManager,
   xaml::FrameworkElement CreateView() noexcept;
 
   // IViewManagerWithChildren
-  void AddView(
-      xaml::FrameworkElement const &parent, xaml::UIElement const &child,
-      int64_t index) noexcept;
+  void AddView(xaml::FrameworkElement const &parent, xaml::UIElement const &child, int64_t index) noexcept;
   void RemoveAllChildren(xaml::FrameworkElement const &parent) noexcept;
   void RemoveChildAt(xaml::FrameworkElement const &parent, int64_t index) noexcept;
   void ReplaceChild(
@@ -30,13 +29,10 @@ class GridViewManager : public winrt::implements<GridViewManager,
       xaml::UIElement const &newChild) noexcept;
 
   // IViewManagerWithNativeProperties
-  winrt::Windows::Foundation::Collections::
-      IMapView<winrt::hstring, React::ViewManagerPropertyType>
-      NativeProps() noexcept;
+  winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, React::ViewManagerPropertyType>
+  NativeProps() noexcept;
 
-  void UpdateProperties(
-      xaml::FrameworkElement const &view,
-      React::IJSValueReader const &propertyMapReader) noexcept;
+  void UpdateProperties(xaml::FrameworkElement const &view, React::IJSValueReader const &propertyMapReader) noexcept;
 
   // IViewManagerRequiresNativeLayout
   bool RequiresNativeLayout() const noexcept {

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.def
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.def
@@ -1,0 +1,3 @@
+﻿EXPORTS
+DllCanUnloadNow = WINRT_CanUnloadNow                    PRIVATE
+DllGetActivationFactory = WINRT_GetActivationFactory    PRIVATE

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
@@ -111,6 +111,9 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="GridItemView.h">
+      <DependentUpon>GridItemView.idl</DependentUpon>
+    </ClInclude>
     <ClInclude Include="GridItemViewManager.h" />
     <ClInclude Include="GridViewManager.h" />
     <ClInclude Include="ReactPackageProvider.h">
@@ -119,6 +122,9 @@
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="GridItemView.cpp">
+      <DependentUpon>GridItemView.idl</DependentUpon>
+    </ClCompile>
     <ClCompile Include="GridItemViewManager.cpp" />
     <ClCompile Include="GridViewManager.cpp" />
     <ClCompile Include="pch.cpp">
@@ -130,6 +136,7 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <Midl Include="GridItemView.idl" />
     <Midl Include="ReactPackageProvider.idl" />
   </ItemGroup>
   <ItemGroup>

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)\ExperimentalFeatures.props" Condition="Exists('$(SolutionDir)\ExperimentalFeatures.props')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <CppWinRTOptimized>true</CppWinRTOptimized>
+    <CppWinRTRootNamespaceAutoMerge>true</CppWinRTRootNamespaceAutoMerge>
+    <MinimalCoreWin>true</MinimalCoreWin>
+    <ProjectGuid>{FBC281F9-E7FA-4D3F-9A15-F7507A803007}</ProjectGuid>
+    <ProjectName>PlaygroundNativeModules</ProjectName>
+    <RootNamespace>PlaygroundNativeModules</RootNamespace>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
+    <AppContainerApplication>true</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>10.0.16299.0</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="ReactNativeWindowsProps">
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(SolutionDir), 'node_modules\react-native-windows\package.json'))\node_modules\react-native-windows\</ReactNativeWindowsDir>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM">
+      <Configuration>Release</Configuration>
+      <Platform>ARM</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="PropertySheet.props" />
+  </ImportGroup>
+  <ImportGroup Label="ReactNativeWindowsPropertySheets">
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\external\Microsoft.ReactNative.Uwp.CppLib.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" />
+    <Import Project="$(SolutionDir)\packages\$(WinUIPackageProps)" Condition="'$(WinUIPackageProps)'!='' And Exists('$(SolutionDir)\packages\$(WinUIPackageProps)')" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
+      <WarningLevel>Level4</WarningLevel>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
+      <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateWindowsMetadata>true</GenerateWindowsMetadata>
+      <ModuleDefinitionFile>PlaygroundNativeModules.def</ModuleDefinitionFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="GridItemViewManager.h" />
+    <ClInclude Include="GridViewManager.h" />
+    <ClInclude Include="ReactPackageProvider.h">
+      <DependentUpon>ReactPackageProvider.idl</DependentUpon>
+    </ClInclude>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="GridItemViewManager.cpp" />
+    <ClCompile Include="GridViewManager.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="ReactPackageProvider.cpp">
+      <DependentUpon>ReactPackageProvider.idl</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Midl Include="ReactPackageProvider.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="PlaygroundNativeModules.def" />
+    <None Include="PropertySheet.props" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ReactNativeWindowsTargets">
+    <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references targets in your node_modules\react-native-windows folder that are missing. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.props'))" />
+    <Error Condition="!Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppLib.targets'))" />
+  </Target>
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />
+  </Target>
+</Project>

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
@@ -2,6 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="GridItemView.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -9,12 +10,14 @@
     <ClCompile Include="ReactPackageProvider.cpp" />
     <ClCompile Include="GridItemViewManager.cpp" />
     <ClCompile Include="GridViewManager.cpp" />
+    <ClCompile Include="GridItemView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
     <ClInclude Include="ReactPackageProvider.h" />
     <ClInclude Include="GridItemViewManager.h" />
     <ClInclude Include="GridViewManager.h" />
+    <ClInclude Include="GridItemView.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="PropertySheet.props" />

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Midl Include="ReactPackageProvider.idl" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
+    <ClCompile Include="ReactPackageProvider.cpp" />
+    <ClCompile Include="GridItemViewManager.cpp" />
+    <ClCompile Include="GridViewManager.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="ReactPackageProvider.h" />
+    <ClInclude Include="GridItemViewManager.h" />
+    <ClInclude Include="GridViewManager.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="PropertySheet.props" />
+    <None Include="packages.config" />
+    <None Include="PlaygroundNativeModules.def" />
+  </ItemGroup>
+</Project>

--- a/packages/playground/windows/PlaygroundNativeModules/PropertySheet.props
+++ b/packages/playground/windows/PlaygroundNativeModules/PropertySheet.props
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <!--
+    To customize common C++/WinRT project properties: 
+    * right-click the project node
+    * expand the Common Properties item
+    * select the C++/WinRT property page
+
+    For more advanced scenarios, and complete documentation, please see:
+    https://github.com/Microsoft/xlang/tree/master/src/package/cppwinrt/nuget 
+    -->
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.cpp
@@ -1,0 +1,18 @@
+#include "pch.h"
+#include "ReactPackageProvider.h"
+#if __has_include("ReactPackageProvider.g.cpp")
+#include "ReactPackageProvider.g.cpp"
+#endif
+#include "GridViewManager.h"
+#include "GridItemViewManager.h"
+
+using namespace winrt::Microsoft::ReactNative;
+
+namespace winrt::PlaygroundNativeModules::implementation {
+
+void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
+  packageBuilder.AddViewManager(L"GridViewManager", []() { return winrt::make<GridViewManager>(); });
+  packageBuilder.AddViewManager(L"GridItemViewManager", []() { return winrt::make<GridItemViewManager>(); });
+}
+
+} // namespace winrt::PlaygroundNativeModules::implementation

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.cpp
@@ -3,8 +3,8 @@
 #if __has_include("ReactPackageProvider.g.cpp")
 #include "ReactPackageProvider.g.cpp"
 #endif
-#include "GridViewManager.h"
 #include "GridItemViewManager.h"
+#include "GridViewManager.h"
 
 using namespace winrt::Microsoft::ReactNative;
 

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.h
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "ReactPackageProvider.g.h"
+
+using namespace winrt::Microsoft::ReactNative;
+
+namespace winrt::PlaygroundNativeModules::implementation
+{
+    struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider>
+    {
+        ReactPackageProvider() = default;
+
+        void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept;
+    };
+} // namespace winrt::PlaygroundNativeModules::implementation
+
+namespace winrt::PlaygroundNativeModules::factory_implementation {
+
+struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider, implementation::ReactPackageProvider> {};
+
+} // namespace winrt::PlaygroundNativeModules::factory_implementation

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.h
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.h
@@ -3,14 +3,12 @@
 
 using namespace winrt::Microsoft::ReactNative;
 
-namespace winrt::PlaygroundNativeModules::implementation
-{
-    struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider>
-    {
-        ReactPackageProvider() = default;
+namespace winrt::PlaygroundNativeModules::implementation {
+struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider> {
+  ReactPackageProvider() = default;
 
-        void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept;
-    };
+  void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept;
+};
 } // namespace winrt::PlaygroundNativeModules::implementation
 
 namespace winrt::PlaygroundNativeModules::factory_implementation {

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.idl
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.idl
@@ -1,0 +1,9 @@
+namespace PlaygroundNativeModules
+{
+    [webhosthidden]
+    [default_interface]
+    runtimeclass ReactPackageProvider : Microsoft.ReactNative.IReactPackageProvider
+    {
+        ReactPackageProvider();
+    };
+} // namespace PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/packages.config
+++ b/packages/playground/windows/PlaygroundNativeModules/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
+  <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
+</packages>

--- a/packages/playground/windows/PlaygroundNativeModules/packages.config
+++ b/packages/playground/windows/PlaygroundNativeModules/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native" />
   <package id="Microsoft.UI.Xaml" version="2.3.191129002" targetFramework="native" />
 </packages>

--- a/packages/playground/windows/PlaygroundNativeModules/pch.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/pch.cpp
@@ -1,0 +1,1 @@
+﻿#include "pch.h"

--- a/packages/playground/windows/PlaygroundNativeModules/pch.h
+++ b/packages/playground/windows/PlaygroundNativeModules/pch.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#define NOMINMAX
+
+#include <hstring.h>
+#include <restrictederrorinfo.h>
+#include <unknwn.h>
+#include <windows.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Windows.UI.Xaml.Controls.h>
+#include <winrt/Windows.UI.Xaml.Data.h>
+#include <winrt/Windows.UI.Xaml.Interop.h>
+#include <winrt/Windows.UI.Xaml.Markup.h>
+#include <winrt/Windows.UI.Xaml.Navigation.h>
+#include <winrt/Windows.UI.Xaml.h>
+
+#include <winrt/Microsoft.ReactNative.h>
+
+#include <winrt/Microsoft.UI.Xaml.Automation.Peers.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.Primitives.h>
+#include <winrt/Microsoft.UI.Xaml.Controls.h>
+#include <winrt/Microsoft.UI.Xaml.Media.h>
+#include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
+using namespace winrt::Windows::Foundation;

--- a/packages/playground/windows/playground-win32.sln
+++ b/packages/playground/windows/playground-win32.sln
@@ -30,6 +30,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\..\vnext\Mso\M
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativePicker", "..\..\..\node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj", "{BEDCC600-4541-41F2-AA46-9E058202B6AD}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlaygroundNativeModules", "PlaygroundNativeModules\PlaygroundNativeModules.vcxproj", "{FBC281F9-E7FA-4D3F-9A15-F7507A803007}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\vnext\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
@@ -130,6 +132,20 @@ Global
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.ActiveCfg = Release|Win32
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.Build.0 = Release|Win32
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.Deploy.0 = Release|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM.ActiveCfg = Debug|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM.Build.0 = Debug|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.ActiveCfg = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.Build.0 = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.Deploy.0 = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x86.ActiveCfg = Debug|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x86.Build.0 = Debug|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM.ActiveCfg = Release|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM.Build.0 = Release|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.ActiveCfg = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.Build.0 = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.Deploy.0 = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x86.ActiveCfg = Release|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.cpp
+++ b/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.cpp
@@ -3,6 +3,8 @@
 #include "pch.h"
 #include "AutolinkedNativeModules.g.h"
 
+#include <winrt/PlaygroundNativeModules.h>
+
 // Includes from @react-native-picker/picker
 #include <winrt/ReactNativePicker.h>
 
@@ -10,9 +12,10 @@ namespace winrt::Microsoft::ReactNative
 {
 
 void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
-{ 
+{
     // IReactPackageProviders from @react-native-picker/picker
     packageProviders.Append(winrt::ReactNativePicker::ReactPackageProvider());
+    packageProviders.Append(winrt::PlaygroundNativeModules::ReactPackageProvider());
 }
 
 }

--- a/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.targets
+++ b/packages/playground/windows/playground-win32/AutolinkedNativeModules.g.targets
@@ -6,5 +6,8 @@
     <ProjectReference Include="$(ProjectDir)..\..\..\..\node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj">
       <Project>{bedcc600-4541-41f2-aa46-9e058202b6ad}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(ProjectDir)..\PlaygroundNativeModules\PlaygroundNativeModules.vcxproj">
+      <Project>{fbc281f9-e7fa-4d3f-9a15-f7507a803007}</Project>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -227,7 +227,8 @@ struct WindowData {
                                                         LR"(Samples\mouse)",        LR"(Samples\scrollViewSnapSample)",
                                                         LR"(Samples\simple)",       LR"(Samples\text)",
                                                         LR"(Samples\textinput)",    LR"(Samples\ticTacToe)",
-                                                        LR"(Samples\view)",         LR"(Samples\debugTest01)"};
+                                                        LR"(Samples\view)",         LR"(Samples\debugTest01)",
+                                                        LR"(Samples\nativeLayout)"};
 
   static INT_PTR CALLBACK Bundle(HWND hwnd, UINT message, WPARAM wparam, LPARAM /*lparam*/) noexcept {
     switch (message) {

--- a/packages/playground/windows/playground.sln
+++ b/packages/playground/windows/playground.sln
@@ -33,6 +33,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mso", "..\..\..\vnext\Mso\M
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ReactNativePicker", "..\..\..\node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj", "{BEDCC600-4541-41F2-AA46-9E058202B6AD}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PlaygroundNativeModules", "PlaygroundNativeModules\PlaygroundNativeModules.vcxproj", "{FBC281F9-E7FA-4D3F-9A15-F7507A803007}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\vnext\Shared\Shared.vcxitems*{2049dbe9-8d13-42c9-ae4b-413ae38fffd0}*SharedItemsImports = 9
@@ -165,6 +167,28 @@ Global
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.ActiveCfg = Release|Win32
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.Build.0 = Release|Win32
 		{BEDCC600-4541-41F2-AA46-9E058202B6AD}.Release|x86.Deploy.0 = Release|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM.ActiveCfg = Debug|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM.Build.0 = Debug|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM64.Build.0 = Debug|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.ActiveCfg = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.Build.0 = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x64.Deploy.0 = Debug|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x86.ActiveCfg = Debug|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x86.Build.0 = Debug|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Debug|x86.Deploy.0 = Debug|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM.ActiveCfg = Release|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM.Build.0 = Release|ARM
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM64.ActiveCfg = Release|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM64.Build.0 = Release|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|ARM64.Deploy.0 = Release|ARM64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.ActiveCfg = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.Build.0 = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x64.Deploy.0 = Release|x64
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x86.ActiveCfg = Release|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x86.Build.0 = Release|Win32
+		{FBC281F9-E7FA-4D3F-9A15-F7507A803007}.Release|x86.Deploy.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/playground/windows/playground/AutolinkedNativeModules.g.cpp
+++ b/packages/playground/windows/playground/AutolinkedNativeModules.g.cpp
@@ -3,6 +3,8 @@
 #include "pch.h"
 #include "AutolinkedNativeModules.g.h"
 
+#include <winrt/PlaygroundNativeModules.h>
+
 // Includes from @react-native-picker/picker
 #include <winrt/ReactNativePicker.h>
 
@@ -10,9 +12,10 @@ namespace winrt::Microsoft::ReactNative
 {
 
 void RegisterAutolinkedNativeModulePackages(winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::IReactPackageProvider> const& packageProviders)
-{ 
+{
     // IReactPackageProviders from @react-native-picker/picker
     packageProviders.Append(winrt::ReactNativePicker::ReactPackageProvider());
+    packageProviders.Append(winrt::PlaygroundNativeModules::ReactPackageProvider());
 }
 
 }

--- a/packages/playground/windows/playground/AutolinkedNativeModules.g.targets
+++ b/packages/playground/windows/playground/AutolinkedNativeModules.g.targets
@@ -6,5 +6,8 @@
     <ProjectReference Include="$(ProjectDir)..\..\..\..\node_modules\@react-native-picker\picker\windows\ReactNativePicker\ReactNativePicker.vcxproj">
       <Project>{bedcc600-4541-41f2-aa46-9e058202b6ad}</Project>
     </ProjectReference>
+    <ProjectReference Include="$(ProjectDir)..\PlaygroundNativeModules\PlaygroundNativeModules.vcxproj">
+      <Project>{fbc281f9-e7fa-4d3f-9a15-f7507a803007}</Project>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/packages/playground/windows/playground/MainPage.xaml
+++ b/packages/playground/windows/playground/MainPage.xaml
@@ -90,6 +90,7 @@
                     <ComboBoxItem Content="Samples\ticTacToe" />
                     <ComboBoxItem Content="Samples\view" />
                     <ComboBoxItem Content="Samples\debugTest01" />
+                    <ComboBoxItem Content="Samples\nativeLayout" />
                 </ComboBox.Items>
             </ComboBox>
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
The GitHub repo Playground projects are missing examples that exercise 3rd party APIs. While there are examples that use 3rd party extensions from NPM, there are some 3rd party APIs that are not used in ecosystem packages (yet).

This native modules project gives us a place to prototype custom view managers and native modules.

### What
The PlaygroundNativeModules project only currently includes a single custom view manager that exercises the `IViewManagerRequiresNativeLayout` functionality.

## Screenshots

<img width="299" alt="image" src="https://user-images.githubusercontent.com/1106239/201180415-dd76db18-ddba-4c31-bd51-4d4b10e0e0d2.png">




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10838)