### PR TITLE
Fix search of react-native module code in vscode

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,10 @@
+# This file modifies how vscode uses .gitignore to filter search results
+
+# Setup for individual module folders to be searchable
+!node_modules
+node_modules/*
+
+# Enable individual module folders
+!node_modules/.fmt
+!node_modules/.folly
+!node_modules/react-native

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,9 @@
     "regex": "cpp"
   },
   "search.exclude": {
-    "**/node_modules": true,
+    "**/dist/**/*.js": true,
     "**/lib/**/*.js": true,
-    "**/dist/**/*.js": true
+    "**/node_modules": false
   },
   "editor.formatOnSave": true,
   "eslint.format.enable": true,


### PR DESCRIPTION
## Description

By default, vscode uses the `.gitignore` file to filter out files when searching and for intellisense. This is usually good because of how many dependencies RNW has that we don't ever look at.

However this limits our ability to easily browse, search, and jump into code we *do* actually want to look at, especially all of the shared C++ in RN (which is only increasing in the new architecture).

This change updates our repo's settings file and adds a new `.ignore` file where we can selectively allow certain folders under `node_modules` to improve the dev experience in vscode.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why

The new RN architecture means we more directly rely on C++ types defined in shared RN code, so it'll be much easier to work on Fabric if VS Code can see those types.

### What

Updated filter rules to allow searching certain paths under `node_modules`, targeting modules that contain C++ code such as RN, folly, and fmt.

## Screenshots
N/A

## Testing
Verified these changes enable search / intellisense in vscode for shared C++ types.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11088)