### PR TITLE
Fix unintended fallthrough causing duplicate WM_CHAR handling in Fabric TextInput

### DIFF
--- a/change/react-native-windows-298c0d56-3472-45c2-a2e6-8d139481f19c.json
+++ b/change/react-native-windows-298c0d56-3472-45c2-a2e6-8d139481f19c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix unintended fallthrough This was causing a WM_CHAR to fallthrough to WM_KEYDOWN and produce a duplicate `sendMessage`",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -164,6 +164,7 @@ int64_t CompositionEventHandler::SendMessage(uint32_t msg, uint64_t wParam, int6
         if (result)
           return result;
       }
+      break;
     }
     case WM_KEYDOWN:
     case WM_KEYUP:


### PR DESCRIPTION
This was causing a WM_CHAR to fallthrough to WM_KEYDOWN and produce a duplicate `sendMessage`

## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #11452

### What
There was a switch case fallthrough happening from WM_CHAR to WM_KEYDOWN. The fix is to add a break statement.

## Testing
Patched the source change into a Fabric app that was reproing the issue (AKA one with a `TextInput`)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11469)