### PR TITLE
Suppress warning in test code when discarding a std::async object

### DIFF
--- a/change/react-native-windows-374819da-ddb8-4457-9ef5-f136eb4f3829.json
+++ b/change/react-native-windows-374819da-ddb8-4457-9ef5-f136eb4f3829.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Supress warning in test code when discarding a std::async object",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Mso.UnitTests/object/refCountedObjectTest.cpp
+++ b/vnext/Mso.UnitTests/object/refCountedObjectTest.cpp
@@ -310,7 +310,7 @@ struct AsyncDeleter {
     try {
       // Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency
       // here.
-#pragma warning(suppress : 4834, 4858) // discarding return value of function with 'nodiscard' attribute
+#pragma warning(suppress : 4834 4858) // discarding return value of function with 'nodiscard' attribute
       std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
     } catch (...) {
       VerifyElseCrashTag(false, 0x01003707 /* tag_bad2h */);

--- a/vnext/Mso.UnitTests/object/refCountedObjectTest.cpp
+++ b/vnext/Mso.UnitTests/object/refCountedObjectTest.cpp
@@ -310,7 +310,7 @@ struct AsyncDeleter {
     try {
       // Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency
       // here.
-#pragma warning(suppress : 4834) // discarding return value of function with 'nodiscard' attribute
+#pragma warning(suppress : 4834, 4858) // discarding return value of function with 'nodiscard' attribute
       std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
     } catch (...) {
       VerifyElseCrashTag(false, 0x01003707 /* tag_bad2h */);

--- a/vnext/Mso.UnitTests/object/unknownObjectTest.cpp
+++ b/vnext/Mso.UnitTests/object/unknownObjectTest.cpp
@@ -454,7 +454,7 @@ struct AsyncDeleter2 {
     try {
       // Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency
       // here.
-#pragma warning(suppress : 4834) // discarding return value of function with 'nodiscard' attribute
+#pragma warning(suppress : 4834, 4858) // discarding return value of function with 'nodiscard' attribute
       std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
     } catch (...) {
       VerifyElseCrashTag(false, 0x01003709 /* tag_bad2j */);

--- a/vnext/Mso.UnitTests/object/unknownObjectTest.cpp
+++ b/vnext/Mso.UnitTests/object/unknownObjectTest.cpp
@@ -454,7 +454,7 @@ struct AsyncDeleter2 {
     try {
       // Ideally we want to show here how to use dispatch queues, but we cannot add DispatchQueue liblet dependency
       // here.
-#pragma warning(suppress : 4834, 4858) // discarding return value of function with 'nodiscard' attribute
+#pragma warning(suppress : 4834 4858) // discarding return value of function with 'nodiscard' attribute
       std::async(std::launch::async, [obj]() noexcept { TObject::RefCountPolicy::template Delete(obj); });
     } catch (...) {
       VerifyElseCrashTag(false, 0x01003709 /* tag_bad2j */);


### PR DESCRIPTION
Not sure if something changed on the CI machines that this just started to hit.  But this adds an additional suppression to some test code to unblock CI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10858)