### PR TITLE
[0.70] CG 11/7/22: Update `@xmldom/xmldom`

### DIFF
--- a/change/@react-native-windows-cli-8a99690d-57f4-46af-9e61-4f6c4bb95384.json
+++ b/change/@react-native-windows-cli-8a99690d-57f4-46af-9e61-4f6c4bb95384.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.70] CG 11/7/22: Update `@xmldom/xmldom`",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-45cb351d-b880-40ef-8838-c884f8f6162b.json
+++ b/change/@react-native-windows-telemetry-45cb351d-b880-40ef-8838-c884f8f6162b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.70] CG 11/7/22: Update `@xmldom/xmldom`",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -22,7 +22,7 @@
     "@react-native-windows/telemetry": "0.70.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
-    "@xmldom/xmldom": "^0.7.5",
+    "@xmldom/xmldom": "^0.7.7",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
     "envinfo": "^7.5.0",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -21,7 +21,7 @@
     "@react-native-windows/fs": "0.70.0",
     "@typescript-eslint/eslint-plugin": "^5.20.0",
     "@typescript-eslint/parser": "^5.20.0",
-    "@xmldom/xmldom": "^0.7.5",
+    "@xmldom/xmldom": "^0.7.7",
     "applicationinsights": "^2.3.1",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,10 +2953,10 @@
   dependencies:
     "@wdio/logger" "6.10.10"
 
-"@xmldom/xmldom@^0.7.5":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.5.tgz#09fa51e356d07d0be200642b0e4f91d8e6dd408d"
-  integrity sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==
+"@xmldom/xmldom@^0.7.7":
+  version "0.7.9"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.7.9.tgz#7f9278a50e737920e21b297b8a35286e9942c056"
+  integrity sha512-yceMpm/xd4W2a85iqZyO09gTnHvXF6pyiWjD2jcOJs7hRoZtNNOO1eJlhHj1ixA+xip2hOyGn+LgcvLCMo5zXA==
 
 "@xmldom/xmldom@^0.8.0":
   version "0.8.2"


### PR DESCRIPTION
This PR backports #10841 to RNW 0.70.

This PR updates the following dependencies:

* `@xmldom/xmldom` to `^0.7.7` to resolve CVE-2022-39353 and CVE-2022-37616

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10843)