### PR TITLE
[0.71] [NetUI] Fix ref's on ViewWin32 (enables ViewWin32.focus() calls to work again)

### DIFF
--- a/change/@office-iss-react-native-win32-fdb45b47-c860-41d5-ad06-6559e9e544bb.json
+++ b/change/@office-iss-react-native-win32-fdb45b47-c860-41d5-ad06-6559e9e544bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix ref's on ViewWin32 (enables ViewWin32.focus() calls to work again)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
@@ -14,8 +14,8 @@ import type {ViewProps} from './ViewPropTypes';
 import View from './View';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
 import UIManager from '../../ReactNative/UIManager';
-import useMergeRefs from '../../Utilities/useMergeRefs';
 import warnOnce from '../../Utilities/warnOnce';
+import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
 /**
  * Basic View component with additional Win32 specific functionality
@@ -126,9 +126,9 @@ const ViewWin32: React.AbstractComponent<
     );
 
     // $FlowFixMe
-    const setNativeRef = useMergeRefs<typeof View | null>({
+    const setNativeRef = setAndForwardRef<typeof View | null>({
+      getForwardedRef: () => forwardedRef,
       setLocalRef,
-      forwardedRef,
     });
 
     return (


### PR DESCRIPTION
The ref property on ViewWin32 was not being correctly forwarded, which would result in refs to ViewWin32 ending up as undefined.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11531)