### PR TITLE
Avoid template type shadowing for CntPtr

### DIFF
--- a/change/react-native-windows-8b277652-e95c-43b7-9c81-00a11493947d.json
+++ b/change/react-native-windows-8b277652-e95c-43b7-9c81-00a11493947d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid shadowing template types in CntPtr",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/smartPtr/cntPtr.h
+++ b/vnext/Mso/smartPtr/cntPtr.h
@@ -124,19 +124,19 @@ struct CntPtr {
 
   template <typename T1, typename T2>
   friend bool operator==(CntPtr<T1> const &left, CntPtr<T2> const &right) noexcept;
-  template <typename T>
-  friend bool operator==(CntPtr<T> const &left, std::nullptr_t) noexcept;
-  template <typename T>
-  friend bool operator==(std::nullptr_t, CntPtr<T> const &right) noexcept;
+  template <typename T1>
+  friend bool operator==(CntPtr<T1> const &left, std::nullptr_t) noexcept;
+  template <typename T1>
+  friend bool operator==(std::nullptr_t, CntPtr<T1> const &right) noexcept;
   template <typename T1, typename T2>
   friend bool operator!=(CntPtr<T1> const &left, CntPtr<T2> const &right) noexcept;
-  template <typename T>
-  friend bool operator!=(CntPtr<T> const &left, std::nullptr_t) noexcept;
-  template <typename T>
-  friend bool operator!=(std::nullptr_t, CntPtr<T> const &right) noexcept;
+  template <typename T1>
+  friend bool operator!=(CntPtr<T1> const &left, std::nullptr_t) noexcept;
+  template <typename T1>
+  friend bool operator!=(std::nullptr_t, CntPtr<T1> const &right) noexcept;
 
-  template <typename T>
-  friend void std::swap(CntPtr<T> &left, CntPtr<T> &right) noexcept;
+  template <typename T1>
+  friend void std::swap(CntPtr<T1> &left, CntPtr<T1> &right) noexcept;
 
   template <typename TOther>
   friend struct CntPtr;
@@ -450,13 +450,13 @@ inline bool operator==(CntPtr<T1> const &left, CntPtr<T2> const &right) noexcept
   return left.m_ptr == right.m_ptr;
 }
 
-template <typename T>
-inline bool operator==(CntPtr<T> const &left, std::nullptr_t) noexcept {
+template <typename T1>
+inline bool operator==(CntPtr<T1> const &left, std::nullptr_t) noexcept {
   return left.m_ptr == nullptr;
 }
 
-template <typename T>
-inline bool operator==(std::nullptr_t, CntPtr<T> const &right) noexcept {
+template <typename T1>
+inline bool operator==(std::nullptr_t, CntPtr<T1> const &right) noexcept {
   return right.m_ptr == nullptr;
 }
 
@@ -465,13 +465,13 @@ inline bool operator!=(CntPtr<T1> const &left, CntPtr<T2> const &right) noexcept
   return left.m_ptr != right.m_ptr;
 }
 
-template <typename T>
-inline bool operator!=(CntPtr<T> const &left, std::nullptr_t) noexcept {
+template <typename T1>
+inline bool operator!=(CntPtr<T1> const &left, std::nullptr_t) noexcept {
   return left.m_ptr != nullptr;
 }
 
-template <typename T>
-inline bool operator!=(std::nullptr_t, CntPtr<T> const &right) noexcept {
+template <typename T1>
+inline bool operator!=(std::nullptr_t, CntPtr<T1> const &right) noexcept {
   return right.m_ptr != nullptr;
 }
 
@@ -479,9 +479,9 @@ inline bool operator!=(std::nullptr_t, CntPtr<T> const &right) noexcept {
 
 namespace std {
 
-template <typename T>
-inline void swap(Mso::CntPtr<T> &left, Mso::CntPtr<T> &right) noexcept {
-  T *temp = left.m_ptr;
+template <typename T1>
+inline void swap(Mso::CntPtr<T1> &left, Mso::CntPtr<T1> &right) noexcept {
+  T1 *temp = left.m_ptr;
   left.m_ptr = right.m_ptr;
   right.m_ptr = temp;
 }


### PR DESCRIPTION
## Description

Avoid template type shadowing for CntPtr.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang compiler has a warning if the same template type used for the class and for its members.
The member template type is "shadowing" the class template type.
If warnings are treated as errors, then it may end up being a compilation error.

We must fix it for Meta team who uses Clang compiler.

### What
Changed template type name from `T` to `T1` where the conflict could be found.

It is not the ideal solution because we do not have a build configuration that uses Clang front end.
It would be great to enable RNW compilation using Clang for future verifications.

## Testing
All code compiles as before, but we still cannot verify that all code is compilable by Clang.