### PR TITLE
Adds collapsable prop to Paper VM for View

### DIFF
--- a/change/react-native-windows-0c94c8d0-a6e7-4de0-97ee-ea94cd1b841e.json
+++ b/change/react-native-windows-0c94c8d0-a6e7-4de0-97ee-ea94cd1b841e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds collapsable prop to Paper VM for View",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -376,6 +376,7 @@ void ViewViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVal
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"focusable", L"boolean");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"enableFocusRing", L"boolean");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"tabIndex", L"number");
+  winrt::Microsoft::ReactNative::WriteProperty(writer, L"collapsable", L"boolean");
 }
 
 bool ViewViewManager::UpdateProperty(


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Fabric reads native view configs from the Paper UIManager. In order for the `collapsable` prop to flow from JS to the native props for Fabric, we need to have this prop set in the VM configuration for View in Paper.

Without this prop, `collapsable="false"` will not work in Fabric.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11249)