### PR TITLE
LogBox should be using a monospace font

### DIFF
--- a/change/@office-iss-react-native-win32-9f5db6b7-3bc9-44a5-8782-b196bf715d0a.json
+++ b/change/@office-iss-react-native-win32-9f5db6b7-3bc9-44a5-8782-b196bf715d0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "LogBox should be using a monospace font",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-eebbc51e-322e-4e65-91b9-06e417fca3e5.json
+++ b/change/react-native-windows-eebbc51e-322e-4e65-91b9-06e417fca3e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "LogBox should be using a monospace font",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.win32.js
@@ -157,11 +157,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
     includeFontPadding: false,
     lineHeight: 16,
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      win32: 'Consolas',
+      win32: 'Consolas', // Win32
     }),
   },
 });

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.win32.js
@@ -147,7 +147,7 @@ const styles = StyleSheet.create({
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      win32: 'Consolas',
     }),
   },
   fileText: {
@@ -161,7 +161,7 @@ const styles = StyleSheet.create({
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      win32: 'Consolas',
     }),
   },
 });

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorHeader.win32.js
@@ -149,13 +149,12 @@ const styles = StyleSheet.create({
   },
   header: {
     flexDirection: 'row',
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     height: Platform.select({
       android: 48,
       ios: 44,
-      // [Windows
-      windows: 48,
-      // Windows]
+      // [Win32
+      win32: 48,
+      // Win32]
     }),
   },
   title: {

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.win32.js
@@ -158,19 +158,21 @@ const componentStyles = StyleSheet.create({
     paddingRight: 10,
   },
   frameName: {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo', win32: 'Consolas'}),
+    fontFamily: Platform.select({
+      android: 'monospace',
+      ios: 'Menlo',
+      win32: 'Consolas', // Win32
+    }),
     color: LogBoxStyle.getTextColor(1),
     fontSize: 14,
     includeFontPadding: false,
     lineHeight: 18,
   },
   bracket: {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      win32: 'Consolas',
+      win32: 'Consolas', // Win32
     }),
     color: LogBoxStyle.getTextColor(0.4),
     fontSize: 14,

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.win32.js
@@ -159,7 +159,7 @@ const componentStyles = StyleSheet.create({
   },
   frameName: {
     // $FlowFixMe[underconstrained-implicit-instantiation]
-    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo'}),
+    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo', win32: 'Consolas'}),
     color: LogBoxStyle.getTextColor(1),
     fontSize: 14,
     includeFontPadding: false,
@@ -170,7 +170,7 @@ const componentStyles = StyleSheet.create({
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      win32: 'Consolas',
     }),
     color: LogBoxStyle.getTextColor(0.4),
     fontSize: 14,

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
@@ -88,7 +88,6 @@ const styles = StyleSheet.create({
     includeFontPadding: false,
     lineHeight: 18,
     fontWeight: '400',
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',

--- a/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.win32.js
@@ -92,7 +92,7 @@ const styles = StyleSheet.create({
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      win32: 'Consolas',
     }),
   },
   location: {

--- a/vnext/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.windows.js
+++ b/vnext/src/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.windows.js
@@ -143,11 +143,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
     includeFontPadding: false,
     lineHeight: 20,
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      windows: 'Consolas',
     }),
   },
   fileText: {
@@ -157,11 +156,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
     includeFontPadding: false,
     lineHeight: 16,
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      windows: 'Consolas',
     }),
   },
 });

--- a/vnext/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.windows.js
+++ b/vnext/src/Libraries/LogBox/UI/LogBoxInspectorReactFrames.windows.js
@@ -158,11 +158,10 @@ const componentStyles = StyleSheet.create({
     paddingRight: 10,
   },
   frameName: {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      windows: 'Consolas',
     }),
     color: LogBoxStyle.getTextColor(1),
     fontSize: 14,
@@ -170,11 +169,10 @@ const componentStyles = StyleSheet.create({
     lineHeight: 18,
   },
   bracket: {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      windows: 'Consolas',
     }),
     color: LogBoxStyle.getTextColor(0.4),
     fontSize: 14,

--- a/vnext/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.windows.js
+++ b/vnext/src/Libraries/LogBox/UI/LogBoxInspectorStackFrame.windows.js
@@ -88,11 +88,10 @@ const styles = StyleSheet.create({
     includeFontPadding: false,
     lineHeight: 18,
     fontWeight: '400',
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     fontFamily: Platform.select({
       android: 'monospace',
       ios: 'Menlo',
-      windows: 'sans-serif',
+      windows: 'Consolas',
     }),
   },
   location: {


### PR DESCRIPTION
## Description
We are providing a windows specific font in various places in the LogBox UI.  But the one we are using on windows is not a monospace font, unlike the ones using on Android/iOS.  This is mostly used to show code, callstacks etc. which are better displayed in monospace.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11208)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11208)