### PR TITLE
[Fabric] Add support for backface visibility

### DIFF
--- a/change/react-native-windows-8930e00f-f3bb-4781-b282-37e9df2b9be7.json
+++ b/change/react-native-windows-8930e00f-f3bb-4781-b282-37e9df2b9be7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add support for backface visibility",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -14,6 +14,13 @@ namespace Microsoft.ReactNative.Composition
     UniformToFill,
   };
 
+  enum BackfaceVisibility
+  {
+    Inherit,
+    Visible,
+    Hidden
+  };
+
   [webhosthidden]
   [uuid("172def51-9e1a-4e3c-841a-e5a470065acc")] // uuid needed for empty interfaces
   [version(1)]
@@ -55,6 +62,7 @@ namespace Microsoft.ReactNative.Composition
     void Offset(Windows.Foundation.Numerics.Vector3 offset);
     void Offset(Windows.Foundation.Numerics.Vector3 offset, Windows.Foundation.Numerics.Vector3 relativeAdjustment);
     void RelativeSizeWithOffset(Windows.Foundation.Numerics.Vector2 size, Windows.Foundation.Numerics.Vector2 relativeSizeAdjustment);
+    BackfaceVisibility BackfaceVisibility{ get; set; };
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -241,6 +241,14 @@ struct CompVisual : public winrt::implements<
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
   }
 
+  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  }
+
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) {
+    m_visual.BackfaceVisibility(static_cast<winrt::Windows::UI::Composition::CompositionBackfaceVisibility>(value));
+  }
+
  private:
   winrt::Windows::UI::Composition::Visual m_visual;
 };
@@ -325,6 +333,14 @@ struct CompSpriteVisual : winrt::Microsoft::ReactNative::Composition::implementa
       winrt::Windows::Foundation::Numerics::float2 relativeSizeAdjustment) noexcept {
     m_visual.Size(size);
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
+  }
+
+  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  }
+
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) {
+    m_visual.BackfaceVisibility(static_cast<winrt::Windows::UI::Composition::CompositionBackfaceVisibility>(value));
   }
 
   void SetClippingPath(ID2D1Geometry *clippingPath) noexcept {
@@ -509,6 +525,14 @@ struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implemen
       winrt::Windows::Foundation::Numerics::float2 relativeSizeAdjustment) noexcept {
     m_visual.Size(size);
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
+  }
+
+  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  }
+
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) {
+    m_visual.BackfaceVisibility(static_cast<winrt::Windows::UI::Composition::CompositionBackfaceVisibility>(value));
   }
 
   void SetClippingPath(ID2D1Geometry *clippingPath) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1164,6 +1164,23 @@ void CompositionViewComponentView::updateProps(
     m_visual.Shadow(shadow);
   }
 
+  if (oldViewProps.backfaceVisibility != newViewProps.backfaceVisibility) {
+    static_assert(
+        static_cast<facebook::react::BackfaceVisibility>(
+            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Inherit) ==
+        facebook::react::BackfaceVisibility::Auto);
+    static_assert(
+        static_cast<facebook::react::BackfaceVisibility>(
+            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Visible) ==
+        facebook::react::BackfaceVisibility::Visible);
+    static_assert(
+        static_cast<facebook::react::BackfaceVisibility>(
+            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Hidden) ==
+        facebook::react::BackfaceVisibility::Hidden);
+    m_visual.BackfaceVisibility(
+        static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(newViewProps.backfaceVisibility));
+  }
+
   // Transform - TODO doesn't handle multiple of the same kind of transform -- Doesn't handle hittesting updates
   if (oldViewProps.transform != newViewProps.transform) {
     winrt::Windows::Foundation::Numerics::float4x4 transformMatrix;


### PR DESCRIPTION
## Description
Implemented `backfaceVisiblity` on fabric.

Note this was never implemented in paper since Xaml doesn't expose it, see https://github.com/microsoft/microsoft-ui-xaml/issues/2728 for more details.

But since it's a pretty trivial implementation for the wincomp implementation I'm going ahead and hooking it up.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11334)