### PR TITLE
[0.70] Use case-insensitive comparison for CORS preflight responses (#11511)

### DIFF
--- a/change/react-native-windows-7cf2e2b2-8bb7-40e6-8859-f584c4033f3a.json
+++ b/change/react-native-windows-7cf2e2b2-8bb7-40e6-8859-f584c4033f3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use case-insensitive comparer for AllowedHeaders",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-7cf2e2b2-8bb7-40e6-8859-f584c4033f3a.json
+++ b/change/react-native-windows-7cf2e2b2-8bb7-40e6-8859-f584c4033f3a.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Use case-insensitive comparer for AllowedHeaders",
-  "packageName": "react-native-windows",
-  "email": "julio.rocha@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/react-native-windows-a522f514-d922-4ef1-b08e-b4ed9da35b8e.json
+++ b/change/react-native-windows-a522f514-d922-4ef1-b08e-b4ed9da35b8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use case-insensitive comparison for CORS preflight responses (#11511)",
+  "packageName": "react-native-windows",
+  "email": "dev@rocha.red",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
+++ b/vnext/Desktop.UnitTests/OriginPolicyHttpFilterTest.cpp
@@ -7,6 +7,9 @@
 #include <Networking/WinRTTypes.h>
 #include "WinRTNetworkingMocks.h"
 
+// Boost Library
+#include <boost/algorithm/string.hpp>
+
 // Windows API
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Web.Http.h>
@@ -17,6 +20,7 @@ using namespace winrt::Windows::Web::Http;
 using Microsoft::React::Networking::OriginPolicyHttpFilter;
 using Microsoft::React::Networking::RequestArgs;
 using Microsoft::React::Networking::ResponseOperation;
+using std::wstring;
 using winrt::Windows::Foundation::Uri;
 
 namespace Microsoft::React::Test {
@@ -249,6 +253,51 @@ TEST_CLASS (OriginPolicyHttpFilterTest) {
       OriginPolicyHttpFilter::RemoveHttpOnlyCookiesFromResponseHeaders(response, true /*removeAll*/);
 
       Assert::AreEqual(2, static_cast<int>(response.Headers().Size()));
+    }
+  }
+
+  TEST_METHOD(ValidatePreflightResponseHeadersCaseMismatchSucceeds) {
+    auto mockFilter = winrt::make<MockHttpBaseFilter>();
+    mockFilter.as<MockHttpBaseFilter>()->Mocks.SendRequestAsync =
+        [](HttpRequestMessage const &request) -> ResponseOperation {
+      HttpResponseMessage response{};
+
+      response.StatusCode(HttpStatusCode::Ok);
+      response.Headers().Insert(L"Access-Control-Allow-Origin", L"*");
+
+      // Return allowed headers as requested by client, in lower case.
+      // This tests case-insensitive preflight validation.
+      auto allowHeaders = boost::to_lower_copy(wstring{request.Headers().Lookup(L"Access-Control-Request-Headers")});
+      response.Headers().Insert(L"Access-Control-Allow-Headers", std::move(allowHeaders));
+
+      co_return response;
+    };
+
+    auto reqArgs = winrt::make<RequestArgs>();
+    auto request = HttpRequestMessage(HttpMethod::Get(), Uri{L"http://somehost"});
+    request.Properties().Insert(L"RequestArgs", reqArgs);
+    request.Headers().TryAppendWithoutValidation(L"ChangeMyCase", L"Value");
+    // Should implicitly set Conent-Length and Content-Type
+    request.Content(HttpStringContent{L"PreflightContent"});
+
+    auto filter = winrt::make<OriginPolicyHttpFilter>(mockFilter);
+    auto opFilter = filter.as<OriginPolicyHttpFilter>();
+
+    OriginPolicyHttpFilter::SetStaticOrigin("http://somehost");
+    try {
+      auto sendOp = opFilter->SendPreflightAsync(request);
+      sendOp.get();
+
+      auto response = sendOp.GetResults();
+      opFilter->ValidatePreflightResponse(request, response);
+
+      OriginPolicyHttpFilter::SetStaticOrigin({});
+      Assert::IsTrue(boost::iequals(
+          response.Headers().Lookup(L"Access-Control-Allow-Headers").c_str(),
+          L"ChangeMyCase, Content-Length, Content-Type"));
+    } catch (const winrt::hresult_error &e) {
+      OriginPolicyHttpFilter::SetStaticOrigin({});
+      Assert::Fail(e.message().c_str());
     }
   }
 

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.cpp
@@ -37,22 +37,26 @@ namespace Microsoft::React::Networking {
 
 #pragma region OriginPolicyHttpFilter
 
-#pragma region ConstWcharComparer
+#pragma region CaseInsensitiveComparer
 
-bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, const wchar_t *b) const {
+bool OriginPolicyHttpFilter::CaseInsensitiveComparer::operator()(const wchar_t *a, const wchar_t *b) const {
   return _wcsicmp(a, b) < 0;
 }
 
-#pragma endregion ConstWcharComparer
+bool OriginPolicyHttpFilter::CaseInsensitiveComparer::operator()(const wstring &a, const wstring &b) const {
+  return _wcsicmp(a.c_str(), b.c_str()) < 0;
+}
+
+#pragma endregion CaseInsensitiveComparer
 
 // https://fetch.spec.whatwg.org/#forbidden-method
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer> OriginPolicyHttpFilter::s_forbiddenMethods =
-    {L"CONNECT", L"TRACE", L"TRACK"};
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
+    OriginPolicyHttpFilter::s_forbiddenMethods = {L"CONNECT", L"TRACE", L"TRACK"};
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_simpleCorsMethods = {L"GET", L"HEAD", L"POST"};
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_simpleCorsRequestHeaderNames = {
         L"Accept",
         L"Accept-Language",
@@ -64,11 +68,11 @@ bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, co
         L"Viewport-Width",
         L"Width"};
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_simpleCorsResponseHeaderNames =
         {L"Cache-Control", L"Content-Language", L"Content-Type", L"Expires", L"Last-Modified", L"Pragma"};
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_simpleCorsContentTypeValues = {
         L"application/x-www-form-urlencoded",
         L"multipart/form-data",
@@ -76,7 +80,7 @@ bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, co
 
 // https://fetch.spec.whatwg.org/#forbidden-header-name
 // Chromium still bans "User-Agent" due to https://crbug.com/571722
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_corsForbiddenRequestHeaderNames = {
         L"Accept-Charset",
         L"Accept-Encoding",
@@ -99,13 +103,13 @@ bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, co
         L"Upgrade",
         L"Via"};
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_cookieSettingResponseHeaders = {
         L"Set-Cookie",
         L"Set-Cookie2", // Deprecated by the spec, but probably still used
 };
 
-/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::ConstWcharComparer>
+/*static*/ set<const wchar_t *, OriginPolicyHttpFilter::CaseInsensitiveComparer>
     OriginPolicyHttpFilter::s_corsForbiddenRequestHeaderNamePrefixes = {L"Proxy-", L"Sec-"};
 
 /*static*/ Uri OriginPolicyHttpFilter::s_origin{nullptr};
@@ -293,7 +297,7 @@ bool OriginPolicyHttpFilter::ConstWcharComparer::operator()(const wchar_t *a, co
 }
 
 /*static*/ OriginPolicyHttpFilter::AccessControlValues OriginPolicyHttpFilter::ExtractAccessControlValues(
-    winrt::Windows::Foundation::Collections::IMap<hstring, hstring> const &headers) {
+    IMap<hstring, hstring> const &headers) {
   using std::wregex;
   using std::wsregex_token_iterator;
 

--- a/vnext/Shared/Networking/OriginPolicyHttpFilter.h
+++ b/vnext/Shared/Networking/OriginPolicyHttpFilter.h
@@ -22,19 +22,20 @@ class OriginPolicyHttpFilter
     : public winrt::
           implements<OriginPolicyHttpFilter, winrt::Windows::Web::Http::Filters::IHttpFilter, IRedirectEventSource> {
  public:
-  struct ConstWcharComparer {
+  struct CaseInsensitiveComparer {
     bool operator()(const wchar_t *, const wchar_t *) const;
+    bool operator()(const std::wstring &, const std::wstring &) const;
   };
 
  private:
-  static std::set<const wchar_t *, ConstWcharComparer> s_forbiddenMethods;
-  static std::set<const wchar_t *, ConstWcharComparer> s_simpleCorsMethods;
-  static std::set<const wchar_t *, ConstWcharComparer> s_simpleCorsRequestHeaderNames;
-  static std::set<const wchar_t *, ConstWcharComparer> s_simpleCorsResponseHeaderNames;
-  static std::set<const wchar_t *, ConstWcharComparer> s_simpleCorsContentTypeValues;
-  static std::set<const wchar_t *, ConstWcharComparer> s_corsForbiddenRequestHeaderNames;
-  static std::set<const wchar_t *, ConstWcharComparer> s_corsForbiddenRequestHeaderNamePrefixes;
-  static std::set<const wchar_t *, ConstWcharComparer> s_cookieSettingResponseHeaders;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_forbiddenMethods;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_simpleCorsMethods;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_simpleCorsRequestHeaderNames;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_simpleCorsResponseHeaderNames;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_simpleCorsContentTypeValues;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_corsForbiddenRequestHeaderNames;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_corsForbiddenRequestHeaderNamePrefixes;
+  static std::set<const wchar_t *, CaseInsensitiveComparer> s_cookieSettingResponseHeaders;
 
   // NOTE: Assumes static origin through owning client/resource/module/(React) instance's lifetime.
   static winrt::Windows::Foundation::Uri s_origin;
@@ -42,9 +43,9 @@ class OriginPolicyHttpFilter
   struct AccessControlValues {
     winrt::hstring AllowedOrigin;
     winrt::hstring AllowedCredentials;
-    std::set<std::wstring> AllowedHeaders;
+    std::set<std::wstring, CaseInsensitiveComparer> AllowedHeaders;
     std::set<std::wstring> AllowedMethods;
-    std::set<std::wstring> ExposedHeaders;
+    std::set<std::wstring, CaseInsensitiveComparer> ExposedHeaders;
     size_t MaxAge;
   };
 


### PR DESCRIPTION
Backport of #11511

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11513)