### PR TITLE
Ensure fabric desktop dll builds in PR

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -112,7 +112,7 @@ jobs:
                 displayName: Update Desktop.IntegrationTests.Filter to exclude RNTester integration tests
 
             - ${{ if eq(matrix.UseFabric, true) }}:
-              -template: ../templates/enable-fabric-experimental-feature.yml
+              - template: ../templates/enable-fabric-experimental-feature.yml
 
             - template: ../templates/msbuild-sln.yml
               parameters:

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -17,12 +17,19 @@ parameters:
           - Name: X64Debug
             BuildConfiguration: Debug
             BuildPlatform: x64
+            UseFabric: false
+          - Name: X64DebugFabric
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            UseFabric: true
           - Name: X64Release
             BuildConfiguration: Release
             BuildPlatform: x64
+            UseFabric: false
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
+            UseFabric: false
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Debug
@@ -43,6 +50,10 @@ parameters:
           - Name: X86Release
             BuildConfiguration: Release
             BuildPlatform: x86
+          - X64DebugFabric:
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            UseFabric: true            
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -99,6 +110,9 @@ jobs:
                   $newValue = '(FullyQualifiedName!~RNTesterIntegrationTests::)&' + "$(Desktop.IntegrationTests.Filter)"
                   Write-Host "##vso[task.setvariable variable=Desktop.IntegrationTests.Filter]$newValue"
                 displayName: Update Desktop.IntegrationTests.Filter to exclude RNTester integration tests
+
+            - ${{ if eq(matrix.UseFabric, true) }}:
+              -template: ../templates/enable-fabric-experimental-feature.yml
 
             - template: ../templates/msbuild-sln.yml
               parameters:
@@ -188,7 +202,10 @@ jobs:
 
             - template: ../templates/publish-build-artifacts.yml
               parameters:
-                artifactName: Desktop
+                ${{ if (eq(matrix.UseFabric, true)) }}:
+                  artifactName: DesktopFabric
+                ${{ if (eq(matrix.UseFabric, false)) }}:
+                  artifactName: Desktop
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration }}
                 contents: |

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -202,9 +202,9 @@ jobs:
 
             - template: ../templates/publish-build-artifacts.yml
               parameters:
-                ${{ if (eq(matrix.UseFabric, true)) }}:
+                ${{ if eq(matrix.UseFabric, true) }}:
                   artifactName: DesktopFabric
-                ${{ if (eq(matrix.UseFabric, false)) }}:
+                ${{ if eq(matrix.UseFabric, false) }}:
                   artifactName: Desktop
                 buildPlatform: ${{ matrix.BuildPlatform }}
                 buildConfiguration: ${{ matrix.BuildConfiguration }}

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -50,9 +50,9 @@ parameters:
           - Name: X86Release
             BuildConfiguration: Release
             BuildPlatform: x86
-          - X64DebugFabric:
-            BuildConfiguration: Debug
-            BuildPlatform: x64
+          - X86ReleaseFabric:
+            BuildConfiguration: Release
+            BuildPlatform: x86
             UseFabric: true            
 
 jobs:

--- a/.ado/templates/enable-fabric-experimental-feature.yml
+++ b/.ado/templates/enable-fabric-experimental-feature.yml
@@ -1,0 +1,13 @@
+steps:
+  - powershell: |
+      [xml] $experimentalFeatures = Get-Content vnext\ExperimentalFeatures.props
+      $nsm = New-Object Xml.XmlNamespaceManager($experimentalFeatures.NameTable)
+      $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
+
+      $xmlNode = $experimentalFeatures.CreateElement("PropertyGroup");
+      $xmlNode.InnerXml = "<UseFabric>true</UseFabric>"
+
+      $experimentalFeatures.DocumentElement.AppendChild($xmlNode);
+
+      $experimentalFeatures.Save("vnext\ExperimentalFeatures.props")
+    displayName: Enable UseFabric experimental feature

--- a/change/react-native-windows-355cf654-ef14-44c6-b026-3063681c3fce.json
+++ b/change/react-native-windows-355cf654-ef14-44c6-b026-3063681c3fce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix desktop dll build when fabric is enabled",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
+++ b/vnext/Desktop.DLL/React.Windows.Desktop.DLL.vcxproj
@@ -101,7 +101,7 @@
       <DelayLoadDLLs>Chakra.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
     <Link Condition="'$(UseFabric)' == 'true'">
-      <AdditionalDependencies>windowscodecs.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>windowscodecs.lib;dxguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>Windowscodecs.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -504,7 +504,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
               bool enableMultiThreadSupport{false};
 #ifdef USE_FABRIC
-              enableMultiThreadSupport = IsFabricEnabled(m_reactContext->Properties());
+              enableMultiThreadSupport = Microsoft::ReactNative::IsFabricEnabled(m_reactContext->Properties());
 #endif // USE_FABRIC
 
               devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -331,18 +331,12 @@ InstanceImpl::InstanceImpl(
             preparedScriptStore = std::make_unique<facebook::react::BasePreparedScriptStoreImpl>(tempPath);
           }
 
-          bool enableMultiThreadSupport{false};
-
-#ifdef USE_FABRIC
-          enableMultiThreadSupport = IsFabricEnabled(m_reactContext->Properties());
-#endif // USE_FABRIC
-
           m_devSettings->jsiRuntimeHolder = std::make_shared<facebook::react::V8JSIRuntimeHolder>(
               m_devSettings,
               m_jsThread,
               std::move(scriptStore),
               std::move(preparedScriptStore),
-              enableMultiThreadSupport);
+              false /* enableMultiThreadSupport */);
           break;
 #else
           assert(false); // V8 is not available in this build, fallthrough


### PR DESCRIPTION
## Description
Add verification that we can build the desktop dll with fabric enabled.

And to prove a point, fix some build breaks in the desktop dll when fabric is enabled.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11116)