### PR TITLE
[0.71] Fix Raw Text Update Clearing Text

### DIFF
--- a/change/@react-native-windows-telemetry-21753aad-03c1-4294-b3d9-1daa90657f55.json
+++ b/change/@react-native-windows-telemetry-21753aad-03c1-4294-b3d9-1daa90657f55.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Backport: Fix raw text update clearing text",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-c9f4944e-e44c-4b9f-ac94-acc86c1fc249.json
+++ b/change/react-native-windows-c9f4944e-e44c-4b9f-ac94-acc86c1fc249.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Backport: Fix raw text update clearing text",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2210.24002-3d61ad03" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.71.1" targetFramework="native"/>
 </packages>

--- a/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
+++ b/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
@@ -72,7 +72,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2210.24002-3d61ad03",
+        "resolved": "0.71.1",
         "contentHash": "b6GLQSLaffgxAXwoTrxfj73W5cxlPxmNlQoVmyAnucXPCwV7HiL0rZsqGpBf+r2rdubUS35patY/c+8RiBR4+Q=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -170,7 +170,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2210.24002-3d61ad03, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/packages/integration-test-app/windows/InteropTestModuleCS/packages.lock.json
+++ b/packages/integration-test-app/windows/InteropTestModuleCS/packages.lock.json
@@ -65,7 +65,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2210.24002-3d61ad03",
+        "resolved": "0.71.1",
         "contentHash": "/RxDNnNA6w42Kz7cEep5wc6j8cmE4jepbjm5ElWXYWPHg4xu5D0AIj6RQ+WW2DxUHaDhbm6pjtS7MJSWagdi+g=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -156,7 +156,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2210.24002-3d61ad03, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/packages/playground/windows/playground-composition/packages.config
+++ b/packages/playground/windows/playground-composition/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2210.24002-3d61ad03" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.71.1" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2210.24002-3d61ad03" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.71.1" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2210.24002-3d61ad03" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.71.1" targetFramework="native"/>
 </packages>

--- a/packages/sample-apps/windows/SampleAppCS/packages.lock.json
+++ b/packages/sample-apps/windows/SampleAppCS/packages.lock.json
@@ -71,7 +71,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.70.0",
+        "resolved": "0.71.1",
         "contentHash": "nh9F1wAhkndqfHG/hrS+ezesunlGhCr32pASEEAkQenn8Ou4dUwjmt0c7aT3pONl9itZ1bF9GWbpXJ7t6AsS+Q=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -163,7 +163,7 @@
           "Microsoft.Windows.CppWinRT": "[2.0.211028.7, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.70.0, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/packages/sample-apps/windows/SampleLibraryCS/packages.lock.json
+++ b/packages/sample-apps/windows/SampleLibraryCS/packages.lock.json
@@ -70,7 +70,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.70.0",
+        "resolved": "0.71.1",
         "contentHash": "nh9F1wAhkndqfHG/hrS+ezesunlGhCr32pASEEAkQenn8Ou4dUwjmt0c7aT3pONl9itZ1bF9GWbpXJ7t6AsS+Q=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -162,7 +162,7 @@
           "Microsoft.Windows.CppWinRT": "[2.0.211028.7, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.70.0, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
@@ -100,7 +100,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2210.24002-3d61ad03",
+        "resolved": "0.71.1",
         "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -310,7 +310,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2210.24002-3d61ad03, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -100,7 +100,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2210.24002-3d61ad03",
+        "resolved": "0.71.1",
         "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -310,7 +310,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2210.24002-3d61ad03, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -85,7 +85,7 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2210.24002-3d61ad03",
+        "resolved": "0.71.1",
         "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
@@ -176,7 +176,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2210.24002-3d61ad03, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -69,7 +69,7 @@ class TextShadowNode final : public ShadowNodeBase {
       UpdateOptimizedText();
     } else if (wasOptimized) {
       // Remove optimized text and re-construct as Inline tree
-      UpdateOptimizedText();
+      UpdateOptimizedText(true);
       if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         for (size_t i = 0; i < m_children.size(); ++i) {
           if (const auto childNode =
@@ -87,8 +87,7 @@ class TextShadowNode final : public ShadowNodeBase {
 
   void removeAllChildren() override {
     if (m_isTextOptimized) {
-      auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
-      textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
+      UpdateOptimizedText();
     } else {
       Super::removeAllChildren();
     }
@@ -104,7 +103,7 @@ class TextShadowNode final : public ShadowNodeBase {
     RecalculateTextHighlighters();
   }
 
-  void UpdateOptimizedText() {
+  void UpdateOptimizedText(bool clearOptimizedText = false) {
     if (m_children.size() > 0 && m_isTextOptimized) {
       if (const auto uiManager = GetNativeUIManager(GetViewManager()->GetReactContext()).lock()) {
         winrt::hstring text = L"";
@@ -117,7 +116,7 @@ class TextShadowNode final : public ShadowNodeBase {
         auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
         textBlock.Text(text);
       }
-    } else {
+    } else if (m_isTextOptimized || clearOptimizedText) {
       auto textBlock = this->GetView().as<xaml::Controls::TextBlock>();
       textBlock.ClearValue(xaml::Controls::TextBlock::TextProperty());
     }

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -14,7 +14,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2210.24002-3d61ad03</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.71.1</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\ReactNative.Hermes.Windows\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #10811, a bug was introduced where a raw text update to a non-optimized Text component would call ClearValue on the TextBlock::TextProperty. This behavior was introduced to ensure that we cleared out the TextProperty before transitioning from optimized to non-optimized text.

### What
To fix this bug, we check that the text is actually optimized before clearing the TextProperty, and for the case of transitioning text from optimized to non-optimized, added an optional flag that must be set to true before attempting to clear the text.

Please note, we never transition from non-optimized to optimized text, so we don't need to worry about that case.

## Testing
One of the examples in RNTester was reproing the case where the text was cleared when a raw text descendant was updated when the text was in non-optimized state. Here's a video showing it no longer repros:

https://user-images.githubusercontent.com/1106239/207144292-b6b7783e-14bf-4db1-90c3-5a6da00b2027.mp4

For good measure, here's a test case where we transition optimized to non-optimized text:
```
import React, {useState} from 'react';
import {Text} from 'react-native';

export default function Test() {
  const [nested, setNested] = useState(false);
  return (
    <Text onPress={() => setNested(!nested)}>
      {nested ? <Text>hello (non-optimized)</Text> : 'hello (optimized)'}
    </Text>
  );
}
```

https://user-images.githubusercontent.com/1106239/207145979-a99f739a-da34-40a5-abd4-fc12ae8b2232.mp4

Backport #11000 to 0.69.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11000)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11020)