### PR TITLE
Fix raw text update clearing Text

### DIFF
--- a/change/react-native-windows-dc9c358f-08b5-4a90-aca1-37f042a31a3f.json
+++ b/change/react-native-windows-dc9c358f-08b5-4a90-aca1-37f042a31a3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix raw text update clearing Text",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -69,7 +69,7 @@ class TextShadowNode final : public ShadowNodeBase {
       UpdateOptimizedText();
     } else if (wasOptimized) {
       // Remove optimized text and re-construct as Inline tree
-      UpdateOptimizedText();
+      UpdateOptimizedText(true);
       if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         for (size_t i = 0; i < m_children.size(); ++i) {
           if (const auto childNode =
@@ -87,8 +87,7 @@ class TextShadowNode final : public ShadowNodeBase {
 
   void removeAllChildren() override {
     if (m_isTextOptimized) {
-      auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
-      textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
+      UpdateOptimizedText();
     } else {
       Super::removeAllChildren();
     }
@@ -104,7 +103,7 @@ class TextShadowNode final : public ShadowNodeBase {
     RecalculateTextHighlighters();
   }
 
-  void UpdateOptimizedText() {
+  void UpdateOptimizedText(bool clearOptimizedText = false) {
     if (m_children.size() > 0 && m_isTextOptimized) {
       if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         winrt::hstring text = L"";
@@ -117,7 +116,7 @@ class TextShadowNode final : public ShadowNodeBase {
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         textBlock.Text(text);
       }
-    } else {
+    } else if (m_isTextOptimized || clearOptimizedText) {
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
       textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
     }


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #10811, a bug was introduced where a raw text update to a non-optimized Text component would call ClearValue on the TextBlock::TextProperty. This behavior was introduced to ensure that we cleared out the TextProperty before transitioning from optimized to non-optimized text.

### What
To fix this bug, we check that the text is actually optimized before clearing the TextProperty, and for the case of transitioning text from optimized to non-optimized, added an optional flag that must be set to true before attempting to clear the text.

Please note, we never transition from non-optimized to optimized text, so we don't need to worry about that case.

## Testing
One of the examples in RNTester was reproing the case where the text was cleared when a raw text descendant was updated when the text was in non-optimized state. Here's a video showing it no longer repros:

https://user-images.githubusercontent.com/1106239/207144292-b6b7783e-14bf-4db1-90c3-5a6da00b2027.mp4

For good measure, here's a test case where we transition optimized to non-optimized text:
```
import React, {useState} from 'react';
import {Text} from 'react-native';

export default function Test() {
  const [nested, setNested] = useState(false);
  return (
    <Text onPress={() => setNested(!nested)}>
      {nested ? <Text>hello (non-optimized)</Text> : 'hello (optimized)'}
    </Text>
  );
}
```

https://user-images.githubusercontent.com/1106239/207145979-a99f739a-da34-40a5-abd4-fc12ae8b2232.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11000)