### PR TITLE
Fix ref's on ViewWin32 (enables ViewWin32.focus() calls to work again)

### DIFF
--- a/change/@office-iss-react-native-win32-c2b31536-e590-4c91-af35-2219dec4d20b.json
+++ b/change/@office-iss-react-native-win32-c2b31536-e590-4c91-af35-2219dec4d20b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Simplify ViewWin32 focus, now devmain properly implements UIManger.focus",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -17,8 +17,8 @@
     "flow-check": "flow check",
     "lint:fix": "rnw-scripts lint:fix",
     "lint": "rnw-scripts lint",
-    "run-win32-devmain": "npx @office-iss/rex-win32@0.68.26-devmain.16206.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain --useDirectDebugger --useFastRefresh",
-    "run-win32": "npx @office-iss/rex-win32@0.68.26-devmain.16206.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDirectDebugger --useFastRefresh",
+    "run-win32-devmain": "npx @office-iss/rex-win32@0.68.33-devmain.16427.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDevMain --useDirectDebugger --useFastRefresh",
+    "run-win32": "npx @office-iss/rex-win32@0.68.33-devmain.16427.10000 --bundle js/RNTesterApp --component RNTesterApp --basePath ./dist/win32/dev --jsEngine v8 --useDirectDebugger --useFastRefresh",
     "start": "react-native start --projectRoot ../react-native-win32-tester",
     "test": "jest",
     "validate-overrides": "react-native-platform-override validate"

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
@@ -8,13 +8,11 @@
  */
 
 import * as React from 'react';
-import {useCallback, useRef, useLayoutEffect} from 'react';
+import { useLayoutEffect} from 'react';
 import type {ViewProps} from './ViewPropTypes';
 
 import View from './View';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
-import UIManager from '../../ReactNative/UIManager';
-import useMergeRefs from '../../Utilities/useMergeRefs';
 import warnOnce from '../../Utilities/warnOnce';
 
 /**
@@ -100,40 +98,9 @@ const ViewWin32: React.AbstractComponent<
       }
     }, [accessibilityControls]);
 
-    /**
-     * Set up the forwarding ref to enable adding the focus method.
-     */
-    const focusRef = useRef<typeof View | null>(null);
-
-    const setLocalRef = useCallback(
-      (instance: typeof View | null) => {
-        focusRef.current = instance;
-        /**
-         * Add focus() as a callable function to the forwarded reference.
-         */
-        if (instance) {
-          // $FlowFixMe[prop-missing] - TODO - focus on a component should already call into TextInputState.focus.. once we remove the refs required for legacy accessibility*By ref support
-          instance.focus = () => {
-            UIManager.dispatchViewManagerCommand(
-              findNodeHandle(instance),
-              UIManager.getViewManagerConfig('RCTView').Commands.focus,
-              null,
-            );
-          };
-        }
-      },
-      [focusRef],
-    );
-
-    // $FlowFixMe
-    const setNativeRef = useMergeRefs<typeof View | null>({
-      setLocalRef,
-      forwardedRef,
-    });
-
     return (
       <View
-        ref={setNativeRef}
+        ref={forwardedRef}
         {...rest}
         {...(controlsTarget !== null
           ? {accessibilityControls: controlsTarget}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewWin32.js
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import { useLayoutEffect} from 'react';
+import {useLayoutEffect} from 'react';
 import type {ViewProps} from './ViewPropTypes';
 
 import View from './View';


### PR DESCRIPTION
The ref property on ViewWin32 was not being correctly forwarded, which would result in refs to ViewWin32 ending up as undefined.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11532)