### PR TITLE
[0.68] Fix CLI to search for correct VS version range

### DIFF
--- a/change/@react-native-windows-cli-8fb1e274-a5a2-4a7c-9dae-2ed655b8f87e.json
+++ b/change/@react-native-windows-cli-8fb1e274-a5a2-4a7c-9dae-2ed655b8f87e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.68] Fix CLI to search for correct VS version range",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/vsInstalls.ts
@@ -8,6 +8,7 @@ import {CodedError} from '@react-native-windows/telemetry';
 import {execSync} from 'child_process';
 import fs from '@react-native-windows/fs';
 import path from 'path';
+import semver from 'semver';
 
 /**
  * A subset of the per-instance properties returned by vswhere
@@ -58,15 +59,46 @@ function vsWhere(args: string[], verbose?: boolean): any[] {
  */
 export function enumerateVsInstalls(opts: {
   requires?: string[];
-  version?: string;
+  minVersion?: string;
   verbose?: boolean;
   latest?: boolean;
   prerelease?: boolean;
 }): VisualStudioInstallation[] {
   const args: string[] = [];
 
-  if (opts.version) {
-    args.push(`-version [${opts.version},${Number(opts.version) + 1})`);
+  if (opts.minVersion) {
+    // VS 2019 ex: minVersion == 16.7 => [16.7,17.0)
+    // VS 2022 ex: minVersion == 17.0 => [17.0,18.0)
+
+    // Try to parse minVersion as both a Number and SemVer
+    const minVersionNum = Number(opts.minVersion);
+    const minVersionSemVer = semver.parse(opts.minVersion);
+
+    let minVersion: string;
+    let maxVersion: string;
+
+    if (minVersionSemVer) {
+      minVersion = minVersionSemVer.toString();
+      maxVersion = (minVersionSemVer.major + 1).toFixed(1);
+    } else if (!Number.isNaN(minVersionNum)) {
+      minVersion = minVersionNum.toFixed(1);
+      maxVersion = (Math.floor(minVersionNum) + 1).toFixed(1);
+    } else {
+      // Unable to parse minVersion and determine maxVersion,
+      // caller will throw error that version couldn't be found.
+      return [];
+    }
+
+    const versionRange =
+      `[${minVersion},${maxVersion}` + (opts.prerelease ? ']' : ')');
+
+    if (opts.verbose) {
+      console.log(
+        `Looking for VS installs with version range: ${versionRange}`,
+      );
+    }
+
+    args.push(`-version ${versionRange}`);
   }
 
   if (opts.requires) {


### PR DESCRIPTION
This PR backports #10922 to RNW 0.68.

The CLI specifies a minimum VS version to look for when running `run-windows`.

However `findLatestVsInstall()` was specifying `opts.minVersion`, but then calling `enumerateVsInstalls()` which was checking for `opts.version`.

The result is we were never specifying a version range when calling `vswhere.exe`, which means we always took whichever was the latest version of VS installed on the machine, regardless of version. Furthermore, we were blindly setting the max version to minVersion + 1, when really we want the max version to be the min major version + 1. I.e. `[16.7,17.0)` not `[16.7,17.7)`.

As we switch to VS 2022, and encourage people to upgrade, this is a problem as our CLI still tries to use VS 2019 if that's all that's installed. It also means if they install VS 2022, our CLI in older RNW releases will just start using that instead of VS 2019. Which is dangerous for compatibility and maintenance, esp. as the latest VS 2022 17.4 can't build RNW < 0.70.

This PR updates the CLI logic to correctly calculate the version range, and this fix should be backported as far back as possible so that previously stable builds don't get broken just by the customer installing VS 2022.

Closes #10917

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10925)