### PR TITLE
Update Sign phase to do prepare-js-env instead of only yarn install

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -326,7 +326,7 @@ jobs:
     steps:
       - template: templates/checkout-shallow.yml
 
-      - template: templates/yarn-install.yml
+      - template: templates/prepare-js-env.yml
 
       - template: templates/apply-published-version-vars.yml
 


### PR DESCRIPTION
## Description
Upgarde the `yarn install ` step to `prepare-js-env .yml` so that we also build the js scripts.
This is now needed because my previous commit extended the set-version script to also generate the right version.g.props.

An alternative fix would have been to add a parameter and conditionalize the stamp-version call but this seems more consistent, easier to understand at the expense of only a minute on the critical path.

This is a fix for the release pipeline, as it is currently broken.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Broken publish pipeline

### What
change to yaml


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11292)