### PR TITLE
Fix copying patch files in Folly and Fmt projects

### DIFF
--- a/change/react-native-windows-e435a388-efe0-4ff8-ade9-5ac10965c163.json
+++ b/change/react-native-windows-e435a388-efe0-4ff8-ade9-5ac10965c163.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix copying substitution files",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Folly/Folly.vcxproj
+++ b/vnext/Folly/Folly.vcxproj
@@ -143,6 +143,7 @@
     <ClInclude Include="$(FollyDir)\folly\IPAddressV4.h" />
     <ClInclude Include="$(FollyDir)\folly\IPAddressV6.h" />
     <ClInclude Include="$(FollyDir)\folly\json.h" />
+    <ClInclude Include="$(FollyDir)\folly\lang\ToAscii.h" />
     <ClInclude Include="$(FollyDir)\folly\Lazy.h" />
     <ClInclude Include="$(FollyDir)\folly\Likely.h" />
     <ClInclude Include="$(FollyDir)\folly\LockTraits.h" />
@@ -320,7 +321,7 @@
   </ItemGroup>
   <Target Name="Deploy" />
   <!-- Reenable this task if we need to temporarily replace any folly files for fixes, while we wait for PRs to land in folly -->
-  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly" Inputs="@(TemporaryFollyPatchFiles)" Outputs="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')">
+  <Target Name="ApplyFollyTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFolly">
     <Message Importance="High" Text="Applying temporary patches to folly." />
     <Copy DestinationFiles="@(TemporaryFollyPatchFiles->'$(FollyDir)folly\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFollyPatchFiles)" />
   </Target>

--- a/vnext/Folly/Folly.vcxproj.filters
+++ b/vnext/Folly/Folly.vcxproj.filters
@@ -28,6 +28,9 @@
     <Filter Include="Source Files\portability">
       <UniqueIdentifier>{9ad1fbe7-56fb-40d8-b0a2-ac0d6d0799e3}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\lang">
+      <UniqueIdentifier>{ed8c80f6-ff7c-4f61-b7ec-a2aee564d575}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(FollyDir)\folly\system\ThreadId.cpp">
@@ -79,6 +82,7 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="$(FollyDir)\folly\system\AtFork.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(FollyDir)\folly\portability\Asm.h">
@@ -532,6 +536,9 @@
       <Filter>Header Files\detail</Filter>
     </ClInclude>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="$(FollyDir)\folly\lang\ToAscii.h">
+      <Filter>Header Files\lang</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="Folly.natvis" />

--- a/vnext/fmt/fmt.vcxproj
+++ b/vnext/fmt/fmt.vcxproj
@@ -146,7 +146,7 @@
   </ItemGroup>
   <Target Name="Deploy" />
   <!-- Allow temporary patches if needed, while we wait for PRs to land in fmt -->
-  <Target Name="ApplyFmtTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFmt" Inputs="@(TemporaryFmtPatchFiles)" Outputs="@(TemporaryFmtPatchFiles->'$(FmtDir)fmt\%(RecursiveDir)%(Filename)%(Extension)')">
+  <Target Name="ApplyFmtTemporaryPatch" BeforeTargets="PrepareForBuild" DependsOnTargets="UnzipFmt">
     <Message Importance="High" Text="Applying temporary patches to fmt." />
     <Copy DestinationFiles="@(TemporaryFmtPatchFiles->'$(FmtDir)fmt\%(RecursiveDir)%(Filename)%(Extension)')" SourceFiles="@(TemporaryFmtPatchFiles)" />
   </Target>


### PR DESCRIPTION
## Description

Fix compilation errors in developer enlistments caused by failed patching of `Folly` files.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We have three different projects that are patching files that are brought from other repos: `Fmt`, `Folly`, and `ReactCommon`.
The `ReactCommon` copies the patch files without using incremental logic where the target has list of inputs and outputs.
The other two projects use the incremental logic.
The problem is that if the external framework has files newer than the patch files in the developer's enlistment, then these patch files are not copied. Thus, developers may see compilation errors with the unpatched code.
These errors are not observed in CI environment because it always sets newer timestamps on checked out files.

### What
To fix the issue, the patch logic is updated in the `Folly` and `Fmt` projects to not use incremental build logic. It matches the `ReactCommon` project behavior where the same issue was fixed long time ago.  
Note, that it does affect the overall incremental project build behavior because the patch phase happens before build starts and the build is not scheduled if there are no changes. Thus, we do not see copying of patch file on each incremental build.

## Testing
x64 and x86 builds succeed after this change.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10910)