### PR TITLE
Fix build from merge conflict

### DIFF
--- a/change/react-native-windows-c68eabbe-3264-4571-b4cf-eca9997af765.json
+++ b/change/react-native-windows-c68eabbe-3264-4571-b4cf-eca9997af765.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix build from merge conflict",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -293,7 +293,7 @@ void ScrollViewComponentView::handleCommand(std::string const &commandName, foll
     auto x = arg[0].asDouble();
     auto y = arg[1].asDouble();
     auto animate = arg[2].asBool();
-    m_visual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
+    m_scrollVisual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
   } else if (commandName == "flashScrollIndicators") {
     // No-op for now
   } else if (commandName == "scrollToEnd") {


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/pull/11344 added a call to TryScrollPosition on ScrollView's visual.  

https://github.com/microsoft/react-native-windows/pull/11323 changed the type of m_visual to IVisual, and moved the ScrollVisual to m_scrollVisual.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11355)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11355)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11355)