### PR TITLE
[Fabric] Move Windows specific properties out of ViewProps into HostPlatformViewProps

### DIFF
--- a/change/react-native-windows-89fafeeb-2f97-4e19-b61a-2b4b290c4b23.json
+++ b/change/react-native-windows-89fafeeb-2f97-4e19-b61a-2b4b290c4b23.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Move Windows specific properties out of ViewProps into HostPlatformViewProps",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "WindowsViewProps.h"
+
+#include <react/renderer/core/CoreFeatures.h>
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook::react {
+
+WindowsViewProps::WindowsViewProps(
+    const PropsParserContext &context,
+    const WindowsViewProps &sourceProps,
+    const RawProps &rawProps,
+    bool shouldSetRawProps)
+    : windowsEvents(sourceProps.windowsEvents),
+      focusable(sourceProps.focusable),
+      enableFocusRing(sourceProps.enableFocusRing)
+      {}
+
+#define WINDOWS_VIEW_EVENT_CASE(eventType)                      \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
+    const auto offset = WindowsViewEvents::Offset::eventType;  \
+    WindowsViewEvents defaultViewEvents{};                     \
+    bool res = defaultViewEvents[offset];               \
+    if (value.hasValue()) {                             \
+      fromRawValue(context, value, res);                \
+    }                                                   \
+    windowsEvents[offset] = res;                               \
+    return;                                             \
+  }
+
+void WindowsViewProps::setProp(
+    const PropsParserContext &context,
+    RawPropsPropNameHash hash,
+    const char *propName,
+    RawValue const &value) {
+
+  static auto defaults = WindowsViewProps{};
+
+  switch (hash) {
+    WINDOWS_VIEW_EVENT_CASE(Focus);
+    WINDOWS_VIEW_EVENT_CASE(Blur);
+    WINDOWS_VIEW_EVENT_CASE(KeyUp);
+    WINDOWS_VIEW_EVENT_CASE(KeyDown);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(enableFocusRing);
+  }
+}
+
+/*static*/ bool WindowsViewProps::requiresFormsStackingContext(const WindowsViewProps& props) noexcept {
+  return props.windowsEvents.bits.any();
+}
+
+/*static*/ bool WindowsViewProps::requiresFormsView(const WindowsViewProps& props) noexcept {
+  return props.focusable;
+}
+
+} // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.cpp
@@ -19,19 +19,18 @@ WindowsViewProps::WindowsViewProps(
     bool shouldSetRawProps)
     : windowsEvents(sourceProps.windowsEvents),
       focusable(sourceProps.focusable),
-      enableFocusRing(sourceProps.enableFocusRing)
-      {}
+      enableFocusRing(sourceProps.enableFocusRing) {}
 
-#define WINDOWS_VIEW_EVENT_CASE(eventType)                      \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
-    const auto offset = WindowsViewEvents::Offset::eventType;  \
-    WindowsViewEvents defaultViewEvents{};                     \
-    bool res = defaultViewEvents[offset];               \
-    if (value.hasValue()) {                             \
-      fromRawValue(context, value, res);                \
-    }                                                   \
-    windowsEvents[offset] = res;                               \
-    return;                                             \
+#define WINDOWS_VIEW_EVENT_CASE(eventType)                    \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): {       \
+    const auto offset = WindowsViewEvents::Offset::eventType; \
+    WindowsViewEvents defaultViewEvents{};                    \
+    bool res = defaultViewEvents[offset];                     \
+    if (value.hasValue()) {                                   \
+      fromRawValue(context, value, res);                      \
+    }                                                         \
+    windowsEvents[offset] = res;                              \
+    return;                                                   \
   }
 
 void WindowsViewProps::setProp(
@@ -39,7 +38,6 @@ void WindowsViewProps::setProp(
     RawPropsPropNameHash hash,
     const char *propName,
     RawValue const &value) {
-
   static auto defaults = WindowsViewProps{};
 
   switch (hash) {
@@ -52,11 +50,11 @@ void WindowsViewProps::setProp(
   }
 }
 
-/*static*/ bool WindowsViewProps::requiresFormsStackingContext(const WindowsViewProps& props) noexcept {
+/*static*/ bool WindowsViewProps::requiresFormsStackingContext(const WindowsViewProps &props) noexcept {
   return props.windowsEvents.bits.any();
 }
 
-/*static*/ bool WindowsViewProps::requiresFormsView(const WindowsViewProps& props) noexcept {
+/*static*/ bool WindowsViewProps::requiresFormsView(const WindowsViewProps &props) noexcept {
   return props.focusable;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.h
@@ -3,13 +3,13 @@
 
 #pragma once
 
+#include <react/components/view/windows/primitives.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
-#include <react/components/view/windows/primitives.h>
 
 namespace facebook::react {
 class WindowsViewProps {
-public:
+ public:
   WindowsViewProps() = default;
   WindowsViewProps(
       const PropsParserContext &context,
@@ -18,21 +18,17 @@ public:
       bool shouldSetRawProps = true);
 
   void
-  setProp(
-      const PropsParserContext &context,
-      RawPropsPropNameHash hash,
-      const char *propName,
-      RawValue const &value);
+  setProp(const PropsParserContext &context, RawPropsPropNameHash hash, const char *propName, RawValue const &value);
 
-  static bool requiresFormsStackingContext(const WindowsViewProps& props) noexcept;
-  static bool requiresFormsView(const WindowsViewProps& props) noexcept;
+  static bool requiresFormsStackingContext(const WindowsViewProps &props) noexcept;
+  static bool requiresFormsView(const WindowsViewProps &props) noexcept;
 
   WindowsViewEvents windowsEvents{};
   bool enableFocusRing{true};
   bool focusable{false};
-  //std::optional<std::string> overflowAnchor{};
-  //std::optional<std::string> tooltip{};
-  //std::vector<HandledKeyEvent> keyDownEvents{};
-  //std::vector<HandledKeyEvent> keyUpEvents{};
+  // std::optional<std::string> overflowAnchor{};
+  // std::optional<std::string> tooltip{};
+  // std::vector<HandledKeyEvent> keyDownEvents{};
+  // std::vector<HandledKeyEvent> keyUpEvents{};
 };
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/WindowsViewProps.h
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/components/view/windows/primitives.h>
+
+namespace facebook::react {
+class WindowsViewProps {
+public:
+  WindowsViewProps() = default;
+  WindowsViewProps(
+      const PropsParserContext &context,
+      const WindowsViewProps &sourceProps,
+      const RawProps &rawProps,
+      bool shouldSetRawProps = true);
+
+  void
+  setProp(
+      const PropsParserContext &context,
+      RawPropsPropNameHash hash,
+      const char *propName,
+      RawValue const &value);
+
+  static bool requiresFormsStackingContext(const WindowsViewProps& props) noexcept;
+  static bool requiresFormsView(const WindowsViewProps& props) noexcept;
+
+  WindowsViewEvents windowsEvents{};
+  bool enableFocusRing{true};
+  bool focusable{false};
+  //std::optional<std::string> overflowAnchor{};
+  //std::optional<std::string> tooltip{};
+  //std::vector<HandledKeyEvent> keyDownEvents{};
+  //std::vector<HandledKeyEvent> keyUpEvents{};
+};
+} // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/primitives.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/primitives.h
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <array>
+#include <bitset>
+#include <cmath>
+#include <optional>
+
+namespace facebook {
+namespace react {
+
+struct WindowsViewEvents {
+  std::bitset<32> bits{};
+
+  enum class Offset : std::size_t {
+    Focus = 0,
+    Blur = 1,
+    KeyUp = 2,
+    KeyDown = 3,
+  };
+  
+  constexpr bool operator[](const Offset offset) const {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+
+  std::bitset<32>::reference operator[](const Offset offset) {
+    return bits[static_cast<std::size_t>(offset)];
+  }
+  };
+
+inline static bool operator==(WindowsViewEvents const &lhs, WindowsViewEvents const &rhs) {
+  return lhs.bits == rhs.bits;
+}
+
+inline static bool operator!=(WindowsViewEvents const &lhs, WindowsViewEvents const &rhs) {
+  return lhs.bits != rhs.bits;
+}
+
+} // namespace react
+} // namespace facebook

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/primitives.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/components/view/windows/primitives.h
@@ -20,7 +20,7 @@ struct WindowsViewEvents {
     KeyUp = 2,
     KeyDown = 3,
   };
-  
+
   constexpr bool operator[](const Offset offset) const {
     return bits[static_cast<std::size_t>(offset)];
   }
@@ -28,7 +28,7 @@ struct WindowsViewEvents {
   std::bitset<32>::reference operator[](const Offset offset) {
     return bits[static_cast<std::size_t>(offset)];
   }
-  };
+};
 
 inline static bool operator==(WindowsViewEvents const &lhs, WindowsViewEvents const &rhs) {
   return lhs.bits == rhs.bits;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewProps.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <react/components/view/windows/WindowsViewProps.h>
+
+namespace facebook::react {
+using HostPlatformViewProps = WindowsViewProps;
+} // namespace facebook::react

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.cpp
@@ -25,6 +25,7 @@ ViewProps::ViewProps(
     bool shouldSetRawProps)
     : YogaStylableProps(context, sourceProps, rawProps, shouldSetRawProps),
       AccessibilityProps(context, sourceProps, rawProps),
+      HostPlatformViewProps(context, sourceProps, rawProps, shouldSetRawProps), // [Windows]
       opacity(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.opacity
                                                  : convertRawProp(
@@ -183,14 +184,6 @@ ViewProps::ViewProps(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.events
               : convertRawProp(context, rawProps, sourceProps.events, {})),
-      enableFocusRing(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.enableFocusRing
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "enableFocusRing",
-                                                       sourceProps.enableFocusRing,
-                                                       true)),
       collapsable(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.collapsable
                                                  : convertRawProp(
@@ -236,8 +229,6 @@ ViewProps::ViewProps(
                     "nativeForegroundAndroid",
                     sourceProps.nativeForeground,
                     {})),
-#endif // [Windows]
-      , // [Windows]
       focusable(
           CoreFeatures::enablePropIteratorSetter ? sourceProps.focusable
                                                  : convertRawProp(
@@ -245,8 +236,7 @@ ViewProps::ViewProps(
                                                        rawProps,
                                                        "focusable",
                                                        sourceProps.focusable,
-                                                       {}))
-#ifdef ANDROID // [Windows]
+                                                       {})),
       hasTVPreferredFocus(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.hasTVPreferredFocus
@@ -291,19 +281,6 @@ ViewProps::ViewProps(
     return;                                             \
   }
 
-// [Windows]
-#define HOST_PLATFORM_VIEW_EVENT_CASE(eventType)                      \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
-    const auto offset = HostPlatformViewEvents::Offset::eventType;  \
-    HostPlatformViewEvents defaultViewEvents{};                     \
-    bool res = defaultViewEvents[offset];               \
-    if (value.hasValue()) {                             \
-      fromRawValue(context, value, res);                \
-    }                                                   \
-    platformEvents[offset] = res;                               \
-    return;                                             \
-  }
-
 void ViewProps::setProp(
     const PropsParserContext &context,
     RawPropsPropNameHash hash,
@@ -314,6 +291,7 @@ void ViewProps::setProp(
   // reuse the same values.
   YogaStylableProps::setProp(context, hash, propName, value);
   AccessibilityProps::setProp(context, hash, propName, value);
+  HostPlatformViewProps::setProp(context, hash, propName, value); // [Windows]
 
   static auto defaults = ViewProps{};
 
@@ -362,18 +340,12 @@ void ViewProps::setProp(
     VIEW_EVENT_CASE(TouchCancel);
     VIEW_EVENT_CASE(MouseEnter); // [Windows]
     VIEW_EVENT_CASE(MouseLeave); // [Windows]
-    HOST_PLATFORM_VIEW_EVENT_CASE(Focus); // [Windows]
-    HOST_PLATFORM_VIEW_EVENT_CASE(Blur); // [Windows]
-    HOST_PLATFORM_VIEW_EVENT_CASE(KeyUp); // [Windows]
-    HOST_PLATFORM_VIEW_EVENT_CASE(KeyDown); // [Windows]
 
 #ifdef ANDROID
     RAW_SET_PROP_SWITCH_CASE_BASIC(elevation);
     RAW_SET_PROP_SWITCH_CASE(nativeBackground, "nativeBackgroundAndroid");
     RAW_SET_PROP_SWITCH_CASE(nativeForeground, "nativeForegroundAndroid");
-#endif // [Windows]
     RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
-#ifdef ANDROID // [Windows]
     RAW_SET_PROP_SWITCH_CASE_BASIC(hasTVPreferredFocus);
     RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing);
     RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid);

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewProps.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/components/view/AccessibilityProps.h>
 #include <react/renderer/components/view/YogaStylableProps.h>
+#include <react/renderer/components/view/HostPlatformViewProps.h> // [Windows]
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/core/LayoutMetrics.h>
 #include <react/renderer/core/Props.h>
@@ -25,7 +26,7 @@ class ViewProps;
 
 using SharedViewProps = std::shared_ptr<ViewProps const>;
 
-class ViewProps : public YogaStylableProps, public AccessibilityProps {
+class ViewProps : public YogaStylableProps, public AccessibilityProps, public HostPlatformViewProps  { // [Windows] added HostPlatformViewProps
  public:
   ViewProps() = default;
   ViewProps(
@@ -77,9 +78,6 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
 
   ViewEvents events{};
 
-  HostPlatformViewEvents platformEvents{}; // [Windows]
-  bool enableFocusRing{true}; // [Windows]
-
   bool collapsable{true};
 
   bool removeClippedSubviews{false};
@@ -91,9 +89,7 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
   std::optional<NativeDrawable> nativeBackground{};
   std::optional<NativeDrawable> nativeForeground{};
 
-#endif // [Windows]
   bool focusable{false};
-#ifdef ANDROID // [Windows]
   bool hasTVPreferredFocus{false};
   bool needsOffscreenAlphaCompositing{false};
   bool renderToHardwareTextureAndroid{false};

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewShadowNode.cpp
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/ViewShadowNode.cpp
@@ -56,17 +56,19 @@ void ViewShadowNode::initialize() noexcept {
       viewProps.importantForAccessibility != ImportantForAccessibility::Auto ||
       viewProps.removeClippedSubviews;
 
-  formsStackingContext = formsStackingContext || viewProps.platformEvents.bits.any(); // [Windows]
-
 #ifdef ANDROID
   formsStackingContext = formsStackingContext || viewProps.elevation != 0;
 #endif
+
+  formsStackingContext = formsStackingContext || HostPlatformViewProps::requiresFormsStackingContext(viewProps); // [Windows]
 
   bool formsView = formsStackingContext ||
       isColorMeaningful(viewProps.backgroundColor) ||
       isColorMeaningful(viewProps.foregroundColor) ||
       !(viewProps.yogaStyle.border() == YGStyle::Edges{}) ||
       !viewProps.testId.empty();
+
+  formsView = formsView || HostPlatformViewProps::requiresFormsView(viewProps); // [Windows]
 
 #ifdef ANDROID
   formsView = formsView || viewProps.nativeBackground.has_value() ||
@@ -75,8 +77,6 @@ void ViewShadowNode::initialize() noexcept {
       viewProps.needsOffscreenAlphaCompositing ||
       viewProps.renderToHardwareTextureAndroid;
 #endif
-
-  formsView = formsView || viewProps.focusable; // [Windows]
 
   if (formsView) {
     traits_.set(ShadowNodeTraits::Trait::FormsView);

--- a/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/primitives.h
+++ b/vnext/ReactCommon/TEMP_UntilReactCommonUpdate/react/renderer/components/view/primitives.h
@@ -82,35 +82,6 @@ inline static bool operator!=(ViewEvents const &lhs, ViewEvents const &rhs) {
   return lhs.bits != rhs.bits;
 }
 
-// [Windows]
-struct HostPlatformViewEvents {
-  std::bitset<32> bits{};
-
-  enum class Offset : std::size_t {
-    Focus = 0,
-    Blur = 1,
-    KeyUp = 2,
-    KeyDown = 3,
-  };
-  
-  constexpr bool operator[](const Offset offset) const {
-    return bits[static_cast<std::size_t>(offset)];
-  }
-
-  std::bitset<32>::reference operator[](const Offset offset) {
-    return bits[static_cast<std::size_t>(offset)];
-  }
-  };
-
-
-inline static bool operator==(HostPlatformViewEvents const &lhs, HostPlatformViewEvents const &rhs) {
-  return lhs.bits == rhs.bits;
-}
-
-inline static bool operator!=(HostPlatformViewEvents const &lhs, HostPlatformViewEvents const &rhs) {
-  return lhs.bits != rhs.bits;
-}
-
 enum class BackfaceVisibility : uint8_t { Auto, Visible, Hidden };
 
 enum class BorderCurve : uint8_t { Circular, Continuous };

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -102,6 +102,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\ImageRequest.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\components\view\windows\WindowsViewProps.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\graphics\Color.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>


### PR DESCRIPTION
This reduces the diff we have in ViewProps down to some diffs that we hope to upstream.  @rozele, comments welcome on the specifics here.  Essentially each platform will be able to define their own HostPlatformViewProps with platform specific properties.  I also extended the functionality of HostPlatformViewProps slightly to allow HostPlatformViewProps to override behavior around what props require forms stacking contexts and form views.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11349)