### PR TITLE
V8 Package Update

### DIFF
--- a/change/react-native-windows-fdeebb2c-7e65-431c-bff1-efc8aeb24786.json
+++ b/change/react-native-windows-fdeebb2c-7e65-431c-bff1-efc8aeb24786.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "V8 package update",
+  "packageName": "react-native-windows",
+  "email": "48035227+tudorms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/NuGet.Config
+++ b/packages/playground/windows/NuGet.Config
@@ -3,4 +3,12 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
+  <packageSources>
+    <clear />
+    <add key="react-native" value="https://pkgs.dev.azure.com/ms/react-native/_packaging/react-native-public/nuget/v3/index.json" />
+    <add key="Nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>  
 </configuration>

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -69,6 +69,11 @@ struct WindowData {
   bool m_breakOnNextLine{false};
   uint16_t m_debuggerPort{defaultDebuggerPort};
   xaml::ElementTheme m_theme{xaml::ElementTheme::Default};
+#if defined(USE_HERMES)
+  winrt::Microsoft::ReactNative::JSIEngine m_jsEngine{winrt::Microsoft::ReactNative::JSIEngine::Hermes};
+#else
+  winrt::Microsoft::ReactNative::JSIEngine m_jsEngine{winrt::Microsoft::ReactNative::JSIEngine::Chakra};
+#endif
 
   WindowData(const hosting::DesktopWindowXamlSource &desktopWindowXamlSource)
       : m_desktopWindowXamlSource(desktopWindowXamlSource) {}
@@ -118,6 +123,7 @@ struct WindowData {
           host.InstanceSettings().UseFastRefresh(m_fastRefreshEnabled);
           host.InstanceSettings().DebuggerPort(m_debuggerPort);
           host.InstanceSettings().UseDeveloperSupport(true);
+          host.InstanceSettings().JSIEngineOverride(m_jsEngine);
 
           auto rootElement = m_desktopWindowXamlSource.Content().as<controls::Panel>();
           winrt::Microsoft::ReactNative::XamlUIService::SetXamlRoot(
@@ -278,7 +284,7 @@ struct WindowData {
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("Chakra"));
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("Hermes"));
         SendMessageW(cmbEngines, (UINT)CB_ADDSTRING, (WPARAM)0, (LPARAM)TEXT("V8"));
-        // SendMessageW(cmbEngines, CB_SETCURSEL, (WPARAM) static_cast<int32_t>(self->m_jsEngine), (LPARAM)0);
+        ComboBox_SetCurSel(cmbEngines, static_cast<int32_t>(self->m_jsEngine));
 
         auto cmbTheme = GetDlgItem(hwnd, IDC_THEME);
         SendMessageW(cmbTheme, CB_ADDSTRING, 0, (LPARAM)L"Default");
@@ -318,9 +324,8 @@ struct WindowData {
               // (E.g. includes letters or symbols).
             }
 
-            // auto cmbEngines = GetDlgItem(hwnd, IDC_JSENGINE);
-            // int itemIndex = (int)SendMessageW(cmbEngines, (UINT)CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
-            // self->m_jsEngine = static_cast<Microsoft::ReactNative::JSIEngine>(itemIndex);
+            auto cmbEngines = GetDlgItem(hwnd, IDC_JSENGINE);
+            self->m_jsEngine = static_cast<winrt::Microsoft::ReactNative::JSIEngine>(ComboBox_GetCurSel(cmbEngines));
           }
             [[fallthrough]];
           case IDCANCEL:

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -13,6 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <AppxPackage>false</AppxPackage>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <PropertyGroup Label="FromWinUI3_VSIX" Condition="'$(UseWinUI3)'=='true'">
     <AppContainerApplication>false</AppContainerApplication>

--- a/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
+++ b/vnext/Desktop.ABITests/React.Windows.Desktop.ABITests.vcxproj
@@ -29,6 +29,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ReactWindowsDesktopABITests</RootNamespace>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <V8AppPlatform>win32</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -165,6 +166,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -154,6 +154,7 @@
     <PackageReference Include="boost" Version="1.76.0.0" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="ReactWindows.OpenSSL.StdCall.Static" Version="1.0.2-p.5" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(EnableSourceLink)' == 'true'">
@@ -161,13 +162,6 @@
         <PackageReference Include="Microsoft.Build.Tasks.Git" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.Common" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="'$(UseV8)' == 'true'">
-      <ItemGroup>
-        <PackageReference Include="ReactNative.V8Jsi.Windows" Version="$(V8Version)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -361,6 +361,7 @@
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="ReactWindows.OpenSSL.StdCall.Static" Version="1.0.2-p.5" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(EnableSourceLink)' == 'true'">
@@ -368,13 +369,6 @@
         <PackageReference Include="Microsoft.Build.Tasks.Git" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.Common" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="'$(UseV8)' == 'true'">
-      <ItemGroup>
-        <PackageReference Include="ReactNative.V8Jsi.Windows" Version="$(V8Version)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -9,7 +9,6 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Microsoft.ReactNative</RootNamespace>
     <CppWinRTNamespaceMergeDepth>2</CppWinRTNamespaceMergeDepth>
-    <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
     <V8AppPlatform>uwp</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -163,7 +162,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
-    <PackageReference Include="$(V8PackageName)" Version="$(V8PackageVersion)" Condition="'$(UseV8)' == 'true'" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.cpp
@@ -7,6 +7,8 @@
 #include "NodeApiJsiRuntime.h"
 
 // Standard Library
+#include <array>
+#include <sstream>
 #include <string_view>
 #include <unordered_set>
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/NodeApiJsiRuntime.h
@@ -5,12 +5,12 @@
 #ifndef MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME
 #define MICROSOFT_REACTNATIVE_JSI_NODEAPIJSIRUNTIME
 
+// Standard Library
+#include <memory>
+
 // JSI
 #include <js_native_ext_api.h>
 #include <jsi/jsi.h>
-
-// Standard Library
-#include <memory>
 
 namespace Microsoft::JSI {
 

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -128,8 +128,9 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildMSRNCxx)' != 'false' and '$(RNExternalReferences)' != 'true'">
     <ClCompile Include="$(MSBuildThisFileDirectory)JSI\NodeApiJsiRuntime.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <ExcludedFromBuild Condition="'$(UseV8)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
   </ItemGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -6,6 +6,7 @@
     <ProjectGuid>{14FA0516-E6D7-4E4D-B097-1470198C5072}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Microsoft.ReactNative.IntegrationTests</RootNamespace>
+    <V8AppPlatform>uwp</V8AppPlatform>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
@@ -164,6 +165,7 @@
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="TestBundle.targets" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -748,6 +748,7 @@
     <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(EnableSourceLink)' == 'true'">
@@ -755,13 +756,6 @@
         <PackageReference Include="Microsoft.Build.Tasks.Git" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.Common" Version="1.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-      </ItemGroup>
-    </When>
-  </Choose>
-  <Choose>
-    <When Condition="'$(UseV8)' == 'true'">
-      <ItemGroup>
-        <PackageReference Include="ReactNative.V8Jsi.Windows.UWP" Version="$(V8Version)" />
       </ItemGroup>
     </When>
   </Choose>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -501,10 +501,20 @@ void ReactInstanceWin::Initialize() noexcept {
                       std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(winrt::to_string(tempPath));
                 }
               }
-            }
+
+              bool enableMultiThreadSupport{false};
+#ifdef USE_FABRIC
+              enableMultiThreadSupport = IsFabricEnabled(m_reactContext->Properties());
+#endif // USE_FABRIC
+
               devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
-                  devSettings, m_jsMessageThread.Load(), std::move(scriptStore), std::move(preparedScriptStore));
-              break;
+                  devSettings,
+                  m_jsMessageThread.Load(),
+                  std::move(scriptStore),
+                  std::move(preparedScriptStore),
+                  enableMultiThreadSupport);
+
+            } break;
 #endif // USE_V8
             case JSIEngine::Chakra:
 #ifndef CORE_ABI

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.ProjectReferences.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.ProjectReferences.props
@@ -4,6 +4,9 @@
   Licensed under the MIT License.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RNExternalReferences>true</RNExternalReferences>
+  </PropertyGroup>
   <!-- To avoid having these references show in in Visual Studio which ignores conditions on items we have to put the source references in source. -->
   <ImportGroup Label="Shared">
     <Import Project="$(ReactNativeWindowsDir)\Microsoft.ReactNative.Cxx\Microsoft.ReactNative.Cxx.vcxitems" 

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -24,10 +24,9 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.69.4</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.71.2</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
-    <V8Package>$(NuGetPackageRoot)\$(V8PackageName).$(V8Version)</V8Package>
   </PropertyGroup>
 
 </Project>

--- a/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
+++ b/vnext/ReactCommon.UnitTests/ReactCommon.UnitTests.vcxproj
@@ -173,6 +173,6 @@
   <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1.4" />
-    <PackageReference Include="ReactNative.V8Jsi.Windows" Version="$(V8Version)" />
+    <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -8,6 +8,8 @@
 #include "RuntimeHolder.h"
 #include "ScriptStore.h"
 
+#include <cxxreact/MessageQueueThread.h>
+
 namespace Microsoft::JSI {
 
 class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -331,8 +331,18 @@ InstanceImpl::InstanceImpl(
             preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
           }
 
+          bool enableMultiThreadSupport{false};
+
+#ifdef USE_FABRIC
+          enableMultiThreadSupport = IsFabricEnabled(m_reactContext->Properties());
+#endif // USE_FABRIC
+
           m_devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
-              m_devSettings, m_jsThread, std::move(scriptStore), std::move(preparedScriptStore));
+              m_devSettings,
+              m_jsThread,
+              std::move(scriptStore),
+              std::move(preparedScriptStore),
+              enableMultiThreadSupport);
           break;
 #else
           assert(false); // V8 is not available in this build, fallthrough

--- a/vnext/Shared/V8JSIRuntimeHolder.cpp
+++ b/vnext/Shared/V8JSIRuntimeHolder.cpp
@@ -56,6 +56,7 @@ void V8JSIRuntimeHolder::initRuntime() noexcept {
 
   args.flags.enableInspector = useDirectDebugger_;
   args.flags.waitForDebugger = debuggerBreakOnNextLine_;
+  args.flags.enableMultiThread = enableMultiThreadSupport_;
   args.debuggerRuntimeName = debuggerRuntimeName_;
 
   args.foreground_task_runner = std::make_shared<TaskRunnerAdapter>(jsQueue_);

--- a/vnext/Shared/V8JSIRuntimeHolder.h
+++ b/vnext/Shared/V8JSIRuntimeHolder.h
@@ -24,14 +24,16 @@ class V8JSIRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
       std::unique_ptr<facebook::jsi::ScriptStore> &&scriptStore,
-      std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept
+      std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore,
+      bool enableMultiThreadSupport) noexcept
       : useDirectDebugger_(devSettings->useDirectDebugger),
         debuggerBreakOnNextLine_(devSettings->debuggerBreakOnNextLine),
         debuggerPort_(devSettings->debuggerPort),
         debuggerRuntimeName_(devSettings->debuggerRuntimeName),
         jsQueue_(std::move(jsQueue)),
         scriptStore_(std::move(scriptStore)),
-        preparedScriptStore_(std::move(preparedScriptStore)) {}
+        preparedScriptStore_(std::move(preparedScriptStore)),
+        enableMultiThreadSupport_(enableMultiThreadSupport) {}
 
  private:
   void initRuntime() noexcept;
@@ -48,6 +50,7 @@ class V8JSIRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
   uint16_t debuggerPort_;
   bool useDirectDebugger_;
   bool debuggerBreakOnNextLine_;
+  bool enableMultiThreadSupport_;
   std::string debuggerRuntimeName_;
 };
 

--- a/vnext/Shared/V8JSIRuntimeHolder.h
+++ b/vnext/Shared/V8JSIRuntimeHolder.h
@@ -10,6 +10,8 @@
 
 #include <Logging.h>
 
+#include <cxxreact/MessageQueueThread.h>
+
 namespace facebook {
 namespace react {
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Picking up an updated V8 package version and fix the projects that broke because we're not actively testing this configuration. This is cherry picking the same change from 0.70 (#10770) and enabling multi-threaded support in V8 for Fabric.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11027)