### PR TITLE
[Fabric] add support for enableFocusRing

### DIFF
--- a/change/react-native-windows-dbb905be-476d-45bd-9f45-1196b92ce512.json
+++ b/change/react-native-windows-dbb905be-476d-45bd-9f45-1196b92ce512.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] add support for enableFocusRing",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -103,6 +103,15 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
+  interface IFocusVisual
+  {
+    IVisual InnerVisual { get; };
+    Boolean IsFocused { get; set; };
+    Single ScaleFactor { get; set; };
+  }
+
+  [webhosthidden]
+  [experimental]
   interface ICompositionContext
   {
     ICompositionDrawingSurface CreateDrawingSurface(Windows.Foundation.Size surfaceSize,
@@ -112,6 +121,7 @@ namespace Microsoft.ReactNative.Composition
     SpriteVisual CreateSpriteVisual();
     ScrollVisual CreateScrollerVisual();
     ICaretVisual CreateCaretVisual();
+    IFocusVisual CreateFocusVisual();
     IDropShadow CreateDropShadow();
     IBrush CreateColorBrush(Windows.UI.Color color);
     SurfaceBrush CreateSurfaceBrush(ICompositionDrawingSurface surface);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -628,6 +628,54 @@ struct CompCaretVisual : winrt::implements<CompCaretVisual, winrt::Microsoft::Re
   winrt::Windows::UI::Composition::Compositor m_compositor{nullptr};
 };
 
+struct CompFocusVisual : winrt::implements<CompFocusVisual, winrt::Microsoft::ReactNative::Composition::IFocusVisual> {
+  CompFocusVisual(winrt::Windows::UI::Composition::Compositor const &compositor)
+      : m_compVisual(compositor.CreateSpriteVisual()), m_brush(compositor.CreateNineGridBrush()) {
+    m_visual = winrt::make<Composition::CompSpriteVisual>(m_compVisual);
+
+    m_compVisual.Opacity(1.0f);
+    m_compVisual.RelativeSizeAdjustment({1, 1});
+    
+    m_brush.Source(compositor.CreateColorBrush(winrt::Windows::UI::Colors::Black()));
+    m_brush.IsCenterHollow(true);
+  }
+
+  winrt::Microsoft::ReactNative::Composition::IVisual InnerVisual() const noexcept {
+    return m_visual;
+  }
+  
+  bool IsFocused() const noexcept {
+    return m_compVisual.Brush() != nullptr;
+  }
+
+  void IsFocused(bool value) noexcept {
+    if (value) {
+      m_compVisual.Brush(m_brush);
+    } else {
+      m_compVisual.Brush(nullptr);
+    }
+  }
+  
+  float ScaleFactor() const noexcept {
+    return m_scaleFactor;
+  }
+
+  void ScaleFactor(float scaleFactor) noexcept {
+    if (m_scaleFactor == scaleFactor) {
+      return;
+    }
+    m_scaleFactor = scaleFactor;
+    auto inset = 2 * scaleFactor;
+    m_brush.SetInsets(inset, inset, inset, inset);
+  }
+
+ private:
+  float m_scaleFactor{0};
+  const winrt::Windows::UI::Composition::CompositionNineGridBrush m_brush;
+  const winrt::Windows::UI::Composition::SpriteVisual m_compVisual;
+  winrt::Microsoft::ReactNative::Composition::IVisual m_visual{nullptr};
+};
+
 struct CompContext : winrt::implements<
                          CompContext,
                          winrt::Microsoft::ReactNative::Composition::ICompositionContext,
@@ -734,6 +782,10 @@ struct CompContext : winrt::implements<
 
   winrt::Microsoft::ReactNative::Composition::ICaretVisual CreateCaretVisual() noexcept {
     return winrt::make<Composition::CompCaretVisual>(m_compositor);
+  }
+
+  winrt::Microsoft::ReactNative::Composition::IFocusVisual CreateFocusVisual() noexcept {
+    return winrt::make<Composition::CompFocusVisual>(m_compositor);
   }
 
   winrt::Windows::UI::Composition::CompositionGraphicsDevice CompositionGraphicsDevice() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -635,7 +635,7 @@ struct CompFocusVisual : winrt::implements<CompFocusVisual, winrt::Microsoft::Re
 
     m_compVisual.Opacity(1.0f);
     m_compVisual.RelativeSizeAdjustment({1, 1});
-    
+
     m_brush.Source(compositor.CreateColorBrush(winrt::Windows::UI::Colors::Black()));
     m_brush.IsCenterHollow(true);
   }
@@ -643,7 +643,7 @@ struct CompFocusVisual : winrt::implements<CompFocusVisual, winrt::Microsoft::Re
   winrt::Microsoft::ReactNative::Composition::IVisual InnerVisual() const noexcept {
     return m_visual;
   }
-  
+
   bool IsFocused() const noexcept {
     return m_compVisual.Brush() != nullptr;
   }
@@ -655,7 +655,7 @@ struct CompFocusVisual : winrt::implements<CompFocusVisual, winrt::Microsoft::Re
       m_compVisual.Brush(nullptr);
     }
   }
-  
+
   float ScaleFactor() const noexcept {
     return m_scaleFactor;
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -192,6 +192,10 @@ struct CompVisual : public winrt::implements<
   }
 
   void SetClippingPath(ID2D1Geometry *clippingPath) noexcept {
+    if (!clippingPath) {
+      m_visual.Clip(nullptr);
+      return;
+    }
     auto geometry = winrt::make<GeometrySource>(clippingPath);
     auto path = winrt::Windows::UI::Composition::CompositionPath(geometry);
     auto pathgeo = m_visual.Compositor().CreatePathGeometry(path);
@@ -512,6 +516,10 @@ struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implemen
   }
 
   void SetClippingPath(ID2D1Geometry *clippingPath) noexcept {
+    if (!clippingPath) {
+      m_visual.Clip(nullptr);
+      return;
+    }
     auto geometry = winrt::make<GeometrySource>(clippingPath);
     auto path = winrt::Windows::UI::Composition::CompositionPath(geometry);
     auto pathgeo = m_visual.Compositor().CreatePathGeometry(path);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -98,6 +98,12 @@ void CompositionBaseComponentView::handleCommand(std::string const &commandName,
     }
     return;
   }
+  if (commandName == "blur") {
+    if (auto root = rootComponentView()) {
+      root->SetFocusedComponent(nullptr); // Todo store this component as previously focused element
+    }
+    return;
+  }
   assert(false); // Unhandled command
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -92,6 +92,12 @@ void CompositionBaseComponentView::updateEventEmitter(
 }
 
 void CompositionBaseComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
+  if (commandName == "focus") {
+    if (auto root = rootComponentView()) {
+      root->SetFocusedComponent(this);
+    }
+    return;
+  }
   assert(false); // Unhandled command
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -21,7 +21,11 @@ namespace Microsoft::ReactNative {
 CompositionBaseComponentView::CompositionBaseComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag)
-    : m_tag(tag), m_compContext(compContext) {}
+    : m_tag(tag), m_compContext(compContext) {
+  m_outerVisual = compContext.CreateSpriteVisual(); // TODO could be a raw ContainerVisual
+  m_focusVisual = compContext.CreateFocusVisual();
+  m_outerVisual.InsertAt(m_focusVisual.InnerVisual(), 0);
+}
 
 facebook::react::Tag CompositionBaseComponentView::tag() const noexcept {
   return m_tag;
@@ -71,10 +75,14 @@ bool CompositionBaseComponentView::runOnChildren(bool forward, Mso::Functor<bool
 
 void CompositionBaseComponentView::onFocusLost() noexcept {
   m_eventEmitter->onBlur();
+  showFocusVisual(false);
 }
 
 void CompositionBaseComponentView::onFocusGained() noexcept {
   m_eventEmitter->onFocus();
+  if (m_enableFocusVisual) {
+    showFocusVisual(true);
+  }
 }
 
 void CompositionBaseComponentView::updateEventEmitter(
@@ -980,6 +988,19 @@ void CompositionBaseComponentView::UpdateSpecialBorderLayers(
   }
 }
 
+winrt::Microsoft::ReactNative::Composition::IVisual CompositionBaseComponentView::OuterVisual() const noexcept {
+  return m_outerVisual ? m_outerVisual : Visual();
+}
+
+void CompositionBaseComponentView::showFocusVisual(bool show) noexcept {
+  if (show) {
+    assert(m_enableFocusVisual);
+    m_focusVisual.IsFocused(true);
+  } else {
+    m_focusVisual.IsFocused(false);
+  }
+}
+
 void CompositionBaseComponentView::updateBorderProps(
     const facebook::react::ViewProps &oldViewProps,
     const facebook::react::ViewProps &newViewProps) noexcept {
@@ -987,6 +1008,11 @@ void CompositionBaseComponentView::updateBorderProps(
       !(oldViewProps.yogaStyle.border() == newViewProps.yogaStyle.border()) ||
       oldViewProps.borderStyles != newViewProps.borderStyles) {
     m_needsBorderUpdate = true;
+  }
+
+  m_enableFocusVisual = newViewProps.enableFocusRing;
+  if (!m_enableFocusVisual) {
+    showFocusVisual(false);
   }
 }
 
@@ -1014,6 +1040,17 @@ void CompositionBaseComponentView::updateBorderLayoutMetrics(
   if (m_layoutMetrics != layoutMetrics) {
     m_needsBorderUpdate = true;
   }
+
+  m_focusVisual.ScaleFactor(layoutMetrics.pointScaleFactor);
+  OuterVisual().Size(
+      {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
+       layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
+  OuterVisual().Offset({
+      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
+      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
+      0.0f,
+  });
+
 }
 
 void CompositionBaseComponentView::indexOffsetForBorder(uint32_t &index) const noexcept {
@@ -1077,7 +1114,7 @@ void CompositionBaseComponentView::EnsureTransformMatrixFacade() noexcept {
           .CreateExpressionAnimation(
               L"Matrix4x4.CreateFromScale(PS.dpiScale3Inv) * Matrix4x4.CreateFromTranslation(PS.translation) * PS.transform * Matrix4x4.CreateFromScale(PS.dpiScale3)");
   expression.SetReferenceParameter(L"PS", centerPointPropSet);
-  winrt::Microsoft::ReactNative::Composition::implementation::CompositionContextHelper::InnerVisual(Visual())
+  winrt::Microsoft::ReactNative::Composition::implementation::CompositionContextHelper::InnerVisual(OuterVisual())
       .StartAnimation(L"TransformMatrix", expression);
 }
 
@@ -1101,6 +1138,7 @@ CompositionViewComponentView::CompositionViewComponentView(
   static auto const defaultProps = std::make_shared<facebook::react::ViewProps const>();
   m_props = defaultProps;
   m_visual = m_compContext.CreateSpriteVisual();
+  OuterVisual().InsertAt(m_visual, 0);
 }
 
 std::vector<facebook::react::ComponentDescriptorProvider>
@@ -1117,7 +1155,7 @@ void CompositionViewComponentView::mountChildComponentView(
 
   childComponentView.parent(this);
 
-  m_visual.InsertAt(static_cast<CompositionBaseComponentView &>(childComponentView).Visual(), index);
+  m_visual.InsertAt(static_cast<CompositionBaseComponentView &>(childComponentView).OuterVisual(), index);
 }
 
 void CompositionViewComponentView::unmountChildComponentView(
@@ -1128,7 +1166,7 @@ void CompositionViewComponentView::unmountChildComponentView(
   indexOffsetForBorder(index);
 
   childComponentView.parent(nullptr);
-  m_visual.Remove(static_cast<CompositionBaseComponentView &>(childComponentView).Visual());
+  m_visual.Remove(static_cast<CompositionBaseComponentView &>(childComponentView).OuterVisual());
 }
 
 void CompositionViewComponentView::updateProps(
@@ -1240,7 +1278,7 @@ void CompositionViewComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
   // Set Position & Size Properties
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
   updateBorderLayoutMetrics(layoutMetrics, *m_props);
@@ -1251,11 +1289,6 @@ void CompositionViewComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
 }
 
 void CompositionViewComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
@@ -1278,6 +1311,20 @@ bool CompositionViewComponentView::focusable() const noexcept {
   return m_props->focusable;
 }
 
+IComponentView* lastDeepChild(IComponentView& view) noexcept
+{
+  auto current = &view;
+  while (current) {
+    auto children = current->children();
+    auto itLastChild = children.rbegin();
+    if (itLastChild == children.rend()) {
+      break;
+    }
+    current = *itLastChild;
+  }
+  return current;
+}
+
 bool walkTree(IComponentView &view, bool forward, Mso::Functor<bool(IComponentView &)> &fn) noexcept {
   if (forward) {
     if (fn(view)) {
@@ -1289,41 +1336,44 @@ bool walkTree(IComponentView &view, bool forward, Mso::Functor<bool(IComponentVi
         return true;
     }
 
-    auto parent = view.parent();
-    if (parent) {
+    auto current = &view;
+    auto parent = current->parent();
+    while (parent) {
       auto &parentsChildren = parent->children();
-      auto itNextView = std::find(parentsChildren.begin(), parentsChildren.end(), &view);
+      auto itNextView = std::find(parentsChildren.begin(), parentsChildren.end(), current);
       assert(itNextView != parentsChildren.end());
-      auto index = std::distance(parentsChildren.begin(), itNextView);
-      for (auto it = parentsChildren.begin() + index + 1; it != parentsChildren.end(); ++it) {
-        if (walkTree(**it, true, fn))
-          return true;
+      ++itNextView;
+      if (itNextView != parentsChildren.end()) {
+        return walkTree(**itNextView, true, fn);
       }
+      current = parent;
+      parent = current->parent();
     }
 
   } else {
-    auto parent = view.parent();
-    if (parent) {
+
+    auto current = &view;
+    auto parent = current->parent();
+    while(parent) {
       auto &parentsChildren = parent->children();
-      auto itNextView = std::find(parentsChildren.rbegin(), parentsChildren.rend(), &view);
+      auto itNextView = std::find(parentsChildren.rbegin(), parentsChildren.rend(), current);
       assert(itNextView != parentsChildren.rend());
       auto index = std::distance(parentsChildren.rbegin(), itNextView);
-      for (auto it = parentsChildren.rbegin() + index + 1; it != parentsChildren.rend(); ++it) {
-        if (fn(**it))
+      ++itNextView;
+      if (itNextView != parentsChildren.rend()) {
+        auto lastChild = lastDeepChild(**itNextView);
+        if (fn(*lastChild))
           return true;
-        if (walkTree(**it, false, fn))
-          return true;
+        return walkTree(*lastChild, false, fn);
       }
-    }
 
-    for (auto it = view.children().rbegin(); it != view.children().rend(); ++it) {
-      if (fn(**it))
+      if (fn(*parent)) {
         return true;
+      }
+      current = parent;
+      parent = current->parent();
     }
 
-    if (fn(view)) {
-      return true;
-    }
   }
   return false;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -22,7 +22,8 @@ CompositionBaseComponentView::CompositionBaseComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag)
     : m_tag(tag), m_compContext(compContext) {
-  m_outerVisual = compContext.CreateSpriteVisual(); // TODO could be a raw ContainerVisual
+  m_outerVisual = compContext.CreateSpriteVisual(); // TODO could be a raw ContainerVisual if we had a
+                                                    // CreateContainerVisual in ICompositionContext
   m_focusVisual = compContext.CreateFocusVisual();
   m_outerVisual.InsertAt(m_focusVisual.InnerVisual(), 0);
 }
@@ -1050,7 +1051,6 @@ void CompositionBaseComponentView::updateBorderLayoutMetrics(
       layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
       0.0f,
   });
-
 }
 
 void CompositionBaseComponentView::indexOffsetForBorder(uint32_t &index) const noexcept {
@@ -1311,8 +1311,7 @@ bool CompositionViewComponentView::focusable() const noexcept {
   return m_props->focusable;
 }
 
-IComponentView* lastDeepChild(IComponentView& view) noexcept
-{
+IComponentView *lastDeepChild(IComponentView &view) noexcept {
   auto current = &view;
   while (current) {
     auto children = current->children();
@@ -1351,10 +1350,9 @@ bool walkTree(IComponentView &view, bool forward, Mso::Functor<bool(IComponentVi
     }
 
   } else {
-
     auto current = &view;
     auto parent = current->parent();
-    while(parent) {
+    while (parent) {
       auto &parentsChildren = parent->children();
       auto itNextView = std::find(parentsChildren.rbegin(), parentsChildren.rend(), current);
       assert(itNextView != parentsChildren.rend());
@@ -1373,7 +1371,6 @@ bool walkTree(IComponentView &view, bool forward, Mso::Functor<bool(IComponentVi
       current = parent;
       parent = current->parent();
     }
-
   }
   return false;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -22,6 +22,8 @@ struct CompositionBaseComponentView : public IComponentView {
       facebook::react::Tag tag);
 
   virtual winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept = 0;
+  // Visual that should be parented to this ComponentView's parent
+  virtual winrt::Microsoft::ReactNative::Composition::IVisual OuterVisual() const noexcept;
   void updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept override;
   const facebook::react::SharedViewEventEmitter &GetEventEmitter() const noexcept;
   void handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept override;
@@ -75,7 +77,14 @@ struct CompositionBaseComponentView : public IComponentView {
   facebook::react::LayoutMetrics m_layoutMetrics;
   bool m_needsBorderUpdate{false};
   bool m_hasTransformMatrixFacade{false};
+  bool m_enableFocusVisual{false};
   uint8_t m_numBorderVisuals{0};
+
+private:
+  void showFocusVisual(bool show) noexcept;
+  winrt::Microsoft::ReactNative::Composition::IFocusVisual m_focusVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IVisual m_outerVisual{nullptr};
+
 };
 
 struct CompositionViewComponentView : public CompositionBaseComponentView {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -80,11 +80,10 @@ struct CompositionBaseComponentView : public IComponentView {
   bool m_enableFocusVisual{false};
   uint8_t m_numBorderVisuals{0};
 
-private:
+ private:
   void showFocusVisual(bool show) noexcept;
   winrt::Microsoft::ReactNative::Composition::IFocusVisual m_focusVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::IVisual m_outerVisual{nullptr};
-
 };
 
 struct CompositionViewComponentView : public CompositionBaseComponentView {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -174,7 +174,7 @@ void ImageComponentView::updateLayoutMetrics(
   // Set Position & Size Properties
 
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
   updateBorderLayoutMetrics(layoutMetrics, *m_props);
@@ -185,11 +185,6 @@ void ImageComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
 }
 
 void ImageComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {}
@@ -399,6 +394,7 @@ facebook::react::Tag ImageComponentView::hitTest(facebook::react::Point pt, face
 void ImageComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     m_visual = m_compContext.CreateSpriteVisual();
+    OuterVisual().InsertAt(m_visual, 0);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -56,6 +56,8 @@ void ParagraphComponentView::updateProps(
     updateTextAlignment(newViewProps.textAttributes.alignment);
   }
 
+  updateBorderProps(oldViewProps, newViewProps);
+
   m_props = std::static_pointer_cast<facebook::react::ParagraphProps const>(props);
 }
 
@@ -84,6 +86,7 @@ void ParagraphComponentView::updateLayoutMetrics(
     OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
+  updateBorderLayoutMetrics(layoutMetrics, *m_props);
   m_layoutMetrics = layoutMetrics;
 
   UpdateCenterPropertySet();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -81,7 +81,7 @@ void ParagraphComponentView::updateLayoutMetrics(
   ensureVisual();
 
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
   m_layoutMetrics = layoutMetrics;
@@ -90,11 +90,6 @@ void ParagraphComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
 }
 void ParagraphComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
   ensureVisual();
@@ -158,6 +153,7 @@ facebook::react::SharedTouchEventEmitter ParagraphComponentView::touchEventEmitt
 void ParagraphComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     m_visual = m_compContext.CreateSpriteVisual();
+    OuterVisual().InsertAt(m_visual, 0);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -127,13 +127,13 @@ void ScrollViewComponentView::mountChildComponentView(IComponentView &childCompo
   m_children.insert(std::next(m_children.begin(), index), &childComponentView);
   childComponentView.parent(this);
 
-  m_visual.InsertAt(static_cast<CompositionBaseComponentView &>(childComponentView).Visual(), index);
+  m_visual.InsertAt(static_cast<CompositionBaseComponentView &>(childComponentView).OuterVisual(), index);
 }
 
 void ScrollViewComponentView::unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept {
   m_children.erase(std::next(m_children.begin(), index));
 
-  m_visual.Remove(static_cast<CompositionBaseComponentView &>(childComponentView).Visual());
+  m_visual.Remove(static_cast<CompositionBaseComponentView &>(childComponentView).OuterVisual());
   childComponentView.parent(nullptr);
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -187,7 +187,7 @@ void ScrollViewComponentView::updateLayoutMetrics(
   ensureVisual();
 
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
   // m_needsBorderUpdate = true;
@@ -197,11 +197,6 @@ void ScrollViewComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
   updateContentVisualSize();
 }
 
@@ -309,6 +304,7 @@ void ScrollViewComponentView::ensureVisual() noexcept {
                 ->onScroll(scrollMetrics);
           }
         });
+    OuterVisual().InsertAt(m_visual, 0);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -82,7 +82,8 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void updateContentVisualSize() noexcept;
 
   facebook::react::Size m_contentSize;
-  winrt::Microsoft::ReactNative::Composition::ScrollVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ScrollVisual m_scrollVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::ScrollVisual::ScrollPositionChanged_revoker
       m_scrollPositionChangedRevoker{};
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -52,6 +52,7 @@ void SwitchComponentView::updateProps(
     m_drawingSurface = nullptr;
   }
 
+  updateBorderProps(oldViewProps, newViewProps);
   m_props = std::static_pointer_cast<facebook::react::ViewProps const>(props);
 }
 
@@ -66,9 +67,10 @@ void SwitchComponentView::updateLayoutMetrics(
   ensureVisual();
 
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
+  updateBorderLayoutMetrics(layoutMetrics, *m_props);
   m_layoutMetrics = layoutMetrics;
 
   UpdateCenterPropertySet();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -75,11 +75,6 @@ void SwitchComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
 }
 
 void SwitchComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
@@ -178,6 +173,7 @@ facebook::react::Props::Shared SwitchComponentView::props() noexcept {
 void SwitchComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     m_visual = m_compContext.CreateSpriteVisual();
+    OuterVisual().InsertAt(m_visual, 0);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -752,7 +752,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   // Set Position & Size Properties
 
   if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
-    m_visual.IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
   }
 
   if ((layoutMetrics.pointScaleFactor != m_layoutMetrics.pointScaleFactor)) {
@@ -783,11 +783,6 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
-  m_visual.Offset({
-      layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
-      layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
-      0.0f,
-  });
 }
 
 // When we are notified by RichEdit that the text changed, we need to notify JS
@@ -1053,6 +1048,7 @@ void WindowsTextInputComponentView::ensureVisual() noexcept {
     winrt::com_ptr<IUnknown> spUnk;
     winrt::check_hresult(g_pfnCreateTextServices(nullptr, m_textHost.get(), spUnk.put()));
     spUnk.as(m_textServices);
+    OuterVisual().InsertAt(m_visual, 0);
   }
 
   if (!m_caretVisual) {

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -209,7 +209,7 @@ void FabricUIManager::startSurface(
         facebook::react::RootShadowNode::Handle(), surfaceId, self->m_compContext);
 
     self->m_surfaceRegistry.at(surfaceId).rootVisual.InsertAt(
-        static_cast<const CompositionBaseComponentView &>(*rootComponentViewDescriptor.view).Visual(), 0);
+        static_cast<const CompositionBaseComponentView &>(*rootComponentViewDescriptor.view).OuterVisual(), 0);
   });
 
   facebook::react::LayoutContext context;

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
@@ -183,6 +183,14 @@ ViewProps::ViewProps(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.events
               : convertRawProp(context, rawProps, sourceProps.events, {})),
+      enableFocusRing(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.enableFocusRing
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "enableFocusRing",
+                                                       sourceProps.enableFocusRing,
+                                                       true)),
       collapsable(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.collapsable
                                                  : convertRawProp(

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.h
@@ -78,6 +78,7 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
   ViewEvents events{};
 
   HostPlatformViewEvents platformEvents{}; // [Windows]
+  bool enableFocusRing{true}; // [Windows]
 
   bool collapsable{true};
 


### PR DESCRIPTION
## Description
`enableFocusRing` is a property to display native focus visualization.  This adds support for that property.  For now, it's using a simple black rect.  In future this should be updated to align with windows visuals (Ex: rounded rect with black/white border)

This involved creating an extra container visual around views so that the focus rect can be outside the views clip (Ex: a view with a rounded rect would clip the focus rect if the focus rect was within the view's visual)

Also fixed some logic in the `walkTree` method, now that I can see focus it became clearer that I completely messed up the first implementation.

Added handling of the focus command, so now `ref.focus()` works.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11323)