### PR TITLE
Ensure NativeAnimatedNodeManager is destroyed on UI thread

### DIFF
--- a/change/react-native-windows-186959bb-b4aa-4a6d-98ce-d9c41cd1623b.json
+++ b/change/react-native-windows-186959bb-b4aa-4a6d-98ce-d9c41cd1623b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure NativeAnimatedNodeManager is destroyed on UI thread",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.cpp
@@ -10,6 +10,15 @@
 
 namespace Microsoft::ReactNative {
 
+NativeAnimatedModule::NativeAnimatedModule() {}
+
+NativeAnimatedModule::~NativeAnimatedModule() {
+  // To make sure that we destroy active animation operations on UI thread.
+  if (m_context && !m_context.UIDispatcher().HasThreadAccess()) {
+    m_context.UIDispatcher().Post([nodesManager = std::move(m_nodesManager)]() mutable { nodesManager = nullptr; });
+  }
+}
+
 void NativeAnimatedModule::Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   m_context = reactContext;
   m_nodesManager = std::make_shared<NativeAnimatedNodeManager>(reactContext);

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedModule.h
@@ -58,6 +58,8 @@ REACT_MODULE(NativeAnimatedModule)
 struct NativeAnimatedModule : std::enable_shared_from_this<NativeAnimatedModule> {
   // Commented out due to missing implementation of updateAnimatedNodeConfig
   // using ModuleSpec = ReactNativeSpecs::AnimatedModuleSpec;
+  NativeAnimatedModule();
+  ~NativeAnimatedModule();
 
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Most operations in the NativeAnimatedNodeManager run on the UI thread, including operations that attempt to resolve Paper shadow nodes, and operations to run the tick-driven animations. It's possible that the UI thread operations may run after the NativeAnimatedNodeManager has been destroyed, in which case, we see crashes when unloading the React instance because we're referencing fields on `this` that no longer correspond to a valid NativeAnimatedNodeManager instance.

### What
This change uses the same pattern we use in the PaperUIManagerModule to ensure that the UIManager instance is cleaned up on the UI thread, by posting the shared_ptr to the instance to the UI thread if it's available.

## Testing
TBD

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://api.github.com/repos/microsoft/react-native-windows/pulls/11169)