### PR TITLE
Use a ReactViewHost to specify view options on CompositionRootView

### DIFF
--- a/change/react-native-windows-e1f270c5-39a5-4d8a-8f95-8a311727dca2.json
+++ b/change/react-native-windows-e1f270c5-39a5-4d8a-8f95-8a311727dca2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use a ReactViewHost to specify view options on CompositionRootView",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -145,8 +145,10 @@ struct WindowData {
           // Nudge the ReactNativeHost to create the instance and wrapping context
           host.ReloadInstance();
 
-          m_CompositionHwndHost.ComponentName(appName);
-          m_CompositionHwndHost.ReactNativeHost(host);
+          winrt::Microsoft::ReactNative::ReactViewOptions viewOptions;
+          viewOptions.ComponentName(appName);
+          m_CompositionHwndHost.ReactViewHost(
+              winrt::Microsoft::ReactNative::ReactCoreInjection::MakeViewHost(host, viewOptions));
 
           auto windowData = WindowData::GetFromWindow(hwnd);
           if (!windowData->m_windowInited) {

--- a/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
+++ b/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "IJSValueWriter.idl";
+import "ReactCoreInjection.idl";
 import "ReactNativeHost.idl";
 #include "NamespaceRedirect.h"
 #include "DocString.h"
@@ -21,18 +22,12 @@ namespace Microsoft.ReactNative
 
     void Initialize(UInt64 hwnd);
 
-    DOC_STRING("The @ReactNativeHost associated with the @CompositionRootView. It must be set to show any React UI elements.")
-    ReactNativeHost ReactNativeHost { get; set; };
+    DOC_STRING(
+      "A ReactViewHost specifies the root UI component and initial properties to render in this RootView"
+      "It must be set to show any React UI elements.")
+    IReactViewHost ReactViewHost { get; set; };
 
     Int64 TranslateMessage(UInt32 msg, UInt64 wParam, Int64 lParam);
-
-    DOC_STRING(
-      "The name of the root UI component registered in JavaScript with help of the "
-      "[`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent) method.")
-    String ComponentName { get; set; };
-
-    DOC_STRING("The @JSValueArgWriter that is used to serialize the main component initial properties.")
-    JSValueArgWriter InitialProps { get; set; };
   }
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/CompositionRootView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionRootView.idl
@@ -3,6 +3,7 @@
 
 import "CompositionContext.idl";
 import "IJSValueWriter.idl";
+import "ReactCoreInjection.idl";
 import "ReactNativeHost.idl";
 #include "NamespaceRedirect.h"
 #include "DocString.h"
@@ -18,8 +19,10 @@ namespace Microsoft.ReactNative
     DOC_STRING("Creates a new instance of @CompositionRootView.")
     CompositionRootView();
 
-    DOC_STRING("The @ReactNativeHost associated with the @CompositionRootView. It must be set to show any React UI elements.")
-    ReactNativeHost ReactNativeHost { get; set; };
+    DOC_STRING(
+      "A ReactViewHost specifies the root UI component and initial properties to render in this RootView"
+      "It must be set to show any React UI elements.")
+    IReactViewHost ReactViewHost { get; set; };
 
     DOC_STRING("The RootVisual associated with the @CompositionRootView. It must be set to show any React UI elements.")
     Microsoft.ReactNative.Composition.IVisual RootVisual { get; set; };
@@ -37,17 +40,6 @@ namespace Microsoft.ReactNative
     //void OnPointerPressed(PointerPressedArgs args);
     //void OnMouseUp(Windows.Foundation.Point point);
     void OnScrollWheel(Windows.Foundation.Point point, Int32 delta);
-
-    DOC_STRING(
-      "The name of the root UI component registered in JavaScript with help of the "
-      "[`AppRegistry.registerComponent`](https://reactnative.dev/docs/appregistry#registercomponent) method.")
-    String ComponentName { get; set; };
-
-    DOC_STRING("The @JSValueArgWriter that is used to serialize the main component initial properties.")
-    JSValueArgWriter InitialProps { get; set; };
-
-    DOC_STRING("Reloads the current @ReactRootView UI components.")
-    void ReloadView();
   }
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -66,10 +66,11 @@ facebook::react::SharedEventEmitter EventEmitterForComponent(
   return nullptr;
 }
 
-CompositionEventHandler::CompositionEventHandler(const Mso::React::IReactContext &context) : m_context(&context) {}
+CompositionEventHandler::CompositionEventHandler(const winrt::Microsoft::ReactNative::ReactContext &context)
+    : m_context(context) {}
 
 CompositionEventHandler::CompositionEventHandler(
-    const Mso::React::IReactContext &context,
+    const winrt::Microsoft::ReactNative::ReactContext &context,
     const winrt::Microsoft::ReactNative::CompositionRootView &CompositionRootView)
     : CompositionEventHandler(context) {
   m_compRootView = CompositionRootView;
@@ -108,8 +109,8 @@ void CompositionEventHandler::ScrollWheel(
     facebook::react::SurfaceId surfaceId,
     facebook::react::Point pt,
     uint32_t delta) {
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -302,8 +303,8 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
   }
 
   std::vector<ReactTaggedView> hoveredViews;
-  std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-      winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()));
+  std::shared_ptr<FabricUIManager> fabricuiManager =
+      ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties());
   auto &viewRegistry = fabricuiManager->GetViewRegistry();
   for (auto &view : eventPathViews) {
     auto componentViewDescriptor = viewRegistry.componentViewDescriptorWithTag(view->tag());
@@ -376,8 +377,8 @@ void CompositionEventHandler::MouseMove(
   auto x = GET_X_LPARAM(lParam);
   auto y = GET_Y_LPARAM(lParam);
 
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -431,8 +432,8 @@ void CompositionEventHandler::PointerPressed(
 
   const auto eventType = TouchEventType::Start;
 
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -514,8 +515,8 @@ void CompositionEventHandler::ButtonDown(
   auto y = GET_Y_LPARAM(lParam);
   const auto eventType = TouchEventType::Start;
 
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -583,8 +584,8 @@ void CompositionEventHandler::PointerUp(
 
   const auto eventType = TouchEventType::Start;
 
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -624,8 +625,8 @@ void CompositionEventHandler::ButtonUp(
   auto x = GET_X_LPARAM(lParam);
   auto y = GET_Y_LPARAM(lParam);
 
-  if (std::shared_ptr<FabricUIManager> fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-          winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()))) {
+  if (std::shared_ptr<FabricUIManager> fabricuiManager =
+          ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
     auto rootComponentViewDescriptor = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(surfaceId);
@@ -726,8 +727,7 @@ void CompositionEventHandler::DispatchTouchEvent(
     facebook::react::SurfaceId surfaceId,
     TouchEventType eventType,
     PointerId pointerId) {
-  auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
-      winrt::Microsoft::ReactNative::ReactPropertyBag(m_context->Properties()));
+  auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties());
 
   if (!fabricuiManager)
     return;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -5,6 +5,7 @@
 #include <Fabric/ReactTaggedView.h>
 #include <IReactInstance.h>
 #include <JSValue.h>
+#include <ReactContext.h>
 #include <react/renderer/components/view/PointerEvent.h>
 #include <react/renderer/components/view/Touch.h>
 #include <react/renderer/components/view/TouchEventEmitter.h>
@@ -26,9 +27,9 @@ typedef int PointerId;
 
 class CompositionEventHandler {
  public:
-  CompositionEventHandler(const Mso::React::IReactContext &context);
+  CompositionEventHandler(const winrt::Microsoft::ReactNative::ReactContext &context);
   CompositionEventHandler(
-      const Mso::React::IReactContext &context,
+      const winrt::Microsoft::ReactNative::ReactContext &context,
       const winrt::Microsoft::ReactNative::CompositionRootView &CompositionRootView);
   virtual ~CompositionEventHandler();
 
@@ -109,7 +110,7 @@ class CompositionEventHandler {
 
   std::map<PointerId, std::vector<ReactTaggedView>> m_currentlyHoveredViewsPerPointer;
   winrt::Microsoft::ReactNative::CompositionRootView m_compRootView{nullptr};
-  Mso::CntPtr<const Mso::React::IReactContext> m_context;
+  winrt::Microsoft::ReactNative::ReactContext m_context;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -54,9 +54,7 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
   CreateDesktopWindowTarget(m_hwnd);
   CreateCompositionRoot();
 
-  m_compRootView.InitialProps(std::move(m_initialPropsWriter));
-  m_compRootView.ComponentName(std::move(m_componentName));
-  m_compRootView.ReactNativeHost(std::move(m_reactNativeHost));
+  m_compRootView.ReactViewHost(std::move(m_reactViewHost));
 
   m_compRootView.ScaleFactor(ScaleFactor());
   m_compRootView.RootVisual(
@@ -123,47 +121,25 @@ LRESULT CompositionHwndHost::TranslateMessage(int msg, uint64_t wParam, int64_t 
   return 0;
 }
 
-ReactNative::ReactNativeHost CompositionHwndHost::ReactNativeHost() const noexcept {
-  return m_reactNativeHost ? m_reactNativeHost : m_compRootView.ReactNativeHost();
+ReactNative::IReactViewHost CompositionHwndHost::ReactViewHost() const noexcept {
+  return m_reactViewHost ? m_reactViewHost : m_compRootView.ReactViewHost();
 }
 
-void CompositionHwndHost::ReactNativeHost(ReactNative::ReactNativeHost const &value) noexcept {
+void CompositionHwndHost::ReactViewHost(ReactNative::IReactViewHost const &value) noexcept {
   if (m_compRootView) {
-    m_compRootView.ReactNativeHost(value);
+    m_compRootView.ReactViewHost(value);
   } else {
-    m_reactNativeHost = value;
+    m_reactViewHost = value;
   }
 }
 
 winrt::Windows::UI::Composition::Compositor CompositionHwndHost::Compositor() const noexcept {
   auto compositionContext =
       winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
-          ReactNativeHost().InstanceSettings().Properties());
+          m_reactViewHost.ReactNativeHost().InstanceSettings().Properties());
 
   return winrt::Microsoft::ReactNative::Composition::implementation::CompositionContextHelper::InnerCompositor(
       compositionContext);
-}
-
-winrt::hstring CompositionHwndHost::ComponentName() noexcept {
-  return m_compRootView ? m_compRootView.ComponentName() : m_componentName;
-}
-
-void CompositionHwndHost::ComponentName(winrt::hstring const &value) noexcept {
-  if (m_compRootView)
-    m_compRootView.ComponentName(value);
-  else
-    m_componentName = value;
-}
-
-ReactNative::JSValueArgWriter CompositionHwndHost::InitialProps() noexcept {
-  return m_compRootView ? m_compRootView.InitialProps() : m_initialPropsWriter;
-}
-
-void CompositionHwndHost::InitialProps(ReactNative::JSValueArgWriter const &value) noexcept {
-  if (m_compRootView)
-    m_compRootView.InitialProps(value);
-  else
-    m_initialPropsWriter = value;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
@@ -17,19 +17,9 @@ struct CompositionHwndHost : CompositionHwndHostT<CompositionHwndHost> {
 
   void Initialize(uint64_t hwnd) noexcept;
 
-  // property ReactNativeHost
-  ReactNative::ReactNativeHost ReactNativeHost() const noexcept;
-  void ReactNativeHost(ReactNative::ReactNativeHost const &value) noexcept;
+  winrt::Microsoft::ReactNative::IReactViewHost ReactViewHost() const noexcept;
+  void ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &value) noexcept;
 
-  // property ComponentName
-  hstring ComponentName() noexcept;
-  void ComponentName(hstring const &value) noexcept;
-
-  // property InitialProps
-  ReactNative::JSValueArgWriter InitialProps() noexcept;
-  void InitialProps(ReactNative::JSValueArgWriter const &value) noexcept;
-
-  void ReloadView() noexcept;
   winrt::Windows::UI::Composition::Visual RootVisual() const noexcept;
 
   LRESULT TranslateMessage(int msg, uint64_t wParam, int64_t lParam) noexcept;
@@ -49,9 +39,7 @@ struct CompositionHwndHost : CompositionHwndHostT<CompositionHwndHost> {
   winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget m_target{nullptr};
 
   // Store locally if set before we have a rootview
-  hstring m_componentName;
-  ReactNative::ReactNativeHost m_reactNativeHost{nullptr};
-  ReactNative::JSValueArgWriter m_initialPropsWriter{nullptr};
+  ReactNative::IReactViewHost m_reactViewHost{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -4,6 +4,7 @@
 
 #include "CompositionRootView.g.h"
 
+#include <ReactContext.h>
 #include <winrt/Microsoft.ReactNative.h>
 #include "CompositionEventHandler.h"
 #include "ReactHost/React.h"
@@ -14,21 +15,13 @@ namespace winrt::Microsoft::ReactNative::implementation {
 struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Microsoft::ReactNative::ICompositionRootView {
   CompositionRootView() noexcept;
 
-  // property ReactNativeHost
-  ReactNative::ReactNativeHost ReactNativeHost() noexcept;
-  void ReactNativeHost(ReactNative::ReactNativeHost const &value) noexcept;
-
-  // property ComponentName
-  hstring ComponentName() noexcept;
-  void ComponentName(hstring const &value) noexcept;
+  // property ReactViewHost
+  ReactNative::IReactViewHost ReactViewHost() noexcept;
+  void ReactViewHost(ReactNative::IReactViewHost const &value) noexcept;
 
   // property RootVisual
   winrt::Microsoft::ReactNative::Composition::IVisual RootVisual() noexcept;
   void RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &value) noexcept;
-
-  // property InitialProps
-  ReactNative::JSValueArgWriter InitialProps() noexcept;
-  void InitialProps(ReactNative::JSValueArgWriter const &value) noexcept;
 
   // property Size
   winrt::Windows::Foundation::Size Size() noexcept;
@@ -37,8 +30,6 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   // ScaleFactor (DPI)
   double ScaleFactor() noexcept;
   void ScaleFactor(double value) noexcept;
-
-  void ReloadView() noexcept;
 
   Windows::Foundation::Size Measure(Windows::Foundation::Size const &availableSize) const;
   Windows::Foundation::Size Arrange(Windows::Foundation::Size finalSize) const;
@@ -58,27 +49,21 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
 
  public: // IReactViewInstance UI-thread implementation
   void InitRootView(
-      Mso::CntPtr<Mso::React::IReactInstance> &&reactInstance,
-      Mso::React::ReactViewOptions &&viewOptions) noexcept;
+      winrt::Microsoft::ReactNative::IReactContext &&context,
+      winrt::Microsoft::ReactNative::ReactViewOptions &&viewOptions) noexcept;
   void UpdateRootView() noexcept;
   void UninitRootView() noexcept;
 
  private:
-  ReactNative::ReactNativeHost m_reactNativeHost{nullptr};
-  hstring m_componentName;
-  ReactNative::JSValueArgWriter m_initialPropsWriter;
-  bool m_isPerspectiveEnabled{true};
   bool m_isInitialized{false};
   bool m_isJSViewAttached{false};
   IReactDispatcher m_uiDispatcher{nullptr};
   int64_t m_rootTag{-1};
   double m_scaleFactor{1.0};
   winrt::Windows::Foundation::Size m_size;
-  std::unique_ptr<Mso::React::ReactOptions> m_reactOptions;
-  Mso::WeakPtr<Mso::React::IReactInstance> m_weakReactInstance;
-  Mso::CntPtr<Mso::React::IReactContext> m_context;
-  Mso::CntPtr<Mso::React::IReactViewHost> m_reactViewHost;
-  std::unique_ptr<Mso::React::ReactViewOptions> m_reactViewOptions;
+  winrt::Microsoft::ReactNative::ReactContext m_context;
+  winrt::Microsoft::ReactNative::IReactViewHost m_reactViewHost;
+  winrt::Microsoft::ReactNative::ReactViewOptions m_reactViewOptions;
   std::shared_ptr<::Microsoft::ReactNative::CompositionEventHandler> m_CompositionEventHandler;
   winrt::Microsoft::ReactNative::Composition::IVisual m_rootVisual{nullptr};
   void UpdateRootViewInternal() noexcept;
@@ -86,10 +71,7 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   void EnsureLoadingUI() noexcept;
   void ShowInstanceLoaded() noexcept;
   void ShowInstanceError() noexcept;
-  void ShowInstanceWaiting() noexcept;
   void ShowInstanceLoading() noexcept;
-  Mso::React::IReactViewHost *ReactViewHost() noexcept;
-  void ReactViewHost(Mso::React::IReactViewHost *viewHost) noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LogBoxModule.cpp
@@ -167,8 +167,10 @@ void LogBox::ShowOnUIThread() noexcept {
 
     if (!m_hwnd) {
       auto CompositionHwndHost = React::CompositionHwndHost();
-      CompositionHwndHost.ComponentName(L"LogBox");
-      CompositionHwndHost.ReactNativeHost(host);
+      winrt::Microsoft::ReactNative::ReactViewOptions viewOptions;
+      viewOptions.ComponentName(L"LogBox");
+      CompositionHwndHost.ReactViewHost(
+          winrt::Microsoft::ReactNative::ReactCoreInjection::MakeViewHost(host, viewOptions));
       HINSTANCE hInstance = GetModuleHandle(NULL);
       winrt::impl::abi<winrt::Microsoft::ReactNative::ICompositionHwndHost>::type *pHost{nullptr};
       winrt::com_ptr<::IUnknown> spunk;

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -70,7 +70,7 @@ ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
                           .Get(winrt::Microsoft::ReactNative::ReactDispatcherHelper::UIDispatcherProperty())
                           .as<winrt::Microsoft::ReactNative::IReactDispatcher>();
   auto viewHost = rnhost->MakeViewHost(viewOptions.as<ReactViewOptions>()->CreateViewOptions());
-  return winrt::make<ReactViewHost>(*viewHost, uiDispatcher);
+  return winrt::make<ReactViewHost>(host, *viewHost, uiDispatcher);
 }
 
 /*static*/ void ReactCoreInjection::PostToUIBatchingQueue(
@@ -81,9 +81,10 @@ ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
 }
 
 ReactViewHost::ReactViewHost(
+    const ReactNative::ReactNativeHost &host,
     Mso::React::IReactViewHost &viewHost,
     const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher)
-    : m_viewHost(&viewHost), m_uiDispatcher(uiDispatcher) {}
+    : m_host(host), m_viewHost(&viewHost), m_uiDispatcher(uiDispatcher) {}
 
 // ReactViewOptions ReactViewHost::Options() noexcept;
 // ReactNative::ReactNativeHost ReactViewHost::ReactHost() noexcept {}
@@ -155,6 +156,10 @@ winrt::Windows::Foundation::IAsyncAction ReactViewHost::AttachViewInstance(
 
 winrt::Windows::Foundation::IAsyncAction ReactViewHost::DetachViewInstance() noexcept {
   return make<Mso::AsyncActionFutureAdapter>(m_viewHost->DetachViewInstance());
+}
+
+winrt::Microsoft::ReactNative::ReactNativeHost ReactViewHost::ReactNativeHost() noexcept {
+  return m_host;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -50,6 +50,7 @@ struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
 
 struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
   ReactViewHost(
+      const winrt::Microsoft::ReactNative::ReactNativeHost &host,
       Mso::React::IReactViewHost &viewHost,
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
@@ -58,8 +59,10 @@ struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
   Windows::Foundation::IAsyncAction UnloadViewInstance() noexcept;
   Windows::Foundation::IAsyncAction AttachViewInstance(IReactViewInstance viewInstance) noexcept;
   Windows::Foundation::IAsyncAction DetachViewInstance() noexcept;
+  winrt::Microsoft::ReactNative::ReactNativeHost ReactNativeHost() noexcept;
 
  private:
+  const ReactNative::ReactNativeHost m_host;
   Mso::CntPtr<Mso::React::IReactViewHost> m_viewHost;
   winrt::Microsoft::ReactNative::IReactDispatcher m_uiDispatcher;
 };

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -63,6 +63,9 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
 
     DOC_STRING("Detaches IReactViewInstance from the IReactViewHost.")
       Windows.Foundation.IAsyncAction DetachViewInstance();
+
+    DOC_STRING("The ReactNativeHost associated with this ReactViewHost.")
+      ReactNativeHost ReactNativeHost { get; };
   }
 
   [experimental]


### PR DESCRIPTION
## Description
Modifies the interface of `CompositionRootView` to take a `ReactViewHost` instead of separate properties for `ComponentName` and `InitialProperties`.  This enables updates to those properties to be made atomically rather than triggering two rootview reloads to update them both.  

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

This aligns the interface much better with how the RootView interfaces have worked in Office for a while.  -- We didn't update the ReactRootView interface to match to avoid making a breaking change. But it makes sense for the new interface to use the newer APIs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10949)