### PR TITLE
[Fabric] TextInput shouldn't block the tab loop

### DIFF
--- a/change/react-native-windows-29007162-af49-4bbc-a6d3-0f9efe78b98c.json
+++ b/change/react-native-windows-29007162-af49-4bbc-a6d3-0f9efe78b98c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] TextInput shouldn't block the tab loop",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -156,7 +156,7 @@ int64_t CompositionEventHandler::SendMessage(uint32_t msg, uint64_t wParam, int6
       MouseMove(msg, wParam, lParam);
       return 0;
     }
-    case WM_CHAR: 
+    case WM_CHAR:
     case WM_SYSCHAR: {
       // TODO full bubbling of events
       if (auto focusedComponent = RootComponentView().GetFocusedComponent()) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -156,10 +156,17 @@ int64_t CompositionEventHandler::SendMessage(uint32_t msg, uint64_t wParam, int6
       MouseMove(msg, wParam, lParam);
       return 0;
     }
+    case WM_CHAR: 
+    case WM_SYSCHAR: {
+      // TODO full bubbling of events
+      if (auto focusedComponent = RootComponentView().GetFocusedComponent()) {
+        auto result = focusedComponent->sendMessage(msg, wParam, lParam);
+        if (result)
+          return result;
+      }
+    }
     case WM_KEYDOWN:
     case WM_KEYUP:
-    case WM_CHAR:
-    case WM_SYSCHAR:
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP: {
       // TODO full bubbling of events
@@ -186,10 +193,11 @@ int64_t CompositionEventHandler::SendMessage(uint32_t msg, uint64_t wParam, int6
           Microsoft::ReactNative::DevMenuManager::Show(
               Mso::CntPtr<Mso::React::IReactContext>(&contextSelf->GetInner()));
         }
-        if (msg == WM_KEYDOWN && wParam == VK_TAB) {
-          if (RootComponentView().TryMoveFocus(!fShift)) {
-            return 1;
+        if (!fCtrl && msg == WM_KEYDOWN && wParam == VK_TAB) {
+          if (!RootComponentView().TryMoveFocus(!fShift)) {
+            // TODO notify rootview that host should move focus
           }
+          return 1;
         }
       }
       return 0;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -542,8 +542,8 @@ void WindowsTextInputComponentView::handleCommand(std::string const &commandName
 }
 
 int64_t WindowsTextInputComponentView::sendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept {
-  // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI behavior
-  // We do forward Ctrl+Tab to the textinput.
+  // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI
+  // behavior We do forward Ctrl+Tab to the textinput.
   if (((msg == WM_KEYDOWN || msg == WM_KEYUP) && wParam == VK_TAB) || (msg == WM_CHAR && wParam == '\t')) {
     BYTE bKeys[256];
     if (GetKeyboardState(bKeys)) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -542,6 +542,18 @@ void WindowsTextInputComponentView::handleCommand(std::string const &commandName
 }
 
 int64_t WindowsTextInputComponentView::sendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept {
+  // Do not forward tab keys into the TextInput, since we want that to do the tab loop instead.  This aligns with WinUI behavior
+  // We do forward Ctrl+Tab to the textinput.
+  if (((msg == WM_KEYDOWN || msg == WM_KEYUP) && wParam == VK_TAB) || (msg == WM_CHAR && wParam == '\t')) {
+    BYTE bKeys[256];
+    if (GetKeyboardState(bKeys)) {
+      bool fCtrl = false;
+      if (!(bKeys[VK_LCONTROL] & 0x80 || bKeys[VK_RCONTROL] & 0x80)) {
+        return 0;
+      }
+    }
+  }
+
   if (m_textServices) {
     LRESULT lresult;
     DrawBlock db(*this);


### PR DESCRIPTION
In WinUI tab will move focus out of a textinput.  Currently in fabric tab will enter a tab into the textinput.  This change updates the behavior to align with paper.  Now the user will have to use CTRL+Tab to enter a tab into a textinput -- and normal tab will move focus to the next control.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11348)