### PR TITLE
Fixes occasional crash in hit testing

### DIFF
--- a/change/react-native-windows-39502c8c-b5bb-4cb1-a869-0a605db2abe3.json
+++ b/change/react-native-windows-39502c8c-b5bb-4cb1-a869-0a605db2abe3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes occasional crash in hit testing",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/Text/TextHitTestUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextHitTestUtils.cpp
@@ -238,9 +238,14 @@ bool TextHitTestUtils::HitTest(const xaml::Documents::Run &run, const winrt::Poi
   // c. Skip step 4 if the first character is LTR
   // d. Skip step 5 if the last character is LTR
 
+  const auto parent = start.VisualParent();
+  if (!parent) {
+    return false;
+  }
+
   // Get the parent bounds
   const auto maxLeft = 0;
-  const auto maxRight = static_cast<float>(start.VisualParent().Width());
+  const auto maxRight = static_cast<float>(parent.Width());
 
   // Check if run is either the start or end of a line
   const auto characterBeforeStart = GetBoundaryCharacter(start, startRect, -1);

--- a/vnext/Microsoft.ReactNative/Views/Text/TextHitTestUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Views/Text/TextHitTestUtils.cpp
@@ -238,14 +238,14 @@ bool TextHitTestUtils::HitTest(const xaml::Documents::Run &run, const winrt::Poi
   // c. Skip step 4 if the first character is LTR
   // d. Skip step 5 if the last character is LTR
 
+  // Get the parent bounds
   const auto parent = start.VisualParent();
   if (!parent) {
     return false;
   }
 
-  // Get the parent bounds
   const auto maxLeft = 0;
-  const auto maxRight = static_cast<float>(parent.Width());
+  const auto maxRight = static_cast<float>(parent.ActualWidth());
 
   // Check if run is either the start or end of a line
   const auto characterBeforeStart = GetBoundaryCharacter(start, startRect, -1);


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We occasionally see crashes where we try to access the Width property of a null VisualParent result.

### What
It's not clear why this would ever return null, but to avoid crashing, we'll just return false on the hit test instead.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11377)