### PR TITLE
Fabric platform color

### DIFF
--- a/change/react-native-windows-4a8225c9-1e85-41fe-8d90-5b644d0b9131.json
+++ b/change/react-native-windows-4a8225c9-1e85-41fe-8d90-5b644d0b9131.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Resolve some XAML style colors in Fabric",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -14,28 +14,15 @@ bool isColorMeaningful(SharedColor const &color) noexcept {
   return colorComponentsFromColor(color).alpha > 0;
 }
 
-struct string_hash {
-  using is_transparent = void;
-  [[nodiscard]] size_t operator()(const char* txt) const {
-    return std::hash<std::string_view>{}(txt);
-  }
-  [[nodiscard]] size_t operator()(std::string_view txt) const {
-    return std::hash<std::string_view>{}(txt);
-  }
-  [[nodiscard]] size_t operator()(const std::string& txt) const {
-    return std::hash<std::string>{}(txt);
-  }
-};
-
 winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
   // Issue #11489. These are all the light-theme values. Which is better than no values.
   // Where did these values come from? WinUI's common theme resources:
-    // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
-    // Specifically these are pulled from the "Light" ResourceDictionary. If any additional values
-    // are needed, they should be taken from that section (not "Dark" or "HighContrast").
-    // For control-specific values, they will be in a theme resource file for that control. Example:
-    // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-  static std::unordered_map<std::string, winrt::Windows::UI::Color, string_hash, std::equal_to<>> s_windowsColors = {
+  // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
+  // Specifically these are pulled from the "Light" ResourceDictionary. If any additional values
+  // are needed, they should be taken from that section (not "Dark" or "HighContrast").
+  // For control-specific values, they will be in a theme resource file for that control. Example:
+  // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
+  static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>> s_windowsColors = {
     {"SolidBackgroundFillColorBase", { 0xFF, 0xF3, 0xF3, 0xF3 }}, 
     {"ControlFillColorDefault", { 0xB3, 0xFF, 0xFF, 0xFF }}, 
     {"ControlFillColorSecondary", { 0x80, 0xF9, 0xF9, 0xF9 }}, 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -64,9 +64,6 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
     if (result != s_windowsColors.end()) {
       return result->second;
     }
-    else {
-      OutputDebugStringA(color->m_platformColor.c_str());
-    }
   }
 
   return color->m_color;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -28,15 +28,26 @@ struct string_hash {
 };
 
 winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
-  // These are all the light-theme values. Which is better than no values
-  // Arguably only the right-most platform colors should be respected, and 
-  // Button should be updated to use those instead, assuming that still 
-  // holds up in high contrast and such.
+  // Issue #11489. These are all the light-theme values. Which is better than no values.
   static std::unordered_map<std::string, winrt::Windows::UI::Color, string_hash, std::equal_to<>> s_windowsColors = {
-    {"SolidBackgroundFillColorBaseBrush", { 0xFF, 0xF3, 0xF3, 0xF3 }}, // SolidBackgroundFillColorBase
+    {"SolidBackgroundFillColorBase", { 0xFF, 0xF3, 0xF3, 0xF3 }}, 
+    {"ControlFillColorDefault", { 0xB3, 0xFF, 0xFF, 0xFF }}, 
+    {"ControlFillColorSecondary", { 0x80, 0xF9, 0xF9, 0xF9 }}, 
+    {"ControlFillColorTertiary", { 0x4D, 0xF9, 0xF9, 0xF9 }}, 
+    {"ControlFillColorDisabled", { 0x4D, 0xF9, 0xF9, 0xF9 }}, 
+    {"ControlFillColorTransparent", { 0x00, 0xFF, 0xFF, 0xFF }}, 
+    {"ControlStrokeColorDefault", { 0x0F, 0x00, 0x00, 0x00 }}, 
+    {"ControlStrokeColorSecondary", { 0x29, 0x00, 0x00, 0x00 }}, 
+    {"ControlStrokeColorOnAccentSecondary", { 0x66, 0x00, 0x00, 0x00 }}, 
+    {"TextFillColorPrimary", { 0xE4, 0x00, 0x00, 0x00 }}, 
+    {"TextFillColorSecondary", { 0x9E, 0x00, 0x00, 0x00 }}, 
+    {"TextFillColorDisabled", { 0x5C, 0x00, 0x00, 0x00 }}, 
+    // Arguably only the control-agnostic platform colors should be respected, and 
+    // Button should be updated to use those instead, assuming that still holds up
+    // in high contrast and such.
     {"ButtonBackgroundPressed", { 0x4D, 0xF9, 0xF9, 0xF9 }}, // ControlFillColorTertiary
     {"ButtonForegroundPressed", { 0x9E, 0x00, 0x00, 0x00 }}, // TextFillColorSecondary
-    {"ButtonForegroundPointerOver", { 0xE4, 0x00, 0x00, 0x00 }}, // TextFillColorPrimaryBrush
+    {"ButtonForegroundPointerOver", { 0xE4, 0x00, 0x00, 0x00 }}, // TextFillColorPrimary
     {"ButtonBackground", { 0xB3, 0xFF, 0xFF, 0xFF }}, // ControlFillColorDefault
     {"ButtonBorderBrush", { 0x29, 0x00, 0x00, 0x00 }}, // gradient from ControlStrokeColorSecondary to ControlStrokeColorDefault
     {"ButtonForeground", { 0xE4, 0x00, 0x00, 0x00 }}, // TextFillColorPrimary

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -29,6 +29,12 @@ struct string_hash {
 
 winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
   // Issue #11489. These are all the light-theme values. Which is better than no values.
+  // Where did these values come from? WinUI's common theme resources:
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
+    // Specifically these are pulled from the "Light" ResourceDictionary. If any additional values
+    // are needed, they should be taken from that section (not "Dark" or "HighContrast").
+    // For control-specific values, they will be in a theme resource file for that control. Example:
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
   static std::unordered_map<std::string, winrt::Windows::UI::Color, string_hash, std::equal_to<>> s_windowsColors = {
     {"SolidBackgroundFillColorBase", { 0xFF, 0xF3, 0xF3, 0xF3 }}, 
     {"ControlFillColorDefault", { 0xB3, 0xFF, 0xFF, 0xFF }}, 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -14,7 +14,7 @@ bool isColorMeaningful(SharedColor const &color) noexcept {
   return colorComponentsFromColor(color).alpha > 0;
 }
 
-winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
+winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
   // Issue #11489. These are all the light-theme values. Which is better than no values.
   // Where did these values come from? WinUI's common theme resources:
   // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
@@ -22,35 +22,38 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
   // are needed, they should be taken from that section (not "Dark" or "HighContrast").
   // For control-specific values, they will be in a theme resource file for that control. Example:
   // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-  static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>> s_windowsColors = {
-    {"SolidBackgroundFillColorBase", { 0xFF, 0xF3, 0xF3, 0xF3 }}, 
-    {"ControlFillColorDefault", { 0xB3, 0xFF, 0xFF, 0xFF }}, 
-    {"ControlFillColorSecondary", { 0x80, 0xF9, 0xF9, 0xF9 }}, 
-    {"ControlFillColorTertiary", { 0x4D, 0xF9, 0xF9, 0xF9 }}, 
-    {"ControlFillColorDisabled", { 0x4D, 0xF9, 0xF9, 0xF9 }}, 
-    {"ControlFillColorTransparent", { 0x00, 0xFF, 0xFF, 0xFF }}, 
-    {"ControlStrokeColorDefault", { 0x0F, 0x00, 0x00, 0x00 }}, 
-    {"ControlStrokeColorSecondary", { 0x29, 0x00, 0x00, 0x00 }}, 
-    {"ControlStrokeColorOnAccentSecondary", { 0x66, 0x00, 0x00, 0x00 }}, 
-    {"TextFillColorPrimary", { 0xE4, 0x00, 0x00, 0x00 }}, 
-    {"TextFillColorSecondary", { 0x9E, 0x00, 0x00, 0x00 }}, 
-    {"TextFillColorDisabled", { 0x5C, 0x00, 0x00, 0x00 }}, 
-    // Arguably only the control-agnostic platform colors should be respected, and 
-    // Button should be updated to use those instead, assuming that still holds up
-    // in high contrast and such.
-    {"ButtonBackgroundPressed", { 0x4D, 0xF9, 0xF9, 0xF9 }}, // ControlFillColorTertiary
-    {"ButtonForegroundPressed", { 0x9E, 0x00, 0x00, 0x00 }}, // TextFillColorSecondary
-    {"ButtonForegroundPointerOver", { 0xE4, 0x00, 0x00, 0x00 }}, // TextFillColorPrimary
-    {"ButtonBackground", { 0xB3, 0xFF, 0xFF, 0xFF }}, // ControlFillColorDefault
-    {"ButtonBorderBrush", { 0x29, 0x00, 0x00, 0x00 }}, // gradient from ControlStrokeColorSecondary to ControlStrokeColorDefault
-    {"ButtonForeground", { 0xE4, 0x00, 0x00, 0x00 }}, // TextFillColorPrimary
-    {"ButtonBackgroundDisabled", { 0x4D, 0xF9, 0xF9, 0xF9 }}, // ControlFillColorDisabled
-    {"ButtonBorderBrushDisabled", { 0x0F, 0x00, 0x00, 0x00 }}, // ControlStrokeColorDefault
-    {"ButtonForegroundDisabled", { 0x5C, 0x00, 0x00, 0x00 }}, // TextFillColorDisabled
-    {"ButtonBackgroundPointerOver", { 0x80, 0xF9, 0xF9, 0xF9 }}, // ControlFillColorSecondary
-    {"ButtonBorderBrushPointerOver", { 0x66, 0x00, 0x00, 0x00 }}, // gradient from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
-    {"ButtonBorderBrushPressed", { 0x00, 0xFF, 0xFF, 0xFF }}, // ControlFillColorTransparent
-  };
+  static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>>
+      s_windowsColors = {
+          {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
+          {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
+          {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
+          {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
+          {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
+          {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
+          {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
+          {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
+          {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
+          {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
+          {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
+          {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
+          // Arguably only the control-agnostic platform colors should be respected, and
+          // Button should be updated to use those instead, assuming that still holds up
+          // in high contrast and such.
+          {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
+          {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
+          {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+          {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
+          {"ButtonBorderBrush",
+           {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
+          {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+          {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
+          {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
+          {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
+          {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
+          {"ButtonBorderBrushPointerOver",
+           {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
+          {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
+      };
 
   if (!color->m_platformColor.empty()) {
     auto result = s_windowsColors.find(color->m_platformColor);
@@ -64,11 +67,7 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const * const color) {
 
 D2D1::ColorF SharedColor::AsD2DColor() const {
   winrt::Windows::UI::Color color = ResolvePlatformColor(m_color.get());
-  return {
-      color.R / 255.0f,
-      color.G / 255.0f,
-      color.B / 255.0f,
-      color.A / 255.0f };
+  return {color.R / 255.0f, color.G / 255.0f, color.B / 255.0f, color.A / 255.0f};
 }
 
 winrt::Windows::UI::Color SharedColor::AsWindowsColor() const {

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.h
@@ -84,17 +84,9 @@ class SharedColor {
     return m_color != nullptr;
   }
 
-  D2D1::ColorF AsD2DColor() const {
-    return {
-        m_color->m_color.R / 255.0f,
-        m_color->m_color.G / 255.0f,
-        m_color->m_color.B / 255.0f,
-        m_color->m_color.A / 255.0f};
-  }
+  D2D1::ColorF AsD2DColor() const;
 
-  winrt::Windows::UI::Color AsWindowsColor() const {
-    return m_color->m_color;
-  }
+  winrt::Windows::UI::Color AsWindowsColor() const;
 
   COLORREF AsColorRefNoAlpha() const {
     return RGB(m_color->m_color.R, m_color->m_color.G, m_color->m_color.B);


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
Resolves #11456

### What
Implements some values in `PlatformColor` so that the built in controls can render.

Note that pending #11489, these colors will all be light mode. This will need to be revisited when theming exists.

## Screenshots
Add any relevant screen captures here from before or after your changes. 
| Before| After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/26607885/231325843-c0e6d879-ebfe-47ed-a541-c00ecec59e5f.png) | ![image](https://user-images.githubusercontent.com/26607885/231326494-abd58e91-5f0e-4312-9819-f7ccd7d8045d.png) |

## Testing
- Manual verification of controls in RNTester
- Integration into a Fabric ap using Button and other non-core controls that use `PlatformColor`

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11504)