### PR TITLE
Fabric text input multiline

### DIFF
--- a/change/react-native-windows-a36ec836-ba77-4333-b68b-b14f0bf3fcdb.json
+++ b/change/react-native-windows-a36ec836-ba77-4333-b68b-b14f0bf3fcdb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for Fabric TextInput `multiline` - Uses TXTBIT_MULTILINE and TXTBIT_WORDWRAP",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -616,7 +616,9 @@ void WindowsTextInputComponentView::updateProps(
 
   if (oldTextInputProps.multiline != newTextInputProps.multiline) {
     propBitsMask |= TXTBIT_MULTILINE | TXTBIT_WORDWRAP;
-    propBits |= TXTBIT_MULTILINE | TXTBIT_WORDWRAP;
+    if (newTextInputProps.multiline) {
+      propBits |= TXTBIT_MULTILINE | TXTBIT_WORDWRAP;
+    }
   }
 
   /*

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -614,6 +614,11 @@ void WindowsTextInputComponentView::updateProps(
     propBits |= TXTBIT_CHARFORMATCHANGE;
   }
 
+  if (oldTextInputProps.multiline != newTextInputProps.multiline) {
+    propBitsMask |= TXTBIT_MULTILINE | TXTBIT_WORDWRAP;
+    propBits |= TXTBIT_MULTILINE | TXTBIT_WORDWRAP;
+  }
+
   /*
   if (oldTextInputProps.textAttributes.foregroundColor != newTextInputProps.textAttributes.foregroundColor) {
     if (newTextInputProps.textAttributes.foregroundColor)
@@ -657,13 +662,6 @@ void WindowsTextInputComponentView::updateProps(
   if (oldTextInputProps.editable != newTextInputProps.editable) {
     m_element.IsReadOnly(!newTextInputProps.editable);
   }
-
-
-    if (oldTextInputProps.multiline != newTextInputProps.multiline) {
-      m_element.TextWrapping(newTextInputProps.multiline ? xaml::TextWrapping::Wrap : xaml::TextWrapping::NoWrap);
-      m_element.AcceptsReturn(newTextInputProps.multiline);
-    }
-
 
   if (oldTextInputProps.selection.start != newTextInputProps.selection.start ||
       oldTextInputProps.selection.end != newTextInputProps.selection.end) {


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #11461

### What
- Set TXTBIT_MULTILINE and TXTBIT_WORDWRAP

## Screenshots
![image](https://user-images.githubusercontent.com/26607885/231324923-c328862c-999e-48ce-a1d2-4111e76b14a6.png)

## Testing
Tested in playground composition on `TextInput` page with multiline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11490)