### PR TITLE
Avoid copying ReactPromise in ImageLoader module

### DIFF
--- a/change/react-native-windows-50d572c0-d904-46d0-88e0-cef6a8f31faf.json
+++ b/change/react-native-windows-50d572c0-d904-46d0-88e0-cef6a8f31faf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid copying ReactPromise in ImageLoader module",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We're seeing crashes when the React instance is destroyed if there is an active ImageLoader::getSizeWithHeaders request in flight (related to JSI trying to create an object on a destroyed runtime).

### What
This is similar to an issue that was resolved and picked into React Native Windows v0.68 (#10436), but even with that fix, the crash still occurs. I suspect it may be related to using the ReactPromise copy constructor, but even if not, it's not so bad to avoid copying the ReactPromise.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11395)