### PR TITLE
Remove work around for broken Utilities import in core

### DIFF
--- a/change/@office-iss-react-native-win32-09122742-d6a3-4232-ad09-91d594721b50.json
+++ b/change/@office-iss-react-native-win32-09122742-d6a3-4232-ad09-91d594721b50.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove work around for broken Utilities import in core",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-9750f78b-6b48-4fa5-ab0b-31b4fa8e7f0c.json
+++ b/change/react-native-platform-override-9750f78b-6b48-4fa5-ab0b-31b4fa8e7f0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove work around for broken Utilities import in core",
+  "packageName": "react-native-platform-override",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d2516c3f-bb61-44bd-980e-846418091114.json
+++ b/change/react-native-windows-d2516c3f-bb61-44bd-980e-846418091114.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove work around for broken Utilities import in core",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/tsconfig.json
+++ b/packages/@office-iss/react-native-win32-tester/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": ".",
-    "paths": {
-      "Utilities": ["./../../../node_modules/react-native/types/Utilities.d.ts"],
-    },
-
     // Some code copied from react-native-win32 is not strict clean
     "noImplicitAny": false,
     "strictNullChecks": false,

--- a/packages/@office-iss/react-native-win32/tsconfig.json
+++ b/packages/@office-iss/react-native-win32/tsconfig.json
@@ -4,10 +4,6 @@
     "baseUrl": ".",
     "outDir": ".",
     "rootDir": "src",
-    "paths": {
-      "Utilities": ["./types/Utilities.d.ts"],
-    },
-
     // Not clean
     "strict": false,
   },

--- a/packages/@react-native-windows/tester/tsconfig.json
+++ b/packages/@react-native-windows/tester/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": ".",
-    "paths": {
-      "Utilities": ["./../../../node_modules/react-native/types/Utilities.d.ts"],
-    },
   },
   "include": ["src"],
   "exclude": ["node_modules"],

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -4,8 +4,5 @@
   "exclude": ["node_modules"],
   "compilerOptions": {
     "noEmit": true,
-    "paths": {
-      "Utilities": ["../../node_modules/react-native/types/Utilities.d.ts"],
-    },
   },
 }

--- a/packages/react-native-platform-override/tsconfig.json
+++ b/packages/react-native-platform-override/tsconfig.json
@@ -2,10 +2,6 @@
   "extends": "@rnw-scripts/ts-config",
   "include": ["src"],
   "exclude": ["node_modules"],
-  "paths": {
-    "Utilities": ["./../../node_modules/react-native/types/Utilities.d.ts"],
-  },
-
   "compilerOptions": {
     // Not clean
     "isolatedModules": false

--- a/vnext/tsconfig.json
+++ b/vnext/tsconfig.json
@@ -4,9 +4,6 @@
     "baseUrl": ".",
     "outDir": ".",
     "rootDir": "src",
-    "paths": {
-      "Utilities": ["./types/Utilities.d.ts"],
-    },
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Description

At one point core had some bad imports within the .d.ts files which required explicit path redirection for "Utilities" in our tsconfigs.  That has since been fixed in core, so we can remove the workaround.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/10994)