### PR TITLE
[Fabric] MouseEnter/Leave events to align with paper

### DIFF
--- a/change/react-native-windows-f8dcfdcc-9a1a-43ae-9fe1-be9df0568477.json
+++ b/change/react-native-windows-f8dcfdcc-9a1a-43ae-9fe1-be9df0568477.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] MouseEnter/Leave events to align with paper",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -47,6 +47,7 @@ struct IComponentView {
   virtual RECT getClientRect() const noexcept = 0;
   virtual void onFocusLost() noexcept = 0;
   virtual void onFocusGained() noexcept = 0;
+  virtual facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept = 0;
   virtual facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept = 0;
   virtual facebook::react::Tag tag() const noexcept = 0;
   virtual facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept = 0;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -18,9 +18,7 @@ const PointerId MOUSE_POINTER_ID = 1; // TODO ensure this is something that does
 bool IsViewListeningToEvent(IComponentView *view, facebook::react::ViewEvents::Offset eventType) {
   if (view) {
     auto const &viewProps = *std::static_pointer_cast<facebook::react::ViewProps const>(view->props());
-    return true;
-    // TODO why arn't the events bits being set?
-    // return viewProps.events[eventType];
+    return viewProps.events[eventType];
   }
   return false;
 }
@@ -234,7 +232,8 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
     auto componentView = *itComponentView;
     bool shouldEmitEvent = componentView != nullptr &&
         (hasParentEnterListener ||
-         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerEnter));
+         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerEnter) ||
+         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::MouseEnter));
 
     if (shouldEmitEvent &&
         std::find(currentlyHoveredViews.begin(), currentlyHoveredViews.end(), componentView) ==
@@ -242,6 +241,7 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
       facebook::react::SharedTouchEventEmitter eventEmitter = componentView->touchEventEmitter();
       if (eventEmitter) {
         eventEmitter->onPointerEnter(event);
+        eventEmitter->onMouseEnter(event);
       }
     }
 
@@ -280,7 +280,8 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
 
     bool shouldEmitEvent = componentView != nullptr &&
         (hasParentLeaveListener ||
-         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerLeave));
+         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::PointerLeave) ||
+         IsViewListeningToEvent(componentView, facebook::react::ViewEvents::Offset::MouseLeave));
 
     if (shouldEmitEvent &&
         std::find(eventPathViews.begin(), eventPathViews.end(), componentView) == eventPathViews.end()) {
@@ -299,6 +300,7 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
     facebook::react::SharedTouchEventEmitter eventEmitter = componentView->touchEventEmitter();
     if (eventEmitter) {
       eventEmitter->onPointerLeave(event);
+      eventEmitter->onMouseLeave(event);
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -241,7 +241,9 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
       facebook::react::SharedTouchEventEmitter eventEmitter = componentView->touchEventEmitter();
       if (eventEmitter) {
         eventEmitter->onPointerEnter(event);
-        eventEmitter->onMouseEnter(event);
+        if (IsMousePointerEvent(event)) {
+          eventEmitter->onMouseEnter(event);
+        }
       }
     }
 
@@ -300,7 +302,9 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
     facebook::react::SharedTouchEventEmitter eventEmitter = componentView->touchEventEmitter();
     if (eventEmitter) {
       eventEmitter->onPointerLeave(event);
-      eventEmitter->onMouseLeave(event);
+      if (IsMousePointerEvent(event)) {
+        eventEmitter->onMouseLeave(event);
+      }
     }
   }
 
@@ -341,6 +345,10 @@ void CompositionEventHandler::UpdateActiveTouch(
   // activeTouch.touch.altKey = false;
 
   // activeTouch.touch.isPrimary = true;
+}
+
+bool IsMousePointerEvent(const facebook::react::PointerEvent &pointerEvent) {
+  return pointerEvent.pointerId == MOUSE_POINTER_ID;
 }
 
 facebook::react::PointerEvent CreatePointerEventFromIncompleteHoverData(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -215,7 +215,7 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
   if (targetView != nullptr && previousTargetTag != targetView->tag()) {
     bool shouldEmitOverEvent =
         IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerOver);
-    facebook::react::SharedTouchEventEmitter eventEmitter = targetView->touchEventEmitter();
+    facebook::react::SharedTouchEventEmitter eventEmitter = targetView->touchEventEmitterAtPoint(event.offsetPoint);
     if (shouldEmitOverEvent && eventEmitter != nullptr) {
       eventEmitter->onPointerOver(event);
     }
@@ -361,7 +361,7 @@ facebook::react::PointerEvent CreatePointerEventFromIncompleteHoverData(
 
   pointerEvent.clientPoint = ptScaled;
   pointerEvent.screenPoint = ptScaled;
-  // pointerEvent.offsetPoint = ptLocal;
+  pointerEvent.offsetPoint = ptLocal;
   pointerEvent.width = 1.0;
   pointerEvent.height = 1.0;
   pointerEvent.tiltX = 0;
@@ -406,7 +406,7 @@ void CompositionEventHandler::MouseMove(
     facebook::react::PointerEvent pointerEvent = CreatePointerEventFromIncompleteHoverData(ptScaled, ptLocal);
 
     auto handler = [targetView, &pointerEvent](std::vector<IComponentView *> &eventPathViews) {
-      facebook::react::SharedTouchEventEmitter eventEmitter = targetView ? targetView->touchEventEmitter() : nullptr;
+      facebook::react::SharedTouchEventEmitter eventEmitter = targetView ? targetView->touchEventEmitterAtPoint(pointerEvent.offsetPoint) : nullptr;
       bool hasMoveEventListeners =
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMove) ||
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMoveCapture);
@@ -546,7 +546,7 @@ void CompositionEventHandler::ButtonDown(
 
     auto componentView = targetComponentView;
     while (componentView) {
-      if (auto eventEmitter = componentView->touchEventEmitter()) {
+      if (auto eventEmitter = componentView->touchEventEmitterAtPoint(ptLocal)) {
         activeTouch.eventEmitter = eventEmitter;
         activeTouch.touch.target = componentView->tag();
         // activeTouch.componentView = componentView;
@@ -695,7 +695,7 @@ facebook::react::PointerEvent CompositionEventHandler::CreatePointerEventFromAct
   event.pointerType = PointerTypeCStringFromUITouchType(activeTouch.touchType);
   event.clientPoint = touch.pagePoint;
   event.screenPoint = touch.screenPoint;
-  // event.offsetPoint = touch.offsetPoint;
+  event.offsetPoint = touch.offsetPoint;
 
   event.pressure = touch.force;
   if (activeTouch.touchType == UITouchType::Mouse) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -15,6 +15,10 @@ namespace Microsoft::ReactNative {
 
 const PointerId MOUSE_POINTER_ID = 1; // TODO ensure this is something that does not conflict with pointer point IDs.
 
+bool IsMousePointerEvent(const facebook::react::PointerEvent &pointerEvent) {
+  return pointerEvent.pointerId == MOUSE_POINTER_ID;
+}
+
 bool IsViewListeningToEvent(IComponentView *view, facebook::react::ViewEvents::Offset eventType) {
   if (view) {
     auto const &viewProps = *std::static_pointer_cast<facebook::react::ViewProps const>(view->props());
@@ -345,10 +349,6 @@ void CompositionEventHandler::UpdateActiveTouch(
   // activeTouch.touch.altKey = false;
 
   // activeTouch.touch.isPrimary = true;
-}
-
-bool IsMousePointerEvent(const facebook::react::PointerEvent &pointerEvent) {
-  return pointerEvent.pointerId == MOUSE_POINTER_ID;
 }
 
 facebook::react::PointerEvent CreatePointerEventFromIncompleteHoverData(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -406,7 +406,8 @@ void CompositionEventHandler::MouseMove(
     facebook::react::PointerEvent pointerEvent = CreatePointerEventFromIncompleteHoverData(ptScaled, ptLocal);
 
     auto handler = [targetView, &pointerEvent](std::vector<IComponentView *> &eventPathViews) {
-      facebook::react::SharedTouchEventEmitter eventEmitter = targetView ? targetView->touchEventEmitterAtPoint(pointerEvent.offsetPoint) : nullptr;
+      facebook::react::SharedTouchEventEmitter eventEmitter =
+          targetView ? targetView->touchEventEmitterAtPoint(pointerEvent.offsetPoint) : nullptr;
       bool hasMoveEventListeners =
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMove) ||
           IsAnyViewInPathListeningToEvent(eventPathViews, facebook::react::ViewEvents::Offset::PointerMoveCapture);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1039,7 +1039,8 @@ facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEven
   return m_eventEmitter;
 }
 
-facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEventEmitterAtPoint(facebook::react::Point /*pt*/) noexcept {
+facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEventEmitterAtPoint(
+    facebook::react::Point /*pt*/) noexcept {
   return m_eventEmitter;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1035,6 +1035,14 @@ void CompositionBaseComponentView::EnsureTransformMatrixFacade() noexcept {
       .StartAnimation(L"TransformMatrix", expression);
 }
 
+facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEventEmitter() noexcept {
+  return m_eventEmitter;
+}
+
+facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEventEmitterAtPoint(facebook::react::Point /*pt*/) noexcept {
+  return m_eventEmitter;
+}
+
 CompositionViewComponentView::CompositionViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag)
@@ -1157,10 +1165,6 @@ facebook::react::Tag CompositionViewComponentView::hitTest(facebook::react::Poin
   }
 
   return -1;
-}
-
-facebook::react::SharedTouchEventEmitter CompositionViewComponentView::touchEventEmitter() noexcept {
-  return m_eventEmitter;
 }
 
 bool CompositionViewComponentView::ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -33,6 +33,8 @@ struct CompositionBaseComponentView : public IComponentView {
   IComponentView *parent() const noexcept override;
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
+  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
+  facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
 
   facebook::react::Tag tag() const noexcept override;
 
@@ -96,7 +98,6 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
       facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept override;
   void finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept override;
   void prepareForRecycle() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
 
   facebook::react::Props::Shared props() noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -396,10 +396,6 @@ facebook::react::Tag ImageComponentView::hitTest(facebook::react::Point pt, face
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter ImageComponentView::touchEventEmitter() noexcept {
-  return m_eventEmitter;
-}
-
 void ImageComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     m_visual = m_compContext.CreateSpriteVisual();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -49,7 +49,6 @@ struct ImageComponentView : CompositionBaseComponentView {
   void prepareForRecycle() noexcept override;
   facebook::react::Props::Shared props() noexcept override;
   void OnRenderingDeviceLost() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -63,7 +63,9 @@ void ParagraphComponentView::updateProps(
   m_props = std::static_pointer_cast<facebook::react::ParagraphProps const>(props);
 }
 
-void ParagraphComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {}
+void ParagraphComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {
+  Super::updateEventEmitter(eventEmitter);
+}
 
 void ParagraphComponentView::updateState(
     facebook::react::State::Shared const &state,
@@ -104,8 +106,7 @@ void ParagraphComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMas
 }
 void ParagraphComponentView::prepareForRecycle() noexcept {}
 facebook::react::Props::Shared ParagraphComponentView::props() noexcept {
-  assert(false);
-  return {};
+  return m_props;
 }
 
 facebook::react::Tag ParagraphComponentView::hitTest(facebook::react::Point pt, facebook::react::Point &localPt)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -136,7 +136,25 @@ facebook::react::Tag ParagraphComponentView::hitTest(facebook::react::Point pt, 
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter ParagraphComponentView::touchEventEmitter() noexcept {
+facebook::react::SharedTouchEventEmitter ParagraphComponentView::touchEventEmitterAtPoint(facebook::react::Point pt) noexcept {
+
+  if (m_attributedStringBox.getValue().getFragments().size()) {
+      BOOL isTrailingHit = false;
+      BOOL isInside = false;
+      DWRITE_HIT_TEST_METRICS metrics;
+      winrt::check_hresult(m_textLayout->HitTestPoint(pt.x, pt.y, &isTrailingHit, &isInside, &metrics));
+      if (isInside) {
+        uint32_t textPosition = metrics.textPosition;
+
+        for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
+          if (textPosition < fragment.string.length()) {
+            return std::static_pointer_cast<const facebook::react::TouchEventEmitter>(fragment.parentShadowView.eventEmitter);
+          }
+          textPosition -= static_cast<uint32_t>(fragment.string.length());
+      }
+    }
+  }
+
   return m_eventEmitter;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -136,21 +136,22 @@ facebook::react::Tag ParagraphComponentView::hitTest(facebook::react::Point pt, 
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter ParagraphComponentView::touchEventEmitterAtPoint(facebook::react::Point pt) noexcept {
-
+facebook::react::SharedTouchEventEmitter ParagraphComponentView::touchEventEmitterAtPoint(
+    facebook::react::Point pt) noexcept {
   if (m_attributedStringBox.getValue().getFragments().size()) {
-      BOOL isTrailingHit = false;
-      BOOL isInside = false;
-      DWRITE_HIT_TEST_METRICS metrics;
-      winrt::check_hresult(m_textLayout->HitTestPoint(pt.x, pt.y, &isTrailingHit, &isInside, &metrics));
-      if (isInside) {
-        uint32_t textPosition = metrics.textPosition;
+    BOOL isTrailingHit = false;
+    BOOL isInside = false;
+    DWRITE_HIT_TEST_METRICS metrics;
+    winrt::check_hresult(m_textLayout->HitTestPoint(pt.x, pt.y, &isTrailingHit, &isInside, &metrics));
+    if (isInside) {
+      uint32_t textPosition = metrics.textPosition;
 
-        for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
-          if (textPosition < fragment.string.length()) {
-            return std::static_pointer_cast<const facebook::react::TouchEventEmitter>(fragment.parentShadowView.eventEmitter);
-          }
-          textPosition -= static_cast<uint32_t>(fragment.string.length());
+      for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
+        if (textPosition < fragment.string.length()) {
+          return std::static_pointer_cast<const facebook::react::TouchEventEmitter>(
+              fragment.parentShadowView.eventEmitter);
+        }
+        textPosition -= static_cast<uint32_t>(fragment.string.length());
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -39,7 +39,7 @@ struct ParagraphComponentView : CompositionBaseComponentView {
   facebook::react::Props::Shared props() noexcept override;
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept override;
   void OnRenderingDeviceLost() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
+  facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
 
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -344,10 +344,6 @@ facebook::react::Tag ScrollViewComponentView::hitTest(facebook::react::Point pt,
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter ScrollViewComponentView::touchEventEmitter() noexcept {
-  return m_eventEmitter;
-}
-
 winrt::Microsoft::ReactNative::Composition::IVisual ScrollViewComponentView::Visual() const noexcept {
   return m_visual;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -70,7 +70,6 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept override;
   void prepareForRecycle() noexcept override;
   facebook::react::Props::Shared props() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -214,10 +214,6 @@ facebook::react::Tag SwitchComponentView::hitTest(facebook::react::Point pt, fac
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter SwitchComponentView::touchEventEmitter() noexcept {
-  return m_eventEmitter;
-}
-
 winrt::Microsoft::ReactNative::Composition::IVisual SwitchComponentView::Visual() const noexcept {
   return m_visual;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -37,7 +37,6 @@ struct SwitchComponentView : CompositionBaseComponentView {
   void finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept override;
   void prepareForRecycle() noexcept override;
   facebook::react::Props::Shared props() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1048,10 +1048,6 @@ facebook::react::Tag WindowsTextInputComponentView::hitTest(facebook::react::Poi
   return -1;
 }
 
-facebook::react::SharedTouchEventEmitter WindowsTextInputComponentView::touchEventEmitter() noexcept {
-  return m_eventEmitter;
-}
-
 void WindowsTextInputComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     HrEnsureRichEd20Loaded();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -51,7 +51,6 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
 
  private:
   struct DrawBlock {

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.cpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TouchEventEmitter.h"
+
+namespace facebook::react {
+
+#pragma mark - Touches
+
+static void setTouchPayloadOnObject(
+    jsi::Object &object,
+    jsi::Runtime &runtime,
+    Touch const &touch) {
+  object.setProperty(runtime, "locationX", touch.offsetPoint.x);
+  object.setProperty(runtime, "locationY", touch.offsetPoint.y);
+  object.setProperty(runtime, "pageX", touch.pagePoint.x);
+  object.setProperty(runtime, "pageY", touch.pagePoint.y);
+  object.setProperty(runtime, "screenX", touch.screenPoint.x);
+  object.setProperty(runtime, "screenY", touch.screenPoint.y);
+  object.setProperty(runtime, "identifier", touch.identifier);
+  object.setProperty(runtime, "target", touch.target);
+  object.setProperty(runtime, "timestamp", touch.timestamp * 1000);
+  object.setProperty(runtime, "force", touch.force);
+}
+
+static jsi::Value touchesPayload(
+    jsi::Runtime &runtime,
+    Touches const &touches) {
+  auto array = jsi::Array(runtime, touches.size());
+  int i = 0;
+  for (auto const &touch : touches) {
+    auto object = jsi::Object(runtime);
+    setTouchPayloadOnObject(object, runtime, touch);
+    array.setValueAtIndex(runtime, i++, object);
+  }
+  return array;
+}
+
+static jsi::Value touchEventPayload(
+    jsi::Runtime &runtime,
+    TouchEvent const &event) {
+  auto object = jsi::Object(runtime);
+  object.setProperty(
+      runtime, "touches", touchesPayload(runtime, event.touches));
+  object.setProperty(
+      runtime, "changedTouches", touchesPayload(runtime, event.changedTouches));
+  object.setProperty(
+      runtime, "targetTouches", touchesPayload(runtime, event.targetTouches));
+
+  if (!event.changedTouches.empty()) {
+    auto const &firstChangedTouch = *event.changedTouches.begin();
+    setTouchPayloadOnObject(object, runtime, firstChangedTouch);
+  }
+  return object;
+}
+
+static jsi::Value pointerEventPayload(
+    jsi::Runtime &runtime,
+    PointerEvent const &event) {
+  auto object = jsi::Object(runtime);
+  object.setProperty(runtime, "pointerId", event.pointerId);
+  object.setProperty(runtime, "pressure", event.pressure);
+  object.setProperty(runtime, "pointerType", event.pointerType);
+  object.setProperty(runtime, "clientX", event.clientPoint.x);
+  object.setProperty(runtime, "clientY", event.clientPoint.y);
+  // x/y are an alias to clientX/Y
+  object.setProperty(runtime, "x", event.clientPoint.x);
+  object.setProperty(runtime, "y", event.clientPoint.y);
+  // since RN doesn't have a scrollable root, pageX/Y will always equal
+  // clientX/Y
+  object.setProperty(runtime, "pageX", event.clientPoint.x);
+  object.setProperty(runtime, "pageY", event.clientPoint.y);
+  object.setProperty(runtime, "screenX", event.screenPoint.x);
+  object.setProperty(runtime, "screenY", event.screenPoint.y);
+  object.setProperty(runtime, "offsetX", event.offsetPoint.x);
+  object.setProperty(runtime, "offsetY", event.offsetPoint.y);
+  object.setProperty(runtime, "width", event.width);
+  object.setProperty(runtime, "height", event.height);
+  object.setProperty(runtime, "tiltX", event.tiltX);
+  object.setProperty(runtime, "tiltY", event.tiltY);
+  object.setProperty(runtime, "detail", event.detail);
+  object.setProperty(runtime, "buttons", event.buttons);
+  object.setProperty(runtime, "tangentialPressure", event.tangentialPressure);
+  object.setProperty(runtime, "twist", event.twist);
+  object.setProperty(runtime, "ctrlKey", event.ctrlKey);
+  object.setProperty(runtime, "shiftKey", event.shiftKey);
+  object.setProperty(runtime, "altKey", event.altKey);
+  object.setProperty(runtime, "metaKey", event.metaKey);
+  object.setProperty(runtime, "isPrimary", event.isPrimary);
+  object.setProperty(runtime, "button", event.button);
+  return object;
+}
+
+void TouchEventEmitter::dispatchTouchEvent(
+    std::string type,
+    TouchEvent const &event,
+    EventPriority priority,
+    RawEvent::Category category) const {
+  dispatchEvent(
+      std::move(type),
+      [event](jsi::Runtime &runtime) {
+        return touchEventPayload(runtime, event);
+      },
+      priority,
+      category);
+}
+
+void TouchEventEmitter::dispatchPointerEvent(
+    std::string type,
+    PointerEvent const &event,
+    EventPriority priority,
+    RawEvent::Category category) const {
+  dispatchEvent(
+      std::move(type),
+      [event](jsi::Runtime &runtime) {
+        return pointerEventPayload(runtime, event);
+      },
+      priority,
+      category);
+}
+
+void TouchEventEmitter::onTouchStart(TouchEvent const &event) const {
+  dispatchTouchEvent(
+      "touchStart",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onTouchMove(TouchEvent const &event) const {
+  dispatchUniqueEvent("touchMove", [event](jsi::Runtime &runtime) {
+    return touchEventPayload(runtime, event);
+  });
+}
+
+void TouchEventEmitter::onTouchEnd(TouchEvent const &event) const {
+  dispatchTouchEvent(
+      "touchEnd",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onTouchCancel(TouchEvent const &event) const {
+  dispatchTouchEvent(
+      "touchCancel",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerCancel(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerCancel",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerDown(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerDown",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onPointerMove(const PointerEvent &event) const {
+  dispatchUniqueEvent("pointerMove", [event](jsi::Runtime &runtime) {
+    return pointerEventPayload(runtime, event);
+  });
+}
+
+void TouchEventEmitter::onPointerUp(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerUp",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerEnter(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerEnter",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onPointerLeave(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerLeave",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousEnd);
+}
+
+void TouchEventEmitter::onPointerOver(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerOver",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onPointerOut(const PointerEvent &event) const {
+  dispatchPointerEvent(
+      "pointerOut",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+// [Windows
+void TouchEventEmitter::onMouseEnter(PointerEvent const &event) const {
+    dispatchPointerEvent(
+      "mouseEnter",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onMouseLeave(PointerEvent const &event) const {
+    dispatchPointerEvent(
+      "mouseLeave",
+      event,
+      EventPriority::AsynchronousBatched,
+      RawEvent::Category::ContinuousStart);
+}
+// Windows]
+
+
+} // namespace facebook::react

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/PointerEvent.h>
+#include <react/renderer/components/view/TouchEvent.h>
+#include <react/renderer/core/EventEmitter.h>
+#include <react/renderer/core/LayoutMetrics.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
+
+namespace facebook {
+namespace react {
+
+class TouchEventEmitter;
+
+using SharedTouchEventEmitter = std::shared_ptr<TouchEventEmitter const>;
+
+class TouchEventEmitter : public EventEmitter {
+ public:
+  using EventEmitter::EventEmitter;
+
+  void onTouchStart(TouchEvent const &event) const;
+  void onTouchMove(TouchEvent const &event) const;
+  void onTouchEnd(TouchEvent const &event) const;
+  void onTouchCancel(TouchEvent const &event) const;
+
+  void onPointerCancel(PointerEvent const &event) const;
+  void onPointerDown(PointerEvent const &event) const;
+  void onPointerMove(PointerEvent const &event) const;
+  void onPointerUp(PointerEvent const &event) const;
+  void onPointerEnter(PointerEvent const &event) const;
+  void onPointerLeave(PointerEvent const &event) const;
+  void onPointerOver(PointerEvent const &event) const;
+  void onPointerOut(PointerEvent const &event) const;
+
+  void onMouseEnter(PointerEvent const &event) const; // [Windows]
+  void onMouseLeave(PointerEvent const &event) const; // [Windows]
+
+ private:
+  void dispatchTouchEvent(
+      std::string type,
+      TouchEvent const &event,
+      EventPriority priority,
+      RawEvent::Category category) const;
+  void dispatchPointerEvent(
+      std::string type,
+      PointerEvent const &event,
+      EventPriority priority,
+      RawEvent::Category category) const;
+};
+
+} // namespace react
+} // namespace facebook

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
@@ -1,0 +1,461 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ViewProps.h"
+
+#include <algorithm>
+
+#include <react/renderer/components/view/conversions.h>
+#include <react/renderer/components/view/propsConversions.h>
+#include <react/renderer/core/CoreFeatures.h>
+#include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/debugStringConvertibleUtils.h>
+#include <react/renderer/graphics/conversions.h>
+
+namespace facebook::react {
+
+ViewProps::ViewProps(
+    const PropsParserContext &context,
+    ViewProps const &sourceProps,
+    RawProps const &rawProps,
+    bool shouldSetRawProps)
+    : YogaStylableProps(context, sourceProps, rawProps, shouldSetRawProps),
+      AccessibilityProps(context, sourceProps, rawProps),
+      opacity(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.opacity
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "opacity",
+                                                       sourceProps.opacity,
+                                                       (Float)1.0)),
+      foregroundColor(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.foregroundColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "foregroundColor",
+                    sourceProps.foregroundColor,
+                    {})),
+      backgroundColor(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.backgroundColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "backgroundColor",
+                    sourceProps.backgroundColor,
+                    {})),
+      borderRadii(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderRadii
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "border",
+                                                       "Radius",
+                                                       sourceProps.borderRadii,
+                                                       {})),
+      borderColors(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderColors
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "border",
+                                                       "Color",
+                                                       sourceProps.borderColors,
+                                                       {})),
+      borderCurves(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderCurves
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "border",
+                                                       "Curve",
+                                                       sourceProps.borderCurves,
+                                                       {})),
+      borderStyles(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderStyles
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "border",
+                                                       "Style",
+                                                       sourceProps.borderStyles,
+                                                       {})),
+      shadowColor(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowColor
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "shadowColor",
+                                                       sourceProps.shadowColor,
+                                                       {})),
+      shadowOffset(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowOffset
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "shadowOffset",
+                                                       sourceProps.shadowOffset,
+                                                       {})),
+      shadowOpacity(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.shadowOpacity
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowOpacity",
+                    sourceProps.shadowOpacity,
+                    {})),
+      shadowRadius(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowRadius
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "shadowRadius",
+                                                       sourceProps.shadowRadius,
+                                                       {})),
+      transform(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.transform
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "transform",
+                                                       sourceProps.transform,
+                                                       {})),
+      backfaceVisibility(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.backfaceVisibility
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "backfaceVisibility",
+                    sourceProps.backfaceVisibility,
+                    {})),
+      shouldRasterize(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.shouldRasterize
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shouldRasterize",
+                    sourceProps.shouldRasterize,
+                    {})),
+      zIndex(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.zIndex
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "zIndex",
+                                                       sourceProps.zIndex,
+                                                       {})),
+      pointerEvents(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.pointerEvents
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "pointerEvents",
+                    sourceProps.pointerEvents,
+                    {})),
+      hitSlop(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.hitSlop
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "hitSlop",
+                                                       sourceProps.hitSlop,
+                                                       {})),
+      onLayout(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.onLayout
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "onLayout",
+                                                       sourceProps.onLayout,
+                                                       {})),
+      events(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.events
+              : convertRawProp(context, rawProps, sourceProps.events, {})),
+      collapsable(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.collapsable
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "collapsable",
+                                                       sourceProps.collapsable,
+                                                       true)),
+      removeClippedSubviews(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.removeClippedSubviews
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "removeClippedSubviews",
+                    sourceProps.removeClippedSubviews,
+                    false))
+#ifdef ANDROID
+      ,
+      elevation(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.elevation
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "elevation",
+                                                       sourceProps.elevation,
+                                                       {})),
+      nativeBackground(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.nativeBackground
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nativeBackgroundAndroid",
+                    sourceProps.nativeBackground,
+                    {})),
+      nativeForeground(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.nativeForeground
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nativeForegroundAndroid",
+                    sourceProps.nativeForeground,
+                    {})),
+      focusable(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.focusable
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "focusable",
+                                                       sourceProps.focusable,
+                                                       {})),
+      hasTVPreferredFocus(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.hasTVPreferredFocus
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "hasTVPreferredFocus",
+                    sourceProps.hasTVPreferredFocus,
+                    {})),
+      needsOffscreenAlphaCompositing(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.needsOffscreenAlphaCompositing
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "needsOffscreenAlphaCompositing",
+                    sourceProps.needsOffscreenAlphaCompositing,
+                    {})),
+      renderToHardwareTextureAndroid(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.renderToHardwareTextureAndroid
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "renderToHardwareTextureAndroid",
+                    sourceProps.renderToHardwareTextureAndroid,
+                    {}))
+
+#endif
+{
+}
+
+#define VIEW_EVENT_CASE(eventType)                      \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
+    const auto offset = ViewEvents::Offset::eventType;  \
+    ViewEvents defaultViewEvents{};                     \
+    bool res = defaultViewEvents[offset];               \
+    if (value.hasValue()) {                             \
+      fromRawValue(context, value, res);                \
+    }                                                   \
+    events[offset] = res;                               \
+    return;                                             \
+  }
+
+void ViewProps::setProp(
+    const PropsParserContext &context,
+    RawPropsPropNameHash hash,
+    const char *propName,
+    RawValue const &value) {
+  // All Props structs setProp methods must always, unconditionally,
+  // call all super::setProp methods, since multiple structs may
+  // reuse the same values.
+  YogaStylableProps::setProp(context, hash, propName, value);
+  AccessibilityProps::setProp(context, hash, propName, value);
+
+  switch (hash) {
+    RAW_SET_PROP_SWITCH_CASE_BASIC(opacity, (Float)1.0);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(foregroundColor, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(backgroundColor, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowColor, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOffset, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowOpacity, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shadowRadius, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(transform, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(backfaceVisibility, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldRasterize, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(zIndex, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(pointerEvents, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(hitSlop, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(onLayout, {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable, true);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews, false);
+    // events field
+    VIEW_EVENT_CASE(PointerEnter);
+    VIEW_EVENT_CASE(PointerEnterCapture);
+    VIEW_EVENT_CASE(PointerMove);
+    VIEW_EVENT_CASE(PointerMoveCapture);
+    VIEW_EVENT_CASE(PointerLeave);
+    VIEW_EVENT_CASE(PointerLeaveCapture);
+    VIEW_EVENT_CASE(PointerOver);
+    VIEW_EVENT_CASE(PointerOut);
+    VIEW_EVENT_CASE(MoveShouldSetResponder);
+    VIEW_EVENT_CASE(MoveShouldSetResponderCapture);
+    VIEW_EVENT_CASE(StartShouldSetResponder);
+    VIEW_EVENT_CASE(StartShouldSetResponderCapture);
+    VIEW_EVENT_CASE(ResponderGrant);
+    VIEW_EVENT_CASE(ResponderReject);
+    VIEW_EVENT_CASE(ResponderStart);
+    VIEW_EVENT_CASE(ResponderEnd);
+    VIEW_EVENT_CASE(ResponderRelease);
+    VIEW_EVENT_CASE(ResponderMove);
+    VIEW_EVENT_CASE(ResponderTerminate);
+    VIEW_EVENT_CASE(ResponderTerminationRequest);
+    VIEW_EVENT_CASE(ShouldBlockNativeResponder);
+    VIEW_EVENT_CASE(TouchStart);
+    VIEW_EVENT_CASE(TouchMove);
+    VIEW_EVENT_CASE(TouchEnd);
+    VIEW_EVENT_CASE(TouchCancel);
+    VIEW_EVENT_CASE(MouseEnter); // [Windows]
+    VIEW_EVENT_CASE(MouseLeave); // [Windows]
+
+#ifdef ANDROID
+    RAW_SET_PROP_SWITCH_CASE_BASIC(elevation, {});
+    RAW_SET_PROP_SWITCH_CASE(nativeBackground, "nativeBackgroundAndroid", {});
+    RAW_SET_PROP_SWITCH_CASE(nativeForeground, "nativeForegroundAndroid", {});
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(hasTVPreferredFocus, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing, false);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid, false);
+#endif
+    // BorderRadii
+    SET_CASCADED_RECTANGLE_CORNERS(borderRadii, "border", "Radius", value);
+    SET_CASCADED_RECTANGLE_EDGES(borderColors, "border", "Color", value);
+    SET_CASCADED_RECTANGLE_EDGES(borderStyles, "border", "Style", value);
+  }
+}
+
+#pragma mark - Convenience Methods
+
+static BorderRadii ensureNoOverlap(BorderRadii const &radii, Size const &size) {
+  // "Corner curves must not overlap: When the sum of any two adjacent border
+  // radii exceeds the size of the border box, UAs must proportionally reduce
+  // the used values of all border radii until none of them overlap."
+  // Source: https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
+
+  auto insets = EdgeInsets{
+      /* .left = */ radii.topLeft + radii.bottomLeft,
+      /* .top = */ radii.topLeft + radii.topRight,
+      /* .right = */ radii.topRight + radii.bottomRight,
+      /* .bottom = */ radii.bottomLeft + radii.bottomRight,
+  };
+
+  auto insetsScale = EdgeInsets{
+      /* .left = */
+      insets.left > 0 ? std::min((Float)1.0, size.height / insets.left) : 0,
+      /* .top = */
+      insets.top > 0 ? std::min((Float)1.0, size.width / insets.top) : 0,
+      /* .right = */
+      insets.right > 0 ? std::min((Float)1.0, size.height / insets.right) : 0,
+      /* .bottom = */
+      insets.bottom > 0 ? std::min((Float)1.0, size.width / insets.bottom) : 0,
+  };
+
+  return BorderRadii{
+      /* topLeft = */
+      radii.topLeft * std::min(insetsScale.top, insetsScale.left),
+      /* topRight = */
+      radii.topRight * std::min(insetsScale.top, insetsScale.right),
+      /* bottomLeft = */
+      radii.bottomLeft * std::min(insetsScale.bottom, insetsScale.left),
+      /* bottomRight = */
+      radii.bottomRight * std::min(insetsScale.bottom, insetsScale.right),
+  };
+}
+
+BorderMetrics ViewProps::resolveBorderMetrics(
+    LayoutMetrics const &layoutMetrics) const {
+  auto isRTL =
+      bool{layoutMetrics.layoutDirection == LayoutDirection::RightToLeft};
+
+  auto borderWidths = CascadedBorderWidths{
+      /* .left = */ optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeLeft]),
+      /* .top = */ optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeTop]),
+      /* .right = */
+      optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeRight]),
+      /* .bottom = */
+      optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeBottom]),
+      /* .start = */
+      optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeStart]),
+      /* .end = */ optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeEnd]),
+      /* .horizontal = */
+      optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeHorizontal]),
+      /* .vertical = */
+      optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeVertical]),
+      /* .all = */ optionalFloatFromYogaValue(yogaStyle.border()[YGEdgeAll]),
+  };
+
+  return {
+      /* .borderColors = */ borderColors.resolve(isRTL, {}),
+      /* .borderWidths = */ borderWidths.resolve(isRTL, 0),
+      /* .borderRadii = */
+      ensureNoOverlap(borderRadii.resolve(isRTL, 0), layoutMetrics.frame.size),
+      /* .borderCurves = */ borderCurves.resolve(isRTL, BorderCurve::Circular),
+      /* .borderStyles = */ borderStyles.resolve(isRTL, BorderStyle::Solid),
+  };
+}
+
+bool ViewProps::getClipsContentToBounds() const {
+  return yogaStyle.overflow() != YGOverflowVisible;
+}
+
+#ifdef ANDROID
+bool ViewProps::getProbablyMoreHorizontalThanVertical_DEPRECATED() const {
+  return yogaStyle.flexDirection() == YGFlexDirectionRow;
+}
+#endif
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+SharedDebugStringConvertibleList ViewProps::getDebugProps() const {
+  const auto &defaultViewProps = ViewProps();
+
+  return AccessibilityProps::getDebugProps() +
+      YogaStylableProps::getDebugProps() +
+      SharedDebugStringConvertibleList{
+          debugStringConvertibleItem(
+              "opacity", opacity, defaultViewProps.opacity),
+          debugStringConvertibleItem(
+              "foregroundColor",
+              foregroundColor,
+              defaultViewProps.foregroundColor),
+          debugStringConvertibleItem(
+              "backgroundColor",
+              backgroundColor,
+              defaultViewProps.backgroundColor),
+          debugStringConvertibleItem(
+              "zIndex", zIndex, defaultViewProps.zIndex.value_or(0)),
+      };
+}
+#endif
+
+} // namespace facebook::react

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/primitives.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/primitives.h
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/RectangleCorners.h>
+#include <react/renderer/graphics/RectangleEdges.h>
+
+#include <array>
+#include <bitset>
+#include <cmath>
+#include <optional>
+
+namespace facebook {
+namespace react {
+
+enum class PointerEventsMode : uint8_t { Auto, None, BoxNone, BoxOnly };
+
+struct ViewEvents {
+  std::bitset<32> bits{};
+
+  enum class Offset : std::size_t {
+    // Pointer events
+    PointerEnter = 0,
+    PointerMove = 1,
+    PointerLeave = 2,
+
+    // PanResponder callbacks
+    MoveShouldSetResponder = 3,
+    MoveShouldSetResponderCapture = 4,
+    StartShouldSetResponder = 5,
+    StartShouldSetResponderCapture = 6,
+    ResponderGrant = 7,
+    ResponderReject = 8,
+    ResponderStart = 9,
+    ResponderEnd = 10,
+    ResponderRelease = 11,
+    ResponderMove = 12,
+    ResponderTerminate = 13,
+    ResponderTerminationRequest = 14,
+    ShouldBlockNativeResponder = 15,
+
+    // Touch events
+    TouchStart = 16,
+    TouchMove = 17,
+    TouchEnd = 18,
+    TouchCancel = 19,
+
+    // W3C Pointer Events
+    PointerEnterCapture = 23,
+    PointerLeaveCapture = 24,
+    PointerMoveCapture = 25,
+    PointerOver = 26,
+    PointerOut = 27,
+    PointerOverCapture = 28,
+    PointerOutCapture = 29,
+
+    MouseEnter = 30, // Windows
+    MouseLeave = 31, // Windows
+
+  };
+
+  constexpr bool operator[](const Offset offset) const {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+
+  std::bitset<32>::reference operator[](const Offset offset) {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+};
+
+inline static bool operator==(ViewEvents const &lhs, ViewEvents const &rhs) {
+  return lhs.bits == rhs.bits;
+}
+
+inline static bool operator!=(ViewEvents const &lhs, ViewEvents const &rhs) {
+  return lhs.bits != rhs.bits;
+}
+
+enum class BackfaceVisibility : uint8_t { Auto, Visible, Hidden };
+
+enum class BorderCurve : uint8_t { Circular, Continuous };
+
+enum class BorderStyle : uint8_t { Solid, Dotted, Dashed };
+
+template <typename T>
+struct CascadedRectangleEdges {
+  using Counterpart = RectangleEdges<T>;
+  using OptionalT = std::optional<T>;
+
+  OptionalT left{};
+  OptionalT top{};
+  OptionalT right{};
+  OptionalT bottom{};
+  OptionalT start{};
+  OptionalT end{};
+  OptionalT horizontal{};
+  OptionalT vertical{};
+  OptionalT all{};
+  OptionalT block{};
+  OptionalT blockStart{};
+  OptionalT blockEnd{};
+
+  Counterpart resolve(bool isRTL, T defaults) const {
+    const auto leadingEdge = isRTL ? end : start;
+    const auto trailingEdge = isRTL ? start : end;
+    const auto horizontalOrAllOrDefault =
+        horizontal.value_or(all.value_or(defaults));
+    const auto verticalOrAllOrDefault =
+        vertical.value_or(all.value_or(defaults));
+
+    return {
+        /* .left = */
+        left.value_or(leadingEdge.value_or(horizontalOrAllOrDefault)),
+        /* .top = */
+        blockStart.value_or(
+            block.value_or(top.value_or(verticalOrAllOrDefault))),
+        /* .right = */
+        right.value_or(trailingEdge.value_or(horizontalOrAllOrDefault)),
+        /* .bottom = */
+        blockEnd.value_or(
+            block.value_or(bottom.value_or(verticalOrAllOrDefault))),
+    };
+  }
+
+  bool operator==(const CascadedRectangleEdges<T> &rhs) const {
+    return std::tie(
+               this->left,
+               this->top,
+               this->right,
+               this->bottom,
+               this->start,
+               this->end,
+               this->horizontal,
+               this->vertical,
+               this->all,
+               this->block,
+               this->blockStart,
+               this->blockEnd) ==
+        std::tie(
+               rhs.left,
+               rhs.top,
+               rhs.right,
+               rhs.bottom,
+               rhs.start,
+               rhs.end,
+               rhs.horizontal,
+               rhs.vertical,
+               rhs.all,
+               rhs.block,
+               rhs.blockStart,
+               rhs.blockEnd);
+  }
+
+  bool operator!=(const CascadedRectangleEdges<T> &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+template <typename T>
+struct CascadedRectangleCorners {
+  using Counterpart = RectangleCorners<T>;
+  using OptionalT = std::optional<T>;
+
+  OptionalT topLeft{};
+  OptionalT topRight{};
+  OptionalT bottomLeft{};
+  OptionalT bottomRight{};
+  OptionalT topStart{};
+  OptionalT topEnd{};
+  OptionalT bottomStart{};
+  OptionalT bottomEnd{};
+  OptionalT all{};
+  OptionalT endEnd{};
+  OptionalT endStart{};
+  OptionalT startEnd{};
+  OptionalT startStart{};
+
+  Counterpart resolve(bool isRTL, T defaults) const {
+    const auto logicalTopStart = topStart ? topStart : startStart;
+    const auto logicalTopEnd = topEnd ? topEnd : startEnd;
+    const auto logicalBottomStart = bottomStart ? bottomStart : endStart;
+    const auto logicalBottomEnd = bottomEnd ? bottomEnd : endEnd;
+
+    const auto topLeading = isRTL ? logicalTopEnd : logicalTopStart;
+    const auto topTrailing = isRTL ? logicalTopStart : logicalTopEnd;
+    const auto bottomLeading = isRTL ? logicalBottomEnd : logicalBottomStart;
+    const auto bottomTrailing = isRTL ? logicalBottomStart : logicalBottomEnd;
+
+    return {
+        /* .topLeft = */ topLeft.value_or(
+            topLeading.value_or(all.value_or(defaults))),
+        /* .topRight = */
+        topRight.value_or(topTrailing.value_or(all.value_or(defaults))),
+        /* .bottomLeft = */
+        bottomLeft.value_or(bottomLeading.value_or(all.value_or(defaults))),
+        /* .bottomRight = */
+        bottomRight.value_or(bottomTrailing.value_or(all.value_or(defaults))),
+    };
+  }
+
+  bool operator==(const CascadedRectangleCorners<T> &rhs) const {
+    return std::tie(
+               this->topLeft,
+               this->topRight,
+               this->bottomLeft,
+               this->bottomRight,
+               this->topStart,
+               this->topEnd,
+               this->bottomStart,
+               this->bottomEnd,
+               this->all,
+               this->endEnd,
+               this->endStart,
+               this->startEnd,
+               this->startStart) ==
+        std::tie(
+               rhs.topLeft,
+               rhs.topRight,
+               rhs.bottomLeft,
+               rhs.bottomRight,
+               rhs.topStart,
+               rhs.topEnd,
+               rhs.bottomStart,
+               rhs.bottomEnd,
+               rhs.all,
+               rhs.endEnd,
+               rhs.endStart,
+               rhs.startEnd,
+               rhs.startStart);
+  }
+
+  bool operator!=(const CascadedRectangleCorners<T> &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+using BorderWidths = RectangleEdges<Float>;
+using BorderCurves = RectangleCorners<BorderCurve>;
+using BorderStyles = RectangleEdges<BorderStyle>;
+using BorderColors = RectangleEdges<SharedColor>;
+using BorderRadii = RectangleCorners<Float>;
+
+using CascadedBorderWidths = CascadedRectangleEdges<Float>;
+using CascadedBorderCurves = CascadedRectangleCorners<BorderCurve>;
+using CascadedBorderStyles = CascadedRectangleEdges<BorderStyle>;
+using CascadedBorderColors = CascadedRectangleEdges<SharedColor>;
+using CascadedBorderRadii = CascadedRectangleCorners<Float>;
+
+struct BorderMetrics {
+  BorderColors borderColors{};
+  BorderWidths borderWidths{};
+  BorderRadii borderRadii{};
+  BorderCurves borderCurves{};
+  BorderStyles borderStyles{};
+
+  bool operator==(const BorderMetrics &rhs) const {
+    return std::tie(
+               this->borderColors,
+               this->borderWidths,
+               this->borderRadii,
+               this->borderCurves,
+               this->borderStyles) ==
+        std::tie(
+               rhs.borderColors,
+               rhs.borderWidths,
+               rhs.borderRadii,
+               rhs.borderCurves,
+               rhs.borderStyles);
+  }
+
+  bool operator!=(const BorderMetrics &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+#ifdef ANDROID
+
+struct NativeDrawable {
+  enum class Kind : uint8_t {
+    Ripple,
+    ThemeAttr,
+  };
+
+  struct Ripple {
+    std::optional<int32_t> color{};
+    std::optional<Float> rippleRadius{};
+    bool borderless{false};
+
+    bool operator==(const Ripple &rhs) const {
+      return std::tie(this->color, this->borderless, this->rippleRadius) ==
+          std::tie(rhs.color, rhs.borderless, rhs.rippleRadius);
+    }
+  };
+
+  std::string themeAttr;
+  Ripple ripple;
+  Kind kind;
+
+  bool operator==(const NativeDrawable &rhs) const {
+    if (this->kind != rhs.kind)
+      return false;
+    switch (this->kind) {
+      case Kind::ThemeAttr:
+        return this->themeAttr == rhs.themeAttr;
+      case Kind::Ripple:
+        return this->ripple == rhs.ripple;
+    }
+  }
+
+  bool operator!=(const NativeDrawable &rhs) const {
+    return !(*this == rhs);
+  }
+
+  ~NativeDrawable() = default;
+};
+
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -81,6 +81,30 @@
       "issue": 9791
     },
     {
+      "type": "derived",
+      "file": "ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/primitives.h",
+      "baseFile": "ReactCommon/react/renderer/components/view/primitives.h",
+      "baseHash": "ca98e8845881b0f78c6c06e96eccb515e49a4b6e"
+    },
+    {
+      "type": "derived",
+      "file": "ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.cpp",
+      "baseFile": "ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp",
+      "baseHash": "a8524dc7a5a1e2d79880cf5f2f9c6cb7e014b197"
+    },
+    {
+      "type": "derived",
+      "file": "ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/TouchEventEmitter.h",
+      "baseFile": "ReactCommon/react/renderer/components/view/TouchEventEmitter.h",
+      "baseHash": "e8e2327d4c67082922c849a3726f73543e314eca"
+    },
+    {
+      "type": "derived",
+      "file": "ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp",
+      "baseFile": "ReactCommon/react/renderer/components/view/ViewProps.cpp",
+      "baseHash": "89b0c87d483455cb33fffed3ce7d50e7f8171619"
+    },
+    {
       "type": "patch",
       "file": "ReactCommon/Yoga.cpp",
       "baseFile": "ReactCommon/yoga/yoga/Yoga.cpp",

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -499,6 +499,7 @@ export default class Pressability {
 
       onResponderGrant: (event: PressEvent): void => {
         event.persist();
+
         this._cancelPressOutDelayTimeout();
 
         this._responderID = event.currentTarget;
@@ -875,7 +876,7 @@ export default class Pressability {
     const {pageX, pageY, button} = getTouchFromPressEvent(event);
     this._touchActivatePosition = {pageX, pageY};
     this._touchActivateTime = Date.now();
-    if (onPressIn != null && button === 0) {
+    if (onPressIn != null && this._isDefaultPressButton(button)) {
       onPressIn(event);
     }
   }


### PR DESCRIPTION
## Description
Core does not have MouseEnter/Leave events.  In order for apps to be able to do the migration to fabric we will need to keep supporting the MouseEnter/Leave events, even if fabric implements PointerEnter/Leave which will be the events we use going forward.

### What
This adds MouseEnter/Leave to the TouchEventEmitter and ViewProps parsing code.  And extends the touch event handler to raise the mouseEnter/Leave events in addition to the newer pointer events.

One thing to note is that this PR uses the last two bits of the `ViewEvents` bitset.  This might cause issues if core adds additional events. -- But the bitset could be expanded on windows if we need to.

This PR also adds support for pointer/touch/mouse events to fire on text spans and fixes an issue in pressability that was preventing onPressIn from firing which caused a lot of RNTester UI to not appear to respond to presses.

Future work will be to expand the properties of touch to include button and some of the other properties we added in paper and pointer leave events are not firing when the mouse leaves the app.

## Testing
The Mouse Events test page in RNTester mostly works now.  Clicking around the various tester pages is greatly improved.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11216)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11216)