### PR TITLE
[0.68] Fix V8 Node API Task Runner implementation

### DIFF
--- a/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
+++ b/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix V8 Node API task runner implementation",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -18,7 +18,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.65.15</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.65.21</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(NuGetPackageRoot)\$(V8PackageName).$(V8Version)</V8Package>

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
@@ -11,57 +11,71 @@ using std::unique_ptr;
 
 namespace Microsoft::JSI {
 
-struct NapiTask {
-  NapiTask(
-      napi_env env,
-      napi_ext_task_callback taskCallback,
-      void *taskData,
-      napi_finalize finalizeCallback,
-      void *finalizeHint) noexcept
-      : m_env{env},
-        m_taskCallback{taskCallback},
-        m_taskData{taskData},
-        m_finalizeCallback{finalizeCallback},
-        m_finalizeHint{finalizeHint} {}
+class NapiTask {
+ public:
+  NapiTask(void *task, v8_task_run_cb onTaskRun, v8_task_release_cb onTaskRelease)
+      : task_(task), onTaskRun_(onTaskRun), onTaskRelease_(onTaskRelease) {}
 
-  NapiTask(const NapiTask &) = delete;
-  NapiTask &operator=(const NapiTask &) = delete;
+  NapiTask(NapiTask &&other)
+      : task_(std::exchange(other.task_, nullptr)),
+        onTaskRun_(std::exchange(other.onTaskRun_, nullptr)),
+        onTaskRelease_(std::exchange(other.onTaskRelease_, nullptr)) {}
+
+  NapiTask &operator=(NapiTask &&other) {
+    if (this != &other) {
+      NapiTask taskToDelete(std::move(*this));
+      task_ = std::exchange(other.task_, nullptr);
+      onTaskRun_ = std::exchange(other.onTaskRun_, nullptr);
+      onTaskRelease_ = std::exchange(other.onTaskRelease_, nullptr);
+    }
+    return *this;
+  }
+
+  NapiTask(const NapiTask &other) = delete;
+  NapiTask &operator=(const NapiTask &other) = delete;
 
   ~NapiTask() {
-    if (m_finalizeCallback) {
-      m_finalizeCallback(m_env, m_taskData, m_finalizeHint);
+    if (task_ != nullptr) {
+      onTaskRelease_(task_);
     }
   }
 
-  void operator()() noexcept {
-    m_taskCallback(m_env, m_taskData);
+  void Run() const {
+    if (task_ != nullptr) {
+      onTaskRun_(task_);
+    }
   }
 
  private:
-  napi_env m_env;
-  napi_ext_task_callback m_taskCallback;
-  void *m_taskData;
-  napi_finalize m_finalizeCallback;
-  void *m_finalizeHint;
+  void *task_;
+  v8_task_run_cb onTaskRun_;
+  v8_task_release_cb onTaskRelease_;
 };
 
-// See napi_ext_schedule_task_callback definition.
-/*static*/ void NapiJsiV8RuntimeHolder::ScheduleTaskCallback(
-    napi_env env,
-    napi_ext_task_callback taskCallback,
-    void *taskData,
-    uint32_t /*delayInMsec*/,
-    napi_finalize finalizeCallback,
-    void *finalizeHint) {
-  NapiJsiV8RuntimeHolder *holder;
-  auto result = napi_get_instance_data(env, (void **)&holder);
-  if (result != napi_status::napi_ok) {
-    std::terminate();
+class NapiTaskRunner {
+ public:
+  NapiTaskRunner(std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) : m_jsQueue(std::move(jsQueue)) {}
+
+  static v8_task_runner_t Create(std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) {
+    NapiTaskRunner *taskRunner = new NapiTaskRunner(std::move(jsQueue));
+    return v8_create_task_runner(reinterpret_cast<void *>(taskRunner), &PostTask, &Release);
   }
 
-  auto task = std::make_shared<NapiTask>(env, taskCallback, taskData, finalizeCallback, finalizeHint);
-  holder->m_jsQueue->runOnQueue([task = std::move(task)]() { task->operator()(); });
-}
+ private:
+  static void PostTask(void *taskRunner, void *task, v8_task_run_cb onTaskRun, v8_task_release_cb onTaskRelease) {
+    auto napiTask = std::make_shared<NapiTask>(task, onTaskRun, onTaskRelease);
+    reinterpret_cast<NapiTaskRunner *>(taskRunner)->m_jsQueue->runOnQueue([napiTask = std::move(napiTask)] {
+      napiTask->Run();
+    });
+  }
+
+  static void Release(void *taskRunner) {
+    delete reinterpret_cast<NapiTaskRunner *>(taskRunner);
+  }
+
+ private:
+  std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
+};
 
 NapiJsiV8RuntimeHolder::NapiJsiV8RuntimeHolder(
     shared_ptr<DevSettings> devSettings,
@@ -85,7 +99,7 @@ void NapiJsiV8RuntimeHolder::InitRuntime() noexcept {
   settings.flags.enable_inspector = m_useDirectDebugger;
   settings.flags.wait_for_debugger = m_debuggerBreakOnNextLine;
   //  TODO: args.debuggerRuntimeName = debuggerRuntimeName_;
-  settings.foreground_scheduler = &NapiJsiV8RuntimeHolder::ScheduleTaskCallback;
+  settings.foreground_task_runner = NapiTaskRunner::Create(m_jsQueue);
 
   napi_ext_script_cache scriptCache = InitScriptCache(std::move(m_preparedScriptStore));
   settings.script_cache = &scriptCache;

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.cpp
@@ -62,14 +62,18 @@ class NapiTaskRunner {
   }
 
  private:
-  static void PostTask(void *taskRunner, void *task, v8_task_run_cb onTaskRun, v8_task_release_cb onTaskRelease) {
+  static void __cdecl PostTask(
+      void *taskRunner,
+      void *task,
+      v8_task_run_cb onTaskRun,
+      v8_task_release_cb onTaskRelease) {
     auto napiTask = std::make_shared<NapiTask>(task, onTaskRun, onTaskRelease);
     reinterpret_cast<NapiTaskRunner *>(taskRunner)->m_jsQueue->runOnQueue([napiTask = std::move(napiTask)] {
       napiTask->Run();
     });
   }
 
-  static void Release(void *taskRunner) {
+  static void __cdecl Release(void *taskRunner) {
     delete reinterpret_cast<NapiTaskRunner *>(taskRunner);
   }
 

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -22,14 +22,6 @@ class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
 
  private:
-  static void __cdecl ScheduleTaskCallback(
-      napi_env env,
-      napi_ext_task_callback taskCb,
-      void *taskData,
-      uint32_t delayMs,
-      napi_finalize finalizeCb,
-      void *finalizeHint);
-
   void InitRuntime() noexcept;
   napi_ext_script_cache InitScriptCache(
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;

--- a/vnext/Shared/Networking/IWebSocketResource.h
+++ b/vnext/Shared/Networking/IWebSocketResource.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

We see that application crashes when we do direct debugging with V8 engine that accessed through the Node-API.
The issue is that current task runner (V8 dispatcher queue) implementation lifetime is bound to the `napi_env` object, and any task posted to that queue is crashing. The correct implementation of the task runner must be independent from the `napi_env`.

### What

In [this v8-jsi PR](https://github.com/microsoft/v8-jsi/pull/153) we change the task runner API and the implementation.
In this PR we do the corresponding changes to the `NapiJsiV8RuntimeHolder.cpp` that implements the task runner on top of the JS message queue. The new `NapiTaskRunner` and `NapiTask` do not have dependency on the `napi_env` and can be deleted at any time by `v8-jsi.dll` as it is being done with the current task runner implemented for JSI.

## Testing

Note that we start the PR from 0.68 branch and the corresponding v8-jsi 0.65 branch to match the versions used in Office apps.
Both PRs were manually tested against Office code, and we do not observe the crash anymore while doing the direct debugging.

The PR verification will fail until we have the new v8-jsi 0.65.21 version created. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10966)