### PR TITLE
Fix Hermes sampling profiler

### DIFF
--- a/change/@react-native-windows-telemetry-778ea18a-3b80-476b-92e7-d46058128073.json
+++ b/change/@react-native-windows-telemetry-778ea18a-3b80-476b-92e7-d46058128073.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use latest Hermes ABI-safe API",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-af5ee70c-4767-4145-82a9-61331fa11ab8.json
+++ b/change/react-native-windows-af5ee70c-4767-4145-82a9-61331fa11ab8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Hermes sampling profiler",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2301.25002-ccf86d4f" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.0.0-2302.1002-2d4bf1df" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground-composition/packages.config
+++ b/packages/playground/windows/playground-composition/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2301.25002-ccf86d4f" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.0.0-2302.1002-2d4bf1df" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground-win32/packages.config
+++ b/packages/playground/windows/playground-win32/packages.config
@@ -9,5 +9,5 @@
   <package id="Microsoft.UI.Xaml" version="2.7.0-prerelease.210913003" targetFramework="native"/>
   <package id="Microsoft.VCRTForwarders.140" version="1.0.2-rc" targetFramework="native"/>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2301.25002-ccf86d4f" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.0.0-2302.1002-2d4bf1df" targetFramework="native"/>
 </packages>

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -3,5 +3,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.0.0-2301.25002-ccf86d4f" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.0.0-2302.1002-2d4bf1df" targetFramework="native"/>
 </packages>

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -124,6 +124,10 @@ void ReactDispatcher::InvokeElsePost(Mso::DispatchTask &&task) const noexcept {
   return jsThreadDispatcherProperty;
 }
 
+/*static*/ IReactDispatcher ReactDispatcher::GetJSDispatcher(IReactPropertyBag const &properties) noexcept {
+  return properties.Get(JSDispatcherProperty()).try_as<IReactDispatcher>();
+}
+
 /*static*/ IReactPropertyName ReactDispatcher::JSDispatcherTaskStartingEventName() noexcept {
   static IReactPropertyName jsThreadDispatcherProperty{ReactPropertyBagHelper::GetName(
       ReactPropertyBagHelper::GetNamespace(L"ReactNative.Dispatcher"), L"JSDispatcherTaskStartingEventName")};

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -38,6 +38,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
   static IReactPropertyName JSDispatcherProperty() noexcept;
+  static IReactDispatcher GetJSDispatcher(IReactPropertyBag const &properties) noexcept;
   static IReactPropertyName JSDispatcherTaskStartingEventName() noexcept;
   static IReactPropertyName JSDispatcherIdleWaitStartingEventName() noexcept;
   static IReactPropertyName JSDispatcherIdleWaitCompletedEventName() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -255,6 +255,7 @@ ReactInstanceWin::ReactInstanceWin(
                                                                onDestroyed = m_options.OnInstanceDestroyed,
                                                                reactContext = m_reactContext]() noexcept {
         whenLoaded.TryCancel(); // It only has an effect if whenLoaded was not set before
+        facebook::react::HermesRuntimeHolder::storeTo(ReactPropertyBag(reactContext->Properties()), nullptr);
         if (onDestroyed) {
           onDestroyed.Get()->Invoke(reactContext);
         }
@@ -484,10 +485,14 @@ void ReactInstanceWin::Initialize() noexcept {
           std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
           switch (m_options.JsiEngine()) {
-            case JSIEngine::Hermes:
-              devSettings->jsiRuntimeHolder =
+            case JSIEngine::Hermes: {
+              auto hermesRuntimeHolder =
                   std::make_shared<facebook::react::HermesRuntimeHolder>(devSettings, m_jsMessageThread.Load());
+              facebook::react::HermesRuntimeHolder::storeTo(
+                  ReactPropertyBag(m_reactContext->Properties()), hermesRuntimeHolder);
+              devSettings->jsiRuntimeHolder = hermesRuntimeHolder;
               break;
+            }
             case JSIEngine::V8:
 #if defined(USE_V8)
             {

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -15,10 +15,16 @@
 #include "winrt/Windows.UI.Core.h"
 #include "winrt/Windows.UI.Xaml.Interop.h"
 
+#include <hermes/hermes.h>
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
+#include "HermesRuntimeHolder.h"
 #include "HermesSamplingProfiler.h"
 
 using namespace winrt::Windows::ApplicationModel;
+
+namespace React {
+using namespace winrt::Microsoft::ReactNative;
+}
 
 namespace Microsoft::ReactNative {
 
@@ -205,12 +211,18 @@ void DevMenuManager::CreateAndShowUI() noexcept {
   if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
     m_samplingProfilerRevoker = devMenu.SamplingProfiler().Click(
         winrt::auto_revoke,
-        [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept
-        -> winrt::fire_and_forget {
+        [wkThis = weak_from_this()](
+            auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept -> winrt::fire_and_forget {
           if (auto strongThis = wkThis.lock()) {
             strongThis->Hide();
+            auto jsDispatcher =
+                React::implementation::ReactDispatcher::GetJSDispatcher(strongThis->m_context->Properties());
             if (!Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
-              Microsoft::ReactNative::HermesSamplingProfiler::Start();
+              jsDispatcher.Post([propertyBag = React::ReactPropertyBag(strongThis->m_context->Properties())] {
+                auto hermesRuntimeHolder = facebook::react::HermesRuntimeHolder::loadFrom(propertyBag);
+                hermesRuntimeHolder->getHermesRuntime()->registerForProfiling();
+                Microsoft::ReactNative::HermesSamplingProfiler::Start();
+              });
             } else {
               auto traceFilePath = co_await Microsoft::ReactNative::HermesSamplingProfiler::Stop();
               auto uiDispatcher =
@@ -219,6 +231,10 @@ void DevMenuManager::CreateAndShowUI() noexcept {
                 DataTransfer::DataPackage data;
                 data.SetText(winrt::to_hstring(traceFilePath));
                 DataTransfer::Clipboard::SetContentWithOptions(data, nullptr);
+              });
+              jsDispatcher.Post([propertyBag = React::ReactPropertyBag(strongThis->m_context->Properties())]() {
+                auto hermesRuntimeHolder = facebook::react::HermesRuntimeHolder::loadFrom(propertyBag);
+                hermesRuntimeHolder->getHermesRuntime()->unregisterForProfiling();
               });
             }
           }

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -14,7 +14,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2301.25002-ccf86d4f</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.0.0-2302.1002-2d4bf1df</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\ReactNative.Hermes.Windows\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -20,8 +20,19 @@
 using namespace facebook;
 using namespace Microsoft::ReactNative;
 
+namespace React {
+using namespace winrt::Microsoft::ReactNative;
+}
+
 namespace facebook {
 namespace react {
+
+React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<HermesRuntimeHolder>>>
+HermesRuntimeHolderProperty() noexcept {
+  static React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<HermesRuntimeHolder>>> propId{
+      L"ReactNative.HermesRuntimeHolder", L"HermesRuntimeHolder"};
+  return propId;
+}
 
 namespace {
 
@@ -90,6 +101,10 @@ facebook::react::JSIEngineOverride HermesRuntimeHolder::getRuntimeType() noexcep
 }
 
 std::shared_ptr<jsi::Runtime> HermesRuntimeHolder::getRuntime() noexcept {
+  return getHermesRuntime();
+}
+
+std::shared_ptr<facebook::hermes::HermesRuntime> HermesRuntimeHolder::getHermesRuntime() noexcept {
   std::call_once(m_once_flag, [this]() { initRuntime(); });
 
   if (!m_hermesRuntime)
@@ -130,6 +145,17 @@ void HermesRuntimeHolder::initRuntime() noexcept {
                             .getPropertyAsObject(*m_hermesRuntime, "Error")
                             .getPropertyAsObject(*m_hermesRuntime, "prototype");
   errorPrototype.setProperty(*m_hermesRuntime, "jsEngine", "hermes");
+}
+
+std::shared_ptr<HermesRuntimeHolder> HermesRuntimeHolder::loadFrom(
+    React::ReactPropertyBag const &propertyBag) noexcept {
+  return *(propertyBag.Get(HermesRuntimeHolderProperty()));
+}
+
+void HermesRuntimeHolder::storeTo(
+    React::ReactPropertyBag const &propertyBag,
+    std::shared_ptr<HermesRuntimeHolder> const &holder) noexcept {
+  propertyBag.Set(HermesRuntimeHolderProperty(), holder);
 }
 
 } // namespace react

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -6,6 +6,7 @@
 #include "HermesRuntimeHolder.h"
 
 #include <JSI/decorator.h>
+#include <crash/verifyElseCrash.h>
 #include <cxxreact/MessageQueueThread.h>
 #include <cxxreact/SystraceSection.h>
 #include <hermes/hermes.h>

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -8,6 +8,7 @@
 #include <thread>
 
 #include <DevSettings.h>
+#include <ReactPropertyBag.h>
 
 namespace facebook::hermes {
 class HermesRuntime;
@@ -28,6 +29,15 @@ class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;
+
+  std::shared_ptr<facebook::hermes::HermesRuntime> getHermesRuntime() noexcept;
+
+  static std::shared_ptr<HermesRuntimeHolder> loadFrom(
+      winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag) noexcept;
+
+  static void storeTo(
+      winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag,
+      std::shared_ptr<HermesRuntimeHolder> const &holder) noexcept;
 
  private:
   void initRuntime() noexcept;

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -14,23 +14,25 @@ namespace facebook::hermes {
 class HermesRuntime;
 }
 
-namespace facebook {
-namespace react {
+namespace Microsoft::ReactNative {
+class HermesShim;
+}
+
+namespace facebook::react {
+
+class MessageQueueThread;
 
 class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
- public:
+ public: // RuntimeHolderLazyInit implementation.
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
   facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
-
   void crashHandler(int fileDescriptor) noexcept override;
-
   void teardown() noexcept override;
 
+ public:
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;
-
-  std::shared_ptr<facebook::hermes::HermesRuntime> getHermesRuntime() noexcept;
 
   static std::shared_ptr<HermesRuntimeHolder> loadFrom(
       winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag) noexcept;
@@ -39,16 +41,19 @@ class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag,
       std::shared_ptr<HermesRuntimeHolder> const &holder) noexcept;
 
+  void addToProfiling() const noexcept;
+  void removeFromProfiling() const noexcept;
+
  private:
   void initRuntime() noexcept;
+
+ private:
+  std::shared_ptr<Microsoft::ReactNative::HermesShim> m_hermesShim;
   std::shared_ptr<facebook::hermes::HermesRuntime> m_hermesRuntime;
-
-  std::once_flag m_once_flag;
-  std::thread::id m_own_thread_id;
-
+  std::once_flag m_onceFlag{};
+  std::thread::id m_ownThreadId{};
   std::weak_ptr<facebook::react::DevSettings> m_weakDevSettings;
   std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/vnext/Shared/HermesSamplingProfiler.h
+++ b/vnext/Shared/HermesSamplingProfiler.h
@@ -3,19 +3,21 @@
 
 #pragma once
 
+#include <ReactHost/React.h>
+#include <atomic>
 #include <string>
 
 namespace Microsoft::ReactNative {
 
 class HermesSamplingProfiler final {
  public:
-  static winrt::fire_and_forget Start() noexcept;
-  static std::future<std::string> Stop() noexcept;
+  static winrt::fire_and_forget Start(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
+  static std::future<std::string> Stop(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
   static std::string GetLastTraceFilePath() noexcept;
   static bool IsStarted() noexcept;
 
  private:
-  static bool s_isStarted;
+  static std::atomic_bool s_isStarted;
   static std::string s_lastTraceFilePath;
 };
 

--- a/vnext/Shared/HermesShim.cpp
+++ b/vnext/Shared/HermesShim.cpp
@@ -4,15 +4,9 @@
 #include "HermesShim.h"
 #include "Crash.h"
 
-#if _M_IX86
-#define SYMBOL_PREFIX "_"
-#else
-#define SYMBOL_PREFIX
-#endif
-
 #define DECLARE_SYMBOL(symbol, importedSymbol) \
   decltype(&importedSymbol) s_##symbol{};      \
-  constexpr const char symbol##Symbol[] = SYMBOL_PREFIX #importedSymbol;
+  constexpr const char symbol##Symbol[] = #importedSymbol;
 
 #define INIT_SYMBOL(symbol)                                                                            \
   s_##symbol = reinterpret_cast<decltype(s_##symbol)>(GetProcAddress(s_hermesModule, symbol##Symbol)); \

--- a/vnext/Shared/HermesShim.h
+++ b/vnext/Shared/HermesShim.h
@@ -9,13 +9,33 @@
 //! use pure delay-loading to achieve this, since WACK will detect the
 //! non-present DLL. Functions in this namespace shim to the Hermes DLL via
 //! GetProcAddress.
-namespace Microsoft::ReactNative::HermesShim {
+namespace Microsoft::ReactNative {
 
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes::vm::RuntimeConfig &runtimeConfig);
-void enableSamplingProfiler();
-void disableSamplingProfiler();
-void dumpSampledTraceToFile(const std::string &fileName);
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeWithWER();
-void hermesCrashHandler(facebook::hermes::HermesRuntime &runtime, int fileDescriptor);
+class HermesShim : public std::enable_shared_from_this<HermesShim> {
+ public:
+  HermesShim(hermes_runtime runtimeAbiPtr) noexcept;
+  ~HermesShim();
 
-} // namespace Microsoft::ReactNative::HermesShim
+  static std::shared_ptr<HermesShim> make() noexcept;
+  static std::shared_ptr<HermesShim> makeWithWER() noexcept;
+
+  std::shared_ptr<facebook::hermes::HermesRuntime> getRuntime() const noexcept;
+
+  void dumpCrashData(int fileDescriptor) const noexcept;
+
+  static void enableSamplingProfiler() noexcept;
+  static void disableSamplingProfiler() noexcept;
+  static void dumpSampledTraceToFile(const std::string &fileName) noexcept;
+  void addToProfiling() const noexcept;
+  void removeFromProfiling() const noexcept;
+
+  HermesShim(const HermesShim &) = delete;
+  HermesShim &operator=(const HermesShim &) = delete;
+
+ private:
+  // It must be a raw pointer to avoid circular reference.
+  facebook::hermes::HermesRuntime *nonAbiSafeRuntime_{};
+  hermes_runtime runtime_{};
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/JSI/RuntimeHolder.h
+++ b/vnext/Shared/JSI/RuntimeHolder.h
@@ -11,7 +11,7 @@ namespace Microsoft::JSI {
 // a. lazily create a JSI Runtime on the first call to getRuntime
 // b. subsequent calls to getRuntime should return the Runtime created in (a)
 
-// Note :: All calls to getRuntime() should happen on the same thread unless you are sure that
+// Note: all calls to getRuntime() should happen on the same thread unless you are sure that
 // the underlying Runtime instance is thread safe.
 
 struct RuntimeHolderLazyInit {
@@ -21,7 +21,7 @@ struct RuntimeHolderLazyInit {
   virtual void teardown() noexcept {};
 
   // You can call this when a crash happens to attempt recording additional data
-  // The fd supplied is a raw file stream an implementation might write JSON to
+  // The fileDescriptor supplied is a raw file stream an implementation might write JSON to.
   virtual void crashHandler(int fileDescriptor) noexcept {};
 };
 


### PR DESCRIPTION
## Description
Enable Hermes sampling profiler for RNW project.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Currently the Hermes sampling profiler does not work.
It prevents any related perf investigations.

### What
The change has the following parts:
- We use new ABI-safe Hermes API based on C. Not all interactions with Hermes are ABI-safe yet. This is just a beginning.
- The `HermesShim` is changed to use the new API.
- We store `HermesRuntimeHolder` in the context properties. It allows us to add current Hermes runtime for the sampling profiling when it starts and then remove it when it is done.
- We must add and remove the runtime for sampling profiler in JS dispatcher queue. In this PR we expose the JS dispatcher from the `ReactDispatcher`.
- New `HermesRuntimeHolder` methods `loadFrom` and `storeTo` are defined to keep the holder in the context properties.
- The `HermesRuntimeHolder` instance is stored on RN instance creation and then removed on RN instance destruction. 

## Testing
The new sampling profiler is tested manually.
I used the Playground application with Hermes engine.
The menu has commands to start and stop the sampling profiler.
**IMPORTANT**: the resulting CPU sampling file in the application local storage cannot be opened directly in Chrome or Edge browsers. It must be first post-processed by [hermes-profile-transformer](https://github.com/react-native-community/hermes-profile-transformer) tool. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11033)