### PR TITLE
[0.69] Remove unnecessary overrides to onFocus and onBlur in Pressable

### DIFF
--- a/change/@office-iss-react-native-win32-d749cec8-efe8-47ab-86f3-2a7777738436.json
+++ b/change/@office-iss-react-native-win32-d749cec8-efe8-47ab-86f3-2a7777738436.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary overrides to onFocus and onBlur in Pressable",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d03682bc-a25c-4760-a5f6-c2f540cb8725.json
+++ b/change/react-native-windows-d03682bc-a25c-4760-a5f6-c2f540cb8725.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unnecessary overrides to onFocus and onBlur in Pressable",
+  "packageName": "react-native-windows",
+  "email": "sanajmi@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
@@ -251,22 +251,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
   useImperativeHandle(forwardedRef, () => viewRef.current);
 
-  // [Windows
-  const _onBlur = (event: BlurEvent) => {
-    TextInputState.blurInput(viewRef.current);
-    if (props.onBlur) {
-      props.onBlur(event);
-    }
-  };
-
-  const _onFocus = (event: FocusEvent) => {
-    TextInputState.focusInput(viewRef.current);
-    if (props.onFocus) {
-      props.onFocus(event);
-    }
-  };
-  // Windows]
-
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
@@ -358,10 +342,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
     <View
       {...restPropsWithDefaults}
       {...eventHandlers}
-      // [Windows
-      onBlur={_onBlur}
-      onFocus={_onFocus}
-      // Windows]
       ref={viewRef}
       style={typeof style === 'function' ? style({pressed}) : style}>
       {typeof children === 'function' ? children({pressed}) : children}

--- a/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/Pressable/PressableExample.windows.js
@@ -102,6 +102,8 @@ function PressableFeedbackEvents() {
           accessibilityLabel="pressable feedback events"
           accessibilityRole="button"
           // [Windows
+          onFocus={() => appendEvent('focus')}
+          onBlur={() => appendEvent('blur')}
           onHoverIn={() => appendEvent('hover in')}
           onHoverOut={() => appendEvent('hover out')}
           // Windows]

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -251,22 +251,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const viewRef = useRef<React.ElementRef<typeof View> | null>(null);
   useImperativeHandle(forwardedRef, () => viewRef.current);
 
-  // [Windows
-  const _onBlur = (event: BlurEvent) => {
-    TextInputState.blurInput(viewRef.current);
-    if (props.onBlur) {
-      props.onBlur(event);
-    }
-  };
-
-  const _onFocus = (event: FocusEvent) => {
-    TextInputState.focusInput(viewRef.current);
-    if (props.onFocus) {
-      props.onFocus(event);
-    }
-  };
-  // Windows]
-
   const android_rippleConfig = useAndroidRippleForView(android_ripple, viewRef);
 
   const [pressed, setPressed] = usePressState(testOnly_pressed === true);
@@ -358,10 +342,6 @@ function Pressable(props: Props, forwardedRef): React.Node {
     <View
       {...restPropsWithDefaults}
       {...eventHandlers}
-      // [Windows
-      onBlur={_onBlur}
-      onFocus={_onFocus}
-      // Windows]
       ref={viewRef}
       style={typeof style === 'function' ? style({pressed}) : style}>
       {typeof children === 'function' ? children({pressed}) : children}


### PR DESCRIPTION
Cherry pick of https://github.com/microsoft/react-native-windows/pull/10942 to 0.69-stable

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11015)