### PR TITLE
[0.70] Remove explicit override of JSI engine in Playground-win32

### DIFF
--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -69,7 +69,6 @@ struct WindowData {
   bool m_breakOnNextLine{false};
   uint16_t m_debuggerPort{defaultDebuggerPort};
   xaml::ElementTheme m_theme{xaml::ElementTheme::Default};
-  winrt::Microsoft::ReactNative::JSIEngine m_jsEngine{winrt::Microsoft::ReactNative::JSIEngine::Chakra};
 
   WindowData(const hosting::DesktopWindowXamlSource &desktopWindowXamlSource)
       : m_desktopWindowXamlSource(desktopWindowXamlSource) {}
@@ -119,7 +118,6 @@ struct WindowData {
           host.InstanceSettings().UseFastRefresh(m_fastRefreshEnabled);
           host.InstanceSettings().DebuggerPort(m_debuggerPort);
           host.InstanceSettings().UseDeveloperSupport(true);
-          host.InstanceSettings().JSIEngineOverride(m_jsEngine);
 
           auto rootElement = m_desktopWindowXamlSource.Content().as<controls::Panel>();
           winrt::Microsoft::ReactNative::XamlUIService::SetXamlRoot(
@@ -279,7 +277,7 @@ struct WindowData {
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("Chakra"));
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("Hermes"));
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("V8"));
-        ComboBox_SetCurSel(cmbEngines, static_cast<int32_t>(self->m_jsEngine));
+        // SendMessageW(cmbEngines, CB_SETCURSEL, (WPARAM) static_cast<int32_t>(self->m_jsEngine), (LPARAM)0);
 
         auto cmbTheme = GetDlgItem(hwnd, IDC_THEME);
         SendMessageW(cmbTheme, CB_ADDSTRING, 0, (LPARAM)L"Default");
@@ -319,8 +317,9 @@ struct WindowData {
               // (E.g. includes letters or symbols).
             }
 
-            auto cmbEngines = GetDlgItem(hwnd, IDC_JSENGINE);
-            self->m_jsEngine = static_cast<winrt::Microsoft::ReactNative::JSIEngine>(ComboBox_GetCurSel(cmbEngines));
+            // auto cmbEngines = GetDlgItem(hwnd, IDC_JSENGINE);
+            // int itemIndex = (int)SendMessageW(cmbEngines, (UINT)CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
+            // self->m_jsEngine = static_cast<Microsoft::ReactNative::JSIEngine>(itemIndex);
           }
             [[fallthrough]];
           case IDCANCEL:


### PR DESCRIPTION
In #10770, a line was added to default Playground-win32 to Chakra, when it previously used Hermes by default. Let's keep using Hermes by default. Reverted the state of Playground-win32.cpp in 0.70-stable to match main.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10892)