### PR TITLE
[0.72] Minor bump of folly to bring in a fix for clang 

### DIFF
--- a/change/react-native-windows-ab602d01-7690-4880-8807-6f30b63422fe.json
+++ b/change/react-native-windows-ab602d01-7690-4880-8807-6f30b63422fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor bump of folly to bring in clang fix",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -16,8 +16,8 @@
     -->
     <EnableSourceLink Condition="'$(EnableSourceLink)' == ''">false</EnableSourceLink>
     <!-- When bumping the Folly version, be sure to bump the git hash of that version's commit and build Folly.vcxproj (to update its cgmanifest.json) too. -->
-    <FollyVersion>2022.11.07.00</FollyVersion>
-    <FollyCommitHash>2aa28128d1f7a04b41521367f0b615f782814089</FollyCommitHash>
+    <FollyVersion>2022.11.28.00</FollyVersion>
+    <FollyCommitHash>6ed36117cdc4831f3a3951e013ae76b405e88e15</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
     <FmtVersion>8.0.0</FmtVersion>
     <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>

--- a/vnext/Folly/cgmanifest.json
+++ b/vnext/Folly/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/facebook/folly",
-                  "CommitHash": "2aa28128d1f7a04b41521367f0b615f782814089"
+                  "CommitHash": "6ed36117cdc4831f3a3951e013ae76b405e88e15"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
The version of folly being used in 0.71 attempts to suppress -Wunknown-warning-option, which isn't implemented by clang.

This version bump bring in https://github.com/facebook/folly/commit/78df96048658cbe83cfc2e76af090aa50f4e36b4 which fixes this issue.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11542)