### PR TITLE
[Fabric] Add visuals for fallback when a native component isn't registered

### DIFF
--- a/change/react-native-windows-e85b54fe-59c7-4b2b-84e2-e5c5e12667db.json
+++ b/change/react-native-windows-e85b54fe-59c7-4b2b-84e2-e5c5e12667db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add visuals for fallback when a native component isn't registered",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -27,6 +27,7 @@
 #include <Fabric/Composition/ScrollViewComponentView.h>
 #include <Fabric/Composition/SwitchComponentView.h>
 #include <Fabric/Composition/TextInput/WindowsTextInputComponentView.h>
+#include <Fabric/Composition/UnimplementedNativeViewComponentView.h>
 
 namespace Microsoft::ReactNative {
 
@@ -54,6 +55,8 @@ ComponentViewDescriptor const &ComponentViewRegistry::dequeueComponentViewWithCo
     view = std::make_shared<SwitchComponentView>(compContext, tag, m_context);
   } else if (componentHandle == facebook::react::RootShadowNode::Handle()) {
     view = std::make_shared<RootComponentView>(compContext, tag);
+  } else if (componentHandle == facebook::react::UnimplementedNativeViewShadowNode::Handle()) {
+    view = std::make_shared<UnimplementedNativeViewComponentView>(compContext, tag);
   } else {
     view = std::make_shared<CompositionViewComponentView>(compContext, tag);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1071,6 +1071,11 @@ void CompositionBaseComponentView::indexOffsetForBorder(uint32_t &index) const n
 
 void CompositionBaseComponentView::OnRenderingDeviceLost() noexcept {}
 
+std::vector<facebook::react::ComponentDescriptorProvider>
+CompositionBaseComponentView::supplementalComponentDescriptorProviders() noexcept {
+  return {};
+}
+
 comp::CompositionPropertySet CompositionBaseComponentView::EnsureCenterPointPropertySet() noexcept {
   if (m_centerPropSet == nullptr) {
     auto compositor =
@@ -1151,11 +1156,6 @@ CompositionViewComponentView::CompositionViewComponentView(
   m_props = defaultProps;
   m_visual = m_compContext.CreateSpriteVisual();
   OuterVisual().InsertAt(m_visual, 0);
-}
-
-std::vector<facebook::react::ComponentDescriptorProvider>
-CompositionViewComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
 }
 
 void CompositionViewComponentView::mountChildComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -35,6 +35,8 @@ struct CompositionBaseComponentView : public IComponentView {
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
   bool focusable() const noexcept override;
+  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
+      override;
   facebook::react::SharedTouchEventEmitter touchEventEmitter() noexcept override;
   facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
   facebook::react::Tag tag() const noexcept override;
@@ -92,8 +94,6 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag);
 
-  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
-      override;
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -55,11 +55,6 @@ ImageComponentView::ImageComponentView(
   m_props = defaultProps;
 }
 
-std::vector<facebook::react::ComponentDescriptorProvider>
-ImageComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
-}
-
 void ImageComponentView::mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept {
   assert(false);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -34,8 +34,6 @@ struct ImageComponentView : CompositionBaseComponentView {
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
-  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
-      override;
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -23,11 +23,6 @@ ParagraphComponentView::ParagraphComponentView(
   m_props = defaultProps;
 }
 
-std::vector<facebook::react::ComponentDescriptorProvider>
-ParagraphComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
-}
-
 void ParagraphComponentView::mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept {
   // auto v = static_cast<ParagraphComponentView &>(childComponentView);
   assert(false);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -116,11 +116,6 @@ ScrollViewComponentView::ScrollViewComponentView(
         */
 }
 
-std::vector<facebook::react::ComponentDescriptorProvider>
-ScrollViewComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
-}
-
 void ScrollViewComponentView::mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept {
   ensureVisual();
 
@@ -293,7 +288,7 @@ void ScrollViewComponentView::handleCommand(std::string const &commandName, foll
     auto x = arg[0].asDouble();
     auto y = arg[1].asDouble();
     auto animate = arg[2].asBool();
-    m_visual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
+    m_scrollVisual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
   } else if (commandName == "flashScrollIndicators") {
     // No-op for now
   } else if (commandName == "scrollToEnd") {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -55,8 +55,6 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag);
 
-  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
-      override;
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -16,11 +16,6 @@ SwitchComponentView::SwitchComponentView(
   m_props = std::make_shared<facebook::react::SwitchProps const>();
 }
 
-std::vector<facebook::react::ComponentDescriptorProvider>
-SwitchComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
-}
-
 void SwitchComponentView::mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept {
   assert(false);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -22,8 +22,6 @@ struct SwitchComponentView : CompositionBaseComponentView {
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
-  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
-      override;
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -565,11 +565,6 @@ int64_t WindowsTextInputComponentView::sendMessage(uint32_t msg, uint64_t wParam
   return Super::sendMessage(msg, wParam, lParam);
 }
 
-std::vector<facebook::react::ComponentDescriptorProvider>
-WindowsTextInputComponentView::supplementalComponentDescriptorProviders() noexcept {
-  return {};
-}
-
 void WindowsTextInputComponentView::mountChildComponentView(
     IComponentView &childComponentView,
     uint32_t index) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -29,8 +29,6 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
-  std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept
-      override;
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -1,0 +1,160 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "UnimplementedNativeViewComponentView.h"
+
+#include <Fabric/DWriteHelpers.h>
+#include "Unicode.h"
+
+namespace Microsoft::ReactNative {
+
+UnimplementedNativeViewComponentView::UnimplementedNativeViewComponentView(
+    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    facebook::react::Tag tag)
+    : Super(compContext, tag) {
+  static auto const defaultProps = std::make_shared<facebook::react::UnimplementedNativeViewProps const>();
+  m_props = defaultProps;
+  m_visual = compContext.CreateSpriteVisual();
+}
+
+void UnimplementedNativeViewComponentView::mountChildComponentView(
+    IComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+}
+
+void UnimplementedNativeViewComponentView::unmountChildComponentView(
+    IComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+}
+
+void UnimplementedNativeViewComponentView::updateProps(
+    facebook::react::Props::Shared const &props,
+    facebook::react::Props::Shared const &oldProps) noexcept {
+  m_props = std::static_pointer_cast<facebook::react::UnimplementedNativeViewProps const>(props);
+}
+
+void UnimplementedNativeViewComponentView::updateLayoutMetrics(
+    facebook::react::LayoutMetrics const &layoutMetrics,
+    facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {
+  if ((layoutMetrics.displayType != m_layoutMetrics.displayType)) {
+    OuterVisual().IsVisible(layoutMetrics.displayType != facebook::react::DisplayType::None);
+  }
+
+  if (m_layoutMetrics.frame.size != layoutMetrics.frame.size ||
+      m_layoutMetrics.pointScaleFactor != layoutMetrics.pointScaleFactor) {
+    // Always make visual a min size, so that even if its laid out at zero size, its clear an unimplemented view was
+    // rendered
+    float width = std::max(m_layoutMetrics.frame.size.width, 200.0f);
+    float height = std::max(m_layoutMetrics.frame.size.width, 50.0f);
+
+    winrt::Windows::Foundation::Size surfaceSize = {
+        width * m_layoutMetrics.pointScaleFactor, height * m_layoutMetrics.pointScaleFactor};
+    auto drawingSurface = m_compContext.CreateDrawingSurface(
+        surfaceSize,
+        winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+        winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
+
+    auto surfaceBrush = m_compContext.CreateSurfaceBrush(drawingSurface);
+    surfaceBrush.HorizontalAlignmentRatio(0.f);
+    surfaceBrush.VerticalAlignmentRatio(0.f);
+    surfaceBrush.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+    m_visual.Brush(surfaceBrush);
+    m_visual.Size(surfaceSize);
+    m_visual.Offset({
+        layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
+        layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
+        0.0f,
+    });
+
+    winrt::com_ptr<ID2D1DeviceContext> d2dDeviceContext;
+    POINT offset;
+
+    winrt::com_ptr<Composition::ICompositionDrawingSurfaceInterop> drawingSurfaceInterop;
+    drawingSurface.as(drawingSurfaceInterop);
+
+    if (CheckForDeviceRemoved(drawingSurfaceInterop->BeginDraw(d2dDeviceContext.put(), &offset))) {
+      d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Red, 0.3f));
+      assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
+      const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
+      float oldDpiX, oldDpiY;
+      d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
+      d2dDeviceContext->SetDpi(dpi, dpi);
+
+      float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
+      float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);
+
+      winrt::com_ptr<IDWriteTextFormat> spTextFormat;
+      winrt::check_hresult(Microsoft::ReactNative::DWriteFactory()->CreateTextFormat(
+          L"Segoe UI",
+          nullptr, // Font collection (nullptr sets it to use the system font collection).
+          DWRITE_FONT_WEIGHT_REGULAR,
+          DWRITE_FONT_STYLE_NORMAL,
+          DWRITE_FONT_STRETCH_NORMAL,
+          12,
+          L"",
+          spTextFormat.put()));
+
+      winrt::com_ptr<ID2D1SolidColorBrush> textBrush;
+      winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::White), textBrush.put()));
+
+      const D2D1_RECT_F rect = {
+          static_cast<float>(offset.x), static_cast<float>(offset.y), width + offset.x, height + offset.y};
+      // const D2D1_RECT_F rect = {0.f, 0.f, width, height};
+
+      auto label = Microsoft::Common::Unicode::Utf8ToUtf16(std::string("Unimplemented component: ") + m_props->name);
+      d2dDeviceContext->DrawText(
+          label.c_str(),
+          static_cast<UINT32>(label.length()),
+          spTextFormat.get(),
+          rect,
+          textBrush.get(),
+          D2D1_DRAW_TEXT_OPTIONS_NONE,
+          DWRITE_MEASURING_MODE_NATURAL);
+
+      winrt::check_hresult(drawingSurfaceInterop->EndDraw());
+    }
+  }
+  m_layoutMetrics = layoutMetrics;
+}
+
+void UnimplementedNativeViewComponentView::updateState(
+    facebook::react::State::Shared const &state,
+    facebook::react::State::Shared const &oldState) noexcept {}
+
+void UnimplementedNativeViewComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {}
+
+void UnimplementedNativeViewComponentView::prepareForRecycle() noexcept {}
+facebook::react::Props::Shared UnimplementedNativeViewComponentView::props() noexcept {
+  return m_props;
+}
+
+winrt::Microsoft::ReactNative::Composition::IVisual UnimplementedNativeViewComponentView::Visual() const noexcept {
+  return m_visual;
+}
+
+winrt::Microsoft::ReactNative::Composition::IVisual UnimplementedNativeViewComponentView::OuterVisual() const noexcept {
+  return m_visual;
+}
+
+facebook::react::Tag UnimplementedNativeViewComponentView::hitTest(
+    facebook::react::Point pt,
+    facebook::react::Point &localPt) const noexcept {
+  facebook::react::Point ptLocal{pt.x - m_layoutMetrics.frame.origin.x, pt.y - m_layoutMetrics.frame.origin.y};
+
+  if ((m_props->pointerEvents == facebook::react::PointerEventsMode::Auto ||
+       m_props->pointerEvents == facebook::react::PointerEventsMode::BoxOnly) &&
+      ptLocal.x >= 0 && ptLocal.x <= m_layoutMetrics.frame.size.width && ptLocal.y >= 0 &&
+      ptLocal.y <= m_layoutMetrics.frame.size.height) {
+    localPt = ptLocal;
+    return tag();
+  }
+
+  return -1;
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
@@ -5,29 +5,27 @@
 #pragma once
 
 #include <Fabric/ComponentView.h>
-#include <d2d1_1.h>
-#include <dwrite.h>
-#include <react/renderer/attributedstring/AttributedStringBox.h>
-#include <react/renderer/components/text/ParagraphProps.h>
-#include <windows.ui.composition.interop.h>
-#include <winrt/Windows.UI.Composition.h>
-#include "CompositionHelpers.h"
+#include <Microsoft.ReactNative.Cxx/ReactContext.h>
+
 #include "CompositionViewComponentView.h"
+
+#include <react/components/rnwcore/ShadowNodes.h>
 
 namespace Microsoft::ReactNative {
 
-struct ParagraphComponentView : CompositionBaseComponentView {
+struct UnimplementedNativeViewComponentView : CompositionBaseComponentView {
   using Super = CompositionBaseComponentView;
-  ParagraphComponentView(
+  UnimplementedNativeViewComponentView(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag);
 
   void mountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
-  void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept
-      override;
-  void updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept override;
+
   void updateState(facebook::react::State::Shared const &state, facebook::react::State::Shared const &oldState) noexcept
+      override;
+
+  void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept
       override;
   void updateLayoutMetrics(
       facebook::react::LayoutMetrics const &layoutMetrics,
@@ -36,25 +34,12 @@ struct ParagraphComponentView : CompositionBaseComponentView {
   void prepareForRecycle() noexcept override;
   facebook::react::Props::Shared props() noexcept override;
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt) const noexcept override;
-  void OnRenderingDeviceLost() noexcept override;
-  facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
-
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::IVisual OuterVisual() const noexcept override;
 
  private:
-  void ensureVisual() noexcept;
-  void updateVisualBrush() noexcept;
-  void DrawText() noexcept;
-  void updateTextAlignment(const std::optional<facebook::react::TextAlignment> &fbAlignment) noexcept;
-
-  std::shared_ptr<facebook::react::ParagraphProps const> m_props;
+  std::shared_ptr<facebook::react::UnimplementedNativeViewProps const> m_props;
   winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
-  winrt::com_ptr<::IDWriteTextLayout> m_textLayout;
-  facebook::react::AttributedStringBox m_attributedStringBox;
-  facebook::react::ParagraphAttributes m_paragraphAttributes;
-
-  bool m_requireRedraw{true};
-  winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface m_drawingSurface;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -113,8 +113,10 @@ class AsyncEventBeat final : public facebook::react::EventBeat {
 std::shared_ptr<facebook::react::ComponentDescriptorProviderRegistry const> sharedProviderRegistry() {
   static auto providerRegistry = []() -> std::shared_ptr<facebook::react::ComponentDescriptorProviderRegistry> {
     auto providerRegistry = std::make_shared<facebook::react::ComponentDescriptorProviderRegistry>();
+    /*
     providerRegistry->add(facebook::react::concreteComponentDescriptorProvider<
                           facebook::react::ActivityIndicatorViewComponentDescriptor>());
+                          */
     providerRegistry->add(
         facebook::react::concreteComponentDescriptorProvider<facebook::react::ImageComponentDescriptor>());
     providerRegistry->add(

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -90,6 +90,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\TextInput\WindowsTextInputState.cpp" DisableSpecificWarnings="4244;%(DisableSpecificWarnings)">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UnimplementedNativeViewComponentView.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\DWriteHelpers.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>


### PR DESCRIPTION
When a component is registered in JS, but does not have a native implementation, we will create an `UnimplementedNativeViewComponentView` which will display an error to the developer in place of the view.

This will show up as a semi-transparent red box, with a string notifying the user which component is missing:
![image](https://user-images.githubusercontent.com/30809111/224400709-af41c8b9-c584-43ae-a1b5-3fb20d4dd91f.png)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11356)