### PR TITLE
[Win32] Minor TS type updates

### DIFF
--- a/change/@office-iss-react-native-win32-4e4c5d54-7364-4499-8466-1a18b13452f9.json
+++ b/change/@office-iss-react-native-win32-4e4c5d54-7364-4499-8466-1a18b13452f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Minor TS type updates",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.d.ts
@@ -9,7 +9,7 @@
 
 import type * as React from 'react';
 import {Constructor} from 'react-native/types/private/Utilities';
-import {ViewProps} from './ViewPropTypes';
+import {ViewProps} from './ViewPropTypes.win32';
 import {NativeMethods} from 'react-native/types/public/ReactNativeTypes';
 
 /**

--- a/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
@@ -6,6 +6,7 @@
 */
 
 export {ViewWin32} from './Components/View/ViewWin32';
+export {IViewWin32Props} from './Components/View/ViewPropTypes.win32';
 export {TextWin32TextStyle, ITextWin32Props } from './Components/Text/TextWin32.Props';
 export {TextWin32} from './Components/Text/TextWin32';
 export {IButtonWin32Props, IButtonWin32Style} from './Components/Button/ButtonWin32.Props';


### PR DESCRIPTION
Minor fixes to output types for users not using `@rnx-kit/metro-plugin-typescript`

Previous versions of RN-win32 would allow usage or win32 specific properties on ViewWin32 without relying on TS to use any .win32 resolution.