### PR TITLE
Fixes for Office usage of latest canary

### DIFF
--- a/change/react-native-windows-810f7970-4604-4fe4-8b17-3bf02d9c14bb.json
+++ b/change/react-native-windows-810f7970-4604-4fe4-8b17-3bf02d9c14bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Office nuget should contain fmt headers",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -5,6 +5,13 @@
 ; **************************************************************************************************
 
 EXPORTS
+??0dynamic@folly@@QEAA@$$QEAU01@@Z
+??8folly@@YA_NAEBUdynamic@0@0@Z
+??4dynamic@folly@@QEAAAEAU01@$$QEAU01@@Z
+?hash@dynamic@folly@@QEBA_KXZ
+?destroy@dynamic@folly@@AEAAXXZ
+??0TypeError@folly@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4Type@dynamic@1@@Z
+??0dynamic@folly@@QEAA@AEBU01@@Z
 ??$safe_assert_terminate@$0A@@detail@folly@@YAXPEBUsafe_assert_arg@01@ZZ
 ??$str_to_floating@N@detail@folly@@YA?AV?$Expected@NW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YA?AV?$Expected@_JW4ConversionCode@folly@@@1@PEAV?$Range@PEBD@1@@Z

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -5,6 +5,15 @@
 ; **************************************************************************************************
 
 EXPORTS
+??0dynamic@folly@@QAE@$$QAU01@@Z
+??8folly@@YG_NABUdynamic@0@0@Z
+??4dynamic@folly@@QAEAAU01@$$QAU01@@Z
+?hash@dynamic@folly@@QBEIXZ
+?destroy@dynamic@folly@@AAEXXZ
+??0TypeError@folly@@QAE@ABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@W4Type@dynamic@1@@Z
+??0dynamic@folly@@QAE@ABU01@@Z
+??4dynamic@folly@@QAEAAU01@ABU01@@Z
+??$safe_assert_terminate@$0A@@detail@folly@@YAXPBUsafe_assert_arg@01@ZZ
 ??$str_to_floating@N@detail@folly@@YG?AV?$Expected@NW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??$str_to_integral@_J@detail@folly@@YG?AV?$Expected@_JW4ConversionCode@folly@@@1@PAV?$Range@PBD@1@@Z
 ??0LayoutAnimation@react@facebook@@QAE@Udynamic@folly@@@Z

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -41,6 +41,7 @@
     <file src="$nugetroot$\inc\jsi\**\*.*" target="inc\jsi"/>
     <file src="$nugetroot$\inc\Yoga\*.*" target="inc\Yoga"/>
     <file src="$nugetroot$\inc\folly\**\*.*" target="inc" />
+    <file src="$nugetroot$\inc\fmt\**\*.*" target="inc\fmt" />
     <file src="$nugetroot$\inc\stubs\**\*.*" target="inc" />
 
     <file src="$nugetroot$\inc\Shared\AbiSafe.h" target="inc"/>

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -13,7 +13,7 @@ param(
 [string] $FollyVersion = $props.Project.PropertyGroup.FollyVersion;
 $FollyVersion = $FollyVersion.Trim() # The extracted FollyVersion contains a space at the end that isn't actually present, issue #6216
 $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
-$FollyOverrideRoot = "$ReactWindowsRoot\Folly\TMEP_UntilFollyUpdate";
+$FollyOverrideRoot = "$ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate";
 
 [string] $FmtVersion = $props.Project.PropertyGroup.FmtVersion;
 $FmtVersion = $FmtVersion.Trim() # The extracted FmtVersion contains a space at the end that isn't actually present, issue #6216

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -37,7 +37,7 @@ if (!(Test-Path $FmtRoot)) {
 	$FmtDest = "$SourceRoot\node_modules\.fmt"
 
 	New-Item $FmtRoot -ItemType Directory
-	Invoke-RestMethod -Uri "https://github.com/fmtlib/fmt/archive/refs/tags/$FollyVersion.zip" -OutFile $FmtZip
+	Invoke-RestMethod -Uri "https://github.com/fmtlib/fmt/archive/refs/tags/$FmtVersion.zip" -OutFile $FmtZip
 	Expand-Archive -LiteralPath $FmtZip -DestinationPath $FmtRoot
 }
 

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -12,7 +12,7 @@ param(
 [xml]$props = gc $PSScriptRoot\..\..\Directory.Build.props
 [string] $FollyVersion = $props.Project.PropertyGroup.FollyVersion;
 $FollyVersion = $FollyVersion.Trim() # The extracted FollyVersion contains a space at the end that isn't actually present, issue #6216
-$FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
+$FollyRoot = "$SourceRoot\node_modules\.folly";
 $FollyOverrideRoot = "$ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate";
 
 [string] $FmtVersion = $props.Project.PropertyGroup.FmtVersion;
@@ -73,7 +73,7 @@ Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Objec
 # Folly overrides
 Get-ChildItem -Path $FollyOverrideRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
 	-Path        $FollyOverrideRoot\$_ `
-	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\folly\$(Split-Path $_) -Force) `
+	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\folly-$FollyVersion\folly\$(Split-Path $_) -Force) `
 	-Force
 }
 

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -13,6 +13,11 @@ param(
 [string] $FollyVersion = $props.Project.PropertyGroup.FollyVersion;
 $FollyVersion = $FollyVersion.Trim() # The extracted FollyVersion contains a space at the end that isn't actually present, issue #6216
 $FollyRoot = "$SourceRoot\node_modules\.folly\folly-${FollyVersion}";
+$FollyOverrideRoot = "$ReactWindowsRoot\Folly\TMEP_UntilFollyUpdate";
+
+[string] $FmtVersion = $props.Project.PropertyGroup.FmtVersion;
+$FmtVersion = $FmtVersion.Trim() # The extracted FmtVersion contains a space at the end that isn't actually present, issue #6216
+$FmtRoot = "$SourceRoot\node_modules\.fmt\fmt-${FmtVersion}\include";
 
 # Download Folly if running on a machine which hasn't run native build logic to acquire it
 if (!(Test-Path $FollyRoot)) {
@@ -23,6 +28,17 @@ if (!(Test-Path $FollyRoot)) {
 	New-Item $FollyRoot -ItemType Directory
 	Invoke-RestMethod -Uri "https://github.com/facebook/folly/archive/v$FollyVersion.zip" -OutFile $FollyZip
 	Expand-Archive -LiteralPath $FollyZip -DestinationPath $FollyRoot
+}
+
+# Download Fmt if running on a machine which hasn't run native build logic to acquire it
+if (!(Test-Path $FmtRoot)) {
+	Write-Host "Downloading Fmt $FmtVersion"
+	$FmtZip = "$SourceRoot\node_modules\.fmt\fmt-${FmtVersion}.zip"
+	$FmtDest = "$SourceRoot\node_modules\.fmt"
+
+	New-Item $FmtRoot -ItemType Directory
+	Invoke-RestMethod -Uri "https://github.com/fmtlib/fmt/archive/refs/tags/$FollyVersion.zip" -OutFile $FmtZip
+	Expand-Archive -LiteralPath $FmtZip -DestinationPath $FmtRoot
 }
 
 Write-Host "Source root: [$SourceRoot]"
@@ -51,6 +67,20 @@ Get-ChildItem -Path $ReactNativeRoot\ReactCommon\yoga\yoga -Name -Recurse -Inclu
 Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
 	-Path        $FollyRoot\$_ `
 	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\$(Split-Path $_) -Force) `
+	-Force
+}
+
+# Folly overrides
+Get-ChildItem -Path $FollyOverrideRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
+	-Path        $FollyOverrideRoot\$_ `
+	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\folly-$FollyVersion\folly\$(Split-Path $_) -Force) `
+	-Force
+}
+
+# Fmt headers
+Get-ChildItem -Path $FmtRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
+	-Path        $FmtRoot\$_ `
+	-Destination (New-Item -ItemType Directory $TargetRoot\inc\$(Split-Path $_) -Force) `
 	-Force
 }
 

--- a/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
+++ b/vnext/Scripts/Tfs/Layout-Desktop-Headers.ps1
@@ -17,7 +17,7 @@ $FollyOverrideRoot = "$ReactWindowsRoot\Folly\TEMP_UntilFollyUpdate";
 
 [string] $FmtVersion = $props.Project.PropertyGroup.FmtVersion;
 $FmtVersion = $FmtVersion.Trim() # The extracted FmtVersion contains a space at the end that isn't actually present, issue #6216
-$FmtRoot = "$SourceRoot\node_modules\.fmt\fmt-${FmtVersion}\include";
+$FmtRoot = "$SourceRoot\node_modules\.fmt\fmt-${FmtVersion}";
 
 # Download Folly if running on a machine which hasn't run native build logic to acquire it
 if (!(Test-Path $FollyRoot)) {
@@ -38,7 +38,7 @@ if (!(Test-Path $FmtRoot)) {
 
 	New-Item $FmtRoot -ItemType Directory
 	Invoke-RestMethod -Uri "https://github.com/fmtlib/fmt/archive/refs/tags/$FmtVersion.zip" -OutFile $FmtZip
-	Expand-Archive -LiteralPath $FmtZip -DestinationPath $FmtRoot
+	Expand-Archive -LiteralPath $FmtZip -DestinationPath $FmtDest
 }
 
 Write-Host "Source root: [$SourceRoot]"
@@ -73,13 +73,13 @@ Get-ChildItem -Path $FollyRoot -Name -Recurse -Include $patterns | ForEach-Objec
 # Folly overrides
 Get-ChildItem -Path $FollyOverrideRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
 	-Path        $FollyOverrideRoot\$_ `
-	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\folly-$FollyVersion\folly\$(Split-Path $_) -Force) `
+	-Destination (New-Item -ItemType Directory $TargetRoot\inc\folly\folly\$(Split-Path $_) -Force) `
 	-Force
 }
 
 # Fmt headers
-Get-ChildItem -Path $FmtRoot -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
-	-Path        $FmtRoot\$_ `
+Get-ChildItem -Path $FmtRoot\include -Name -Recurse -Include $patterns | ForEach-Object { Copy-Item `
+	-Path        $FmtRoot\include\$_ `
 	-Destination (New-Item -ItemType Directory $TargetRoot\inc\$(Split-Path $_) -Force) `
 	-Force
 }


### PR DESCRIPTION
## Description
- Latest version of folly headers depend on fmt.  So, we need to add the fmt headers to the office nuget.
- Also fixed it so that we ship the patched folly headers in the nuget.
- Export additional folly symbols required by office from desktop dll

None of these changes will affect the MS.RN dll.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10898)