### PR TITLE
CG 11/7/22: Update `@xmldom/xmldom`

### DIFF
--- a/change/@react-native-windows-cli-30efcfa1-a7c7-45e7-b9c2-186edfadad49.json
+++ b/change/@react-native-windows-cli-30efcfa1-a7c7-45e7-b9c2-186edfadad49.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CG 11/7/22: Update `@xmldom/xmldom`",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-9dcd5adb-bcbf-4696-b9ab-aac6ed63515d.json
+++ b/change/@react-native-windows-telemetry-9dcd5adb-bcbf-4696-b9ab-aac6ed63515d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "CG 11/7/22: Update `@xmldom/xmldom`",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -23,7 +23,7 @@
     "@react-native-windows/telemetry": "^0.0.0-canary.49",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "@xmldom/xmldom": "^0.7.5",
+    "@xmldom/xmldom": "^0.7.7",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -21,7 +21,7 @@
     "@react-native-windows/fs": "^0.0.0-canary.7",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
-    "@xmldom/xmldom": "^0.7.5",
+    "@xmldom/xmldom": "^0.7.7",
     "applicationinsights": "^2.3.1",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,10 +2896,10 @@
   dependencies:
     "@wdio/logger" "6.10.10"
 
-"@xmldom/xmldom@^0.7.5":
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.8.tgz#a8d0a0067c9554c187b0d04e86ad1845053c0e06"
-  integrity sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==
+"@xmldom/xmldom@^0.7.7":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
+  integrity sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==
 
 "@xmldom/xmldom@^0.8.0":
   version "0.8.2"


### PR DESCRIPTION
This PR updates the following dependencies:

* `@xmldom/xmldom` to `^0.7.7` to resolve CVE-2022-39353 and CVE-2022-37616

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10841)