### PR TITLE
improve debug target name for hermes

### DIFF
--- a/packages/debug-test/DebuggingFeatures.test.ts
+++ b/packages/debug-test/DebuggingFeatures.test.ts
@@ -96,6 +96,7 @@ test('debug target properties', async () => {
     for (const debugTarget of debugTargets) {
       expect(debugTarget.hasOwnProperty('id')).toBeTruthy();
       expect(debugTarget.hasOwnProperty('title')).toBeTruthy();
+      debugTarget.title.startsWith('Samples\\debugTest01');
       expect(debugTarget.hasOwnProperty('faviconUrl')).toBeTruthy();
       expect(debugTarget.hasOwnProperty('devtoolsFrontendUrl')).toBeTruthy();
       expect(debugTarget.hasOwnProperty('type')).toBeTruthy();

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -31,6 +31,11 @@ class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
 
  private:
   void initRuntime() noexcept;
+
+#ifdef HERMES_ENABLE_DEBUGGER
+  static std::string getDebugTargetName(const DevSettings& devSettings) noexcept;
+#endif
+
   std::shared_ptr<facebook::hermes::HermesRuntime> m_hermesRuntime;
 
   std::once_flag m_once_flag;


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Unless a RNW dev sets the 'debuggerRuntimeName' property in the DevSettings, we advertise the debug target for the React Instance via the hardcoded string "Hermes React Native". We should provide more info to enable the RNW dev to connect to the instance s/he wants to debug.

Resolves [10915](https://github.com/microsoft/react-native-windows/issues/10915)

### What
If present, name debug target after bundle path, Include process name and identifier.

## Screenshots
[Placeholder, don't know how to add image it to PR] 

## Testing
Augmented existing debug feature test to check debug target name.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10916)