### PR TITLE
[Fabric] Fix Alert crash when not using XAML

### DIFF
--- a/change/react-native-windows-c99cd5a3-0fac-4b41-b8c7-cd6099ea9c3b.json
+++ b/change/react-native-windows-c99cd5a3-0fac-4b41-b8c7-cd6099ea9c3b.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "[Fabric] Fix Alert crash when no using XAML",
+  "comment": "[Fabric] Fix Alert crash when not using XAML",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-c99cd5a3-0fac-4b41-b8c7-cd6099ea9c3b.json
+++ b/change/react-native-windows-c99cd5a3-0fac-4b41-b8c7-cd6099ea9c3b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix Alert crash when no using XAML",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -138,10 +138,8 @@ struct WindowData {
           host.InstanceSettings().UseDeveloperSupport(true);
 
           host.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
-          winrt::Microsoft::ReactNative::ReactPropertyBag(host.InstanceSettings().Properties())
-              .Set(
-                  winrt::Microsoft::ReactNative::ReactPropertyId<uint64_t>(L"RootHwndForDevUI"),
-                  reinterpret_cast<uint64_t>(hwnd));
+          winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetTopLevelWindowHandle(
+              host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
 
           // Nudge the ReactNativeHost to create the instance and wrapping context
           host.ReloadInstance();

--- a/vnext/Microsoft.ReactNative/CompositionUIService.idl
+++ b/vnext/Microsoft.ReactNative/CompositionUIService.idl
@@ -20,5 +20,15 @@ namespace Microsoft.ReactNative.Composition
     DOC_STRING(
       "Sets the CompositionContext for this react instance.  This can be created using @CompositionContextHelper.CreateContext")
     static void SetCompositionContext(Microsoft.ReactNative.IReactPropertyBag properties, ICompositionContext compositionContext);
+    
+    DOC_STRING(
+      "Gets the window handle HWND (as an UInt64) for the active top level application window.")
+    static UInt64 GetTopLevelWindowHandle(Microsoft.ReactNative.IReactPropertyBag properties);
+
+    DOC_STRING(
+      "Sets the window handle HWND (as an UInt64) for the active top level application window."
+      "This must be manually provided to the @ReactInstanceSettings object when using ReactNativeWindows"
+      "without XAML for certain APIs work correctly.")
+    static void SetTopLevelWindowHandle(Microsoft.ReactNative.IReactPropertyBag properties, UInt64 windowHandle);
   }
 } // namespace Microsoft.ReactNative.Composition

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
@@ -14,6 +14,11 @@ static const ReactPropertyId<ICompositionContext> &CompositionContextPropertyId(
   return prop;
 }
 
+static const ReactPropertyId<uint64_t> &TopLevelHwndPropertyId() noexcept {
+  static const ReactPropertyId<uint64_t> prop{L"ReactNative.Composition", L"TopLevelHwnd"};
+  return prop;
+}
+
 void CompositionUIService::SetCompositionContext(
     IReactPropertyBag const &properties,
     ICompositionContext const &compositionContext) noexcept {
@@ -22,6 +27,16 @@ void CompositionUIService::SetCompositionContext(
 
 ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &properties) noexcept {
   return ReactPropertyBag(properties).Get(CompositionContextPropertyId());
+}
+
+uint64_t CompositionUIService::GetTopLevelWindowHandle(const IReactPropertyBag &properties) noexcept {
+  return ReactPropertyBag(properties).Get(TopLevelHwndPropertyId()).value_or(0);
+}
+
+void CompositionUIService::SetTopLevelWindowHandle(
+    const IReactPropertyBag &properties,
+    uint64_t windowHandle) noexcept {
+  ReactPropertyBag(properties).Set(TopLevelHwndPropertyId(), windowHandle);
 }
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
@@ -14,6 +14,9 @@ struct CompositionUIService : CompositionUIServiceT<CompositionUIService> {
       const ICompositionContext &compositionContext) noexcept;
 
   static ICompositionContext GetCompositionContext(const IReactPropertyBag &properties) noexcept;
+
+  static uint64_t GetTopLevelWindowHandle(const IReactPropertyBag &properties) noexcept;
+  static void SetTopLevelWindowHandle(const IReactPropertyBag &properties, uint64_t windowHandle) noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -10,8 +10,15 @@
 #include <UI.Xaml.Media.h>
 #include <UI.Xaml.Shapes.h>
 #include <Utils/ValueUtils.h>
+#include <XamlUtils.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 #include "Utils/Helpers.h"
+
+#ifdef USE_FABRIC
+#include <Fabric/Composition/CompositionUIService.h>
+#include <Shobjidl.h>
+#include <winrt/Windows.UI.Popups.h>
+#endif
 
 namespace Microsoft::ReactNative {
 
@@ -29,9 +36,7 @@ void Alert::showAlert(
   });
 }
 
-void Alert::ProcessPendingAlertRequests() noexcept {
-  if (pendingAlerts.empty())
-    return;
+void Alert::ProcessPendingAlertRequestsXaml() noexcept {
   const auto &pendingAlert = pendingAlerts.front();
   const auto &args = pendingAlert.args;
   const auto &result = pendingAlert.result;
@@ -142,6 +147,80 @@ void Alert::ProcessPendingAlertRequests() noexcept {
       });
 }
 
+#ifdef USE_FABRIC
+void Alert::ProcessPendingAlertRequestsMessageDialog() noexcept {
+  const auto &pendingAlert = pendingAlerts.front();
+  const auto &args = pendingAlert.args;
+  const auto &result = pendingAlert.result;
+  auto jsDispatcher = m_context.JSDispatcher();
+
+  auto cancelable = args.cancelable.value_or(true);
+  auto messageDialog = winrt::Windows::UI::Popups::MessageDialog(
+      winrt::to_hstring(args.message.value_or(std::string{})), winrt::to_hstring(args.title.value_or(std::string{})));
+
+  if (args.buttonPositive) {
+    auto uicommand = winrt::Windows::UI::Popups::UICommand(winrt::to_hstring(args.buttonPositive.value()));
+    uicommand.Id(winrt::box_value(m_constants.buttonPositive));
+    messageDialog.Commands().Append(uicommand);
+    if (args.defaultButton.value_or(0) == m_constants.buttonPositive) {
+      messageDialog.DefaultCommandIndex(messageDialog.Commands().Size() - 1);
+    }
+  }
+  if (args.buttonNegative) {
+    auto uicommand = winrt::Windows::UI::Popups::UICommand(winrt::to_hstring(args.buttonNegative.value()));
+    uicommand.Id(winrt::box_value(m_constants.buttonNegative));
+    messageDialog.Commands().Append(uicommand);
+    if (args.defaultButton.value_or(0) == m_constants.buttonNegative) {
+      messageDialog.DefaultCommandIndex(messageDialog.Commands().Size() - 1);
+    }
+  }
+  if (args.buttonNeutral) {
+    auto uicommand = winrt::Windows::UI::Popups::UICommand(winrt::to_hstring(args.buttonNeutral.value()));
+    uicommand.Id(winrt::box_value(m_constants.buttonNeutral));
+    messageDialog.Commands().Append(uicommand);
+    if (args.defaultButton.value_or(0) == m_constants.buttonNeutral) {
+      messageDialog.DefaultCommandIndex(messageDialog.Commands().Size() - 1);
+    }
+  }
+
+  if (!args.cancelable.value_or(true)) {
+    messageDialog.CancelCommandIndex(0xffffffff /* -1 doesn't allow cancelation of message dialog */);
+  }
+
+  auto hwnd = winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetTopLevelWindowHandle(
+      m_context.Properties().Handle());
+  if (hwnd) {
+    auto initializeWithWindow{messageDialog.as<::IInitializeWithWindow>()};
+    initializeWithWindow->Initialize(reinterpret_cast<HWND>(hwnd));
+  }
+
+  auto asyncOp = messageDialog.ShowAsync();
+  asyncOp.Completed(
+      [jsDispatcher, result, this](
+          const winrt::IAsyncOperation<winrt::Windows::UI::Popups::IUICommand> &asyncOp, winrt::AsyncStatus status) {
+        auto uicommand = asyncOp.GetResults();
+        jsDispatcher.Post(
+            [id = uicommand.Id(), result, this] { result(m_constants.buttonClicked, winrt::unbox_value<int>(id)); });
+        pendingAlerts.pop();
+        ProcessPendingAlertRequests();
+      });
+}
+#endif
+
+void Alert::ProcessPendingAlertRequests() noexcept {
+  if (pendingAlerts.empty())
+    return;
+
+  if (xaml::TryGetCurrentApplication()) {
+    ProcessPendingAlertRequestsXaml();
+  }
+#ifdef USE_FABRIC
+  else {
+    // If we dont have xaml loaded, fallback to using MessageDialog
+    ProcessPendingAlertRequestsMessageDialog();
+  }
+#endif
+}
 Alert::Constants Alert::GetConstants() noexcept {
   return m_constants;
 }

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.h
@@ -44,6 +44,10 @@ struct Alert : public std::enable_shared_from_this<Alert> {
   std::queue<AlertRequest> pendingAlerts{};
 
   void ProcessPendingAlertRequests() noexcept;
+  void ProcessPendingAlertRequestsXaml() noexcept;
+#ifdef USE_FABRIC
+  void ProcessPendingAlertRequestsMessageDialog() noexcept;
+#endif
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -17,6 +17,7 @@
 #ifndef CORE_ABI
 
 #ifdef USE_FABRIC
+#include <Fabric/Composition/CompositionUIService.h>
 #include <Shobjidl.h>
 #include <Utils/Helpers.h>
 #include <winrt/Windows.UI.Popups.h>
@@ -92,7 +93,8 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
     auto msg = winrt::Windows::UI::Popups::MessageDialog(winrt::to_hstring(ss.str()), L"React Native Error");
     auto hwnd = reinterpret_cast<HWND>(
-        *m_propBag.Get(winrt::Microsoft::ReactNative::ReactPropertyId<uint64_t>(L"RootHwndForDevUI")));
+        winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetTopLevelWindowHandle(
+            m_propBag.Handle()));
     auto initializeWithWindow{msg.as<::IInitializeWithWindow>()};
     initializeWithWindow->Initialize(hwnd);
     msg.Commands().Append(


### PR DESCRIPTION
## Description

When running fabric, if XAML is not loaded in the app, then alerts cause the app to crash.

### What
Provide a fallback implementation of alert which does not rely on Xaml

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11218)