### PR TITLE
Sequentialize ETW init

### DIFF
--- a/vnext/Shared/tracing/tracing.cpp
+++ b/vnext/Shared/tracing/tracing.cpp
@@ -377,11 +377,8 @@ void initializeJSHooks(jsi::Runtime &runtime, bool isProfiling) {
 
 void initializeETW() {
   // Register the provider
-  static bool etwInitialized = false;
-  if (!etwInitialized) {
-    TraceLoggingRegister(g_hTraceLoggingProvider);
-    etwInitialized = true;
-  }
+  static std::once_flag etwInitialized;
+  std::call_once(etwInitialized, [] { TraceLoggingRegister(g_hTraceLoggingProvider); });
 }
 
 void log(const char *msg) {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Office is creating instances on multiple threads and sees crashes due to repeated ETW initialization.

Resolves [11254](https://github.com/microsoft/react-native-windows/issues/11254)

### What
Sequentialize ETW initialization

## Screenshots
n/a
