### PR TITLE
Bump C++ Windows Version macros to Windows 10

### DIFF
--- a/change/react-native-windows-1959bf92-81c5-460b-81bf-d0721ed575fa.json
+++ b/change/react-native-windows-1959bf92-81c5-460b-81bf-d0721ed575fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Bump default _WIN32_WINNT_VERSION",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -20,8 +20,8 @@
   <Import Project="$(MSBuildThisFileDirectory)NuGet.Cpp.props" />
 
   <PropertyGroup Label="Desktop">
-    <!-- See https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt -->
-    <WinVer>_WIN32_WINNT_WINBLUE</WinVer>
+    <!-- See https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt -->
+    <WinVer Condition="'$(WinVer)' == ''">_WIN32_WINNT_WIN10</WinVer>
     <EnableBeast Condition="'$(EnableBeast)' == ''">0</EnableBeast>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description
Have C++ Windows SDK macros support Windows 10 and later.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Office, main dependant of `react-native-win32.dll` now supports only Windows 10 and later. Support for Windows 8.1 is no longer needed.

### What
- Bump default setting of `_WIN32_WINNT_VERSION` to `_WIN32_WINNT_WIN10`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11516)