### PR TITLE
fix: fix RNW not being detected on case-sensitive file systems

### DIFF
--- a/change/@react-native-windows-codegen-d22ec400-245b-4772-9490-51187b083906.json
+++ b/change/@react-native-windows-codegen-d22ec400-245b-4772-9490-51187b083906.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix RNW not being detected on case-sensitive file systems",
+  "packageName": "@react-native-windows/codegen",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -28,7 +28,7 @@ const TypeScriptParser = require(path.resolve(
 
 const schemaValidator = require(path.resolve(
   rncodegenPath,
-  'lib/schemaValidator',
+  'lib/SchemaValidator',
 ));
 
 interface Options {


### PR DESCRIPTION
## Description

Metro fails to create a Windows bundle on non-Windows platforms:

```
error Invalid platform "windows" selected.
info Available platforms are: "ios", "android", "macos", "native". If you are trying to bundle for an out-of-tree platform, it may not be installed.
```

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Windows is not detected on case-sensitive file systems because it fails to import `react-native-codegen/lib/schemaValidator.js`. The filename is PascalCased.

### What

Capitalizing the 's' in `schemaValidator.js` fixes the issue.

## Testing

Create a Codespaces for https://github.com/microsoft/rnx-kit/tree/tido/bump-react-native. Run:

```
yarn
yarn build-scope test-app
yarn bundle
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11492)