### PR TITLE
Remove unnecessary overrides to `onFocus` and `onBlur` in Pressable

### DIFF
--- a/change/@office-iss-react-native-win32-d749cec8-efe8-47ab-86f3-2a7777738436.json
+++ b/change/@office-iss-react-native-win32-d749cec8-efe8-47ab-86f3-2a7777738436.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary overrides to onFocus and onBlur in Pressable",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d03682bc-a25c-4760-a5f6-c2f540cb8725.json
+++ b/change/react-native-windows-d03682bc-a25c-4760-a5f6-c2f540cb8725.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary overrides to onFocus and onBlur in Pressable",
+  "packageName": "react-native-windows",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
@@ -289,22 +289,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
   useImperativeHandle(forwardedRef, () => viewRef.current);
 
-  // [Windows
-  const _onBlur = (event: BlurEvent) => {
-    TextInputState.blurInput(viewRef.current);
-    if (props.onBlur) {
-      props.onBlur(event);
-    }
-  };
-
-  const _onFocus = (event: FocusEvent) => {
-    TextInputState.focusInput(viewRef.current);
-    if (props.onFocus) {
-      props.onFocus(event);
-    }
-  };
-  // Windows]
-
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
@@ -418,10 +402,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
     <View
       {...restPropsWithDefaults}
       {...eventHandlers}
-      // [Windows
-      onBlur={_onBlur}
-      onFocus={_onFocus}
-      // Windows]
       ref={viewRef}
       style={typeof style === 'function' ? style({pressed}) : style}>
       {typeof children === 'function' ? children({pressed}) : children}

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -121,6 +121,8 @@ function PressableFeedbackEvents() {
           accessibilityLabel="pressable feedback events"
           accessibilityRole="button"
           // [Windows
+          onFocus={() => appendEvent('focus')}
+          onBlur={() => appendEvent('blur')}
           onHoverIn={() => appendEvent('hover in')}
           onHoverOut={() => appendEvent('hover out')}
           // Windows]

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -289,22 +289,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
   useImperativeHandle(forwardedRef, () => viewRef.current);
 
-  // [Windows
-  const _onBlur = (event: BlurEvent) => {
-    TextInputState.blurInput(viewRef.current);
-    if (props.onBlur) {
-      props.onBlur(event);
-    }
-  };
-
-  const _onFocus = (event: FocusEvent) => {
-    TextInputState.focusInput(viewRef.current);
-    if (props.onFocus) {
-      props.onFocus(event);
-    }
-  };
-  // Windows]
-
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
@@ -418,10 +402,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
     <View
       {...restPropsWithDefaults}
       {...eventHandlers}
-      // [Windows
-      onBlur={_onBlur}
-      onFocus={_onFocus}
-      // Windows]
       ref={viewRef}
       style={typeof style === 'function' ? style({pressed}) : style}>
       {typeof children === 'function' ? children({pressed}) : children}


### PR DESCRIPTION
## Description

Remove some legacy code that unnecessarily overrides `onBlur` and `onFocus` in Pressable

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

As far as I can tell, we were unnecessarily overriding `onFocus` and `onBlur` in the desktop Pressable forks. This (may) have caused Pressable to fail shallow compare and re-render unnecessarily, affecting downstream components in FluentUI React Native. Those specific event handlers are already handled in `Pressability.js` and passed into Pressable via the `{...eventHandlers}` spread across React Native Core, windows, and macOS. 

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing

Tested in Playground.

https://user-images.githubusercontent.com/6722175/206961910-ffed124a-1939-495e-a4fb-f6b3e15ee129.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10941)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10942)