### PR TITLE
Minor build fixes to enable fabric in desktop dll

### DIFF
--- a/change/react-native-windows-11b3105a-6557-4333-84b6-ebcf40ffc432.json
+++ b/change/react-native-windows-11b3105a-6557-4333-84b6-ebcf40ffc432.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor build fixes to enable fabric in desktop dll",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -7,7 +7,7 @@
 #include "winrt/base.h"
 void* winrt_make_Microsoft_Internal_TestController();
 #ifdef USE_FABRIC
-void* winrt_make_Microsoft_ReactNative_CompRootView();
+void* winrt_make_Microsoft_ReactNative_CompositionRootView();
 #endif
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
@@ -45,8 +45,8 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     }
 
 #ifdef USE_FABRIC
-    if (requal(name, L"Microsoft.ReactNative.CompRootView")) {
-      return winrt_make_Microsoft_ReactNative_CompRootView();
+    if (requal(name, L"Microsoft.ReactNative.CompositionRootView")) {
+      return winrt_make_Microsoft_ReactNative_CompositionRootView();
     }
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -10,6 +10,7 @@
 #include <Views/ShadowNodeBase.h>
 #include <windows.h>
 #include <windowsx.h>
+#include <winuser.h>
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -10,7 +10,6 @@
 #include <Views/ShadowNodeBase.h>
 #include <windows.h>
 #include <windowsx.h>
-#include <winuser.h>
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <guid/msoGuid.h>
 #include <Composition/CompositionSwitcher.interop.h>
 
 #include <winrt/Windows.UI.Composition.h>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <guid/msoGuid.h>
 #include <Composition/CompositionSwitcher.interop.h>
+#include <guid/msoGuid.h>
 
 #include <winrt/Windows.UI.Composition.h>
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -499,7 +499,7 @@ void SetBorderLayerProperties(
 
       winrt::com_ptr<ID2D1TransformedGeometry> transformedShape;
       D2D1::Matrix3x2F translationTransform = D2D1::Matrix3x2F::Translation(-textureRect.left, -textureRect.top);
-      VerifySucceededElseCrash(
+      winrt::check_hresult(
           spD2dFactory->CreateTransformedGeometry(&shape, &translationTransform, transformedShape.put()));
 
       layer.as<Composition::IVisualInterop>()->SetClippingPath(transformedShape.get());

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -549,7 +549,6 @@
     </ClCompile>
     <ClCompile Include="Utils\AccessibilityUtils.cpp" />
     <ClCompile Include="Utils\Helpers.cpp" />
-    <ClCompile Include="Utils\ImageUtils.cpp" />
     <ClCompile Include="Utils\LocalBundleReader.cpp" />
     <ClCompile Include="Utils\ResourceBrushUtils.cpp" />
     <ClCompile Include="Utils\UwpPreparedScriptStore.cpp" />

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -21,7 +21,7 @@
 
   <PropertyGroup Label="Desktop">
     <!-- See https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt -->
-    <WinVer>_WIN32_WINNT_WIN8</WinVer>
+    <WinVer>_WIN32_WINNT_WINBLUE</WinVer>
     <EnableBeast Condition="'$(EnableBeast)' == ''">0</EnableBeast>
   </PropertyGroup>
 

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -162,6 +162,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)V8JSIRuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)WebSocketJSExecutorFactory.h" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ReactRootViewTagGenerator.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -155,6 +155,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobModule.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
When turning on UseFabric experimental flag on the desktop build I hit a few build errors.  These changes make it so that the dll will build when the UseFabric flag is specified.

### Why
Prep for running fabric in Office.

I'm not going to turn on UseFabric by default in the desktop dll yet, since it increases the DLL size from 3.6MB to 5.5MB - And I don't think we'll be shipping fabric in 0.71.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10956)