### PR TITLE
[0.70] Ensure ReactNativeWindowsDir is set in Directory.Build.props

### DIFF
--- a/change/react-native-windows-2444e581-3cff-4874-99cb-83042f354ad0.json
+++ b/change/react-native-windows-2444e581-3cff-4874-99cb-83042f354ad0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.70] Ensure ReactNativeWindowsDir is set in Directory.Build.props",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -23,6 +23,25 @@
     <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>
   </PropertyGroup>
 
+  <!--
+    IMPORTANT: Traversals left in a directory will break some tools like midl, but we also cannot call
+    [MSBuild]::NormalizeDirectory on relative paths since cwd is not always correct. This logic should prefer to operate
+    on full paths and avoid extra normalization.
+  -->
+  <PropertyGroup>
+    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)</ReactNativeWindowsDir>
+
+    <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativeDir>
+
+    <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)ReactCommon\yoga</YogaDir>
+
+    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-$(FollyVersion)</FollyDir>
+    <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
+
+    <FmtDir Condition="'$(FmtDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.fmt\fmt-$(FmtVersion)</FmtDir>
+    <FmtDir>$([MSBuild]::NormalizeDirectory($(FmtDir)))</FmtDir>
+  </PropertyGroup>
+
   <PropertyGroup Label="Configuration">
     <ProjectName Condition="'$(ProjectName)'==''">$(MSBuildProjectName)</ProjectName>
 
@@ -44,25 +63,6 @@
 
     <IntermediateOutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(IntDir)</IntermediateOutputPath>
     <OutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(OutDir)</OutputPath>
-  </PropertyGroup>
-
-  <!--
-    IMPORTANT: Traversals left in a directory will break some tools like midl, but we also cannot call
-    [MSBuild]::NormalizeDirectory on relative paths since cwd is not always correct. This logic should prefer to operate
-    on full paths and avoid extra normalization.
-  -->
-  <PropertyGroup>
-    <ReactNativeWindowsDir Condition="'$(ReactNativeWindowsDir)' == ''">$(MSBuildThisFileDirectory)</ReactNativeWindowsDir>
-
-    <ReactNativeDir Condition="'$(ReactNativeDir)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'node_modules\react-native\package.json'))\node_modules\react-native\</ReactNativeDir>
-
-    <YogaDir Condition="'$(YogaDir)' == ''">$(ReactNativeDir)ReactCommon\yoga</YogaDir>
-
-    <FollyDir Condition="'$(FollyDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.folly\folly-$(FollyVersion)</FollyDir>
-    <FollyDir>$([MSBuild]::NormalizeDirectory($(FollyDir)))</FollyDir>
-
-    <FmtDir Condition="'$(FmtDir)' == '' AND Exists('$([MSBuild]::NormalizeDirectory($(ReactNativeDir)..\..\node_modules))')">$(ReactNativeDir)..\..\node_modules\.fmt\fmt-$(FmtVersion)</FmtDir>
-    <FmtDir>$([MSBuild]::NormalizeDirectory($(FmtDir)))</FmtDir>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">


### PR DESCRIPTION
This PR backports #11464 to 0.70.

This PR fixes a problem where we use the `ReactNativeWindowsDir` prop to determine where to build intermediate and output files, but we do so *before* verifying that the prop has been set.

This regression was introduced in RNW 0.68 and the result is that rather than all build outputs being placed under the root `build` and `target` folders, they are placed deeper in the folder structure. This can cause file paths to exceed the default max path length, which can cause build problems as not every tool supports long paths (even if it's enabled in the system).

- Bug fix (non-breaking change which fixes an issue)

Resolves intermittent issues due to build tools trying to access file paths that are too long by removing the unnecessary extra deep paths the regression caused. Our CodeGen tool (and the tools that make it like Roslyn) are specifically susceptible to this.

Switched the order of the props so that the default for `ReactNativeWindowsDir` is set before using it, not after.

N/A

Successfully built AppServiceDemo, which was affected by this change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11466)