### PR TITLE
Revert rollback of "Simplify root node lookups"

### DIFF
--- a/change/react-native-windows-3cc0e9ad-707a-4364-90b8-dc391040fade.json
+++ b/change/react-native-windows-3cc0e9ad-707a-4364-90b8-dc391040fade.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Simplify root node lookups",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/INativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/INativeUIManager.h
@@ -29,7 +29,6 @@ struct INativeUIManagerHost {
   virtual std::unordered_set<int64_t> &GetAllRootTags() = 0;
   virtual ShadowNode &GetShadowNodeForTag(int64_t tag) = 0;
   virtual ShadowNode *FindShadowNodeForTag(int64_t tag) = 0;
-  virtual ShadowNode *FindParentRootShadowNode(int64_t tag) = 0;
 };
 
 struct INativeUIManager {

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -1155,8 +1155,8 @@ void NativeUIManager::blur(int64_t reactTag) {
 // m_tagsToXamlReactControl to get the IXamlReactControl
 winrt::weak_ref<winrt::Microsoft::ReactNative::ReactRootView> NativeUIManager::GetParentXamlReactControl(
     int64_t tag) const {
-  if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindParentRootShadowNode(tag))) {
-    auto it = m_tagsToXamlReactControl.find(shadowNode->m_tag);
+  if (auto shadowNode = m_host->FindShadowNodeForTag(tag)) {
+    auto it = m_tagsToXamlReactControl.find(shadowNode->m_rootTag);
     if (it != m_tagsToXamlReactControl.end()) {
       return it->second;
     }

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -205,20 +205,7 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
       std::function<void(double left, double top, double width, double height, double pageX, double pageY)>
           &&callback) noexcept {
     if (auto node = m_nodeRegistry.findNode(reactTag)) {
-      int64_t rootTag = reactTag;
-      while (true) {
-        if (auto currNode = m_nodeRegistry.findNode(rootTag)) {
-          if (currNode->m_parent == -1) {
-            break;
-          }
-          rootTag = currNode->m_parent;
-        } else {
-          callback(0, 0, 0, 0, 0, 0);
-          return;
-        }
-      }
-      auto &rootNode = m_nodeRegistry.getNode(rootTag);
-
+      auto &rootNode = m_nodeRegistry.getNode(node->m_rootTag);
       m_nativeUIManager->measure(*node, rootNode, std::move(callback));
     }
   }
@@ -382,10 +369,6 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
 
   ShadowNode *FindShadowNodeForTag(int64_t tag) {
     return m_nodeRegistry.findNode(tag);
-  }
-
-  ShadowNode *FindParentRootShadowNode(int64_t tag) {
-    return m_nodeRegistry.getParentRootShadowNode(tag);
   }
 
   ShadowNode &GetShadowNodeForTag(int64_t tag) {

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.cpp
@@ -55,18 +55,6 @@ std::unordered_set<int64_t> &ShadowNodeRegistry::getAllRoots() {
   return m_roots;
 }
 
-// iterate its parent to get the root shadow node
-ShadowNode *ShadowNodeRegistry::getParentRootShadowNode(int64_t nodeTag) {
-  auto node = findNode(nodeTag);
-  while (node) {
-    if (m_roots.find(node->m_tag) != m_roots.end()) {
-      return node;
-    }
-    node = findNode(node->m_parent);
-  }
-  return nullptr;
-}
-
 void ShadowNodeRegistry::ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept {
   for (auto &kvp : m_allNodes) {
     fnDo(kvp.first, kvp.second);

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeRegistry.h
@@ -30,8 +30,6 @@ struct ShadowNodeRegistry {
 
   std::unordered_set<int64_t> &getAllRoots();
 
-  ShadowNode *getParentRootShadowNode(int64_t nodeTag);
-
   void ForAllNodes(const Mso::FunctorRef<void(int64_t, shadow_ptr const &) noexcept> &fnDo) noexcept;
 
  private:

--- a/vnext/Microsoft.ReactNative/XamlUIService.cpp
+++ b/vnext/Microsoft.ReactNative/XamlUIService.cpp
@@ -54,13 +54,13 @@ winrt::Microsoft::ReactNative::ReactRootView XamlUIService::GetReactRootView(
     xaml::FrameworkElement const &view) noexcept {
   if (auto uiManager = ::Microsoft::ReactNative::GetNativeUIManager(*m_context).lock()) {
     const auto reactTag = ::Microsoft::ReactNative::GetTag(view);
-    auto shadowNode = uiManager->getHost()->FindParentRootShadowNode(reactTag);
-    if (!shadowNode)
-      return nullptr;
-
-    return static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(shadowNode)
-        ->GetView()
-        .as<winrt::Microsoft::ReactNative::ReactRootView>();
+    if (auto shadowNode = static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(
+            uiManager->getHost()->FindShadowNodeForTag(reactTag))) {
+      if (auto rootNode = static_cast<::Microsoft::ReactNative::ShadowNodeBase *>(
+              uiManager->getHost()->FindShadowNodeForTag(shadowNode->m_rootTag))) {
+        return rootNode->GetView().as<winrt::Microsoft::ReactNative::ReactRootView>();
+      }
+    }
   }
   return nullptr;
 }


### PR DESCRIPTION
In #10797, #10689 was rolled back due to a build break that emerged due to a conflicting new API surface on XamlUIService. This brings back the original code in #10689 and fixes the build break.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10840)