### PR TITLE
Add submitBehavior prop to Paper VM for TextInput

### DIFF
--- a/change/react-native-windows-5ba1a75b-3ae5-44cf-a4db-a34fc827f883.json
+++ b/change/react-native-windows-5ba1a75b-3ae5-44cf-a4db-a34fc827f883.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add submitBehavior prop to Paper VM for TextInput",
+  "packageName": "react-native-windows",
+  "email": "helenistic@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -824,7 +824,7 @@ void TextInputViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::I
   React::WriteProperty(writer, L"selectionColor", L"Color");
   React::WriteProperty(writer, L"selectTextOnFocus", L"boolean");
   React::WriteProperty(writer, L"spellCheck", L"boolean");
-  React::WriteProperty(writer, L"submitBehavior", L"boolean");
+  React::WriteProperty(writer, L"submitBehavior", L"string");
   React::WriteProperty(writer, L"text", L"string");
   React::WriteProperty(writer, L"mostRecentEventCount", L"int");
   React::WriteProperty(writer, L"secureTextEntry", L"boolean");

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -824,6 +824,7 @@ void TextInputViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::I
   React::WriteProperty(writer, L"selectionColor", L"Color");
   React::WriteProperty(writer, L"selectTextOnFocus", L"boolean");
   React::WriteProperty(writer, L"spellCheck", L"boolean");
+  React::WriteProperty(writer, L"submitBehavior", L"boolean");
   React::WriteProperty(writer, L"text", L"string");
   React::WriteProperty(writer, L"mostRecentEventCount", L"int");
   React::WriteProperty(writer, L"secureTextEntry", L"boolean");


### PR DESCRIPTION
## Description
Similar to https://github.com/microsoft/react-native-windows/pull/11249, I need to add submitBehavior as a prop to the TextInput Paper VM in order to use it in Fabric

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
I'm currently implementing blurOnSubmit in Fabric, which reads from submitBehavior. Since blurOnSubmit was never supported in Paper, this prop needed to be added. Merging this will allow the Composition version of Fabric to use it as well.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11351)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11351)