### PR TITLE
[0.69] CrashManager: handle abort signal

### DIFF
--- a/change/react-native-windows-00d5b8db-bd21-4d37-a622-82dbec4eac24.json
+++ b/change/react-native-windows-00d5b8db-bd21-4d37-a622-82dbec4eac24.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.69] CrashManager should also handle SIGABRT",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -426,6 +426,7 @@ void ReactInstanceWin::Initialize() noexcept {
 
           devSettings->waitingForDebuggerCallback = GetWaitingForDebuggerCallback();
           devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
+          devSettings->enableDefaultCrashHandler = m_options.EnableDefaultCrashHandler();
 
 #ifndef CORE_ABI
           devSettings->showDevMenuCallback = [weakThis]() noexcept {


### PR DESCRIPTION
This PR backports #11374 to 0.69.

If there is a noexcept function on the stack, the CRT just calls abort instead of calling the handler registered via SetUnhandledExceptionFilter.

This change registers a handler for the SIG_ABRT (the abort signal) to attempt to collect crash details.

As before, nothing happens by default, this code path is only enabled if EnableDefaultCrashHandler is set to true.