### PR TITLE
[0.71] Align V8 version with JSI version

### DIFF
--- a/change/react-native-windows-586654cb-7c55-466f-af1f-9dbd6119915e.json
+++ b/change/react-native-windows-586654cb-7c55-466f-af1f-9dbd6119915e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update V8 version to be one with matching JSI version",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -24,7 +24,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.69.4</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.71.2</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
     <V8Package>$(NuGetPackageRoot)\$(V8PackageName).$(V8Version)</V8Package>


### PR DESCRIPTION
Currently the version of V8 being used does not align with the JSI version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11525)