### PR TITLE
Fix the publish buld

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -166,7 +166,7 @@ jobs:
         - template: templates/prepare-build-env.yml
           parameters:
             platform: ${{ matrix.BuildPlatform }}
-            configuration: ${{ matrixBuildConfiguration }}
+            configuration: ${{ matrix.BuildConfiguration }}
             buildEnvironment: Publish
 
         - template: templates/apply-published-version-vars.yml
@@ -179,7 +179,7 @@ jobs:
             solutionDir: vnext
             solutionName: ReactWindows-Desktop.sln
             buildPlatform: ${{ matrix.BuildPlatform }}
-            buildConfiguration: ${{ matrixBuildConfiguration }}
+            buildConfiguration: ${{ matrix.BuildConfiguration }}
 
         - template: templates/publish-build-artifacts.yml
           parameters:
@@ -188,7 +188,7 @@ jobs:
             ${{ if eq(matrix.UseFabric, false) }}:
               artifactName: Desktop
             buildPlatform: ${{ matrix.BuildPlatform }}
-            buildConfiguration: ${{ matrixBuildConfiguration }}
+            buildConfiguration: ${{ matrix.BuildConfiguration }}
             contents: |
               React.Windows.Desktop\**
               React.Windows.Desktop.DLL\**

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -316,6 +316,8 @@ jobs:
   - job: RNWNuget
     dependsOn:
       - RnwNpmPublish
+      - ${{ each matrix in parameters.desktopBuildMatrix }}:
+        - RnwNativeBuildDesktop${{ matrix.Name }}
       - RnwNativeBuildDesktop
       - RnwNativeBuildUniversal
       - RnwNativeBuildWinAppSDK

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -160,41 +160,41 @@ jobs:
       dependsOn: RnwNpmPublish
       pool: ${{ parameters.AgentPool.Large }}
 
-    steps:
-      - template: templates/prepare-js-env.yml
+      steps:
+        - template: templates/prepare-js-env.yml
 
-      - template: templates/prepare-build-env.yml
-        parameters:
-          platform: ${{ matrix.BuildPlatform }}
-          configuration: ${{ matrixBuildConfiguration }}
-          buildEnvironment: Publish
+        - template: templates/prepare-build-env.yml
+          parameters:
+            platform: ${{ matrix.BuildPlatform }}
+            configuration: ${{ matrixBuildConfiguration }}
+            buildEnvironment: Publish
 
-      - template: templates/apply-published-version-vars.yml
+        - template: templates/apply-published-version-vars.yml
 
-      - ${{ if eq(matrix.UseFabric, true) }}:
-        - template: templates/enable-fabric-experimental-feature.yml
+        - ${{ if eq(matrix.UseFabric, true) }}:
+          - template: templates/enable-fabric-experimental-feature.yml
 
-      - template: templates/msbuild-sln.yml
-        parameters:
-          solutionDir: vnext
-          solutionName: ReactWindows-Desktop.sln
-          buildPlatform: ${{ matrix.BuildPlatform }}
-          buildConfiguration: ${{ matrixBuildConfiguration }}
+        - template: templates/msbuild-sln.yml
+          parameters:
+            solutionDir: vnext
+            solutionName: ReactWindows-Desktop.sln
+            buildPlatform: ${{ matrix.BuildPlatform }}
+            buildConfiguration: ${{ matrixBuildConfiguration }}
 
-      - template: templates/publish-build-artifacts.yml
-        parameters:
-          ${{ if eq(matrix.UseFabric, true) }}:
-            artifactName: DesktopFabric
-          ${{ if eq(matrix.UseFabric, false) }}:
-            artifactName: Desktop
-          buildPlatform: ${{ matrix.BuildPlatform }}
-          buildConfiguration: ${{ matrixBuildConfiguration }}
-          contents: |
-            React.Windows.Desktop\**
-            React.Windows.Desktop.DLL\**
-            React.Windows.Desktop.Test.DLL\**
+        - template: templates/publish-build-artifacts.yml
+          parameters:
+            ${{ if eq(matrix.UseFabric, true) }}:
+              artifactName: DesktopFabric
+            ${{ if eq(matrix.UseFabric, false) }}:
+              artifactName: Desktop
+            buildPlatform: ${{ matrix.BuildPlatform }}
+            buildConfiguration: ${{ matrixBuildConfiguration }}
+            contents: |
+              React.Windows.Desktop\**
+              React.Windows.Desktop.DLL\**
+              React.Windows.Desktop.Test.DLL\**
 
-      - template: templates/component-governance.yml
+        - template: templates/component-governance.yml
 
   - job: RnwNativeBuildUniversal
     displayName: Build Universal

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -167,8 +167,8 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
-        - template: templates/enable-fabric-experimental-feature.yml
+      - template: templates/enable-fabric-experimental-feature.yml
+        condition: and(succeeded(), eq(variables.UseFabric, true))
 
       - template: templates/msbuild-sln.yml
         parameters:
@@ -178,11 +178,20 @@ jobs:
           buildConfiguration: $(BuildConfiguration)
 
       - template: templates/publish-build-artifacts.yml
+        condition: and(succeeded(), eq(variables.UseFabric, false))
         parameters:
-          ${{ if eq(variables['UseFabric'], true) }}:
-            artifactName: DesktopFabric
-          ${{ if eq(variables['UseFabric'], false) }}:
-            artifactName: Desktop
+          artifactName: Desktop
+          buildPlatform: $(BuildPlatform)
+          buildConfiguration: $(BuildConfiguration)
+          contents: |
+            React.Windows.Desktop\**
+            React.Windows.Desktop.DLL\**
+            React.Windows.Desktop.Test.DLL\**
+
+      - template: templates/publish-build-artifacts.yml
+        condition: and(succeeded(), eq(variables.UseFabric, true))
+        parameters:
+          artifactName: DesktopFabric
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)
           contents: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -161,7 +161,7 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - ${{ if eq(Matrix.UseFabric, true) }}:
+      - ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
         - template: templates/enable-fabric-experimental-feature.yml
 
       - template: templates/msbuild-sln.yml
@@ -173,9 +173,9 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          ${{ if eq(Matrix.UseFabric, true) }}:
+          ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
             artifactName: DesktopFabric
-          ${{ if eq(Matrix.UseFabric, false) }}:
+          ${{ if eq(variables['buildConfiguration.UseFabric'], false) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -179,9 +179,9 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
+          ${{ if eq(variables['UseFabric'], true) }}:
             artifactName: DesktopFabric
-          ${{ if eq(variables['buildConfiguration.UseFabric'], false) }}:
+          ${{ if eq(variables['UseFabric'], false) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -161,7 +161,7 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - ${{ if eq(UseFabric, true) }}:
+      - ${{ if eq(matrix.UseFabric, true) }}:
         - template: templates/enable-fabric-experimental-feature.yml
 
       - template: templates/msbuild-sln.yml
@@ -173,9 +173,9 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          ${{ if eq(UseFabric, true) }}:
+          ${{ if eq(matrix.UseFabric, true) }}:
             artifactName: DesktopFabric
-          ${{ if eq(UseFabric, false) }}:
+          ${{ if eq(matrix.UseFabric, false) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -175,7 +175,7 @@ jobs:
         parameters:
           ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
             artifactName: DesktopFabric
-          ${{ if eq(variables['buildConfiguration.UseFabric'], false) }}:
+          ${{ if neq(variables['buildConfiguration.UseFabric'], true) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -161,7 +161,7 @@ jobs:
 
       - template: templates/apply-published-version-vars.yml
 
-      - ${{ if eq(matrix.UseFabric, true) }}:
+      - ${{ if eq(Matrix.UseFabric, true) }}:
         - template: templates/enable-fabric-experimental-feature.yml
 
       - template: templates/msbuild-sln.yml
@@ -173,9 +173,9 @@ jobs:
 
       - template: templates/publish-build-artifacts.yml
         parameters:
-          ${{ if eq(matrix.UseFabric, true) }}:
+          ${{ if eq(Matrix.UseFabric, true) }}:
             artifactName: DesktopFabric
-          ${{ if eq(matrix.UseFabric, false) }}:
+          ${{ if eq(Matrix.UseFabric, false) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -117,21 +117,27 @@ jobs:
         X64Debug:
           BuildConfiguration: Debug
           BuildPlatform: x64
+          UseFabric: false
         X64Release:
           BuildConfiguration: Release
           BuildPlatform: x64
+          UseFabric: false
         X86Debug:
           BuildConfiguration: Debug
           BuildPlatform: x86
+          UseFabric: false
         X86Release:
           BuildConfiguration: Release
           BuildPlatform: x86
+          UseFabric: false
         ARM64Debug:
           BuildConfiguration: Debug
           BuildPlatform: ARM64
+          UseFabric: false
         ARM64Release:
           BuildConfiguration: Release
           BuildPlatform: ARM64
+          UseFabric: false
         X64DebugFabric:
           BuildConfiguration: Debug
           BuildPlatform: x64
@@ -175,7 +181,7 @@ jobs:
         parameters:
           ${{ if eq(variables['buildConfiguration.UseFabric'], true) }}:
             artifactName: DesktopFabric
-          ${{ if neq(variables['buildConfiguration.UseFabric'], true) }}:
+          ${{ if eq(variables['buildConfiguration.UseFabric'], false) }}:
             artifactName: Desktop
           buildPlatform: $(BuildPlatform)
           buildConfiguration: $(BuildConfiguration)

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -23,6 +23,51 @@ parameters:
       name: rnw-pool-8-microsoft
       demands: ImageOverride -equals rnw-img-vs2022
 
+- name: desktopBuildMatrix
+  type: object
+  default:
+    - Name: X64Debug
+      BuildConfiguration: Debug
+      BuildPlatform: x64
+      UseFabric: false
+    - Name: X64Release
+      BuildConfiguration: Release
+      BuildPlatform: x64
+      UseFabric: false
+    - Name: X86Debug
+      BuildConfiguration: Debug
+      BuildPlatform: x86
+      UseFabric: false
+    - Name: X86Release
+      BuildConfiguration: Release
+      BuildPlatform: x86
+      UseFabric: false
+    - Name: ARM64Debug
+      BuildConfiguration: Debug
+      BuildPlatform: ARM64
+      UseFabric: false
+    - Name: ARM64Release
+      BuildConfiguration: Release
+      BuildPlatform: ARM64
+      UseFabric: false
+    - Name: X64DebugFabric
+      BuildConfiguration: Debug
+      BuildPlatform: x64
+      UseFabric: true
+    - Name: X64ReleaseFabric
+      BuildConfiguration: Release
+      BuildPlatform: x64
+      UseFabric: true
+    - Name: X86DebugFabric
+      BuildConfiguration: Debug
+      BuildPlatform: x86
+      UseFabric: true
+    - Name: X86ReleaseFabric
+      BuildConfiguration: Release
+      BuildPlatform: x86
+      UseFabric: true
+
+
 variables:
   - template: variables/windows.yml
   - group: RNW Secrets
@@ -109,91 +154,41 @@ jobs:
     
       - template: templates/publish-version-vars.yml
 
-  - job: RnwNativeBuildDesktop
-    displayName: Build Desktop
-    dependsOn: RnwNpmPublish
-    strategy:
-      matrix:
-        X64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-          UseFabric: false
-        X64Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-          UseFabric: false
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseFabric: false
-        X86Release:
-          BuildConfiguration: Release
-          BuildPlatform: x86
-          UseFabric: false
-        ARM64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: ARM64
-          UseFabric: false
-        ARM64Release:
-          BuildConfiguration: Release
-          BuildPlatform: ARM64
-          UseFabric: false
-        X64DebugFabric:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-          UseFabric: true
-        X64ReleaseFabric:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-          UseFabric: true
-        X86DebugFabric:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-          UseFabric: true
-        X86ReleaseFabric:
-          BuildConfiguration: Release
-          BuildPlatform: x86
-          UseFabric: true
-    pool: ${{ parameters.AgentPool.Large }}
+  - ${{ each matrix in parameters.desktopBuildMatrix }}:
+    - job: RnwNativeBuildDesktop${{ matrix.Name }}
+      displayName: Build Desktop ${{ matrix.Name }}
+      dependsOn: RnwNpmPublish
+      pool: ${{ parameters.AgentPool.Large }}
 
     steps:
       - template: templates/prepare-js-env.yml
 
       - template: templates/prepare-build-env.yml
         parameters:
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
+          platform: ${{ matrix.BuildPlatform }}
+          configuration: ${{ matrixBuildConfiguration }}
           buildEnvironment: Publish
 
       - template: templates/apply-published-version-vars.yml
 
-      - template: templates/enable-fabric-experimental-feature.yml
-        condition: and(succeeded(), eq(variables.UseFabric, true))
+      - ${{ if eq(matrix.UseFabric, true) }}:
+        - template: templates/enable-fabric-experimental-feature.yml
 
       - template: templates/msbuild-sln.yml
         parameters:
           solutionDir: vnext
           solutionName: ReactWindows-Desktop.sln
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
+          buildPlatform: ${{ matrix.BuildPlatform }}
+          buildConfiguration: ${{ matrixBuildConfiguration }}
 
       - template: templates/publish-build-artifacts.yml
-        condition: and(succeeded(), eq(variables.UseFabric, false))
         parameters:
-          artifactName: Desktop
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
-          contents: |
-            React.Windows.Desktop\**
-            React.Windows.Desktop.DLL\**
-            React.Windows.Desktop.Test.DLL\**
-
-      - template: templates/publish-build-artifacts.yml
-        condition: and(succeeded(), eq(variables.UseFabric, true))
-        parameters:
-          artifactName: DesktopFabric
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
+          ${{ if eq(matrix.UseFabric, true) }}:
+            artifactName: DesktopFabric
+          ${{ if eq(matrix.UseFabric, false) }}:
+            artifactName: Desktop
+          buildPlatform: ${{ matrix.BuildPlatform }}
+          buildConfiguration: ${{ matrixBuildConfiguration }}
           contents: |
             React.Windows.Desktop\**
             React.Windows.Desktop.DLL\**

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -318,7 +318,6 @@ jobs:
       - RnwNpmPublish
       - ${{ each matrix in parameters.desktopBuildMatrix }}:
         - RnwNativeBuildDesktop${{ matrix.Name }}
-      - RnwNativeBuildDesktop
       - RnwNativeBuildUniversal
       - RnwNativeBuildWinAppSDK
     displayName: Sign Binaries and Publish NuGet


### PR DESCRIPTION
Fix the publish build.

My previous attempt to add publishing of fabric nugets as trying to use the matrix variables using template expressions.  Unfortunately, the matrix variables are only available at runtime, and the template expressions are evaluated at compile time.  So, I switched around the matrix and made everything compile time. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11142)