### PR TITLE
Move 0.70-stable to Legacy

### DIFF
--- a/change/@office-iss-react-native-win32-e6d5c674-2a76-46cb-bec5-e1cc8ce449bb.json
+++ b/change/@office-iss-react-native-win32-e6d5c674-2a76-46cb-bec5-e1cc8ce449bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-50376967-4cd2-4166-84fe-bbf1e72173c6.json
+++ b/change/@react-native-windows-cli-50376967-4cd2-4166-84fe-bbf1e72173c6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-03cb2506-ecd5-4a5f-b89e-8800325b9715.json
+++ b/change/@react-native-windows-codegen-03cb2506-ecd5-4a5f-b89e-8800325b9715.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-b5cc413e-590a-4470-9aa5-de640a8edd88.json
+++ b/change/@react-native-windows-find-repo-root-b5cc413e-590a-4470-9aa5-de640a8edd88.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-2a7cf726-c9b8-4047-83ef-31ccbfe51b58.json
+++ b/change/@react-native-windows-fs-2a7cf726-c9b8-4047-83ef-31ccbfe51b58.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-c4ddf68b-c90f-47b0-a51f-b12caeff9de8.json
+++ b/change/@react-native-windows-package-utils-c4ddf68b-c90f-47b0-a51f-b12caeff9de8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-e66b54d8-5dd1-45f4-9276-8d2496a0a6a8.json
+++ b/change/@react-native-windows-telemetry-e66b54d8-5dd1-45f4-9276-8d2496a0a6a8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-virtualized-list-7817ad4c-deff-4759-a98d-d43348b60245.json
+++ b/change/@react-native-windows-virtualized-list-7817ad4c-deff-4759-a98d-d43348b60245.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "@react-native-windows/virtualized-list",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-24dfeb0e-5cea-4819-8dc3-4667eb5e1f99.json
+++ b/change/react-native-windows-24dfeb0e-5cea-4819-8dc3-4667eb5e1f99.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.70 to legacy",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -84,7 +84,7 @@
     "react-native": "^0.70.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -69,7 +69,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -51,7 +51,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -36,7 +36,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.4.4"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -50,7 +50,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/virtualized-list/package.json
+++ b/packages/@react-native-windows/virtualized-list/package.json
@@ -33,7 +33,7 @@
     "react-native": "^0.70.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -87,7 +87,7 @@
     "react-native": "^0.70.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.70-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
## Description

Move 0.70-stable to Legacy.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11103)