### PR TITLE
Removed warnings that were not being triggered

### DIFF
--- a/change/react-native-windows-315d6384-1100-4d1e-a3d3-bee8022d6556.json
+++ b/change/react-native-windows-315d6384-1100-4d1e-a3d3-bee8022d6556.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Removed warnings that were not being triggered",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -10,7 +10,7 @@
         C4458 - declaration of 'identifier' hides class member
         C4702 - unreachable code
       -->
-    <OfficePreDisabledWarnings>4456;4702</OfficePreDisabledWarnings>
+    <OfficePreDisabledWarnings>4456;4702;4458</OfficePreDisabledWarnings>
     <!--
         The following list matches the list in ..\make.inc
           C4068 - unknown pragma

--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -10,7 +10,7 @@
         C4458 - declaration of 'identifier' hides class member
         C4702 - unreachable code
       -->
-    <OfficePreDisabledWarnings>4201;4505;4456;4458;4702</OfficePreDisabledWarnings>
+    <OfficePreDisabledWarnings>4456;4702</OfficePreDisabledWarnings>
     <!--
         The following list matches the list in ..\make.inc
           C4068 - unknown pragma


### PR DESCRIPTION
## Removed the pre-disabled warnings from header that were not being triggered when building and running playground-win32 in VS 2022.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves [#7251]

### What
Removed warnings from the header that weren't being triggered

## Screenshots
All warnings removed:
![image](https://user-images.githubusercontent.com/30995198/210466351-a18f416a-d651-4ca5-9861-b6b28b81f5d3.png)

Only 4456 and 4702 included:
![image](https://user-images.githubusercontent.com/30995198/210465173-1bdc8641-a916-4197-acf3-1ba54b78ed58.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11052)