### PR TITLE
Use standard Panel APIs for children in ViewViewManager

### DIFF
--- a/change/react-native-windows-ff50e610-93be-4811-8f59-c025680f6f77.json
+++ b/change/react-native-windows-ff50e610-93be-4811-8f59-c025680f6f77.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use standard Panel APIs for children in ViewViewManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.cpp
@@ -27,14 +27,14 @@ winrt::AutomationPeer ViewControl::OnCreateAutomationPeer() {
   return winrt::make<winrt::Microsoft::ReactNative::implementation::DynamicAutomationPeer>(*this);
 }
 
-winrt::Microsoft::ReactNative::ViewPanel ViewControl::GetPanel() const {
+xaml::Controls::Panel ViewControl::GetPanel() const {
   auto child = Content();
 
   if (auto border = child.try_as<xaml::Controls::Border>()) {
     child = border.Child();
   }
 
-  auto panel = child.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
+  auto panel = child.try_as<xaml::Controls::Panel>();
   assert(panel != nullptr);
 
   return panel;

--- a/vnext/Microsoft.ReactNative/Views/ViewControl.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewControl.h
@@ -22,7 +22,7 @@ struct ViewControl : ViewControlT<ViewControl> {
 
   xaml::Automation::Peers::AutomationPeer OnCreateAutomationPeer();
 
-  winrt::Microsoft::ReactNative::ViewPanel GetPanel() const;
+  xaml::Controls::Panel GetPanel() const;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -46,7 +46,7 @@ class ViewShadowNode : public ShadowNodeBase {
   void createView(const winrt::Microsoft::ReactNative::JSValueObject &props) override {
     Super::createView(props);
 
-    auto panel = GetViewPanel();
+    auto panel = GetPanel();
 
     DynamicAutomationProperties::SetAccessibilityInvokeEventHandler(panel, [=]() {
       if (OnClick())
@@ -150,16 +150,16 @@ class ViewShadowNode : public ShadowNodeBase {
           Microsoft::Common::Unicode::Utf16ToUtf8(name.c_str()));
     }
 
-    GetViewPanel().InsertAt(static_cast<uint32_t>(index), view.as<xaml::UIElement>());
+    GetPanel().Children().InsertAt(static_cast<uint32_t>(index), view.as<xaml::UIElement>());
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
     if (indexToRemove == static_cast<uint32_t>(indexToRemove))
-      GetViewPanel().RemoveAt(static_cast<uint32_t>(indexToRemove));
+      GetPanel().Children().RemoveAt(static_cast<uint32_t>(indexToRemove));
   }
 
   void removeAllChildren() override {
-    GetViewPanel().Clear();
+    GetPanel().Children().Clear();
 
     XamlView current = m_view;
 
@@ -183,12 +183,12 @@ class ViewShadowNode : public ShadowNodeBase {
   }
 
   void ReplaceChild(const XamlView &oldChildView, const XamlView &newChildView) override {
-    auto pPanel = GetViewPanel();
+    auto pPanel = GetPanel();
     if (pPanel != nullptr) {
       uint32_t index;
       if (pPanel.Children().IndexOf(oldChildView.as<xaml::UIElement>(), index)) {
-        pPanel.RemoveAt(index);
-        pPanel.InsertAt(index, newChildView.as<xaml::UIElement>());
+        pPanel.Children().RemoveAt(index);
+        pPanel.Children().InsertAt(index, newChildView.as<xaml::UIElement>());
       } else {
         assert(false);
       }
@@ -204,7 +204,7 @@ class ViewShadowNode : public ShadowNodeBase {
     static_cast<FrameworkElementViewManager *>(GetViewManager())->RefreshTransformMatrix(this);
   }
 
-  winrt::Microsoft::ReactNative::ViewPanel GetViewPanel() {
+  xaml::Controls::Panel GetPanel() {
     XamlView current = m_view;
 
     if (IsControl()) {
@@ -219,7 +219,7 @@ class ViewShadowNode : public ShadowNodeBase {
       }
     }
 
-    auto panel = current.try_as<winrt::Microsoft::ReactNative::ViewPanel>();
+    auto panel = current.try_as<xaml::Controls::Panel>();
     assert(panel != nullptr);
 
     return panel;
@@ -399,7 +399,7 @@ bool ViewViewManager::UpdateProperty(
     const winrt::Microsoft::ReactNative::JSValue &propertyValue) {
   auto *pViewShadowNode = static_cast<ViewShadowNode *>(nodeToUpdate);
 
-  auto pPanel = pViewShadowNode->GetViewPanel();
+  auto pPanel = pViewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
   bool ret = true;
   if (pPanel != nullptr) {
     if (TryUpdateBackgroundBrush(pPanel, propertyName, propertyValue)) {
@@ -460,7 +460,7 @@ bool ViewViewManager::UpdateProperty(
 
 void ViewViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto *viewShadowNode = static_cast<ViewShadowNode *>(node);
-  auto panel = viewShadowNode->GetViewPanel();
+  auto panel = viewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
 
   if (panel.ReadLocalValue(ViewPanel::ViewBackgroundProperty()) == xaml::DependencyProperty::UnsetValue()) {
     // In XAML, a null background means no hit-test will happen.
@@ -632,7 +632,7 @@ void ViewViewManager::SetLayoutProps(
   // Do this first so that it is setup properly before any events are fired by
   // the Super implementation
   auto *pViewShadowNode = static_cast<ViewShadowNode *>(&nodeToUpdate);
-  auto pPanel = pViewShadowNode->GetViewPanel();
+  auto pPanel = pViewShadowNode->GetPanel().as<winrt::Microsoft::ReactNative::ViewPanel>();
   if (pViewShadowNode->IsControl()) {
     pPanel.Width(width);
     pPanel.Height(height);

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -15,11 +15,11 @@ namespace Microsoft.ReactNative
 
     // Public Methods
     void InsertAt(UInt32 index, XAML_NAMESPACE.UIElement value);
-      void RemoveAt(UInt32 index);
-      void Clear();
+    void RemoveAt(UInt32 index);
+    void Clear();
 
     void FinalizeProperties();
-      XAML_NAMESPACE.Controls.Border GetOuterBorder();
+    XAML_NAMESPACE.Controls.Border GetOuterBorder();
 
     // Public Properties
     XAML_NAMESPACE.Media.Brush ViewBackground { get; set; };
@@ -51,6 +51,6 @@ namespace Microsoft.ReactNative
   {
     ViewControl();
 
-    ViewPanel GetPanel();
+    XAML_NAMESPACE.Controls.Panel GetPanel();
   }
 }


### PR DESCRIPTION
In preparation for a change that moves away from a custom ViewPanel implementation to core XAML controls (like Grid and Canvas), this change removes the dependency on ViewPanel wrapper calls to manage children.

It also changes ViewControl to return a generic XAML Panel type rather than ViewPanel. There are no callsites in react-native-windows where this must be a ViewPanel type, but since this is API is exposed via the ViewControl ABI to third parties, this must be considered a breaking change.

This just re-publishes #10640, which was already approved.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10890)