### PR TITLE
[Fabric] Fix debug menu crash when not using Xaml

### DIFF
--- a/change/react-native-windows-3e9d5740-8654-448c-9431-3b681c4de19d.json
+++ b/change/react-native-windows-3e9d5740-8654-448c-9431-3b681c4de19d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix debug menu crash when not using Xaml",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -138,7 +138,7 @@ struct WindowData {
           host.InstanceSettings().UseDeveloperSupport(true);
 
           host.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
-          winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetTopLevelWindowHandle(
+          winrt::Microsoft::ReactNative::ReactCoreInjection::SetTopLevelWindowId(
               host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
 
           // Nudge the ReactNativeHost to create the instance and wrapping context

--- a/vnext/Microsoft.ReactNative/CompositionUIService.idl
+++ b/vnext/Microsoft.ReactNative/CompositionUIService.idl
@@ -20,15 +20,5 @@ namespace Microsoft.ReactNative.Composition
     DOC_STRING(
       "Sets the CompositionContext for this react instance.  This can be created using @CompositionContextHelper.CreateContext")
     static void SetCompositionContext(Microsoft.ReactNative.IReactPropertyBag properties, ICompositionContext compositionContext);
-    
-    DOC_STRING(
-      "Gets the window handle HWND (as an UInt64) for the active top level application window.")
-    static UInt64 GetTopLevelWindowHandle(Microsoft.ReactNative.IReactPropertyBag properties);
-
-    DOC_STRING(
-      "Sets the window handle HWND (as an UInt64) for the active top level application window."
-      "This must be manually provided to the @ReactInstanceSettings object when using ReactNativeWindows"
-      "without XAML for certain APIs work correctly.")
-    static void SetTopLevelWindowHandle(Microsoft.ReactNative.IReactPropertyBag properties, UInt64 windowHandle);
   }
 } // namespace Microsoft.ReactNative.Composition

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -7,6 +7,8 @@
 
 #include <Fabric/Composition/CompositionViewComponentView.h>
 #include <Fabric/FabricUIManagerModule.h>
+#include <IReactContext.h>
+#include <Views/DevMenu.h>
 #include <Views/ShadowNodeBase.h>
 #include <windows.h>
 #include <windowsx.h>
@@ -161,6 +163,27 @@ int64_t CompositionEventHandler::SendMessage(
         auto result = focusedComponent->SendMessage(msg, wParam, lParam);
         if (result)
           return result;
+      }
+
+      if (msg == WM_KEYDOWN && wParam == VkKeyScanA('d')) {
+        BYTE bKeys[256];
+        if (GetKeyboardState(bKeys)) {
+          bool fShift = false;
+          if (bKeys[VK_LSHIFT] & 0x80)
+            fShift = true;
+          if (bKeys[VK_RSHIFT] & 0x80)
+            fShift = true;
+          bool fCtrl = false;
+          if (bKeys[VK_LCONTROL] & 0x80)
+            fCtrl = true;
+          if (bKeys[VK_RCONTROL] & 0x80)
+            fCtrl = true;
+          if (fShift && fCtrl) {
+            auto contextSelf = winrt::get_self<React::implementation::ReactContext>(m_context.Handle());
+            Microsoft::ReactNative::DevMenuManager::Show(
+                Mso::CntPtr<Mso::React::IReactContext>(&contextSelf->GetInner()));
+          }
+        }
       }
       return 0;
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
@@ -14,11 +14,6 @@ static const ReactPropertyId<ICompositionContext> &CompositionContextPropertyId(
   return prop;
 }
 
-static const ReactPropertyId<uint64_t> &TopLevelHwndPropertyId() noexcept {
-  static const ReactPropertyId<uint64_t> prop{L"ReactNative.Composition", L"TopLevelHwnd"};
-  return prop;
-}
-
 void CompositionUIService::SetCompositionContext(
     IReactPropertyBag const &properties,
     ICompositionContext const &compositionContext) noexcept {
@@ -27,16 +22,6 @@ void CompositionUIService::SetCompositionContext(
 
 ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &properties) noexcept {
   return ReactPropertyBag(properties).Get(CompositionContextPropertyId());
-}
-
-uint64_t CompositionUIService::GetTopLevelWindowHandle(const IReactPropertyBag &properties) noexcept {
-  return ReactPropertyBag(properties).Get(TopLevelHwndPropertyId()).value_or(0);
-}
-
-void CompositionUIService::SetTopLevelWindowHandle(
-    const IReactPropertyBag &properties,
-    uint64_t windowHandle) noexcept {
-  ReactPropertyBag(properties).Set(TopLevelHwndPropertyId(), windowHandle);
 }
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
@@ -14,9 +14,6 @@ struct CompositionUIService : CompositionUIServiceT<CompositionUIService> {
       const ICompositionContext &compositionContext) noexcept;
 
   static ICompositionContext GetCompositionContext(const IReactPropertyBag &properties) noexcept;
-
-  static uint64_t GetTopLevelWindowHandle(const IReactPropertyBag &properties) noexcept;
-  static void SetTopLevelWindowHandle(const IReactPropertyBag &properties, uint64_t windowHandle) noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -556,7 +556,6 @@
     <ClCompile Include="Views\ActivityIndicatorViewManager.cpp" />
     <ClCompile Include="Views\ConfigureBundlerDlg.cpp" />
     <ClCompile Include="Views\ControlViewManager.cpp" />
-    <ClCompile Include="Views\DevMenu.cpp" />
     <ClCompile Include="Views\DynamicAutomationPeer.cpp" />
     <ClCompile Include="Views\DynamicAutomationProperties.cpp" />
     <ClCompile Include="Views\DynamicValueProvider.cpp" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -188,9 +188,6 @@
     <ClCompile Include="Views\ControlViewManager.cpp">
       <Filter>Views</Filter>
     </ClCompile>
-    <ClCompile Include="Views\DevMenu.cpp">
-      <Filter>Views</Filter>
-    </ClCompile>
     <ClCompile Include="Views\DynamicAutomationPeer.cpp">
       <Filter>Views</Filter>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AlertModule.cpp
@@ -15,7 +15,7 @@
 #include "Utils/Helpers.h"
 
 #ifdef USE_FABRIC
-#include <Fabric/Composition/CompositionUIService.h>
+#include <ReactCoreInjection.h>
 #include <Shobjidl.h>
 #include <winrt/Windows.UI.Popups.h>
 #endif
@@ -187,7 +187,7 @@ void Alert::ProcessPendingAlertRequestsMessageDialog() noexcept {
     messageDialog.CancelCommandIndex(0xffffffff /* -1 doesn't allow cancelation of message dialog */);
   }
 
-  auto hwnd = winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetTopLevelWindowHandle(
+  auto hwnd = winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::GetTopLevelWindowId(
       m_context.Properties().Handle());
   if (hwnd) {
     auto initializeWithWindow{messageDialog.as<::IInitializeWithWindow>()};

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -41,6 +41,11 @@ Mso::React::ReactViewOptions ReactViewOptions::CreateViewOptions() noexcept {
 
 ReactCoreInjection::ReactCoreInjection() noexcept {}
 
+static const ReactPropertyId<uint64_t> &TopLevelWindowIdPropertyId() noexcept {
+  static const ReactPropertyId<uint64_t> prop{L"ReactNative.Injection", L"TopLevelWindowId"};
+  return prop;
+}
+
 /*static*/ ReactPropertyId<UIBatchCompleteCallback> ReactCoreInjection::UIBatchCompleteCallbackProperty() noexcept {
   static ReactPropertyId<UIBatchCompleteCallback> prop{L"ReactNative.Injection", L"UIBatchCompleteCallback"};
   return prop;
@@ -94,6 +99,14 @@ ReactPropertyId<winrt::hstring> PlatformNameOverrideProperty() noexcept {
   return winrt::to_string(ReactNative::ReactPropertyBag(properties)
                               .Get(PlatformNameOverrideProperty())
                               .value_or(winrt::to_hstring(STRING(RN_PLATFORM))));
+}
+
+uint64_t ReactCoreInjection::GetTopLevelWindowId(const IReactPropertyBag &properties) noexcept {
+  return ReactPropertyBag(properties).Get(TopLevelWindowIdPropertyId()).value_or(0);
+}
+
+void ReactCoreInjection::SetTopLevelWindowId(const IReactPropertyBag &properties, uint64_t windowId) noexcept {
+  ReactPropertyBag(properties).Set(TopLevelWindowIdPropertyId(), windowId);
 }
 
 ReactViewHost::ReactViewHost(

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -49,6 +49,9 @@ struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
 
   static void SetPlatformNameOverride(IReactPropertyBag const &properties, winrt::hstring const &platformName) noexcept;
   static std::string GetPlatformName(IReactPropertyBag const &properties) noexcept;
+
+  static uint64_t GetTopLevelWindowId(const IReactPropertyBag &properties) noexcept;
+  static void SetTopLevelWindowId(const IReactPropertyBag &properties, uint64_t windowId) noexcept;
 };
 
 struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -92,6 +92,16 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
 
     DOC_STRING("Override platform name. This will change the platform used when requesting bundles from metro. Default: \"windows\"")
     static void SetPlatformNameOverride(IReactPropertyBag properties, String platformName);
+    
+    DOC_STRING(
+      "Gets the window handle HWND (as an UInt64) for the active top level application window.")
+    static UInt64 GetTopLevelWindowId(IReactPropertyBag properties);
+
+    DOC_STRING(
+      "Sets the window handle HWND (as an UInt64) for the active top level application window."
+      "This must be manually provided to the @ReactInstanceSettings object when using ReactNativeWindows"
+      "without XAML for certain APIs work correctly.")
+    static void SetTopLevelWindowId(IReactPropertyBag properties, UInt64 windowId);
   }
 
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -35,8 +35,8 @@
 #include "DynamicWriter.h"
 #ifndef CORE_ABI
 #include "ConfigureBundlerDlg.h"
-#include "DevMenu.h"
 #endif
+#include "DevMenu.h"
 #include "IReactContext.h"
 #include "IReactDispatcher.h"
 #ifndef CORE_ABI

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -403,11 +403,13 @@ void ReactInstanceWin::Initialize() noexcept {
 #ifndef CORE_ABI
   // InitUIManager uses m_legacyReactInstance
   InitUIManager();
+#endif
 
   Microsoft::ReactNative::DevMenuManager::InitDevMenu(m_reactContext, [weakReactHost = m_weakReactHost]() noexcept {
+#ifndef CORE_ABI
     Microsoft::ReactNative::ShowConfigureBundlerDialog(weakReactHost);
+#endif // CORE_ABI
   });
-#endif
 
   m_uiQueue->Post([this, weakThis = Mso::WeakPtr{this}]() noexcept {
     // Objects that must be created on the UI thread
@@ -447,16 +449,12 @@ void ReactInstanceWin::Initialize() noexcept {
                   strongThis->m_reactContext->Properties());
           devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
           devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
-
-#ifndef CORE_ABI
           devSettings->showDevMenuCallback = [weakThis]() noexcept {
             if (auto strongThis = weakThis.GetStrongPtr()) {
-              strongThis->m_uiQueue->Post([context = strongThis->m_reactContext]() {
-                Microsoft::ReactNative::DevMenuManager::Show(context->Properties());
-              });
+              strongThis->m_uiQueue->Post(
+                  [context = strongThis->m_reactContext]() { Microsoft::ReactNative::DevMenuManager::Show(context); });
             }
           };
-#endif
 
 #ifdef CORE_ABI
           std::vector<facebook::react::NativeModuleDescription> cxxModules;

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -17,7 +17,7 @@
 #ifndef CORE_ABI
 
 #ifdef USE_FABRIC
-#include <Fabric/Composition/CompositionUIService.h>
+#include <ReactCoreInjection.h>
 #include <Shobjidl.h>
 #include <Utils/Helpers.h>
 #include <winrt/Windows.UI.Popups.h>
@@ -93,8 +93,7 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
 
     auto msg = winrt::Windows::UI::Popups::MessageDialog(winrt::to_hstring(ss.str()), L"React Native Error");
     auto hwnd = reinterpret_cast<HWND>(
-        winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetTopLevelWindowHandle(
-            m_propBag.Handle()));
+        winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::GetTopLevelWindowId(m_propBag.Handle()));
     auto initializeWithWindow{msg.as<::IInitializeWithWindow>()};
     initializeWithWindow->Initialize(hwnd);
     msg.Commands().Append(

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -7,12 +7,12 @@
 
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include "HermesSamplingProfiler.h"
+#include "Modules/DevSettingsModule.h"
+#include "IReactDispatcher.h"
 
 #ifndef CORE_ABI
 #include <XamlUtils.h>
 #include "DevMenuControl.h"
-#include "IReactDispatcher.h"
-#include "Modules/DevSettingsModule.h"
 #include "UI.Xaml.Controls.Primitives.h"
 #include "UI.Xaml.Controls.h"
 #include "UI.Xaml.Input.h"
@@ -293,7 +293,7 @@ struct InAppXamlDevMenu : public IDevMenu, public std::enable_shared_from_this<I
     m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
   }
 
-  void Hide() noexcept override {
+  void Hide() noexcept {
     if (!m_flyout)
       return;
     m_flyout.Hide();
@@ -436,7 +436,7 @@ std::shared_ptr<IDevMenu> GetOrCreateDevMenu(Mso::CntPtr<Mso::React::IReactConte
 }
 
 /*static*/ void DevMenuManager::Show(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
-  if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context->Properties()))
+  if (!Mso::React::ReactOptions::UseDeveloperSupport(reactContext->Properties()))
     return;
 
   if (auto devMenu = GetOrCreateDevMenu(reactContext)) {

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -7,8 +7,8 @@
 
 #include <winrt/Windows.ApplicationModel.DataTransfer.h>
 #include "HermesSamplingProfiler.h"
-#include "Modules/DevSettingsModule.h"
 #include "IReactDispatcher.h"
+#include "Modules/DevSettingsModule.h"
 
 #ifndef CORE_ABI
 #include <XamlUtils.h>

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.cpp
@@ -2,7 +2,14 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
+
 #include "DevMenu.h"
+
+#include <winrt/Windows.ApplicationModel.DataTransfer.h>
+#include "HermesSamplingProfiler.h"
+
+#ifndef CORE_ABI
+#include <XamlUtils.h>
 #include "DevMenuControl.h"
 #include "IReactDispatcher.h"
 #include "Modules/DevSettingsModule.h"
@@ -14,13 +21,38 @@
 #include "Views/KeyboardEventHandler.h"
 #include "winrt/Windows.UI.Core.h"
 #include "winrt/Windows.UI.Xaml.Interop.h"
+#endif // CORE_ABI
 
-#include <winrt/Windows.ApplicationModel.DataTransfer.h>
-#include "HermesSamplingProfiler.h"
+#if defined(CORE_ABI) || defined(USE_FABRIC)
+#include <ReactCoreInjection.h>
+#include <Shobjidl.h>
+#include "winrt/Windows.UI.Popups.h"
+#endif
 
 using namespace winrt::Windows::ApplicationModel;
 
 namespace Microsoft::ReactNative {
+
+struct IDevMenu {
+  virtual void Show() noexcept = 0;
+};
+
+#ifndef CORE_ABI
+bool IsCtrlShiftD(winrt::Windows::System::VirtualKey key) noexcept {
+  return (
+      key == winrt::Windows::System::VirtualKey::D &&
+      KeyboardHelper::IsModifiedKeyPressed(
+          winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
+      KeyboardHelper::IsModifiedKeyPressed(
+          winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control));
+}
+#endif // CORE_ABI
+
+React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<IDevMenu>>> DevMenuImplProperty() noexcept {
+  static React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<IDevMenu>>> propId{
+      L"ReactNative.DevMenuManager", L"DevMenuImpl"};
+  return propId;
+}
 
 React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<DevMenuManager>>> DevMenuManagerProperty() noexcept {
   static React::ReactPropertyId<React::ReactNonAbiValue<std::shared_ptr<DevMenuManager>>> propId{
@@ -34,25 +66,310 @@ React::ReactPropertyId<React::ReactNonAbiValue<Mso::VoidFunctor>> ConfigureBundl
   return propId;
 }
 
-/*static*/ void DevMenuManager::InitDevMenu(
-    Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
-    Mso::VoidFunctor &&configureBundler) noexcept {
-  auto devMenu = std::make_shared<DevMenuManager>(reactContext);
-  devMenu->Init();
-  React::ReactPropertyBag(reactContext->Properties()).Set(DevMenuManagerProperty(), devMenu);
-  React::ReactPropertyBag(reactContext->Properties()).Set(ConfigureBundlerProperty(), std::move(configureBundler));
+void ToggleDirectDebugger(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  Mso::React::ReactOptions::SetUseDirectDebugger(
+      reactContext->Properties(), !Mso::React::ReactOptions::UseDirectDebugger(reactContext->Properties()));
+  DevSettings::Reload(React::ReactPropertyBag(reactContext->Properties()));
 }
 
-bool IsCtrlShiftD(winrt::Windows::System::VirtualKey key) noexcept {
-  return (
-      key == winrt::Windows::System::VirtualKey::D &&
-      KeyboardHelper::IsModifiedKeyPressed(
-          winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Shift) &&
-      KeyboardHelper::IsModifiedKeyPressed(
-          winrt::CoreWindow::GetForCurrentThread(), winrt::Windows::System::VirtualKey::Control));
+const wchar_t *DirectDebuggerLabel(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  return Mso::React::ReactOptions::UseDirectDebugger(reactContext->Properties()) ? L"Disable Direct Debugging"
+                                                                                 : L"Enable Direct Debugging";
 }
+
+void ToggleBreakOnNextLine(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  Mso::React::ReactOptions::SetDebuggerBreakOnNextLine(
+      reactContext->Properties(), !Mso::React::ReactOptions::DebuggerBreakOnNextLine(reactContext->Properties()));
+  DevSettings::Reload(React::ReactPropertyBag(reactContext->Properties()));
+}
+
+const wchar_t *BreakOnNextLineLabel(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  return Mso::React::ReactOptions::DebuggerBreakOnNextLine(reactContext->Properties()) ? L"Disable Break on First Line"
+                                                                                       : L"Enable Break on First Line";
+}
+
+void ToggleFastRefresh(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  Mso::React::ReactOptions::SetUseFastRefresh(
+      reactContext->Properties(), !Mso::React::ReactOptions::UseFastRefresh(reactContext->Properties()));
+  DevSettings::Reload(React::ReactPropertyBag(reactContext->Properties()));
+}
+
+winrt::fire_and_forget ToggleHermesProfiler(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  if (!Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
+    Microsoft::ReactNative::HermesSamplingProfiler::Start(reactContext);
+  } else {
+    auto traceFilePath = co_await Microsoft::ReactNative::HermesSamplingProfiler::Stop(reactContext);
+    auto uiDispatcher = React::implementation::ReactDispatcher::GetUIDispatcher(reactContext->Properties());
+    uiDispatcher.Post([traceFilePath]() {
+      DataTransfer::DataPackage data;
+      data.SetText(winrt::to_hstring(traceFilePath));
+      DataTransfer::Clipboard::SetContentWithOptions(data, nullptr);
+    });
+  }
+}
+
+const wchar_t *FastRefreshLabel(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  return Mso::React::ReactOptions::UseFastRefresh(reactContext->Properties()) ? L"Disable Fast Refresh"
+                                                                              : L"Enable Fast Refresh";
+}
+
+const wchar_t *HermesProfilerLabel(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  return !Microsoft::ReactNative::HermesSamplingProfiler::IsStarted() ? L"Start Hermes sampling profiler"
+                                                                      : L"Stop and copy trace path to clipboard";
+}
+
+#ifndef CORE_ABI
+struct InAppXamlDevMenu : public IDevMenu, public std::enable_shared_from_this<InAppXamlDevMenu> {
+  InAppXamlDevMenu(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
+
+ private:
+  void Show() noexcept override {
+    winrt::Microsoft::ReactNative::DevMenuControl devMenu{};
+
+    devMenu.RemoteDebugText().Text(
+        Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) ? L"Disable Remote JS Debugging"
+                                                                          : L"Enable Remote JS Debugging");
+    devMenu.RemoteDebugDesc().Text(
+        L"When enabled runs the JS remotely in VSCode or Chrome based on what you attach to the packager.  This means that the JS may run with a different JS engine than it runs in on in the real application, in addition synchronous native module calls, and JSI native modules will not work.");
+
+    devMenu.FastRefreshText().Text(FastRefreshLabel(m_context));
+    if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
+      devMenu.SamplingProfilerText().Text(HermesProfilerLabel(m_context));
+      devMenu.SamplingProfilerIcon().Glyph(
+          !Microsoft::ReactNative::HermesSamplingProfiler::IsStarted() ? L"\ue1e5" : L"\ue15b");
+
+      std::ostringstream os;
+      if (Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
+        os << "Hermes Sampling profiler is running!";
+      } else {
+        os << "Click to start.";
+      }
+
+      auto lastTraceFilePath = Microsoft::ReactNative::HermesSamplingProfiler::GetLastTraceFilePath();
+      if (!lastTraceFilePath.empty()) {
+        os << std::endl
+           << "Samples from last invocation are stored at " << lastTraceFilePath.c_str()
+           << "  (path copied to clipboard).";
+        os << std::endl << "Navigate to \"edge:\\tracing\" and load the trace file.";
+      }
+
+      devMenu.SamplingProfilerDescText().Text(winrt::to_hstring(os.str()));
+    }
+
+    devMenu.DirectDebugText().Text(DirectDebuggerLabel(m_context));
+    devMenu.DirectDebugDesc().Text(
+        L"If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.");
+
+    devMenu.BreakOnNextLineText().Text(BreakOnNextLineLabel(m_context));
+
+    m_reloadJSRevoker = devMenu.Reload().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+          }
+        });
+
+    m_remoteDebugJSRevoker = devMenu.RemoteDebug().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            Mso::React::ReactOptions::SetUseWebDebugger(
+                strongThis->m_context->Properties(),
+                !Mso::React::ReactOptions::UseWebDebugger(strongThis->m_context->Properties()));
+            DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
+          }
+        });
+
+    m_directDebuggingRevoker = devMenu.DirectDebug().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            ToggleDirectDebugger(strongThis->m_context);
+          }
+        });
+
+    m_breakOnNextLineRevoker = devMenu.BreakOnNextLine().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            ToggleBreakOnNextLine(strongThis->m_context);
+          }
+        });
+
+    m_fastRefreshRevoker = devMenu.FastRefresh().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            ToggleFastRefresh(strongThis->m_context);
+          }
+        });
+
+    if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
+      m_samplingProfilerRevoker = devMenu.SamplingProfiler().Click(
+          winrt::auto_revoke,
+          [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+            if (auto strongThis = wkThis.lock()) {
+              strongThis->Hide();
+              ToggleHermesProfiler(strongThis->m_context);
+            }
+          });
+    } else {
+      devMenu.SamplingProfiler().Visibility(xaml::Visibility::Collapsed);
+    }
+
+    m_toggleInspectorRevoker = devMenu.Inspector().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            DevSettings::ToggleElementInspector(*(strongThis->m_context));
+          }
+        });
+
+    m_configBundlerRevoker = devMenu.ConfigBundler().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+            React::ReactPropertyBag(strongThis->m_context->Properties()).Get(ConfigureBundlerProperty())();
+          }
+        });
+    // Only show Configure Bundler when connected to a bundler
+    devMenu.ConfigBundler().Visibility(
+        (Mso::React::ReactOptions::UseFastRefresh(m_context->Properties()) ||
+         Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()))
+            ? xaml::Visibility::Visible
+            : xaml::Visibility::Collapsed);
+
+    m_cancelRevoker = devMenu.Cancel().Click(
+        winrt::auto_revoke,
+        [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) {
+          if (auto strongThis = wkThis.lock()) {
+            strongThis->Hide();
+          }
+        });
+
+    m_flyout = xaml::Controls::Flyout{};
+    m_flyout.Content(devMenu);
+    if (Is19H1OrHigher()) {
+      // ShouldConstrainToRootBounds added in 19H1
+      m_flyout.ShouldConstrainToRootBounds(false);
+    }
+
+    xaml::UIElement root{nullptr};
+    auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context->Properties());
+    if (xamlRoot) {
+      m_flyout.XamlRoot(xamlRoot);
+      root = xamlRoot.Content();
+    } else {
+      auto window = xaml::Window::Current();
+      root = window.Content();
+    }
+
+    m_flyout.LightDismissOverlayMode(xaml::Controls::LightDismissOverlayMode::On);
+    devMenu.XYFocusKeyboardNavigation(xaml::Input::XYFocusKeyboardNavigationMode::Enabled);
+
+    auto style = xaml::Style(winrt::xaml_typename<xaml::Controls::FlyoutPresenter>());
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::HorizontalScrollBarVisibilityProperty(),
+        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::VerticalScrollBarVisibilityProperty(),
+        winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::HorizontalScrollModeProperty(),
+        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+    style.Setters().Append(xaml::Setter(
+        xaml::Controls::ScrollViewer::VerticalScrollModeProperty(),
+        winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
+
+    m_flyout.FlyoutPresenterStyle(style);
+    m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
+  }
+
+  void Hide() noexcept override {
+    if (!m_flyout)
+      return;
+    m_flyout.Hide();
+    m_flyout = nullptr;
+  }
+
+ private:
+  const Mso::CntPtr<Mso::React::IReactContext> m_context;
+  xaml::Controls::Flyout m_flyout{nullptr};
+  xaml::Controls::Button::Click_revoker m_remoteDebugJSRevoker{};
+  xaml::Controls::Button::Click_revoker m_cancelRevoker{};
+  xaml::Controls::Button::Click_revoker m_toggleInspectorRevoker{};
+  xaml::Controls::Button::Click_revoker m_configBundlerRevoker{};
+  xaml::Controls::Button::Click_revoker m_reloadJSRevoker{};
+  xaml::Controls::Button::Click_revoker m_fastRefreshRevoker{};
+  xaml::Controls::Button::Click_revoker m_directDebuggingRevoker{};
+  xaml::Controls::Button::Click_revoker m_breakOnNextLineRevoker{};
+  xaml::Controls::Button::Click_revoker m_samplingProfilerRevoker{};
+};
+#endif // CORE_ABI
+
+#if defined(CORE_ABI) || defined(USE_FABRIC)
+struct WindowsPopupMenuDevMenu : public IDevMenu, public std::enable_shared_from_this<WindowsPopupMenuDevMenu> {
+  WindowsPopupMenuDevMenu(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
+
+  void Show() noexcept override {
+    m_menu = winrt::Windows::UI::Popups::PopupMenu();
+
+    auto hwnd =
+        winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::GetTopLevelWindowId(m_context->Properties());
+    if (hwnd) {
+      auto initializeWithWindow{m_menu.as<::IInitializeWithWindow>()};
+      initializeWithWindow->Initialize(reinterpret_cast<HWND>(hwnd));
+    }
+
+    m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+        L"Reload", [reactContext = m_context](winrt::Windows::UI::Popups::IUICommand const &) {
+          DevSettings::Reload(React::ReactPropertyBag(reactContext->Properties()));
+        }));
+
+    m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+        DirectDebuggerLabel(m_context),
+        [context = m_context](winrt::Windows::UI::Popups::IUICommand const &) { ToggleDirectDebugger(context); }));
+
+    m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+        BreakOnNextLineLabel(m_context),
+        [context = m_context](winrt::Windows::UI::Popups::IUICommand const &) { ToggleBreakOnNextLine(context); }));
+
+    m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+        FastRefreshLabel(m_context),
+        [context = m_context](winrt::Windows::UI::Popups::IUICommand const &) { ToggleFastRefresh(context); }));
+
+    m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+        L"Toggle Inspector", [context = m_context](winrt::Windows::UI::Popups::IUICommand const &) {
+          DevSettings::ToggleElementInspector(*context);
+        }));
+
+    if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
+      m_menu.Commands().Append(winrt::Windows::UI::Popups::UICommand(
+          HermesProfilerLabel(m_context),
+          [context = m_context](winrt::Windows::UI::Popups::IUICommand const &) { ToggleHermesProfiler(context); }));
+    }
+
+    m_menu.ShowAsync({0, 0});
+  }
+
+ private:
+  winrt::Windows::UI::Popups::PopupMenu m_menu{nullptr};
+  const Mso::CntPtr<Mso::React::IReactContext> m_context;
+};
+#endif // defined(CORE_ABI) || defined(USE_FABRIC)
+
+DevMenuManager::DevMenuManager(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
 
 void DevMenuManager::Init() noexcept {
+#ifndef CORE_ABI
   auto uiDispatcher = React::implementation::ReactDispatcher::GetUIDispatcher(m_context->Properties());
   uiDispatcher.Post([weakThis = weak_from_this()]() {
     if (auto strongThis = weakThis.lock()) {
@@ -65,7 +382,7 @@ void DevMenuManager::Init() noexcept {
             strongThis->m_keyDownRevoker = rootContent.KeyDown(
                 winrt::auto_revoke, [context](const auto & /*sender*/, const xaml::Input::KeyRoutedEventArgs &args) {
                   if (IsCtrlShiftD(args.Key())) {
-                    DevMenuManager::Show(context->Properties());
+                    DevMenuManager::Show(context);
                   }
                 });
             return;
@@ -77,233 +394,57 @@ void DevMenuManager::Init() noexcept {
         strongThis->m_coreDispatcherAKARevoker = coreWindow.Dispatcher().AcceleratorKeyActivated(
             winrt::auto_revoke, [context](const auto & /*sender*/, const winrt::AcceleratorKeyEventArgs &args) {
               if (IsCtrlShiftD(args.VirtualKey())) {
-                DevMenuManager::Show(context->Properties());
+                DevMenuManager::Show(context);
               }
             });
       }
     }
   });
+#endif // CORE_ABI
 }
 
-/*static*/ void DevMenuManager::Show(React::IReactPropertyBag const &properties) noexcept {
-  (*React::ReactPropertyBag(properties).Get(DevMenuManagerProperty()))->CreateAndShowUI();
+/*static*/ void DevMenuManager::InitDevMenu(
+    Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
+    Mso::VoidFunctor &&configureBundler) noexcept {
+  auto devMenuManager = std::make_shared<DevMenuManager>(reactContext);
+  devMenuManager->Init();
+  React::ReactPropertyBag(reactContext->Properties()).Set(DevMenuManagerProperty(), devMenuManager);
+  React::ReactPropertyBag(reactContext->Properties()).Set(ConfigureBundlerProperty(), std::move(configureBundler));
 }
 
-/*static*/ void DevMenuManager::Hide(React::IReactPropertyBag const &properties) noexcept {
-  (*React::ReactPropertyBag(properties).Get(DevMenuManagerProperty()))->Hide();
+std::shared_ptr<IDevMenu> GetOrCreateDevMenu(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
+  return React::ReactPropertyBag(reactContext->Properties())
+      .GetOrCreate(
+          DevMenuImplProperty(),
+          [reactContext]() -> std::shared_ptr<IDevMenu> {
+#ifndef CORE_ABI
+            if (xaml::TryGetCurrentApplication()) {
+              auto devMenu = std::make_shared<InAppXamlDevMenu>(reactContext);
+              return devMenu;
+            } else
+#endif // CORE_ABI
+
+#if defined(CORE_ABI) || defined(USE_FABRIC)
+            {
+              auto devMenu = std::make_shared<WindowsPopupMenuDevMenu>(reactContext);
+              return devMenu;
+            }
+#endif
+            return nullptr;
+          })
+      .Value();
 }
 
-DevMenuManager::DevMenuManager(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) : m_context(reactContext) {}
-
-void DevMenuManager::CreateAndShowUI() noexcept {
+/*static*/ void DevMenuManager::Show(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept {
   if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context->Properties()))
     return;
 
-  winrt::Microsoft::ReactNative::DevMenuControl devMenu{};
-
-  devMenu.RemoteDebugText().Text(
-      Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()) ? L"Disable Remote JS Debugging"
-                                                                        : L"Enable Remote JS Debugging");
-  devMenu.RemoteDebugDesc().Text(
-      L"When enabled runs the JS remotely in VSCode or Chrome based on what you attach to the packager.  This means that the JS may run with a different JS engine than it runs in on in the real application, in addition synchronous native module calls, and JSI native modules will not work.");
-
-  devMenu.FastRefreshText().Text(
-      Mso::React::ReactOptions::UseFastRefresh(m_context->Properties()) ? L"Disable Fast Refresh"
-                                                                        : L"Enable Fast Refresh");
-  if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
-    devMenu.SamplingProfilerText().Text(
-        !Microsoft::ReactNative::HermesSamplingProfiler::IsStarted() ? L"Start Hermes sampling profiler"
-                                                                     : L"Stop and copy trace path to clipboard");
-    devMenu.SamplingProfilerIcon().Glyph(
-        !Microsoft::ReactNative::HermesSamplingProfiler::IsStarted() ? L"\ue1e5" : L"\ue15b");
-
-    std::ostringstream os;
-    if (Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
-      os << "Hermes Sampling profiler is running!";
-    } else {
-      os << "Click to start.";
-    }
-
-    auto lastTraceFilePath = Microsoft::ReactNative::HermesSamplingProfiler::GetLastTraceFilePath();
-    if (!lastTraceFilePath.empty()) {
-      os << std::endl
-         << "Samples from last invocation are stored at " << lastTraceFilePath.c_str()
-         << "  (path copied to clipboard).";
-      os << std::endl << "Navigate to \"edge:\\tracing\" and load the trace file.";
-    }
-
-    devMenu.SamplingProfilerDescText().Text(winrt::to_hstring(os.str()));
+  if (auto devMenu = GetOrCreateDevMenu(reactContext)) {
+    devMenu->Show();
   }
-
-  devMenu.DirectDebugText().Text(
-      Mso::React::ReactOptions::UseDirectDebugger(m_context->Properties()) ? L"Disable Direct Debugging"
-                                                                           : L"Enable Direct Debugging");
-  devMenu.DirectDebugDesc().Text(
-      L"If using Chakra, this will allow Visual Studio to be attached directly to the application using \"Script Debugging\" to debug the JS running directly in this app.\nIf using V8/Hermes, this will enable standard JS debugging tools such as VSCode to attach to the application.");
-
-  devMenu.BreakOnNextLineText().Text(
-      Mso::React::ReactOptions::DebuggerBreakOnNextLine(m_context->Properties()) ? L"Disable Break on First Line"
-                                                                                 : L"Enable Break on First Line");
-
-  m_reloadJSRevoker = devMenu.Reload().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
-        }
-      });
-
-  m_remoteDebugJSRevoker = devMenu.RemoteDebug().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          Mso::React::ReactOptions::SetUseWebDebugger(
-              strongThis->m_context->Properties(),
-              !Mso::React::ReactOptions::UseWebDebugger(strongThis->m_context->Properties()));
-          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
-        }
-      });
-
-  m_directDebuggingRevoker = devMenu.DirectDebug().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          Mso::React::ReactOptions::SetUseDirectDebugger(
-              strongThis->m_context->Properties(),
-              !Mso::React::ReactOptions::UseDirectDebugger(strongThis->m_context->Properties()));
-          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
-        }
-      });
-
-  m_breakOnNextLineRevoker = devMenu.BreakOnNextLine().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          Mso::React::ReactOptions::SetDebuggerBreakOnNextLine(
-              strongThis->m_context->Properties(),
-              !Mso::React::ReactOptions::DebuggerBreakOnNextLine(strongThis->m_context->Properties()));
-          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
-        }
-      });
-
-  m_fastRefreshRevoker = devMenu.FastRefresh().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          Mso::React::ReactOptions::SetUseFastRefresh(
-              strongThis->m_context->Properties(),
-              !Mso::React::ReactOptions::UseFastRefresh(strongThis->m_context->Properties()));
-          DevSettings::Reload(React::ReactPropertyBag(strongThis->m_context->Properties()));
-        }
-      });
-
-  if (Mso::React::ReactOptions::JsiEngine(m_context->Properties()) == Mso::React::JSIEngine::Hermes) {
-    m_samplingProfilerRevoker = devMenu.SamplingProfiler().Click(
-        winrt::auto_revoke,
-        [wkThis = weak_from_this()](auto & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept
-        -> winrt::fire_and_forget {
-          if (auto strongThis = wkThis.lock()) {
-            strongThis->Hide();
-            if (!Microsoft::ReactNative::HermesSamplingProfiler::IsStarted()) {
-              Microsoft::ReactNative::HermesSamplingProfiler::Start(strongThis->m_context);
-            } else {
-              auto traceFilePath = co_await Microsoft::ReactNative::HermesSamplingProfiler::Stop(strongThis->m_context);
-              auto uiDispatcher =
-                  React::implementation::ReactDispatcher::GetUIDispatcher(strongThis->m_context->Properties());
-              uiDispatcher.Post([traceFilePath]() {
-                DataTransfer::DataPackage data;
-                data.SetText(winrt::to_hstring(traceFilePath));
-                DataTransfer::Clipboard::SetContentWithOptions(data, nullptr);
-              });
-            }
-          }
-        });
-  } else {
-    devMenu.SamplingProfiler().Visibility(xaml::Visibility::Collapsed);
-  }
-
-  m_toggleInspectorRevoker = devMenu.Inspector().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          DevSettings::ToggleElementInspector(*(strongThis->m_context));
-        }
-      });
-
-  m_configBundlerRevoker = devMenu.ConfigBundler().Click(
-      winrt::auto_revoke,
-      [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) noexcept {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-          React::ReactPropertyBag(strongThis->m_context->Properties()).Get(ConfigureBundlerProperty())();
-        }
-      });
-  // Only show Configure Bundler when connected to a bundler
-  devMenu.ConfigBundler().Visibility(
-      (Mso::React::ReactOptions::UseFastRefresh(m_context->Properties()) ||
-       Mso::React::ReactOptions::UseWebDebugger(m_context->Properties()))
-          ? xaml::Visibility::Visible
-          : xaml::Visibility::Collapsed);
-
-  m_cancelRevoker = devMenu.Cancel().Click(
-      winrt::auto_revoke, [wkThis = weak_from_this()](auto const & /*sender*/, xaml::RoutedEventArgs const & /*args*/) {
-        if (auto strongThis = wkThis.lock()) {
-          strongThis->Hide();
-        }
-      });
-
-  m_flyout = xaml::Controls::Flyout{};
-  m_flyout.Content(devMenu);
-  if (Is19H1OrHigher()) {
-    // ShouldConstrainToRootBounds added in 19H1
-    m_flyout.ShouldConstrainToRootBounds(false);
-  }
-
-  xaml::UIElement root{nullptr};
-  auto xamlRoot = React::XamlUIService::GetXamlRoot(m_context->Properties());
-  if (xamlRoot) {
-    m_flyout.XamlRoot(xamlRoot);
-    root = xamlRoot.Content();
-  } else {
-    auto window = xaml::Window::Current();
-    root = window.Content();
-  }
-
-  m_flyout.LightDismissOverlayMode(xaml::Controls::LightDismissOverlayMode::On);
-  devMenu.XYFocusKeyboardNavigation(xaml::Input::XYFocusKeyboardNavigationMode::Enabled);
-
-  auto style = xaml::Style(winrt::xaml_typename<xaml::Controls::FlyoutPresenter>());
-  style.Setters().Append(xaml::Setter(
-      xaml::Controls::ScrollViewer::HorizontalScrollBarVisibilityProperty(),
-      winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
-  style.Setters().Append(xaml::Setter(
-      xaml::Controls::ScrollViewer::VerticalScrollBarVisibilityProperty(),
-      winrt::box_value(xaml::Controls::ScrollBarVisibility::Disabled)));
-  style.Setters().Append(xaml::Setter(
-      xaml::Controls::ScrollViewer::HorizontalScrollModeProperty(),
-      winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
-  style.Setters().Append(xaml::Setter(
-      xaml::Controls::ScrollViewer::VerticalScrollModeProperty(),
-      winrt::box_value(xaml::Controls::ScrollMode::Disabled)));
-
-  m_flyout.FlyoutPresenterStyle(style);
-  m_flyout.ShowAt(root.as<xaml::FrameworkElement>());
 
   // Notify instance that dev menu is shown -- This is used to trigger a connection to dev tools
-  m_context->CallJSFunction("RCTNativeAppEventEmitter", "emit", folly::dynamic::array("RCTDevMenuShown"));
-}
-
-void DevMenuManager::Hide() noexcept {
-  if (!m_flyout)
-    return;
-  m_flyout.Hide();
-  m_flyout = nullptr;
+  reactContext->CallJSFunction("RCTNativeAppEventEmitter", "emit", folly::dynamic::array("RCTDevMenuShown"));
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DevMenu.h
+++ b/vnext/Microsoft.ReactNative/Views/DevMenu.h
@@ -16,27 +16,15 @@ struct DevMenuManager : public std::enable_shared_from_this<DevMenuManager> {
   static void InitDevMenu(
       Mso::CntPtr<Mso::React::IReactContext> const &reactContext,
       Mso::VoidFunctor &&configureBundler) noexcept;
-  static void Show(React::IReactPropertyBag const &properties) noexcept;
-  static void Hide(React::IReactPropertyBag const &properties) noexcept;
+  static void Show(Mso::CntPtr<Mso::React::IReactContext> const &reactContext) noexcept;
 
  private:
-  void CreateAndShowUI() noexcept;
-  void Hide() noexcept;
   void Init() noexcept;
-
   const Mso::CntPtr<Mso::React::IReactContext> m_context;
-  xaml::Controls::Flyout m_flyout{nullptr};
-  xaml::Controls::Button::Click_revoker m_remoteDebugJSRevoker{};
-  xaml::Controls::Button::Click_revoker m_cancelRevoker{};
-  xaml::Controls::Button::Click_revoker m_toggleInspectorRevoker{};
-  xaml::Controls::Button::Click_revoker m_configBundlerRevoker{};
-  xaml::Controls::Button::Click_revoker m_reloadJSRevoker{};
-  xaml::Controls::Button::Click_revoker m_fastRefreshRevoker{};
-  xaml::Controls::Button::Click_revoker m_directDebuggingRevoker{};
-  xaml::Controls::Button::Click_revoker m_breakOnNextLineRevoker{};
+#ifndef CORE_ABI
   winrt::CoreDispatcher::AcceleratorKeyActivated_revoker m_coreDispatcherAKARevoker{};
   xaml::UIElement::KeyDown_revoker m_keyDownRevoker;
-  xaml::Controls::Button::Click_revoker m_samplingProfilerRevoker{};
+#endif
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Shared/HermesSamplingProfiler.h
+++ b/vnext/Shared/HermesSamplingProfiler.h
@@ -6,6 +6,7 @@
 #include <ReactHost/React.h>
 #include <atomic>
 #include <string>
+#include <future>
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Shared/HermesSamplingProfiler.h
+++ b/vnext/Shared/HermesSamplingProfiler.h
@@ -5,8 +5,8 @@
 
 #include <ReactHost/React.h>
 #include <atomic>
-#include <string>
 #include <future>
+#include <string>
 
 namespace Microsoft::ReactNative {
 

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -150,6 +150,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ReactRootViewTagGenerator.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\Helpers.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Views\DevMenu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -139,6 +139,7 @@
     </ClCompile>
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\Helpers.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Views\DevMenu.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
Currently when the debug menu is triggered in fabric the app will crash if the app isn't a Xaml app.

 - Adds an implementation of the debug menu using `MenuPopup`.
 - Fallback to the `MenuPopup` implementation if there is not an active `XamlApplication`.
 - Fallback to a no-op if the debug menu is triggered in a non-UI scenario rather than crashing.
 - Support `MenuPopup` devmenu in the desktop dll reducing the diff between the dlls
 - Moved `SetTopLevelWindowHandle` from `CompositionUIService` to `ReactCoreInjection`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11236)