### PR TITLE
[0.70] Fix CLI to search for correct VS version range

### DIFF
--- a/change/@react-native-windows-cli-8fb1e274-a5a2-4a7c-9dae-2ed655b8f87e.json
+++ b/change/@react-native-windows-cli-8fb1e274-a5a2-4a7c-9dae-2ed655b8f87e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.70] Fix CLI to search for correct VS version range",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
This PR backports #10922 to RNW 0.70.

The CLI specifies a minimum VS version to look for when running `run-windows`.

However `findLatestVsInstall()` was specifying `opts.minVersion`, but then calling `enumerateVsInstalls()` which was checking for `opts.version`.

The result is we were never specifying a version range when calling `vswhere.exe`, which means we always took whichever was the latest version of VS installed on the machine, regardless of version. Furthermore, we were blindly setting the max version to minVersion + 1, when really we want the max version to be the min major version + 1. I.e. `[16.7,17.0)` not `[16.7,17.7)`.

As we switch to VS 2022, and encourage people to upgrade, this is a problem as our CLI still tries to use VS 2019 if that's all that's installed. It also means if they install VS 2022, our CLI in older RNW releases will just start using that instead of VS 2019. Which is dangerous for compatibility and maintenance, esp. as the latest VS 2022 17.4 can't build RNW < 0.70.

This PR updates the CLI logic to correctly calculate the version range, and this fix should be backported as far back as possible so that previously stable builds don't get broken just by the customer installing VS 2022.

Closes #10917

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10923)