### PR TITLE
Cleanup unnecessary include in TouchEventHandler

### DIFF
--- a/change/react-native-windows-d248c415-5cbc-46a9-8128-aa395fea889c.json
+++ b/change/react-native-windows-d248c415-5cbc-46a9-8128-aa395fea889c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Cleanup unnecessary include in TouchEventHandler",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Views/TouchEventHandler.h
@@ -12,10 +12,6 @@
 #include "Utils/BatchingEventEmitter.h"
 #include "XamlView.h"
 
-#ifdef USE_FABRIC
-#include <react/renderer/components/view/Touch.h>
-#endif
-
 namespace winrt {
 using namespace Windows::UI;
 using namespace xaml;


### PR DESCRIPTION
This was missed when reverting the WinUI Fabric implementation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11021)