### PR TITLE
Update version logic to fix n-1 bug in version on binaries

### DIFF
--- a/.ado/templates/apply-published-version-vars.yml
+++ b/.ado/templates/apply-published-version-vars.yml
@@ -11,3 +11,14 @@ steps:
     displayName: Apply version variables
     inputs:
       script: node $(Build.StagingDirectory)/versionEnvVars/versionEnvVars.js
+
+  # During the official publish (in publish.yml) The stamp-version script that updates the value
+  # runs during beachball. But this stayed on the machine that ran the Setup phase and doesn't make
+  # it to the machines that run the actual buld. This script does run on those machines
+  # and the previous step sets the environment/pipeline variables to the right version
+  # So we'll rerun the stamp-version script on each machine that  builds native code so that the 
+  # binaries are stamped with the right version.
+  - task: CmdLine@2
+    displayName: Update PackageVersion.g.props
+    inputs:
+      script: yarn stamp-version $(RNW_PKG_VERSION_STR)


### PR DESCRIPTION
## Description
Our binaries (the version on the native dll's) for both win32 and UWP are always n-1. I.e. if the buld is 0.64.4 then the binaries are labeled 0.64.3. 

This is because the native versions are picked up from PackageVersions.g.props
This file is updated by beachball. This happens on the 'RnwNpmPublish` phase. but the bulid is happening on other machines .
So they see the versions in the file as the repo was cloned which is actually the previous version, not the updated version.

This change will run the script that updates the packageversion.g.props file on each build machine (after it pulled in all the pipeline/environment variables from that phse.


### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We are shipping with mismathed versions (nuget is n, binaries are n-1)

### What
Upodate to release pipeliens


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11275)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11275)