### PR TITLE
[Fabric] Adds text measure caching. Add support for lineHeight, letterSpacing, maximumNumberOfLines and textTransform

### DIFF
--- a/change/react-native-windows-f98b2d6c-89f0-47c2-8138-147e647c09d8.json
+++ b/change/react-native-windows-f98b2d6c-89f0-47c2-8138-147e647c09d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Adds text measure caching. Add support for lineHeight, letterSpacing, maximumNumberOfLines and textTransform",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -211,13 +211,8 @@ void ParagraphComponentView::updateVisualBrush() noexcept {
     contraints.maximumSize.height =
         m_layoutMetrics.frame.size.height - m_layoutMetrics.contentInsets.top - m_layoutMetrics.contentInsets.bottom;
 
-    // TODO Figure out how to get text alignment not through m_props and only use StringBox and ParagraphAttributes
-    // instead
-    const auto &paragraphProps = *std::static_pointer_cast<const facebook::react::ParagraphProps>(m_props);
-    const std::optional<facebook::react::TextAlignment> &textAlignment = m_props->textAttributes.alignment;
-
     facebook::react::TextLayoutManager::GetTextLayout(
-        m_attributedStringBox, {} /*TODO*/, contraints, textAlignment, m_textLayout);
+        m_attributedStringBox, {} /*TODO*/, contraints, m_textLayout);
     requireNewBrush = true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -211,8 +211,7 @@ void ParagraphComponentView::updateVisualBrush() noexcept {
     contraints.maximumSize.height =
         m_layoutMetrics.frame.size.height - m_layoutMetrics.contentInsets.top - m_layoutMetrics.contentInsets.bottom;
 
-    facebook::react::TextLayoutManager::GetTextLayout(
-        m_attributedStringBox, {} /*TODO*/, contraints, m_textLayout);
+    facebook::react::TextLayoutManager::GetTextLayout(m_attributedStringBox, {} /*TODO*/, contraints, m_textLayout);
     requireNewBrush = true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -6,7 +6,10 @@
 #include "pch.h"
 
 #include <Fabric/DWriteHelpers.h>
+#include <Utils/TransformableText.h>
 #include <dwrite.h>
+#include <dwrite_1.h>
+#include <react/renderer/telemetry/TransactionTelemetry.h>
 #include "TextLayoutManager.h"
 
 #include <unicode.h>
@@ -17,7 +20,6 @@ void TextLayoutManager::GetTextLayout(
     AttributedStringBox attributedStringBox,
     ParagraphAttributes paragraphAttributes,
     LayoutConstraints layoutConstraints,
-    const std::optional<TextAlignment> &textAlignment,
     winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept {
   if (attributedStringBox.getValue().isEmpty())
     return;
@@ -45,9 +47,21 @@ void TextLayoutManager::GetTextLayout(
       L"",
       spTextFormat.put()));
 
+  if (!isnan(outerFragment.textAttributes.lineHeight)) {
+    winrt::check_hresult(spTextFormat->SetLineSpacing(
+        DWRITE_LINE_SPACING_METHOD_UNIFORM,
+        outerFragment.textAttributes.lineHeight,
+        // Recommended ratio of baseline to lineSpacing is 80%
+        // https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritetextformat-getlinespacing
+        // It is possible we need to load full font metrics to calculate a better baseline value.
+        // For a particular font, you can determine what lineSpacing and baseline should be by examing a DWRITE_FONT_METRICS method available from the GetMetrics method of IDWriteFont or IDWriteFontFace.
+        // For normal behavior, you'd set lineSpacing to the sum of ascent, descent and lineGap (adjusted for the em size, of course), and baseline to the ascent value.
+        outerFragment.textAttributes.lineHeight * 0.8f));
+  }
+
   DWRITE_TEXT_ALIGNMENT alignment = DWRITE_TEXT_ALIGNMENT_LEADING;
-  if (textAlignment) {
-    switch (*textAlignment) {
+  if (outerFragment.textAttributes.alignment) {
+    switch (*outerFragment.textAttributes.alignment) {
       case facebook::react::TextAlignment::Center:
         alignment = DWRITE_TEXT_ALIGNMENT_CENTER;
         break;
@@ -70,11 +84,11 @@ void TextLayoutManager::GetTextLayout(
   }
   winrt::check_hresult(spTextFormat->SetTextAlignment(alignment));
 
-  auto str = Microsoft::Common::Unicode::Utf8ToUtf16(attributedStringBox.getValue().getString());
+  auto str = GetTransformedText(attributedStringBox);
 
   winrt::check_hresult(Microsoft::ReactNative::DWriteFactory()->CreateTextLayout(
       str.c_str(), // The string to be laid out and formatted.
-      static_cast<UINT32>(str.length()), // The length of the string.
+      static_cast<UINT32>(str.size()), // The length of the string.
       spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
       layoutConstraints.maximumSize.width, // The width of the layout box.
       layoutConstraints.maximumSize.height, // The height of the layout box.
@@ -104,6 +118,11 @@ void TextLayoutManager::GetTextLayout(
     winrt::check_hresult(spTextLayout->SetFontStyle(fragmentStyle, range));
     winrt::check_hresult(spTextLayout->SetFontSize(attributes.fontSize, range));
 
+    if (!isnan(attributes.letterSpacing)) {
+      winrt::check_hresult(
+          spTextLayout.as<IDWriteTextLayout1>()->SetCharacterSpacing(0, attributes.letterSpacing, 0, range));
+    }
+
     position += length;
   }
 }
@@ -112,17 +131,48 @@ TextMeasurement TextLayoutManager::measure(
     AttributedStringBox attributedStringBox,
     ParagraphAttributes paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
-  winrt::com_ptr<IDWriteTextLayout> spTextLayout;
+  TextMeasurement measurement{};
+  auto &attributedString = attributedStringBox.getValue();
+  measurement = m_measureCache.get(
+      {attributedString, paragraphAttributes, layoutConstraints}, [&](TextMeasureCacheKey const &key) {
+        auto telemetry = TransactionTelemetry::threadLocalTelemetry();
+        if (telemetry) {
+          telemetry->willMeasureText();
+        }
 
-  GetTextLayout(attributedStringBox, paragraphAttributes, layoutConstraints, TextAlignment::Left, spTextLayout);
+        winrt::com_ptr<IDWriteTextLayout> spTextLayout;
 
-  TextMeasurement tm{};
-  if (spTextLayout) {
-    DWRITE_TEXT_METRICS dtm{};
-    winrt::check_hresult(spTextLayout->GetMetrics(&dtm));
-    tm.size = {dtm.width, dtm.height};
-  }
-  return tm;
+        GetTextLayout(attributedStringBox, paragraphAttributes, layoutConstraints, spTextLayout);
+
+        if (spTextLayout) {
+          auto maxHeight = std::numeric_limits<float>().max();
+          if (paragraphAttributes.maximumNumberOfLines > 0) {
+            std::vector<DWRITE_LINE_METRICS> lineMetrics;
+            uint32_t actualLineCount;
+            spTextLayout->GetLineMetrics(nullptr, 0, &actualLineCount);
+            lineMetrics.resize(static_cast<size_t>(actualLineCount));
+            winrt::check_hresult(spTextLayout->GetLineMetrics(lineMetrics.data(), actualLineCount, &actualLineCount));
+            maxHeight = 0;
+            const auto count =
+                std::min(static_cast<uint32_t>(paragraphAttributes.maximumNumberOfLines), actualLineCount);
+            for (uint32_t i = 0; i < count; ++i) {
+              maxHeight += lineMetrics[i].height;
+            }
+          }
+
+          DWRITE_TEXT_METRICS dtm{};
+          winrt::check_hresult(spTextLayout->GetMetrics(&dtm));
+          measurement.size = {dtm.width, std::min(dtm.height, maxHeight)};
+        }
+
+        if (telemetry) {
+          telemetry->didMeasureText();
+        }
+
+        return measurement;
+      });
+
+  return measurement;
 }
 
 /**
@@ -147,6 +197,36 @@ LinesMeasurements TextLayoutManager::measureLines(
 
 void *TextLayoutManager::getNativeTextLayoutManager() const {
   return (void *)this;
+}
+
+Microsoft::ReactNative::TextTransform ConvertTextTransform(std::optional<TextTransform> const &transform) {
+  if (transform) {
+    switch (transform.value()) {
+      case TextTransform::Capitalize:
+        return Microsoft::ReactNative::TextTransform::Capitalize;
+      case TextTransform::Lowercase:
+        return Microsoft::ReactNative::TextTransform::Lowercase;
+      case TextTransform::Uppercase:
+        return Microsoft::ReactNative::TextTransform::Uppercase;
+      case TextTransform::None:
+        return Microsoft::ReactNative::TextTransform::None;
+      default:
+        break;
+    }
+  }
+
+  return Microsoft::ReactNative::TextTransform::Undefined;
+}
+
+winrt::hstring TextLayoutManager::GetTransformedText(AttributedStringBox const &attributedStringBox) {
+  winrt::hstring result{};
+  for (const auto &fragment : attributedStringBox.getValue().getFragments()) {
+    result = result +
+        Microsoft::ReactNative::TransformableText::TransformText(
+                 winrt::hstring{Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string)},
+                 ConvertTextTransform(fragment.textAttributes.textTransform));
+  }
+  return result;
 }
 
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -54,8 +54,10 @@ void TextLayoutManager::GetTextLayout(
         // Recommended ratio of baseline to lineSpacing is 80%
         // https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nf-dwrite-idwritetextformat-getlinespacing
         // It is possible we need to load full font metrics to calculate a better baseline value.
-        // For a particular font, you can determine what lineSpacing and baseline should be by examing a DWRITE_FONT_METRICS method available from the GetMetrics method of IDWriteFont or IDWriteFontFace.
-        // For normal behavior, you'd set lineSpacing to the sum of ascent, descent and lineGap (adjusted for the em size, of course), and baseline to the ascent value.
+        // For a particular font, you can determine what lineSpacing and baseline should be by examing a
+        // DWRITE_FONT_METRICS method available from the GetMetrics method of IDWriteFont or IDWriteFontFace. For normal
+        // behavior, you'd set lineSpacing to the sum of ascent, descent and lineGap (adjusted for the em size, of
+        // course), and baseline to the ascent value.
         outerFragment.textAttributes.lineHeight * 0.8f));
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -64,13 +64,18 @@ class TextLayoutManager {
       AttributedStringBox attributedStringBox,
       ParagraphAttributes paragraphAttributes,
       LayoutConstraints layoutConstraints,
-      const std::optional<TextAlignment> &textAlignment,
       winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept;
 
 #pragma endregion
 
  private:
+  static winrt::hstring GetTransformedText(AttributedStringBox const &attributedStringBox);
+
   ContextContainer::Shared m_contextContainer;
+#pragma warning(push)
+#pragma warning(disable : 5028)
+  TextMeasureCache m_measureCache{};
+#pragma warning(pop)
 };
 
 } // namespace react

--- a/vnext/Microsoft.ReactNative/Utils/TransformableText.h
+++ b/vnext/Microsoft.ReactNative/Utils/TransformableText.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <JSValue.h>
 #include <Utils/TextTransform.h>
 
 namespace Microsoft::ReactNative {


### PR DESCRIPTION
## Description
Adds a cache for text measure.

Adds support for `lineHeight`, `letterSpacing`, `maximumNumberOfLines` and `textTransform` properties on text.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11327)