### PR TITLE
Revert Suppress Flyout if XamlRoot does not have focus

### DIFF
--- a/change/react-native-windows-dfa2ac41-b89e-4284-b024-1919b83bce8a.json
+++ b/change/react-native-windows-dfa2ac41-b89e-4284-b024-1919b83bce8a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert 10863",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FlyoutViewManager.cpp
@@ -409,10 +409,7 @@ void FlyoutShadowNode::OnShowFlyout() {
       LogErrorAndClose("The target view window was closed before flyout could be shown.");
     } else if (!m_targetElement && m_targetTag > 0) {
       LogErrorAndClose("The target view unmounted before flyout could be shown.");
-    } else if (
-        m_targetElement &&
-        (m_flyout.XamlRoot() != m_targetElement.XamlRoot() ||
-         m_flyout.XamlRoot() != React::XamlUIService::GetXamlRoot(GetViewManager()->GetReactContext().Properties()))) {
+    } else if (m_targetElement && m_flyout.XamlRoot() != m_targetElement.XamlRoot()) {
       LogErrorAndClose("The target view window lost focus before flyout could be shown.");
     } else {
       m_flyout.ShowAt(m_targetElement, m_showOptions);


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
For UWP apps, Flyouts were failing to launch with error message "The target view window lost focus before flyout could be shown."


### What
Reverts #10863 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11099)