### PR TITLE
Align folly commit hash with folly version

### DIFF
--- a/change/react-native-windows-d6678bf6-0866-4c10-95bb-05c3f23042b9.json
+++ b/change/react-native-windows-d6678bf6-0866-4c10-95bb-05c3f23042b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update folly hash for current version",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -17,7 +17,7 @@
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit and build Folly.vcxproj (to update its cgmanifest.json) too. -->
     <FollyVersion>2022.11.07.00</FollyVersion>
-    <FollyCommitHash>4baba28200d7446c870e96f3cdbeb492f54625d0</FollyCommitHash>
+    <FollyCommitHash>2aa28128d1f7a04b41521367f0b615f782814089</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
     <FmtVersion>8.0.0</FmtVersion>
     <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>

--- a/vnext/Folly/cgmanifest.json
+++ b/vnext/Folly/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/facebook/folly",
-                  "CommitHash": "4baba28200d7446c870e96f3cdbeb492f54625d0"
+                  "CommitHash": "2aa28128d1f7a04b41521367f0b615f782814089"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description
In #10881 I missed updating the commit hash for the manifest.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10891)