### PR TITLE
Remove invalid accessibilityValue from SwitchExample

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples-win/Switch/SwitchExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Switch/SwitchExample.windows.js
@@ -291,7 +291,6 @@ class AccessibilitySwitchExample extends React.Component<
         <ExampleRow>
           <Switch
             accessibilityLabel="This is a Switch"
-            accessibilityValue={this.state.switchValue}
             accessibilityHint="Switch"
             nativeID="accessibility-switch"
             onValueChange={value => this.setState({switchValue: value})}
@@ -299,7 +298,6 @@ class AccessibilitySwitchExample extends React.Component<
           />
           <Switch
             accessibilityLabel="This is a Switch with focusable set to false"
-            accessibilityValue={this.state.noFocusableValue}
             accessibilityHint="Switch"
             // focusable={false}
             onValueChange={value => this.setState({noFocusableValue: value})}
@@ -309,7 +307,6 @@ class AccessibilitySwitchExample extends React.Component<
         <ExampleRow>
           <Switch
             accessibilityLabel="This is a Switch with accessible set to false"
-            accessibilityValue={this.state.noAccessibleValue}
             accessibilityHint="Switch"
             // accessible={false}
             onValueChange={value => this.setState({noAccessibleValue: value})}
@@ -317,7 +314,6 @@ class AccessibilitySwitchExample extends React.Component<
           />
           <Switch
             accessibilityLabel="This is a Switch with focusable and accessible set to false"
-            accessibilityValue={this.state.noFocusValue}
             accessibilityHint="Switch"
             // focusable={false}
             // accessible={false}


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
The `accessibilityValue` prop is supposed to be an object with 4 properties: 'now', 'min', 'max', 'text'. The SwitchExample override for RNTester on Windows sets the accessibilityValue to a boolean value, which is not correct. For now, this just removes the accessibilityValue in this example as it will be problematic for prop deserialization in Fabric.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11097)