### PR TITLE
Avoid having to launch PowerShell for every react-native config query

### DIFF
--- a/change/@react-native-windows-cli-857835a8-a178-4d42-b725-4dbbf8babe70.json
+++ b/change/@react-native-windows-cli-857835a8-a178-4d42-b725-4dbbf8babe70.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid having to launch PowerShell for every react-native config query",
+  "packageName": "@react-native-windows/cli",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-0ffb618e-eb3c-4e1d-ac63-a02a84886056.json
+++ b/change/react-native-windows-0ffb618e-eb3c-4e1d-ac63-a02a84886056.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid having to launch PowerShell for every react-native config query",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/e2etest/healthChecks.test.ts
+++ b/packages/@react-native-windows/cli/src/e2etest/healthChecks.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ * @format
+ */
+
+import {execSync} from 'child_process';
+import path from 'path';
+import {powershell} from '../runWindows/utils/commandWithProgress';
+import {HealthCheckList} from '../healthCheckList';
+
+test('Verify list of health checks aligns with rnw-dependencies', async () => {
+  const rnwDepScriptPath = path.join(
+    path.dirname(
+      require.resolve('react-native-windows/package.json', {
+        paths: [process.cwd()],
+      }),
+    ),
+    'Scripts/rnw-dependencies.ps1',
+  );
+
+  const rnwDeps = execSync(
+    `${powershell} -ExecutionPolicy Unrestricted -NoProfile "${rnwDepScriptPath}" -NoPrompt -ListChecks`,
+    {stdio: 'pipe'},
+  );
+  const deps = rnwDeps.toString().trim().split('\n');
+  const rnwHelathChecks = deps.map(dep => {
+    const match = /([^:]+): ([^:]+): (.*)/.exec(dep);
+    if (!match) {
+      throw new Error(`Unexpected output from ${rnwDepScriptPath}`);
+    }
+    const [, optional, id, name] = match;
+    return [optional.trim() === 'Required', id, name];
+  });
+
+  expect(HealthCheckList).toEqual(rnwHelathChecks);
+});

--- a/packages/@react-native-windows/cli/src/healthCheckList.ts
+++ b/packages/@react-native-windows/cli/src/healthCheckList.ts
@@ -1,0 +1,12 @@
+// Store list of health checks here to avoid having to launch PowerShell on every react-native config call
+export const HealthCheckList = [
+  [false, "FreeSpace", "Free space on E: > 15 GB"],
+  [false, "InstalledMemory", "Installed memory >= 16 GB"],
+  [true, "WindowsVersion", "Windows version >= 10.0.17763.0"],
+  [true, "DeveloperMode", "Developer mode is on"],
+  [true, "LongPath", "Long path support is enabled"],
+  [true, "VSUWP", "Visual Studio 2022 (>= 17.3) & req. components"],
+  [true, "Node", "Node.js (LTS, >= 16.0)"],
+  [true, "Yarn", "Yarn"],
+  [true, "DotNetCore", ".NET SDK (LTS, = 6.0)"]
+]

--- a/packages/@react-native-windows/cli/src/healthCheckList.ts
+++ b/packages/@react-native-windows/cli/src/healthCheckList.ts
@@ -1,6 +1,6 @@
 // Store list of health checks here to avoid having to launch PowerShell on every react-native config call
 export const HealthCheckList = [
-  [false, "FreeSpace", "Free space on E: > 15 GB"],
+  [false, "FreeSpace", "Free space on current drive > 15 GB"],
   [false, "InstalledMemory", "Installed memory >= 16 GB"],
   [true, "WindowsVersion", "Windows version >= 10.0.17763.0"],
   [true, "DeveloperMode", "Developer mode is on"],

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -360,7 +360,7 @@ $requiredFreeSpaceGB = 15;
 $requirements = @(
     @{
         Id=[CheckId]::FreeSpace;
-        Name = "Free space on $drive`: > $requiredFreeSpaceGB GB";
+        Name = "Free space on current drive > $requiredFreeSpaceGB GB";
         Tags = @('appDev');
         Valid = { $drive.Free/1GB -gt $requiredFreeSpaceGB; }
         HasVerboseOutput = $true;


### PR DESCRIPTION
## Description
Almost any command run through react-native will first require the construction of the react-native config.  Part of react-native-window's contribution to the config runs PowerShell to get the list of health checks.  This change extracts the list of health checks so that the config can be returned without having to trigger PowerShell.

I also added some quotes around the PowerShell path, which fixes the health checks actually running correctly on my machine.

### Why
The invocation of PowerShell here is causing an intermittent failure during the strict build graph of Office.  This is also a slight performance improvement over the previous code.

## Testing
Added a jest test to verify that the list in JS remains in sync with the checks in rnw-dependencies.ps1.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11550)