### PR TITLE
Fixes issue where Alert crashes

### DIFF
--- a/change/react-native-windows-7857ea29-339a-42e2-958b-383fecd2ce0e.json
+++ b/change/react-native-windows-7857ea29-339a-42e2-958b-383fecd2ce0e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes issue where Alert crashes",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -98,6 +98,13 @@ void Alert::ProcessPendingAlertRequests() noexcept {
       });
 
       dialog.Closed([=](auto &&, auto &&) { xamlRoot.Changed(rootChangedToken); });
+    } else if (IsXamlIsland()) {
+      // We cannot show a ContentDialog in a XAML Island unless it is assigned a
+      // XamlRoot instance. In such cases, we just treat the alert as dismissed.
+      jsDispatcher.Post([result, this] { result(m_constants.dismissed, m_constants.buttonNeutral); });
+      pendingAlerts.pop();
+      ProcessPendingAlertRequests();
+      return;
     }
   }
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
There are edge cases where an Alert may be shown while the app is exiting. Generally, when the app is exiting, apps will have set the XamlRoot instance on XamlUIService to null. In this case, we may still attempt to show the alert on a XAML Island with a null XamlRoot instance, which would cause a crash.

### What
This change just ensures that, if we are in a XAML Island and we don't have a valid XamlRoot to attach to the ContentDialog, we just treat the alert as dismissed.

## Testing
Set up simple.tsx example to wire up onDismiss, added native button to Playground-Win32 to clear XamlRoot setting on XamlUIService, confirmed that trying to show an alert after setting XamlRoot to null on XamlUIService results in `onDismiss` callback.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/react-native-windows/pulls/11168)