### PR TITLE
Remove usage of RestoreUseStaticGraphEvaluation

### DIFF
--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -65,9 +65,4 @@
     <OutputPath Condition="'$(MSBuildProjectExtension)' == '.csproj'">$(OutDir)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
-    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
-    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
-  </PropertyGroup>
-
 </Project>

--- a/vnext/Directory.Build.targets
+++ b/vnext/Directory.Build.targets
@@ -16,9 +16,8 @@
 
       RestoreProjectStyle=PackagesConfig    - Required to use the packages.config mechanism
       RestorePackagesConfig=true            - Required to use the packages.config mechanism
-      RestoreUseStaticGraphEvaluation=false - Override setting from Directory.Build.props
     -->
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Common.targets
@@ -26,9 +26,8 @@
 
       RestoreProjectStyle=PackagesConfig    - Required to use the packages.config mechanism
       RestorePackagesConfig=true            - Required to use the packages.config mechanism
-      RestoreUseStaticGraphEvaluation=false - Override setting from Microsoft.ReactNative.Common.props
     -->
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true;RestoreUseStaticGraphEvaluation=false" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="Restore" Properties="RestoreProjectStyle=PackagesConfig;RestorePackagesConfig=true" />
   </Target>
 
 </Project>

--- a/vnext/PropertySheets/NuGet.Cpp.props
+++ b/vnext/PropertySheets/NuGet.Cpp.props
@@ -8,10 +8,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="NuGet">
-    <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.props -->
-    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
-    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
-
     <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
     <ResolveNuGetPackages>false</ResolveNuGetPackages>
 


### PR DESCRIPTION
## Description
Stop using experimental restore graph evaluation.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Some apps consuming Microsoft.ReactNative have found issues when `RestoreUseStaticGraphEvaluation` is enabled (MSRN sets it automatically when building inside Visual Studio).

It seems the bug that caused an erratic build behavior inside Visual Studio 17.x is no longer happening as of version 17.5.
Such behavior was fixed by setting the property being removed by this PR.

### What
Remove all instances where `RestoreUseStaticGraphEvaluation` is set to true.

## Testing
Manually building inside Visual Studio.