### PR TITLE
Remove an unneeded force include from yoga/utils.cpp

### DIFF
--- a/change/react-native-windows-6c7cee5f-4e4d-4054-8e32-718e45346198.json
+++ b/change/react-native-windows-6c7cee5f-4e4d-4054-8e32-718e45346198.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove an unneeded force include from yoga/utils.cpp",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -130,10 +130,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\logger\react_native_log.cpp" />
     <CLCompile Include="$(ReactNativeDir)\ReactCommon\reactperflogger\reactperflogger\BridgeNativeModulePerfLogger.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\log.cpp" />
-    <!-- We should ideally upstream a fix for missing stdexcept, but Yoga hasn't been accepting PRs as of May 2020 -->
-    <ClCompile Include="$(YogaDir)\yoga\Utils.cpp">
-      <ForcedIncludeFiles>stdexcept;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-    </ClCompile>
+    <ClCompile Include="$(YogaDir)\yoga\Utils.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGConfig.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGEnums.cpp" />
     <ClCompile Include="$(YogaDir)\yoga\YGLayout.cpp" />


### PR DESCRIPTION
## Description
The ForcedIncludeFiles is including a file that was added as an include in this commit. https://github.com/facebook/yoga/commit/084d5935e6f6bf7306ad8041bdc2f097889b8e58

### Why
Code cleanup.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11308)