### PR TITLE
Test Access-Control-Request-Headers

### DIFF
--- a/change/react-native-windows-02bc19fb-606a-49b9-b555-145c15e79849.json
+++ b/change/react-native-windows-02bc19fb-606a-49b9-b555-145c15e79849.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Test Access-Control-Request-Headers",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
+++ b/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
@@ -15,6 +15,7 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace winrt::Windows::Web::Http;
 
 using Microsoft::React::Networking::OriginPolicyHttpFilter;
+using Microsoft::React::Networking::RequestArgs;
 using Microsoft::React::Networking::ResponseOperation;
 using winrt::Windows::Foundation::Uri;
 
@@ -258,21 +259,21 @@ TEST_CLASS (OriginPolicyHttpFilterTest) {
       HttpResponseMessage response{};
 
       response.StatusCode(HttpStatusCode::Ok);
+      response.Headers().Insert(L"Access-Control-Allow-Origin", L"*");
       response.Content(HttpStringContent{L""});
 
       co_return response;
     };
 
+    auto reqArgs = winrt::make<RequestArgs>();
     auto request = HttpRequestMessage(HttpMethod::Get(), Uri{L"http://somehost"});
+    request.Properties().Insert(L"RequestArgs", reqArgs);
 
     auto filter = winrt::make<OriginPolicyHttpFilter>(mockFilter);
-    auto client = HttpClient{filter};
     auto opFilter = filter.as<OriginPolicyHttpFilter>();
 
     OriginPolicyHttpFilter::SetStaticOrigin("http://somehost");
     try {
-      //auto sendOp = client.SendRequestAsync(request);
-      //sendOp.get();
       auto sendOp = opFilter->SendPreflightAsync(request);
       sendOp.get();
 

--- a/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
+++ b/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
@@ -285,9 +285,12 @@ TEST_CLASS (OriginPolicyHttpFilterTest) {
       auto response = sendOp.GetResults();
       opFilter->ValidatePreflightResponse(request, response);
 
-      Assert::AreEqual(L"Authorization, Content-Length, Content-Type", response.Headers().Lookup(L"Access-Control-Allow-Headers").c_str());
       OriginPolicyHttpFilter::SetStaticOrigin({});
+      Assert::AreEqual(
+          L"Authorization, Content-Length, Content-Type",
+          response.Headers().Lookup(L"Access-Control-Allow-Headers").c_str());
     } catch (const winrt::hresult_error &e) {
+      OriginPolicyHttpFilter::SetStaticOrigin({});
       Assert::Fail(e.message().c_str());
     }
   }

--- a/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
+++ b/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
@@ -23,7 +23,7 @@ namespace Microsoft::React::Test {
 
 TEST_CLASS (OriginPolicyHttpFilterTest) {
   TEST_CLASS_INITIALIZE(Initialize) {
-    winrt::uninit_apartment(); // Why does this work?
+    winrt::uninit_apartment();
   }
 
   // TEMP tests to see if Uri has comparison capabilities

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -664,6 +664,10 @@ ResponseOperation OriginPolicyHttpFilter::SendPreflightAsync(HttpRequestMessage 
 
   if (coRequest.Content()) {
     for (const auto &header : coRequest.Content().Headers()) {
+      //// Ensure content headers are prefixed by a comma if request headers exist
+      //if (coRequest.Headers().Size() > 0) {
+      //  headerNames += L", ";
+      //}
       if (writeSeparator) {
         headerNames += L", ";
       } else {

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -664,10 +664,6 @@ ResponseOperation OriginPolicyHttpFilter::SendPreflightAsync(HttpRequestMessage 
 
   if (coRequest.Content()) {
     for (const auto &header : coRequest.Content().Headers()) {
-      //// Ensure content headers are prefixed by a comma if request headers exist
-      //if (coRequest.Headers().Size() > 0) {
-      //  headerNames += L", ";
-      //}
       if (writeSeparator) {
         headerNames += L", ";
       } else {

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -113,6 +113,8 @@ bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, co
 /*static*/ void OriginPolicyHttpFilter::SetStaticOrigin(std::string &&url) {
   if (!url.empty())
     s_origin = Uri{to_hstring(url)};
+  else
+    s_origin = nullptr;
 }
 
 /*static*/ bool OriginPolicyHttpFilter::IsSameOrigin(Uri const &u1, Uri const &u2) noexcept {


### PR DESCRIPTION
## Description

See #10278.

#10278 indirectly fixes a header list rendering bug (trailing comma skipped if both request and request body have headers).

This bug still exists in branch `0.68-stable` as of `react-native-windows_v0.68.25`.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Missing coverage for `OriginPolicyHttpFilter::SendPreflightAsync`'s header handling.

### What
- Defines test `Microsoft::React::Test::OriginPolicyHttpFilterTest::ValidatePreflightResponseMainAndContentHeadersSucceeds` covering bug fixed by #10278.
- Allows resetting static instance HTTP origin to `nullptr` (empty string).

## Testing
- Added test `Microsoft::React::Test::OriginPolicyHttpFilterTest::ValidatePreflightResponseMainAndContentHeadersSucceeds`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11031)