### PR TITLE
Update bug-report.yaml version command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -36,7 +36,7 @@ body:
       label: CLI version
       description: |
         Run the command `npx react-native --version` in your terminal and copy the results here
-      value: "npx react-native --version"
+      value: "npx react-native -v"
     id: cli
   - type: textarea
     validations:


### PR DESCRIPTION
## Description
Update issue template to use `react-native -v` instead of `react-native --version` since `--version` has been removed in new versions for some reason.

### Type of Change
No code change, just github stuff.

### Why

Avoid `unknown option '--version'` error when following the steps to file a bug.

### What
Github bug issue template

## Testing
```
$ npx react-native --version
error: unknown option '--version'
$ npx react-native -v
10.1.3
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11369)