### PR TITLE
Mark Text dirty when descendant Text updates occur

### DIFF
--- a/change/react-native-windows-a67cca50-e44b-4dfd-82c0-d862ee697ddb.json
+++ b/change/react-native-windows-a67cca50-e44b-4dfd-82c0-d862ee697ddb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Mark Text dirty when descendant Text updates occur",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Text/TextPropertyChangedParentVisitor.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextPropertyChangedParentVisitor.cpp
@@ -41,6 +41,7 @@ void TextPropertyChangedParentVisitor::VisitText(ShadowNodeBase *node) {
     }
 
     TextViewManager::UpdateOptimizedText(node);
+    node->GetViewManager()->MarkDirty(node->m_tag);
   }
 
   // Refresh text highlighters

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -83,6 +83,7 @@ class TextShadowNode final : public ShadowNodeBase {
     }
 
     RecalculateTextHighlighters();
+    GetViewManager()->MarkDirty(m_tag);
   }
 
   void removeAllChildren() override {
@@ -93,6 +94,7 @@ class TextShadowNode final : public ShadowNodeBase {
       Super::removeAllChildren();
     }
     RecalculateTextHighlighters();
+    GetViewManager()->MarkDirty(m_tag);
   }
 
   void RemoveChildAt(int64_t indexToRemove) override {
@@ -102,6 +104,7 @@ class TextShadowNode final : public ShadowNodeBase {
       Super::RemoveChildAt(indexToRemove);
     }
     RecalculateTextHighlighters();
+    GetViewManager()->MarkDirty(m_tag);
   }
 
   void UpdateOptimizedText() {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Text should be marked dirty when descendant text nodes are added or removed, and Text should also be marked dirty when descendants of descendant virtual text nodes have changes to their text content.

Resolves #11007

### What
This change ensures that the Yoga node for Text is appropriately updated when these types of changes occur.

Please note, this is likely to create a slight performance regression for apps that modify nested text content after initial mount, as these changes previously would not trigger text measurement, and now they will. But it's worthwhile to trade correctness for a minor performance benefit.

## Testing
Ran a test in simple.tsx:
```
import React, {useState} from 'react';
import {AppRegistry, Text, View} from 'react-native';

function Test() {
  const [toggled, setToggled] = useState(false);
  return (
    <>
      <Text onPress={() => setToggled(!toggled)}>Click Me</Text>
      <View style={{width: 50}}>
        <Text>{toggled ? <>hello world</> : null}</Text>
      </View>
    </>
  );
}

AppRegistry.registerComponent('Bootstrap', () => Test);
```

Text is now remeasured when descendant virtual or raw text is updated:

https://user-images.githubusercontent.com/1106239/207414785-bfe47ef8-b3f0-4793-8e61-a5e83f762f5b.mp4

Here is the before:

https://user-images.githubusercontent.com/1106239/207414792-e911ca13-e8d8-479d-be7b-3556b3e89dce.mp4

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11008)