### PR TITLE
Update `rnw-dependencies.ps1` to improve messaging

### DIFF
--- a/change/react-native-windows-bc1ccb33-c9d8-427a-9fe4-af8cbcd246a0.json
+++ b/change/react-native-windows-bc1ccb33-c9d8-427a-9fe4-af8cbcd246a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update `rnw-dependencies.ps1` to improve messaging",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -426,15 +426,6 @@ $requirements = @(
         HasVerboseOutput = $true;
     },
     @{
-        Id=[CheckId]::Chrome;
-        Name = 'Chrome';
-        Tags = @('appDev'); # For now this is still required. Edge has been added, but only when it is already running...
-        Valid = { try { ((Get-Item (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe' -ErrorAction Stop).'(Default)').VersionInfo).ProductMajorPart
-        } catch { $false } ; }
-        Install = { choco install -y GoogleChrome };
-        Optional = $true;
-    },
-    @{
         Id=[CheckId]::Yarn;
         Name = 'Yarn';
         Tags = @('appDev');

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -182,6 +182,9 @@ function InstallVS {
 
     if (($vsWhere -eq $null) -or ($channelId -eq $null) -or ($productId -eq $null)) {
         # No VSWhere / VS_Installer
+
+        EnsureChocoForInstall;
+        
         if ($Enterprise) {
             # The CI machines need the enterprise version of VS as that is what is hardcoded in all the scripts
             & choco install -y visualstudio2022enterprise;
@@ -400,7 +403,6 @@ $requirements = @(
         Tags = @('appDev', 'vs2022');
         Valid = { CheckVS; }
         Install = { InstallVS };
-        InstallsWithChoco = $true;
         HasVerboseOutput = $true;
     },
     @{


### PR DESCRIPTION
This PR does the following:

* Updates checks to allow for verbose output
* Updates messaging for checks looking for specific versions
* Updates the .NET check to look for the SDK, not the Runtime
* Updates the VS check to check for workloads and also have clearer messaging
* Removes the `Choco` check, instead only checking for Choco right before using it in an installer.
* Removes the `Chrome` check, as the Edge launches fine for a web-debugger
* Removes the `MSBuild64LongPath` check, as it's no longer required with VS 2022

Closes #10864
Closes #10865
Closes #10866

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10868)