### PR TITLE
Suppress Flyout if XamlRoot does not have focus

### DIFF
--- a/change/react-native-windows-e50a72d1-525f-4752-a90d-fbb61a073ff1.json
+++ b/change/react-native-windows-e50a72d1-525f-4752-a90d-fbb61a073ff1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Suppress Flyout if XamlRoot does not have focus",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -408,7 +408,10 @@ void FlyoutShadowNode::OnShowFlyout() {
       LogErrorAndClose("The target view window was closed before flyout could be shown.");
     } else if (!m_targetElement && m_targetTag > 0) {
       LogErrorAndClose("The target view unmounted before flyout could be shown.");
-    } else if (m_targetElement && m_flyout.XamlRoot() != m_targetElement.XamlRoot()) {
+    } else if (
+        m_targetElement &&
+        (m_flyout.XamlRoot() != m_targetElement.XamlRoot() ||
+         m_flyout.XamlRoot() != React::XamlUIService::GetXamlRoot(GetViewManager()->GetReactContext().Properties()))) {
       LogErrorAndClose("The target view window lost focus before flyout could be shown.");
     } else {
       m_flyout.ShowAt(m_targetElement, m_showOptions);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
If attempting to show a flyout on an unfocused window, the flyout will show on top of the window currently in focus and appear unattached to anything in particular.

### What
This change ensures that we only attempt to show a flyout if the XamlRoot attached to the flyout is the same as the active XamlRoot set in XamlUIService.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10633)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10863)