### PR TITLE
Fabric text input editable

### DIFF
--- a/change/react-native-windows-abfbdd0b-71c7-4d78-97a4-755729f5a8f4.json
+++ b/change/react-native-windows-abfbdd0b-71c7-4d78-97a4-755729f5a8f4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement Fabric TextInput editable - Uses TXTBIT_READONLY",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -621,6 +621,11 @@ void WindowsTextInputComponentView::updateProps(
     }
   }
 
+  if (oldTextInputProps.editable != newTextInputProps.editable) {
+    propBitsMask |= TXTBIT_READONLY;
+    propBits |= TXTBIT_READONLY;
+  }
+
   /*
   if (oldTextInputProps.textAttributes.foregroundColor != newTextInputProps.textAttributes.foregroundColor) {
     if (newTextInputProps.textAttributes.foregroundColor)
@@ -659,10 +664,6 @@ void WindowsTextInputComponentView::updateProps(
 
   if (oldTextInputProps.placeholder != newTextInputProps.placeholder) {
     m_element.PlaceholderText(winrt::to_hstring(newTextInputProps.placeholder));
-  }
-
-  if (oldTextInputProps.editable != newTextInputProps.editable) {
-    m_element.IsReadOnly(!newTextInputProps.editable);
   }
 
   if (oldTextInputProps.selection.start != newTextInputProps.selection.start ||

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -623,7 +623,9 @@ void WindowsTextInputComponentView::updateProps(
 
   if (oldTextInputProps.editable != newTextInputProps.editable) {
     propBitsMask |= TXTBIT_READONLY;
-    propBits |= TXTBIT_READONLY;
+    if (!newTextInputProps.editable) {
+      propBits |= TXTBIT_READONLY;
+    }
   }
 
   /*


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #11487

### What
- Set TXTBIT_READONLY

## Screenshots
![image](https://user-images.githubusercontent.com/26607885/231319058-7b17dc5e-ee53-4e96-bc09-f84f0ded6d03.png)

## Testing
Ran playground Composition with `TextInput` tests.
- Non-editable text can't be edited
- Editable (default) text can be edited
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11488)