### PR TITLE
Use --sourcemap-use-absolute-path when creating release bundles

### DIFF
--- a/change/react-native-windows-2b98d0b9-8ee1-4b0b-b3f8-7a6ecb8210e1.json
+++ b/change/react-native-windows-2b98d0b9-8ee1-4b0b-b3f8-7a6ecb8210e1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use `--sourcemap-use-absolute-path` when creating release bundles",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/Bundle.Common.targets
+++ b/vnext/PropertySheets/Bundle.Common.targets
@@ -12,8 +12,8 @@
     Condition="'$(UseBundle)' == 'true' And ('$(BuildingInsideVisualStudio)'!='true' Or '$(BuildingProject)'=='true')">
       <MakeDir Directories="$(BundleContentRoot)" />
       <MakeDir Directories="$(BundleSourceMapDir)" />
-      <Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file $(BundleEntryFile) --bundle-output $(BundleOutputFile) --assets-dest $(BundleContentRoot) --dev $(UseDevBundle) --reset-cache --sourcemap-output $(PackagerSourceMap) $(BundlerExtraArgs)] to build bundle file." />
-      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" />
+      <Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file $(BundleEntryFile) --bundle-output $(BundleOutputFile) --assets-dest $(BundleContentRoot) --dev $(UseDevBundle) --reset-cache --sourcemap-use-absolute-path --sourcemap-output $(PackagerSourceMap) $(BundlerExtraArgs)] to build bundle file." />
+      <Exec Command='$(BundleCliCommand) --platform windows --entry-file "$(BundleEntryFile)" --bundle-output "$(BundleOutputFile)" --assets-dest "$(BundleContentRoot)" --dev $(UseDevBundle) --reset-cache --sourcemap-use-absolute-path --sourcemap-output "$(PackagerSourceMap)" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" />
   </Target>
 
   <!-- See https://github.com/facebook/react-native/blob/07d090dbc6c46b8f3760dbd25dbe0540c18cb3f3/react.gradle#L190 for reference -->


### PR DESCRIPTION
## Description

This PR adds `--sourcemap-use-absolute-path` to the command run by Visual Studio to build a bundle when building in release, to enable more straight-forward direct debugging.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

The last string at the bottom of a bundle is the path to the sourcemap for that bundle. Right now, we just put the name of the sourcemap, assuming that it will be kept side-by-side with the bundle. However by default we don't put the sourcemap side-by-side with the bundle output.

This change to use `--sourcemap-use-absolute-path` will put an absolute path to the sourcemap, which makes it possible to direct debug bundles when using Chakra, with Visual Studio.

Note: Hermes direct debug always requires Metro, so this change doesn't improve the Hermes debugging experience.

Also, this shouldn't affect many internal CI systems as they often overwrite this line anyway as sourcemaps get moved to shared build servers.

### What

Added `--sourcemap-use-absolute-path` to the command run by Visual Studio to build a bundle when building in release.

## Screenshots
N/A

## Testing
Verified that I can direct debug the E2Etest app with Visual Studio after running the app with `yarn windows --no-packager --msbuildprops UseBundle=true`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11533)