### PR TITLE
Fix RedBox Dismiss

### DIFF
--- a/change/react-native-windows-7f362cee-b1e5-48ae-80f4-893a406c40b3.json
+++ b/change/react-native-windows-7f362cee-b1e5-48ae-80f4-893a406c40b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix RedBox Dismiss",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/RedBox.cpp
+++ b/vnext/Microsoft.ReactNative/RedBox.cpp
@@ -57,11 +57,9 @@ struct RedBox : public std::enable_shared_from_this<RedBox> {
         m_errorInfo(std::move(errorInfo)) {}
 
   void Dismiss() noexcept {
-#ifdef USE_FABRIC
     if (m_popup) {
       m_popup.IsOpen(false);
     }
-#endif // USE_FABRIC
   }
 
   void Reload() noexcept {


### PR DESCRIPTION
## Description
When a RedBox error is shown, the user cannot dismiss it.
