### PR TITLE
More support for running fabric in desktop dll

### DIFF
--- a/change/react-native-windows-5ac680e0-432f-409a-9330-c652a9b8c923.json
+++ b/change/react-native-windows-5ac680e0-432f-409a-9330-c652a9b8c923.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "More support for running fabric in desktop dll",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -254,6 +254,31 @@
     </ClCompile>
     <ClCompile Include="WebSocketResourceFactory.cpp" />
   </ItemGroup>
+  <ItemGroup Condition="'$(UseFabric)' == 'true'">
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\AdditionAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\AnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\AnimatedPlatformConfig.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\AnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\CalculatedAnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\DecayAnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\DiffClampAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\DivisionAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\EventAnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\FrameAnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\InterpolationAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\ModulusAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\MultiplicationAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\NativeAnimatedModule.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\NativeAnimatedNodeManager.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\PropsAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\SpringAnimationDriver.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\StyleAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\SubtractionAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\TrackingAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\TransformAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\Animated\ValueAnimatedNode.cpp" />
+    <ClCompile Include="..\Microsoft.ReactNative\Modules\ImageViewManagerModule.cpp" />
+  </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ABI\MessageQueueShim.h">
       <DependentUpon>ABI\MessageQueue.idl</DependentUpon>

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -8,6 +8,8 @@
 void* winrt_make_Microsoft_Internal_TestController();
 #ifdef USE_FABRIC
 void* winrt_make_Microsoft_ReactNative_CompositionRootView();
+void *winrt_make_Microsoft_ReactNative_Composition_CompositionContextHelper();
+void *winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
 #endif
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
@@ -47,6 +49,12 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
 #ifdef USE_FABRIC
     if (requal(name, L"Microsoft.ReactNative.CompositionRootView")) {
       return winrt_make_Microsoft_ReactNative_CompositionRootView();
+    }
+    if (requal(name, L"Microsoft.ReactNative.Composition.CompositionContextHelper")) {
+      return winrt_make_Microsoft_ReactNative_Composition_CompositionContextHelper();
+    }
+    if (requal(name, L"Microsoft.ReactNative.Composition.CompositionUIService")) {
+      return winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
     }
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -5,8 +5,6 @@
 #pragma once
 
 #include <Composition/CompositionSwitcher.interop.h>
-#include <guid/msoGuid.h>
-
 #include <winrt/Windows.UI.Composition.h>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -548,7 +548,6 @@
       <SubType>Code</SubType>
     </ClCompile>
     <ClCompile Include="Utils\AccessibilityUtils.cpp" />
-    <ClCompile Include="Utils\Helpers.cpp" />
     <ClCompile Include="Utils\LocalBundleReader.cpp" />
     <ClCompile Include="Utils\ResourceBrushUtils.cpp" />
     <ClCompile Include="Utils\UwpPreparedScriptStore.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -272,9 +272,6 @@
     <ClCompile Include="Utils\AccessibilityUtils.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
-    <ClCompile Include="Utils\Helpers.cpp">
-      <Filter>Utils</Filter>
-    </ClCompile>
     <ClCompile Include="Utils\LocalBundleReader.cpp">
       <Filter>Utils</Filter>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -3,8 +3,11 @@
 
 #include "pch.h"
 
+#ifndef CORE_ABI
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#endif
+
 #include <Utils/Helpers.h>
 #include <Views/ShadowNodeBase.h>
 #include <Views/XamlFeatures.h>
@@ -318,16 +321,19 @@ void PropsAnimatedNode::MakeAnimation(int64_t valueNodeTag, FacadeType facadeTyp
 }
 
 Microsoft::ReactNative::ShadowNodeBase *PropsAnimatedNode::GetShadowNodeBase() {
+#ifndef CORE_ABI
   if (const auto uiManager = Microsoft::ReactNative::GetNativeUIManager(m_context).lock()) {
     if (const auto nativeUIManagerHost = uiManager->getHost()) {
       return static_cast<Microsoft::ReactNative::ShadowNodeBase *>(
           nativeUIManagerHost->FindShadowNodeForTag(m_connectedViewTag));
     }
   }
+#endif
   return nullptr;
 }
 
 xaml::UIElement PropsAnimatedNode::GetUIElement() {
+#ifndef CORE_ABI
   if (IsRS5OrHigher()) {
     if (const auto shadowNodeBase = GetShadowNodeBase()) {
       if (const auto shadowNodeView = shadowNodeBase->GetView()) {
@@ -335,15 +341,18 @@ xaml::UIElement PropsAnimatedNode::GetUIElement() {
       }
     }
   }
+#endif
   return nullptr;
 }
 
 void PropsAnimatedNode::CommitProps() {
+#ifndef CORE_ABI
   if (const auto node = GetShadowNodeBase()) {
     if (!node->m_zombie) {
       node->updateProperties(m_props);
     }
   }
+#endif
 }
 
 PropsAnimatedNode::AnimationView PropsAnimatedNode::GetAnimationView() {
@@ -355,7 +364,8 @@ PropsAnimatedNode::AnimationView PropsAnimatedNode::GetAnimationView() {
       return {nullptr, std::static_pointer_cast<CompositionBaseComponentView>(componentView)};
     }
   }
-#endif
+#endif // USE_FABRIC
+#ifndef CORE_ABI
   if (IsRS5OrHigher()) {
     if (const auto shadowNodeBase = GetShadowNodeBase()) {
       if (const auto shadowNodeView = shadowNodeBase->GetView()) {
@@ -367,6 +377,7 @@ PropsAnimatedNode::AnimationView PropsAnimatedNode::GetAnimationView() {
       }
     }
   }
+#endif // CORE_ABI
 
 #ifdef USE_FABRIC
   return {nullptr, nullptr};
@@ -404,10 +415,13 @@ void PropsAnimatedNode::StartAnimation(
 }
 
 comp::CompositionPropertySet PropsAnimatedNode::EnsureCenterPointPropertySet(const AnimationView &view) noexcept {
+#ifndef CORE_ABI
   if (view.m_element) {
     return GetShadowNodeBase()->EnsureTransformPS();
+  }
+#endif
 #ifdef USE_FABRIC
-  } else if (view.m_componentView) {
+  if (view.m_componentView) {
     return view.m_componentView->EnsureCenterPointPropertySet();
 #endif
   }

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -423,8 +423,8 @@ comp::CompositionPropertySet PropsAnimatedNode::EnsureCenterPointPropertySet(con
 #ifdef USE_FABRIC
   if (view.m_componentView) {
     return view.m_componentView->EnsureCenterPointPropertySet();
-#endif
   }
+#endif
   return nullptr;
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/ValueAnimatedNode.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <CppWinRTIncludes.h>
 #include <JSValue.h>
 #include <UI.Composition.h>
 #include <unordered_set>

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -80,6 +80,22 @@ ReactCoreInjection::PostToUIBatchingQueueProperty() noexcept {
   postFn(callback);
 }
 
+ReactPropertyId<winrt::hstring> PlatformNameOverrideProperty() noexcept {
+  static ReactPropertyId<winrt::hstring> prop{L"ReactNative.Injection", L"PlatformNameOverride"};
+  return prop;
+}
+
+/*static*/ void ReactCoreInjection::SetPlatformNameOverride(
+    IReactPropertyBag const &properties,
+    winrt::hstring const &platformName) noexcept {
+  ReactNative::ReactPropertyBag(properties).Set(PlatformNameOverrideProperty(), platformName);
+}
+/*static*/ std::string ReactCoreInjection::GetPlatformName(IReactPropertyBag const &properties) noexcept {
+  return winrt::to_string(ReactNative::ReactPropertyBag(properties)
+                              .Get(PlatformNameOverrideProperty())
+                              .value_or(winrt::to_hstring(STRING(RN_PLATFORM))));
+}
+
 ReactViewHost::ReactViewHost(
     const ReactNative::ReactNativeHost &host,
     Mso::React::IReactViewHost &viewHost,

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -46,6 +46,9 @@ struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
   static void PostToUIBatchingQueue(
       ReactNative::IReactContext context,
       ReactNative::ReactDispatcherCallback callback) noexcept;
+
+  static void SetPlatformNameOverride(IReactPropertyBag const &properties, winrt::hstring const &platformName) noexcept;
+  static std::string GetPlatformName(IReactPropertyBag const &properties) noexcept;
 };
 
 struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -89,6 +89,9 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
 
     DOC_STRING("Post something to the main UI dispatcher using the batching queue")
     static void PostToUIBatchingQueue(IReactContext context, ReactDispatcherCallback callback);
+
+    DOC_STRING("Override platform name. This will change the platform used when requesting bundles from metro. Default: \"windows\"")
+    static void SetPlatformNameOverride(IReactPropertyBag properties, String platformName);
   }
 
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -43,7 +43,9 @@
 #include "Modules/AccessibilityInfoModule.h"
 #include "Modules/AlertModule.h"
 #endif
+#if !defined(CORE_ABI) || defined(USE_FABRIC)
 #include "Modules/Animated/NativeAnimatedModule.h"
+#endif
 #ifndef CORE_ABI
 #include "Modules/AppStateModule.h"
 #include "Modules/AppThemeModuleUwp.h"
@@ -54,7 +56,9 @@
 #include "Modules/DeviceInfoModule.h"
 #include "Modules/I18nManagerModule.h"
 #endif
+#if !defined(CORE_ABI) || defined(USE_FABRIC)
 #include <Modules/ImageViewManagerModule.h>
+#endif
 #ifndef CORE_ABI
 #include "Modules/LinkingManagerModule.h"
 #include "Modules/LogBoxModule.h"

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -3,12 +3,10 @@
 
 #include "pch.h"
 
-#include <Modules/NativeUIManager.h>
 #include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 
-#include <Modules/PaperUIManagerModule.h>
 #include <appmodel.h>
 #include <processthreadsapi.h>
 
@@ -23,35 +21,6 @@ using namespace Windows::Foundation::Metadata;
 } // namespace winrt
 
 namespace Microsoft::ReactNative {
-
-// Not only react-native, native modules could set tag too for controls.
-// For example, to identify an clicked item, customer may add tag in
-// NavigationView since content for the two NavigationViewItem are empty.
-//
-// <NavigationView>
-//  <NavigationViewItem Icon="Accept" Tag="1" />
-//  <NavigationViewItem Icon="Accept" Tag="2" />
-// </NavigationView>
-// Instead of deduce view id directly from FrameworkElement.Tag, this do
-// additional check by uimanager.
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe) {
-  ReactId reactId{};
-  if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(context).lock()) {
-    if (auto peer = uiManager->reactPeerOrContainerFrom(fe)) {
-      reactId.isValid = true;
-      reactId.tag = Microsoft::ReactNative::GetTag(peer);
-    }
-  }
-  return reactId;
-};
-
-std::int32_t CountOpenPopups() {
-  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
-  // RS6
-  winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
-      xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
-  return (int32_t)popups.Size();
-}
 
 template <uint16_t APIVersion>
 bool IsAPIContractVxAvailable() {

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.cpp
@@ -3,7 +3,6 @@
 
 #include "pch.h"
 
-#include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>
 #include <winrt/Windows.Foundation.Metadata.h>
 

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -12,11 +12,6 @@ namespace Microsoft::ReactNative {
 
 using namespace std;
 
-struct ReactId {
-  int64_t tag{0};
-  bool isValid{false};
-};
-
 template <typename T>
 inline T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -22,9 +22,6 @@ inline T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());
 }
 
-ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe);
-std::int32_t CountOpenPopups();
-
 bool IsRS3OrHigher();
 bool IsRS4OrHigher();
 bool IsRS5OrHigher();

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -17,6 +17,7 @@
 #include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>
 #include <Utils/PropertyHandlerUtils.h>
+#include <XamlHelper.h>
 
 #ifdef USE_WINUI3
 namespace winrt::Microsoft::UI::Xaml::Controls::Primitives {
@@ -122,7 +123,7 @@ class FlyoutShadowNode : public ShadowNodeBase {
   winrt::Popup GetFlyoutParentPopup() const;
   winrt::FlyoutPresenter GetFlyoutPresenter() const;
   void OnShowFlyout();
-  void LogErrorAndClose(const string &error);
+  void LogErrorAndClose(const std::string &error);
   xaml::FrameworkElement m_targetElement = nullptr;
   winrt::Flyout m_flyout = nullptr;
   bool m_isLightDismissEnabled = true;

--- a/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Views/KeyboardEventHandler.cpp
@@ -9,6 +9,7 @@
 #include "Utils/Helpers.h"
 #include "Utils/PropertyHandlerUtils.h"
 #include "Views/KeyboardEventHandler.h"
+#include "XamlHelper.h"
 
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Input.h>

--- a/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/PopupViewManager.cpp
@@ -16,6 +16,7 @@
 #include <UI.Xaml.Media.h>
 #include <Utils/Helpers.h>
 #include <Utils/ValueUtils.h>
+#include <XamlHelper.h>
 #include <winrt/Windows.UI.Core.h>
 
 namespace winrt {

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -7,6 +7,7 @@
 
 #include <Modules/NativeUIManager.h>
 #include <Modules/PaperUIManagerModule.h>
+#include <UI.Xaml.Media.h>
 #include <Utils/ValueUtils.h>
 #include "DynamicWriter.h"
 #include "XamlView.h"

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -5,6 +5,8 @@
 #include "XamlHelper.h"
 #include "XamlHelper.g.cpp"
 
+#include <Modules/NativeUIManager.h>
+#include <Modules/PaperUIManagerModule.h>
 #include <Utils/ValueUtils.h>
 #include "DynamicWriter.h"
 #include "XamlView.h"
@@ -40,3 +42,36 @@ folly::dynamic XamlHelper::GetFollyDynamicFromValueProvider(JSValueArgWriter con
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace Microsoft::ReactNative {
+
+// Not only react-native, native modules could set tag too for controls.
+// For example, to identify an clicked item, customer may add tag in
+// NavigationView since content for the two NavigationViewItem are empty.
+//
+// <NavigationView>
+//  <NavigationViewItem Icon="Accept" Tag="1" />
+//  <NavigationViewItem Icon="Accept" Tag="2" />
+// </NavigationView>
+// Instead of deduce view id directly from FrameworkElement.Tag, this do
+// additional check by uimanager.
+ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe) {
+  ReactId reactId{};
+  if (auto uiManager = Microsoft::ReactNative::GetNativeUIManager(context).lock()) {
+    if (auto peer = uiManager->reactPeerOrContainerFrom(fe)) {
+      reactId.isValid = true;
+      reactId.tag = Microsoft::ReactNative::GetTag(peer);
+    }
+  }
+  return reactId;
+};
+
+std::int32_t CountOpenPopups() {
+  // TODO: Use VisualTreeHelper::GetOpenPopupsFromXamlRoot when running against
+  // RS6
+  winrt::Windows::Foundation::Collections::IVectorView<xaml::Controls::Primitives::Popup> popups =
+      xaml::Media::VisualTreeHelper::GetOpenPopups(xaml::Window::Current());
+  return (int32_t)popups.Size();
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -5,6 +5,10 @@
 #include "XamlHelper.g.h"
 #include "Base/FollyIncludes.h"
 
+namespace Mso::React {
+struct IReactContext;
+} // namespace Mso::React
+
 namespace winrt::Microsoft::ReactNative::implementation {
 
 struct XamlHelper : XamlHelperT<XamlHelper> {
@@ -27,6 +31,11 @@ struct XamlHelper : XamlHelperT<XamlHelper, implementation::XamlHelper> {};
 } // namespace winrt::Microsoft::ReactNative::factory_implementation
 
 namespace Microsoft::ReactNative {
+
+struct ReactId {
+  int64_t tag{0};
+  bool isValid{false};
+};
 
 // Not only react-native, native modules could set tag too for controls.
 // For example, to identify an clicked item, customer may add tag in

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -25,3 +25,21 @@ struct XamlHelper : XamlHelperT<XamlHelper> {
 namespace winrt::Microsoft::ReactNative::factory_implementation {
 struct XamlHelper : XamlHelperT<XamlHelper, implementation::XamlHelper> {};
 } // namespace winrt::Microsoft::ReactNative::factory_implementation
+
+namespace Microsoft::ReactNative {
+
+// Not only react-native, native modules could set tag too for controls.
+// For example, to identify an clicked item, customer may add tag in
+// NavigationView since content for the two NavigationViewItem are empty.
+//
+// <NavigationView>
+//  <NavigationViewItem Icon="Accept" Tag="1" />
+//  <NavigationViewItem Icon="Accept" Tag="2" />
+// </NavigationView>
+// Instead of deduce view id directly from FrameworkElement.Tag, this do
+// additional check by uimanager.
+ReactId getViewId(const Mso::React::IReactContext &context, xaml::FrameworkElement const &fe);
+
+std::int32_t CountOpenPopups();
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Composition/CompositionSwitcher.interop.h
+++ b/vnext/Shared/Composition/CompositionSwitcher.interop.h
@@ -10,6 +10,7 @@
 #include <d2d1_1.h>
 #include <d3d11.h>
 #include <d3d11_4.h>
+#include <guid/msoGuid.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
 

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -163,6 +163,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)WebSocketJSExecutorFactory.h" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ReactRootViewTagGenerator.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\Helpers.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -156,6 +156,7 @@
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\Helpers.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
Changes to further support of fabric in the desktop dll. 

### What
 - Adds a property to allow apps to override the platform that RNW uses when requesting bundles from metro.  (The Desktop DLL uses win32 currently, and we want it to use windows when running fabric).
 - Add the ImageLoader and Animation native modules to the desktop dll, while if def-ing out some of the paper specific functionality.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10993)