### PR TITLE
Allow some usage of wstring when using spec files

### DIFF
--- a/change/react-native-windows-f6189755-f586-4f3e-b16b-be081501c566.json
+++ b/change/react-native-windows-f6189755-f586-4f3e-b16b-be081501c566.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow some usage of wstring when using spec files",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -370,9 +370,24 @@ struct MethodSignature {
     }
   }
 
+  template <class TInputArg, class TOtherInputArg>
+  static constexpr bool MatchInputArg() noexcept {
+    return std::is_same_v<TInputArg, TOtherInputArg>;
+  }
+
+  template <>
+  static constexpr bool MatchInputArg<std::wstring, std::string>() noexcept {
+    return true;
+  }
+
+  template <>
+  static constexpr bool MatchInputArg<std::string, std::wstring>() noexcept {
+    return true;
+  }
+
   template <class TOtherInputArgs, size_t... I>
   static constexpr bool MatchInputArgs(std::index_sequence<I...>) noexcept {
-    return (std::is_same_v<std::tuple_element_t<I, InputArgs>, std::tuple_element_t<I, TOtherInputArgs>> && ...);
+    return (MatchInputArg<std::tuple_element_t<I, InputArgs>, std::tuple_element_t<I, TOtherInputArgs>>() && ...);
   }
 
   template <class TOtherOutputCallbacks, size_t... I>

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.cpp
@@ -38,7 +38,7 @@ void AccessibilityInfo::setAccessibilityFocus(double /*reactTag*/) noexcept {
   // no-op - This appears to be unused in RN
 }
 
-void AccessibilityInfo::announceForAccessibility(std::string announcement) noexcept {
+void AccessibilityInfo::announceForAccessibility(std::wstring announcement) noexcept {
   m_context.UIDispatcher().Post([context = m_context, announcement = std::move(announcement)] {
     // Windows requires a specific element to announce from. Unfortunately the react-native API does not provide a tag
     // So we need to find something to raise the notification event from.
@@ -61,7 +61,7 @@ void AccessibilityInfo::announceForAccessibility(std::string announcement) noexc
       return;
     }
 
-    winrt::hstring hstr{Microsoft::Common::Unicode::Utf8ToUtf16(announcement)};
+    winrt::hstring hstr{announcement};
     peer.RaiseNotificationEvent(
         xaml::Automation::Peers::AutomationNotificationKind::Other,
         xaml::Automation::Peers::AutomationNotificationProcessing::ImportantMostRecent,

--- a/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AccessibilityInfoModule.h
@@ -24,7 +24,7 @@ struct AccessibilityInfo : public std::enable_shared_from_this<AccessibilityInfo
   void setAccessibilityFocus(double reactTag) noexcept;
 
   REACT_METHOD(announceForAccessibility)
-  void announceForAccessibility(std::string announcement) noexcept;
+  void announceForAccessibility(std::wstring announcement) noexcept;
 
   REACT_METHOD(getRecommendedTimeoutMillis)
   void getRecommendedTimeoutMillis(double mSec, std::function<void(double)> const &onSuccess) noexcept;

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.cpp
@@ -48,10 +48,10 @@ void Clipboard::getString(React::ReactPromise<std::string> result) noexcept {
   );
 }
 
-void Clipboard::setString(std::string content) noexcept {
+void Clipboard::setString(std::wstring content) noexcept {
   m_reactContext.UIDispatcher().Post([=] {
     DataTransfer::DataPackage data;
-    data.SetText(Microsoft::Common::Unicode::Utf8ToUtf16(content));
+    data.SetText(content);
     DataTransfer::Clipboard::SetContent(data);
   });
 }

--- a/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ClipboardModule.h
@@ -18,7 +18,7 @@ struct Clipboard {
   void getString(React::ReactPromise<std::string> result) noexcept;
 
   REACT_METHOD(setString)
-  void setString(std::string content) noexcept;
+  void setString(std::wstring content) noexcept;
 
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
 };

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -60,7 +60,7 @@ LinkingManager::~LinkingManager() noexcept {
 
 fire_and_forget openUrlAsync(std::wstring url, ::React::ReactPromise<void> result) noexcept {
   try {
-    winrt::Windows::Foundation::Uri uri(Utf8ToUtf16(url));
+    winrt::Windows::Foundation::Uri uri(url);
 
     if (co_await Launcher::LaunchUriAsync(uri)) {
       result.Resolve();

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -48,8 +48,8 @@ LinkingManager::~LinkingManager() noexcept {
   }
 }
 
-/*static*/ fire_and_forget LinkingManager::canOpenURL(std::string url, ::React::ReactPromise<bool> result) noexcept {
-  winrt::Windows::Foundation::Uri uri(Utf8ToUtf16(url));
+/*static*/ fire_and_forget LinkingManager::canOpenURL(std::wstring url, ::React::ReactPromise<bool> result) noexcept {
+  winrt::Windows::Foundation::Uri uri(url);
   auto status = co_await Launcher::QueryUriSupportAsync(uri, LaunchQuerySupportType::Uri);
   if (status == LaunchQuerySupportStatus::Available) {
     result.Resolve(true);
@@ -58,7 +58,7 @@ LinkingManager::~LinkingManager() noexcept {
   }
 }
 
-fire_and_forget openUrlAsync(std::string url, ::React::ReactPromise<void> result) noexcept {
+fire_and_forget openUrlAsync(std::wstring url, ::React::ReactPromise<void> result) noexcept {
   try {
     winrt::Windows::Foundation::Uri uri(Utf8ToUtf16(url));
 
@@ -72,7 +72,7 @@ fire_and_forget openUrlAsync(std::string url, ::React::ReactPromise<void> result
   }
 }
 
-void LinkingManager::openURL(std::string &&url, ::React::ReactPromise<void> &&result) noexcept {
+void LinkingManager::openURL(std::wstring &&url, ::React::ReactPromise<void> &&result) noexcept {
   m_context.UIDispatcher().Post(
       [url = std::move(url), result = std::move(result)]() { openUrlAsync(std::move(url), std::move(result)); });
 }

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -65,10 +65,10 @@ fire_and_forget openUrlAsync(std::wstring url, ::React::ReactPromise<void> resul
     if (co_await Launcher::LaunchUriAsync(uri)) {
       result.Resolve();
     } else {
-      result.Reject(("Unable to open URL: " + url).c_str());
+      result.Reject(("Unable to open URL: " + Utf16ToUtf8(url)).c_str());
     }
   } catch (winrt::hresult_error &e) {
-    result.Reject(("Unable to open URL: " + url + "error: " + winrt::to_string(e.message())).c_str());
+    result.Reject(("Unable to open URL: " + Utf16ToUtf8(url) + "error: " + winrt::to_string(e.message())).c_str());
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.h
@@ -22,10 +22,10 @@ struct LinkingManager {
   void Initialize(React::ReactContext const &reactContext) noexcept;
 
   REACT_METHOD(canOpenURL)
-  static winrt::fire_and_forget canOpenURL(std::string url, ::React::ReactPromise<bool> result) noexcept;
+  static winrt::fire_and_forget canOpenURL(std::wstring url, ::React::ReactPromise<bool> result) noexcept;
 
   REACT_METHOD(openURL)
-  void openURL(std::string &&url, ::React::ReactPromise<void> &&result) noexcept;
+  void openURL(std::wstring &&url, ::React::ReactPromise<void> &&result) noexcept;
 
   REACT_METHOD(openSettings)
   static void openSettings(::React::ReactPromise<void> &&result) noexcept;


### PR DESCRIPTION
## Description
When using a spec file to ensure the correctness of a TurboModule a javascript `string` must be treated as a `std::string`.  The `REACT_METHOD` macros already support using `std::string` or `std::wstring`.  This just extends the correctness check to allow either.

Then I'm simplified some of the existing methods of some of our module, now that they can take a wstring.


Not supported in this iteration is 
```cpp
  REACT_METHOD(getString)
  void getString(React::ReactPromise<std::wstring> result) noexcept;
```

@ZihanChen-MSFT , feel free to add to this PR, and change say ClipboardModule.cpp's getString to take a wstring.
Otherwise we can treat this PR as a step in the right direction.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11197)