### PR TITLE
Workaround fix for "missing-asset-registry-path" error to unblock PRs

### DIFF
--- a/change/react-native-windows-a5110142-aafe-4bbf-ac8b-1a6c6cdd9405.json
+++ b/change/react-native-windows-a5110142-aafe-4bbf-ac8b-1a6c6cdd9405.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Workaround fix for \"missing-asset-registry-path\" error to unblock PRs",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/template/metro.config.js
+++ b/vnext/template/metro.config.js
@@ -26,6 +26,11 @@ module.exports = {
     ]),
   },
   transformer: {
+    // This fixes the 'missing-asset-registry-path` error (see https://github.com/microsoft/react-native-windows/issues/11437)
+    assetRegistryPath: require.resolve(
+      rnwPath,
+      './Libraries/Image/AssetRegistry',
+    ),
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,

--- a/vnext/template/metro.config.js
+++ b/vnext/template/metro.config.js
@@ -26,16 +26,13 @@ module.exports = {
     ]),
   },
   transformer: {
-    // This fixes the 'missing-asset-registry-path` error (see https://github.com/microsoft/react-native-windows/issues/11437)
-    assetRegistryPath: require.resolve(
-      rnwPath,
-      './Libraries/Image/AssetRegistry',
-    ),
     getTransformOptions: async () => ({
       transform: {
         experimentalImportSupport: false,
         inlineRequires: true,
       },
     }),
+    // This fixes the 'missing-asset-registry-path` error (see https://github.com/microsoft/react-native-windows/issues/11437)
+    assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
   },
 };


### PR DESCRIPTION
## Description

New app projects built against main are unable to create their bundle (see https://github.com/microsoft/react-native-windows/issues/11437).

As such, all PRs are blocked as the New CLI app checks all fail.

The problem is that the metro config needs `transformer.assetRegistryPath` to be set to the location of `'react-native/Libraries/Image/AssetRegistry'`, as for some reason this isn't set anymore upstream.

This PR adds a workaround of specifying that path in our app template's metro.config.js file. This unblocks our PRs but we should probably find a better place than in an app template file.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why

Unblock our PRs.

Resolves #11437

### What

Updates the new app template's metro.config.js file with the correct path which is no longer getting set for us.

## Screenshots
N/A

## Testing

Tested with a new CLI app.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11438)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11438)