### PR TITLE
Workaround cached network issue bug with ReactImageBrush

### DIFF
--- a/change/react-native-windows-1d53260a-f2d2-4dac-b2ff-0cc6809e4ca0.json
+++ b/change/react-native-windows-1d53260a-f2d2-4dac-b2ff-0cc6809e4ca0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Workaround cached network issue bug with ReactImageBrush",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
+++ b/vnext/Microsoft.ReactNative/Views/Image/ReactImage.h
@@ -57,6 +57,9 @@ struct ReactImage : xaml::Controls::GridT<ReactImage> {
   winrt::fire_and_forget SetBackground(bool fireLoadEndEvent);
   double GetWidth();
   double GetHeight();
+  void OnSurfaceLoadedSuccess(
+      xaml::Media::LoadedImageSurface const &surface,
+      winrt::com_ptr<ReactImageBrush> compositionBrush);
 
   bool m_useCompositionBrush{false};
   float m_blurRadius{0};


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In clang builds, the LoadCompleted event does not fire consistently when applying ReactImageBrush features to images that may exist in XAML's internal image cache.

Resolves #10962

### What
This works around that issue by checking if the surface returned from `LoadedImageSurface::StartLoadFromUri` already has physical dimensions defined.

## Testing
Confirmed that this resolves an issue in Messenger (built with clang) where a Background brush is not applied for network / URI resolved images after they've been cached by XAML.

_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10963)