### PR TITLE
Publish a fabric version of the desktop nuget.

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -132,6 +132,22 @@ jobs:
         ARM64Release:
           BuildConfiguration: Release
           BuildPlatform: ARM64
+        X64DebugFabric:
+          BuildConfiguration: Debug
+          BuildPlatform: x64
+          UseFabric: true
+        X64ReleaseFabric:
+          BuildConfiguration: Release
+          BuildPlatform: x64
+          UseFabric: true
+        X86DebugFabric:
+          BuildConfiguration: Debug
+          BuildPlatform: x86
+          UseFabric: true
+        X86ReleaseFabric:
+          BuildConfiguration: Release
+          BuildPlatform: x86
+          UseFabric: true
     pool: ${{ parameters.AgentPool.Large }}
 
     steps:
@@ -145,6 +161,9 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
+      - ${{ if eq(UseFabric, true) }}:
+        - template: templates/enable-fabric-experimental-feature.yml
+
       - template: templates/msbuild-sln.yml
         parameters:
           solutionDir: vnext
@@ -154,7 +173,10 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          artifactName: Desktop
+          ${{ if eq(UseFabric, true) }}:
+            artifactName: DesktopFabric
+          ${{ if eq(UseFabric, false) }}:
+            artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |
@@ -350,6 +372,29 @@ jobs:
               configuration: Debug
             - platform: ARM64
               configuration: Debug
+
+      - template: templates/prep-and-pack-nuget.yml
+        parameters:
+          artifactName: DesktopFabric
+          publishCommitId: $(publishCommitId)
+          npmVersion: $(npmVersion)-Fabric
+          nugetroot: $(System.DefaultWorkingDirectory)\Desktop
+          packDesktop: true
+          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+            signMicrosoft: true
+          slices:
+            - platform: x64
+              configuration: Release
+            - platform: x86
+              configuration: Release
+            # - platform: ARM64
+            #   configuration: Release
+            - platform: x64
+              configuration: Debug
+            - platform: x86
+              configuration: Debug
+            # - platform: ARM64
+            #   configuration: Debug              
 
       - template: templates/prep-and-pack-nuget.yml
         parameters:


### PR DESCRIPTION
## Description
Publishes a 2nd version of the Office nuget with an augmented version number: eg: `0.72.3-fabric` which includes binaries built with fabric support enabled.

### Why
Allows easier testing of fabric in office.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11128)