### PR TITLE
[0.69] Fix Hermes sampling profiler (#11033)

### DIFF
--- a/change/@react-native-windows-telemetry-a883e2fb-184e-4a5c-8e6a-c893f19aab47.json
+++ b/change/@react-native-windows-telemetry-a883e2fb-184e-4a5c-8e6a-c893f19aab47.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Hermes sampling profiler (#11033)",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-161cd4d0-000f-40c3-8a37-f0260ef756d7.json
+++ b/change/react-native-windows-161cd4d0-000f-40c3-8a37-f0260ef756d7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Hermes sampling profiler (#11033)",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackageReference/UsesPackageReference.csproj
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackageReference/UsesPackageReference.csproj
@@ -144,12 +144,8 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props')" />
   </ImportGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
-    </PackageReference>
-    <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.8.1-ms.5</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
+    <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets')" />

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackageReference/UsesPackageReference.csproj
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackageReference/UsesPackageReference.csproj
@@ -144,8 +144,12 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props')" />
   </ImportGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
-    <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+      <Version>6.2.9</Version>
+    </PackageReference>
+    <PackageReference Include="ReactNative.Hermes.Windows">
+      <Version>0.8.1-ms.5</Version>
+    </PackageReference>
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets')" />

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/UsesPackagesConfig.vcxproj
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/UsesPackagesConfig.vcxproj
@@ -176,7 +176,7 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets')" />
+    <Import Project="..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets" Condition="Exists('..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets')" />
     <Import Project="..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets')" />
     <Import Project="..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
@@ -187,7 +187,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets'))" />
     <Error Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/UsesPackagesConfig.vcxproj
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/UsesPackagesConfig.vcxproj
@@ -176,7 +176,7 @@
   </Target>
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" />
+    <Import Project="..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets" Condition="Exists('..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets')" />
     <Import Project="..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets" Condition="Exists('..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets')" />
     <Import Project="..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets" Condition="Exists('..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets')" />
     <Import Project="..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets" Condition="Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" />
@@ -187,7 +187,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.210312.4\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.8.1-ms.5\build\native\ReactNative.Hermes.Windows.targets'))" />
+    <Error Condition="!Exists('..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\ReactNative.Hermes.Windows.0.69.1\build\native\ReactNative.Hermes.Windows.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ReactNative.0.0.0-canary.359\build\native\Microsoft.ReactNative.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ReactNative.Cxx.0.0.0-canary.359\build\native\Microsoft.ReactNative.Cxx.targets'))" />
     <Error Condition="!Exists('..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\$(WinUIPackageName).$(WinUIPackageVersion)\build\native\$(WinUIPackageName).targets'))" />

--- a/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
+++ b/packages/@react-native-windows/telemetry/src/test/projects/UsesPackagesConfig/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.6.0" targetFramework="native"/>
-  <package id="ReactNative.Hermes.Windows" version="0.8.1-ms.5" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.69.1" targetFramework="native"/>
 </packages>

--- a/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
+++ b/packages/@react-native-windows/tester/src/js/examples-win/Accessibility/AccessibilityInfoExample.js
@@ -40,10 +40,10 @@ function AccessibilityInfoExample(props): React.Node {
   let myElement = React.createRef();
 
   React.useEffect(() => {
-    AccessibilityInfo.isReduceMotionEnabled().done(isEnabled => {
+    AccessibilityInfo.isReduceMotionEnabled().then(isEnabled => {
       setIsReduceMotionEnabled(isEnabled);
     });
-    AccessibilityInfo.isScreenReaderEnabled().done(isEnabled => {
+    AccessibilityInfo.isScreenReaderEnabled().then(isEnabled => {
       setIsScreenReaderEnabled(isEnabled);
     });
   }, [setIsReduceMotionEnabled, setIsScreenReaderEnabled]);

--- a/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
+++ b/packages/e2e-test-app/windows/RNTesterApp/RNTesterApp.csproj
@@ -142,15 +142,9 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props')" />
   </ImportGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
-    </PackageReference>
-    <PackageReference Include="XamlTreeDump">
-      <Version>1.0.9</Version>
-    </PackageReference>
-    <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.12.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
+    <PackageReference Include="XamlTreeDump" Version="1.0.9" />
+    <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets')" />

--- a/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
+++ b/packages/e2e-test-app/windows/RNTesterApp/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Direct",
-        "requested": "[0.11.0-ms.6, )",
-        "resolved": "0.11.0-ms.6",
-        "contentHash": "U+0FecIUFhmuLDNGT+kIhQdzoIgOvaGHU5gQOl66G5JdbO8xpful+E5OH/NL9Ue6N1l+ecqTH9shGrVDsdG5ow=="
+        "requested": "[0.69.1, )",
+        "resolved": "0.69.1",
+        "contentHash": "/Xd5l7wBKOO7IvS2IYDPPzXvlU4sYmoRIbX3wt35La9aAzIDEzlE5qWwRu0usRFyEeZoLWjQpnLqItMMy4mvQg=="
       },
       "XamlTreeDump": {
         "type": "Direct",
@@ -56,7 +56,7 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
+        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -147,16 +147,10 @@
         }
       },
       "reactnativepicker": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.ReactNative": "1.0.0"
-        }
+        "type": "Project"
       },
       "reactnativexaml": {
-        "type": "Project",
-        "dependencies": {
-          "Microsoft.ReactNative": "1.0.0"
-        }
+        "type": "Project"
       }
     },
     "UAP,Version=v10.0.16299/win10-arm": {

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -180,7 +180,7 @@
     <!-- <PackageReference Include="Microsoft.UI.Xaml" Version="2.6.1-prerelease.210709001" /> -->
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.2-rc" />
-    <PackageReference Include="ReactNative.Hermes.Windows" Version="0.12.1" />
+    <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <Target Name="EnsureReactNativeWindowsTargets" BeforeTargets="PrepareForBuild">

--- a/packages/playground/windows/playground/packages.config
+++ b/packages/playground/windows/playground/packages.config
@@ -3,4 +3,5 @@
   <package id="Microsoft.Windows.CppWinRT" version="2.0.210312.4" targetFramework="native"/>
   <package id="Microsoft.UI.Xaml" version="2.7.0" targetFramework="native"/>
   <package id="Microsoft.WinUI" version="3.0.0-preview4.210210.4" targetFramework="native"/>
+  <package id="ReactNative.Hermes.Windows" version="0.69.1" targetFramework="native"/>
 </packages>

--- a/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
+++ b/packages/sample-apps/windows/SampleAppCS/SampleAppCS.csproj
@@ -154,12 +154,8 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.props')" />
   </ImportGroup>
   <ItemGroup>
-   <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.9</Version>
-    </PackageReference>
-    <PackageReference Include="ReactNative.Hermes.Windows">
-      <Version>0.12.1</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.9" />
+    <PackageReference Include="ReactNative.Hermes.Windows" Version="$(HermesVersion)" />
   </ItemGroup>
   <ImportGroup Label="ReactNativeWindowsTargets">
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CSharpApp.targets')" />

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -51,6 +51,7 @@
     <CppWinRTUsePrefixes>true</CppWinRTUsePrefixes>
     <UseV8>true</UseV8>
     <V8AppPlatform>win32</V8AppPlatform>
+    <HermesCompileRtti>false</HermesCompileRtti>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -24,11 +24,6 @@
           "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
-      "boost": {
-        "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
@@ -58,40 +53,20 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
+        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Transitive",
-        "resolved": "2.7.0",
-        "contentHash": "dB4im13tfmMgL/V3Ei+3kD2rUF+/lTxAmR4gjJ45l577eljHfdo/KUrxpq/3I1Vp6e5GCDG1evDaEGuDxypLMg=="
-      },
-      "Microsoft.Windows.CppWinRT": {
-        "type": "Transitive",
-        "resolved": "2.0.211028.7",
-        "contentHash": "JBGI0c3WLoU6aYJRy9Qo0MLDQfObEp+d4nrhR95iyzf7+HOgjRunHDp/6eGFREd7xq3OI1mll9ecJrMfzBvlyg=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22000.194",
-        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
-      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
-      },
-      "ReactNative.Hermes.Windows": {
-        "type": "Transitive",
-        "resolved": "0.11.0-ms.6",
-        "contentHash": "WAVLsSZBV4p/3hNC3W67su7xu3f/ZMSKxu0ON7g2GaKRbkJmH0Qyif1IlzcJwtvR48kuOdfgPu7Bgtz3AY+gqg=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -160,31 +135,8 @@
         "resolved": "2.2.9",
         "contentHash": "qF6RRZKaflI+LR1YODNyWYjq5YoX8IJ2wx5y8O+AW2xO+1t/Q6Mm+jQ38zJbWnmXbrcOqUYofn7Y3/KC6lTLBQ=="
       },
-      "common": {
-        "type": "Project"
-      },
-      "fmt": {
-        "type": "Project"
-      },
-      "folly": {
-        "type": "Project",
-        "dependencies": {
-          "fmt": "1.0.0"
-        }
-      },
       "microsoft.reactnative": {
-        "type": "Project",
-        "dependencies": {
-          "Common": "1.0.0",
-          "Folly": "1.0.0",
-          "ReactCommon": "1.0.0"
-        }
-      },
-      "reactcommon": {
-        "type": "Project",
-        "dependencies": {
-          "Folly": "1.0.0"
-        }
+        "type": "Project"
       }
     },
     "UAP,Version=v10.0.16299/win10-arm": {

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.cpp
@@ -124,4 +124,8 @@ void ReactDispatcher::InvokeElsePost(Mso::DispatchTask &&task) const noexcept {
   return jsThreadDispatcherProperty;
 }
 
+/*static*/ IReactDispatcher ReactDispatcher::GetJSDispatcher(IReactPropertyBag const &properties) noexcept {
+  return properties.Get(JSDispatcherProperty()).try_as<IReactDispatcher>();
+}
+
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/IReactDispatcher.h
+++ b/vnext/Microsoft.ReactNative/IReactDispatcher.h
@@ -38,6 +38,7 @@ struct ReactDispatcher : implements<ReactDispatcher, IReactDispatcher, Mso::Reac
   static void SetUIThreadDispatcher(IReactPropertyBag const &properties) noexcept;
 
   static IReactPropertyName JSDispatcherProperty() noexcept;
+  static IReactDispatcher GetJSDispatcher(IReactPropertyBag const &properties) noexcept;
 
   void Post(Mso::DispatchTask &&task) const noexcept override;
   void InvokeElsePost(Mso::DispatchTask &&task) const noexcept override;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -250,6 +250,7 @@ ReactInstanceWin::ReactInstanceWin(
                                                                onDestroyed = m_options.OnInstanceDestroyed,
                                                                reactContext = m_reactContext]() noexcept {
         whenLoaded.TryCancel(); // It only has an effect if whenLoaded was not set before
+        facebook::react::HermesRuntimeHolder::storeTo(ReactPropertyBag(reactContext->Properties()), nullptr);
         if (onDestroyed) {
           onDestroyed.Get()->Invoke(reactContext);
         }
@@ -463,10 +464,14 @@ void ReactInstanceWin::Initialize() noexcept {
           std::unique_ptr<facebook::jsi::PreparedScriptStore> preparedScriptStore = nullptr;
 
           switch (m_options.JsiEngine()) {
-            case JSIEngine::Hermes:
-              devSettings->jsiRuntimeHolder =
+            case JSIEngine::Hermes: {
+              auto hermesRuntimeHolder =
                   std::make_shared<facebook::react::HermesRuntimeHolder>(devSettings, m_jsMessageThread.Load());
+              facebook::react::HermesRuntimeHolder::storeTo(
+                  ReactPropertyBag(m_reactContext->Properties()), hermesRuntimeHolder);
+              devSettings->jsiRuntimeHolder = hermesRuntimeHolder;
               break;
+            }
             case JSIEngine::V8:
 #if defined(USE_V8)
             {

--- a/vnext/Microsoft.ReactNative/Utils/Helpers.h
+++ b/vnext/Microsoft.ReactNative/Utils/Helpers.h
@@ -18,7 +18,7 @@ struct ReactId {
 };
 
 template <typename T>
-inline typename T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
+inline T asEnum(winrt::Microsoft::ReactNative::JSValue const &obj) {
   return static_cast<T>(obj.AsInt64());
 }
 

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -119,7 +119,7 @@ void DevMenuManager::CreateAndShowUI() noexcept {
 
     std::ostringstream os;
     if (Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
-      os << "Hermes Sampling profiler is running.. !";
+      os << "Hermes Sampling profiler is running!";
     } else {
       os << "Click to start.";
     }
@@ -210,9 +210,9 @@ void DevMenuManager::CreateAndShowUI() noexcept {
           if (auto strongThis = wkThis.lock()) {
             strongThis->Hide();
             if (!Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
-              Microsoft::ReactNative::HermesSamplingProfiler::Start();
+              Microsoft::ReactNative::HermesSamplingProfiler::Start(strongThis->m_context);
             } else {
-              auto traceFilePath = co_await Microsoft::ReactNative::HermesSamplingProfiler::Stop();
+              auto traceFilePath = co_await Microsoft::ReactNative::HermesSamplingProfiler::Stop(strongThis->m_context);
               auto uiDispatcher =
                   React::implementation::ReactDispatcher::GetUIDispatcher(strongThis->m_context->Properties());
               uiDispatcher.Post([traceFilePath]() {

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -8,7 +8,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.12.1</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.69.1</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgReactNative_Hermes_Windows)')">$(PkgReactNative_Hermes_Windows)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\ReactNative.Hermes.Windows\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>

--- a/vnext/Shared/HermesRuntimeHolder.h
+++ b/vnext/Shared/HermesRuntimeHolder.h
@@ -8,37 +8,52 @@
 #include <thread>
 
 #include <DevSettings.h>
+#include <ReactPropertyBag.h>
 
 namespace facebook::hermes {
 class HermesRuntime;
 }
 
-namespace facebook {
-namespace react {
+namespace Microsoft::ReactNative {
+class HermesShim;
+}
+
+namespace facebook::react {
+
+class MessageQueueThread;
 
 class HermesRuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
- public:
+ public: // RuntimeHolderLazyInit implementation.
   std::shared_ptr<facebook::jsi::Runtime> getRuntime() noexcept override;
   facebook::react::JSIEngineOverride getRuntimeType() noexcept override;
-
   void crashHandler(int fileDescriptor) noexcept override;
-
   void teardown() noexcept override;
 
+ public:
   HermesRuntimeHolder(
       std::shared_ptr<facebook::react::DevSettings> devSettings,
       std::shared_ptr<facebook::react::MessageQueueThread> jsQueue) noexcept;
 
+  static std::shared_ptr<HermesRuntimeHolder> loadFrom(
+      winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag) noexcept;
+
+  static void storeTo(
+      winrt::Microsoft::ReactNative::ReactPropertyBag const &propertyBag,
+      std::shared_ptr<HermesRuntimeHolder> const &holder) noexcept;
+
+  void addToProfiling() const noexcept;
+  void removeFromProfiling() const noexcept;
+
  private:
   void initRuntime() noexcept;
+
+ private:
+  std::shared_ptr<Microsoft::ReactNative::HermesShim> m_hermesShim;
   std::shared_ptr<facebook::hermes::HermesRuntime> m_hermesRuntime;
-
-  std::once_flag m_once_flag;
-  std::thread::id m_own_thread_id;
-
+  std::once_flag m_onceFlag{};
+  std::thread::id m_ownThreadId{};
   std::weak_ptr<facebook::react::DevSettings> m_weakDevSettings;
   std::shared_ptr<facebook::react::MessageQueueThread> m_jsQueue;
 };
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/vnext/Shared/HermesSamplingProfiler.h
+++ b/vnext/Shared/HermesSamplingProfiler.h
@@ -3,19 +3,21 @@
 
 #pragma once
 
+#include <ReactHost/React.h>
+#include <atomic>
 #include <string>
 
 namespace Microsoft::ReactNative {
 
 class HermesSamplingProfiler final {
  public:
-  static winrt::fire_and_forget Start() noexcept;
-  static std::future<std::string> Stop() noexcept;
+  static winrt::fire_and_forget Start(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
+  static std::future<std::string> Stop(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
   static std::string GetLastTraceFilePath() noexcept;
   static bool IsStarted() noexcept;
 
  private:
-  static bool s_isStarted;
+  static std::atomic_bool s_isStarted;
   static std::string s_lastTraceFilePath;
 };
 

--- a/vnext/Shared/HermesShim.cpp
+++ b/vnext/Shared/HermesShim.cpp
@@ -4,115 +4,119 @@
 #include "HermesShim.h"
 #include "Crash.h"
 
-namespace Microsoft::ReactNative::HermesShim {
+#define DECLARE_SYMBOL(symbol, importedSymbol) \
+  decltype(&importedSymbol) s_##symbol{};      \
+  constexpr const char symbol##Symbol[] = #importedSymbol;
 
-static HMODULE s_hermesModule{nullptr};
-static decltype(&facebook::hermes::makeHermesRuntime) s_makeHermesRuntime{nullptr};
-static decltype(&facebook::hermes::HermesRuntime::enableSamplingProfiler) s_enableSamplingProfiler{nullptr};
-static decltype(&facebook::hermes::HermesRuntime::disableSamplingProfiler) s_disableSamplingProfiler{nullptr};
-static decltype(&facebook::hermes::HermesRuntime::dumpSampledTraceToFile) s_dumpSampledTraceToFile{nullptr};
-static decltype(&facebook::hermes::makeHermesRuntimeWithWER) s_makeHermesRuntimeWithWER{nullptr};
-static decltype(&facebook::hermes::hermesCrashHandler) s_hermesCrashHandler{nullptr};
+#define INIT_SYMBOL(symbol)                                                                            \
+  s_##symbol = reinterpret_cast<decltype(s_##symbol)>(GetProcAddress(s_hermesModule, symbol##Symbol)); \
+  VerifyElseCrash(s_##symbol);
 
-#if _M_X64
-constexpr const char *makeHermesRuntimeSymbol =
-    "?makeHermesRuntime@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@AEBVRuntimeConfig@vm@1@@Z";
-constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *dumpSampledTraceToFileSymbol =
-    "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
-constexpr const char *makeHermesRuntimeWithWERSymbol =
-    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
-constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAEAVHermesRuntime@12@H@Z";
-#endif
+#define CRASH_ON_ERROR(result) VerifyElseCrash(result == hermes_ok);
 
-#if _M_ARM64
-constexpr const char *makeHermesRuntimeSymbol =
-    "?makeHermesRuntime@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@AEBVRuntimeConfig@vm@1@@Z";
-constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *dumpSampledTraceToFileSymbol =
-    "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXAEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
-constexpr const char *makeHermesRuntimeWithWERSymbol =
-    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
-constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAEAVHermesRuntime@12@H@Z";
-#endif
+namespace Microsoft::ReactNative {
 
-#if _M_IX86
-constexpr const char *makeHermesRuntimeSymbol =
-    "?makeHermesRuntime@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@ABVRuntimeConfig@vm@1@@Z";
-constexpr const char *enableSamlingProfilerSymbol = "?enableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *disableSamlingProfilerSymbol = "?disableSamplingProfiler@HermesRuntime@hermes@facebook@@SAXXZ";
-constexpr const char *dumpSampledTraceToFileSymbol =
-    "?dumpSampledTraceToFile@HermesRuntime@hermes@facebook@@SAXABV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z";
-constexpr const char *makeHermesRuntimeWithWERSymbol =
-    "?makeHermesRuntimeWithWER@hermes@facebook@@YA?AV?$unique_ptr@VHermesRuntime@hermes@facebook@@U?$default_delete@VHermesRuntime@hermes@facebook@@@std@@@std@@XZ";
-constexpr const char *hermesCrashHandlerSymbol = "?hermesCrashHandler@hermes@facebook@@YAXAAVHermesRuntime@12@H@Z";
-#endif
+namespace {
 
-static std::once_flag s_hermesLoading;
+DECLARE_SYMBOL(createRuntime, hermes_create_runtime);
+DECLARE_SYMBOL(createRuntimeWithWER, hermes_create_runtime_with_wer);
+DECLARE_SYMBOL(deleteRuntime, hermes_delete_runtime);
+DECLARE_SYMBOL(getNonAbiSafeRuntime, hermes_get_non_abi_safe_runtime);
+DECLARE_SYMBOL(dumpCrashData, hermes_dump_crash_data);
+DECLARE_SYMBOL(samplingProfilerEnable, hermes_sampling_profiler_enable);
+DECLARE_SYMBOL(samplingProfilerDisable, hermes_sampling_profiler_disable);
+DECLARE_SYMBOL(samplingProfilerAdd, hermes_sampling_profiler_add);
+DECLARE_SYMBOL(samplingProfilerRemove, hermes_sampling_profiler_remove);
+DECLARE_SYMBOL(samplingProfilerDumpToFile, hermes_sampling_profiler_dump_to_file);
 
-static void EnsureHermesLoaded() noexcept {
+HMODULE s_hermesModule{};
+std::once_flag s_hermesLoading;
+
+void EnsureHermesLoaded() noexcept {
   std::call_once(s_hermesLoading, []() {
     VerifyElseCrashSz(!s_hermesModule, "Invalid state: \"hermes.dll\" being loaded again.");
 
     s_hermesModule = LoadLibrary(L"hermes.dll");
     VerifyElseCrashSz(s_hermesModule, "Could not load \"hermes.dll\"");
 
-    s_makeHermesRuntime =
-        reinterpret_cast<decltype(s_makeHermesRuntime)>(GetProcAddress(s_hermesModule, makeHermesRuntimeSymbol));
-    VerifyElseCrash(s_makeHermesRuntime);
-
-    s_enableSamplingProfiler = reinterpret_cast<decltype(s_enableSamplingProfiler)>(
-        GetProcAddress(s_hermesModule, enableSamlingProfilerSymbol));
-    VerifyElseCrash(s_enableSamplingProfiler);
-
-    s_disableSamplingProfiler = reinterpret_cast<decltype(s_disableSamplingProfiler)>(
-        GetProcAddress(s_hermesModule, disableSamlingProfilerSymbol));
-    VerifyElseCrash(s_disableSamplingProfiler);
-
-    s_dumpSampledTraceToFile = reinterpret_cast<decltype(s_dumpSampledTraceToFile)>(
-        GetProcAddress(s_hermesModule, dumpSampledTraceToFileSymbol));
-    VerifyElseCrash(s_dumpSampledTraceToFile);
-
-    s_makeHermesRuntimeWithWER = reinterpret_cast<decltype(s_makeHermesRuntimeWithWER)>(
-        GetProcAddress(s_hermesModule, makeHermesRuntimeWithWERSymbol));
-    VerifyElseCrash(s_makeHermesRuntimeWithWER);
-
-    s_hermesCrashHandler =
-        reinterpret_cast<decltype(s_hermesCrashHandler)>(GetProcAddress(s_hermesModule, hermesCrashHandlerSymbol));
-    VerifyElseCrash(s_hermesCrashHandler);
+    INIT_SYMBOL(createRuntime);
+    INIT_SYMBOL(createRuntimeWithWER);
+    INIT_SYMBOL(deleteRuntime);
+    INIT_SYMBOL(getNonAbiSafeRuntime);
+    INIT_SYMBOL(dumpCrashData);
+    INIT_SYMBOL(samplingProfilerEnable);
+    INIT_SYMBOL(samplingProfilerDisable);
+    INIT_SYMBOL(samplingProfilerAdd);
+    INIT_SYMBOL(samplingProfilerRemove);
+    INIT_SYMBOL(samplingProfilerDumpToFile);
   });
 }
 
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes::vm::RuntimeConfig &runtimeConfig) {
-  EnsureHermesLoaded();
-  return s_makeHermesRuntime(runtimeConfig);
+struct RuntimeDeleter {
+  RuntimeDeleter(std::shared_ptr<const HermesShim> &&hermesShimPtr) noexcept
+      : hermesShimPtr_(std::move(hermesShimPtr)) {}
+
+  void operator()(facebook::hermes::HermesRuntime * /*runtime*/) {
+    // Do nothing. Instead, we rely on the RuntimeDeleter destructor.
+  }
+
+ private:
+  std::shared_ptr<const HermesShim> hermesShimPtr_;
+};
+
+} // namespace
+
+HermesShim::HermesShim(hermes_runtime runtime) noexcept : runtime_(runtime) {
+  CRASH_ON_ERROR(s_getNonAbiSafeRuntime(runtime_, reinterpret_cast<void **>(&nonAbiSafeRuntime_)));
 }
 
-void enableSamplingProfiler() {
-  EnsureHermesLoaded();
-  s_enableSamplingProfiler();
+HermesShim::~HermesShim() {
+  CRASH_ON_ERROR(s_deleteRuntime(runtime_));
 }
 
-void disableSamplingProfiler() {
+/*static*/ std::shared_ptr<HermesShim> HermesShim::make() noexcept {
   EnsureHermesLoaded();
-  s_disableSamplingProfiler();
+  hermes_runtime runtime{};
+  CRASH_ON_ERROR(s_createRuntime(&runtime));
+  return std::make_shared<HermesShim>(runtime);
 }
 
-void dumpSampledTraceToFile(const std::string &fileName) {
+/*static*/
+std::shared_ptr<HermesShim> HermesShim::makeWithWER() noexcept {
   EnsureHermesLoaded();
-  s_dumpSampledTraceToFile(fileName);
+  hermes_runtime runtime{};
+  CRASH_ON_ERROR(s_createRuntimeWithWER(&runtime));
+  return std::make_shared<HermesShim>(runtime);
 }
 
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeWithWER() {
-  EnsureHermesLoaded();
-  return s_makeHermesRuntimeWithWER();
+std::shared_ptr<facebook::hermes::HermesRuntime> HermesShim::getRuntime() const noexcept {
+  return std::shared_ptr<facebook::hermes::HermesRuntime>(nonAbiSafeRuntime_, RuntimeDeleter(shared_from_this()));
 }
 
-void hermesCrashHandler(facebook::hermes::HermesRuntime &runtime, int fileDescriptor) {
-  EnsureHermesLoaded();
-  s_hermesCrashHandler(runtime, fileDescriptor);
+void HermesShim::dumpCrashData(int fileDescriptor) const noexcept {
+  CRASH_ON_ERROR(s_dumpCrashData(runtime_, fileDescriptor));
 }
 
-} // namespace Microsoft::ReactNative::HermesShim
+/*static*/ void HermesShim::enableSamplingProfiler() noexcept {
+  EnsureHermesLoaded();
+  CRASH_ON_ERROR(s_samplingProfilerEnable());
+}
+
+/*static*/ void HermesShim::disableSamplingProfiler() noexcept {
+  EnsureHermesLoaded();
+  CRASH_ON_ERROR(s_samplingProfilerDisable());
+}
+
+/*static*/ void HermesShim::dumpSampledTraceToFile(const std::string &fileName) noexcept {
+  EnsureHermesLoaded();
+  CRASH_ON_ERROR(s_samplingProfilerDumpToFile(fileName.c_str()));
+}
+void HermesShim::addToProfiling() const noexcept {
+  CRASH_ON_ERROR(s_samplingProfilerAdd(runtime_));
+}
+
+void HermesShim::removeFromProfiling() const noexcept {
+  CRASH_ON_ERROR(s_samplingProfilerRemove(runtime_));
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/HermesShim.h
+++ b/vnext/Shared/HermesShim.h
@@ -3,19 +3,39 @@
 
 #pragma once
 
-#include <hermes/hermes.h>
+#include <hermes/hermes_win.h>
 
 //! We do not package hermes.dll for projects that do not require it. We cannot
 //! use pure delay-loading to achieve this, since WACK will detect the
 //! non-present DLL. Functions in this namespace shim to the Hermes DLL via
 //! GetProcAddress.
-namespace Microsoft::ReactNative::HermesShim {
+namespace Microsoft::ReactNative {
 
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntime(const hermes::vm::RuntimeConfig &runtimeConfig);
-void enableSamplingProfiler();
-void disableSamplingProfiler();
-void dumpSampledTraceToFile(const std::string &fileName);
-std::unique_ptr<facebook::hermes::HermesRuntime> makeHermesRuntimeWithWER();
-void hermesCrashHandler(facebook::hermes::HermesRuntime &runtime, int fileDescriptor);
+class HermesShim : public std::enable_shared_from_this<HermesShim> {
+ public:
+  HermesShim(hermes_runtime runtimeAbiPtr) noexcept;
+  ~HermesShim();
 
-} // namespace Microsoft::ReactNative::HermesShim
+  static std::shared_ptr<HermesShim> make() noexcept;
+  static std::shared_ptr<HermesShim> makeWithWER() noexcept;
+
+  std::shared_ptr<facebook::hermes::HermesRuntime> getRuntime() const noexcept;
+
+  void dumpCrashData(int fileDescriptor) const noexcept;
+
+  static void enableSamplingProfiler() noexcept;
+  static void disableSamplingProfiler() noexcept;
+  static void dumpSampledTraceToFile(const std::string &fileName) noexcept;
+  void addToProfiling() const noexcept;
+  void removeFromProfiling() const noexcept;
+
+  HermesShim(const HermesShim &) = delete;
+  HermesShim &operator=(const HermesShim &) = delete;
+
+ private:
+  // It must be a raw pointer to avoid circular reference.
+  facebook::hermes::HermesRuntime *nonAbiSafeRuntime_{};
+  hermes_runtime runtime_{};
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/JSI/RuntimeHolder.h
+++ b/vnext/Shared/JSI/RuntimeHolder.h
@@ -11,7 +11,7 @@ namespace Microsoft::JSI {
 // a. lazily create a JSI Runtime on the first call to getRuntime
 // b. subsequent calls to getRuntime should return the Runtime created in (a)
 
-// Note :: All calls to getRuntime() should happen on the same thread unless you are sure that
+// Note: all calls to getRuntime() should happen on the same thread unless you are sure that
 // the underlying Runtime instance is thread safe.
 
 struct RuntimeHolderLazyInit {
@@ -21,7 +21,7 @@ struct RuntimeHolderLazyInit {
   virtual void teardown() noexcept {};
 
   // You can call this when a crash happens to attempt recording additional data
-  // The fd supplied is a raw file stream an implementation might write JSON to
+  // The fileDescriptor supplied is a raw file stream an implementation might write JSON to.
   virtual void crashHandler(int fileDescriptor) noexcept {};
 };
 

--- a/vnext/Shared/Networking/IWebSocketResource.h
+++ b/vnext/Shared/Networking/IWebSocketResource.h
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Cherry pick PR #11033 to 0.69-stable branch. Original description:

## Description
Enable Hermes sampling profiler for RNW project.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Currently the Hermes sampling profiler does not work.
It prevents any related perf investigations.

### What
The change has the following parts:
- We use new ABI-safe Hermes API based on C. Not all interactions with Hermes are ABI-safe yet. This is just a beginning.
- The `HermesShim` is changed to use the new API.
- We store `HermesRuntimeHolder` in the context properties. It allows us to add current Hermes runtime for the sampling profiling when it starts and then remove it when it is done.
- We must add and remove the runtime for sampling profiler in JS dispatcher queue. In this PR we expose the JS dispatcher from the `ReactDispatcher`.
- New `HermesRuntimeHolder` methods `loadFrom` and `storeTo` are defined to keep the holder in the context properties.
- The `HermesRuntimeHolder` instance is stored on RN instance creation and then removed on RN instance destruction. 

## Testing
The new sampling profiler is tested manually.
I used the Playground application with Hermes engine.
The menu has commands to start and stop the sampling profiler.
**IMPORTANT**: the resulting CPU sampling file in the application local storage cannot be opened directly in Chrome or Edge browsers. It must be first post-processed by [hermes-profile-transformer](https://github.com/react-native-community/hermes-profile-transformer) tool. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11203)