### PR TITLE
Do not conditionally ignore event props

### DIFF
--- a/change/react-native-windows-b23dc862-597b-4f85-a0e1-d8972cd1d250.json
+++ b/change/react-native-windows-b23dc862-597b-4f85-a0e1-d8972cd1d250.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Do not conditionally ignore event props",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
+++ b/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
@@ -307,7 +307,9 @@ const validAttributesForNonEventProps = {
 };
 
 // Props for bubbling and direct events
-const validAttributesForEventProps = ConditionallyIgnoredEventHandlers({
+// [Windows
+const validAttributesForEventProps = {
+// Windows]
   onLayout: true,
   onMagicTap: true,
 
@@ -346,13 +348,18 @@ const validAttributesForEventProps = ConditionallyIgnoredEventHandlers({
   onPointerLeave: true,
   onPointerOver: true,
   onPointerOut: true,
-});
+// [Windows
+};
+// Windows]
+
 
 /**
  * On iOS, view managers define all of a component's props.
  * All view managers extend RCTViewManager, and RCTViewManager declares these props.
  */
+// [Windows
 const PlatformBaseViewConfigWindows: PartialViewConfigWithoutName = {
+// Windows]
   bubblingEventTypes,
   directEventTypes,
   validAttributes: {

--- a/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
+++ b/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
@@ -162,6 +162,15 @@ const directEventTypes = {
   onGestureHandlerStateChange: DynamicallyInjectedByGestureHandler({
     registrationName: 'onGestureHandlerStateChange',
   }),
+  // [Windows
+  // Mouse enter/leave events
+  topMouseEnter: {
+    registrationName: 'onMouseEnter',
+  },
+  topMouseLeave: {
+    registrationName: 'onMouseLeave',
+  },
+  // Windows]
 };
 
 const validAttributesForNonEventProps = {
@@ -348,6 +357,12 @@ const validAttributesForEventProps = {
   onPointerLeave: true,
   onPointerOver: true,
   onPointerOut: true,
+
+  // [Windows
+  // Mouse enter/leave events
+  onMouseEnter: true,
+  onMouseLeave: true,
+  // Windows]
 // [Windows
 };
 // Windows]

--- a/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
+++ b/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
@@ -11,10 +11,7 @@
 import type {PartialViewConfigWithoutName} from './PlatformBaseViewConfig';
 
 import ReactNativeStyleAttributes from '../Components/View/ReactNativeStyleAttributes';
-import {
-  ConditionallyIgnoredEventHandlers,
-  DynamicallyInjectedByGestureHandler,
-} from './ViewConfigIgnore';
+import {DynamicallyInjectedByGestureHandler} from './ViewConfigIgnore';
 
 const bubblingEventTypes = {
   // Generic Events
@@ -318,7 +315,7 @@ const validAttributesForNonEventProps = {
 // Props for bubbling and direct events
 // [Windows
 const validAttributesForEventProps = {
-// Windows]
+  // Windows]
   onLayout: true,
   onMagicTap: true,
 
@@ -363,10 +360,9 @@ const validAttributesForEventProps = {
   onMouseEnter: true,
   onMouseLeave: true,
   // Windows]
-// [Windows
+  // [Windows
 };
 // Windows]
-
 
 /**
  * On iOS, view managers define all of a component's props.
@@ -374,7 +370,7 @@ const validAttributesForEventProps = {
  */
 // [Windows
 const PlatformBaseViewConfigWindows: PartialViewConfigWithoutName = {
-// Windows]
+  // Windows]
   bubblingEventTypes,
   directEventTypes,
   validAttributes: {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We derive BaseViewConfig from the iOS implementation, which included a line that conditionally ignored event props in case the code was used on any platform other than iOS. This prevented event props from reaching native components that used `createViewConfig` (e.g., Text).

Resolves #11058 
Resolves #11060

### What
This removes the conditional function from BaseViewProps for Windows.

## Testing
Ran this simple example:
```
/**
 * Copyright (c) Microsoft Corporation.
 * Licensed under the MIT License.
 * @format
 */
import React from 'react';
import {AppRegistry, Text} from 'react-native';

export default class Bootstrap extends React.Component {
  render() {
    return <Text onLayout={e => alert(JSON.stringify(e.nativeEvent.layout))} />;
  }
}

AppRegistry.registerComponent('Bootstrap', () => Bootstrap);
```

![image](https://user-images.githubusercontent.com/1106239/211070755-d8d4c732-91cf-4403-8f01-3758ed77e9d6.png)

For `onMouseEnter/Leave`:

https://user-images.githubusercontent.com/1106239/211072034-401948f7-33bc-4ad8-ac9d-33459363ccfc.mp4


_Optional_: Describe the tests that you ran locally to verify your changes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11059)