### PR TITLE
Fix issue with mixed border widths on Fabric

### DIFF
--- a/change/react-native-windows-1d22a163-fe34-4bb8-84cd-16ca4ee138cb.json
+++ b/change/react-native-windows-1d22a163-fe34-4bb8-84cd-16ca4ee138cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Borders should show if mixed widths but not colors They were checking if the color was variable per side but assuming width wouldn't be. Fixes #11549",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -897,11 +897,11 @@ bool CompositionBaseComponentView::TryUpdateSpecialBorderLayers(
   // We only handle a single borderStyle for now
   auto borderStyle = borderMetrics.borderStyles.left;
 
-  if (borderMetrics.borderColors.isUniform()) {
-    if (!borderMetrics.borderWidths.left)
-      return false;
-    if (!facebook::react::isColorMeaningful(borderMetrics.borderColors.left))
-      return false;
+  bool hasMeaningfulColor =
+      !borderMetrics.borderColors.isUniform() || !facebook::react::isColorMeaningful(borderMetrics.borderColors.left);
+  bool hasMeaningfulWidth = !borderMetrics.borderWidths.isUniform() || (borderMetrics.borderWidths.left != 0);
+  if (!hasMeaningfulColor && !hasMeaningfulWidth) {
+    return false;
   }
 
   // Create the special border layers if they don't exist yet


### PR DESCRIPTION
## Description

In Fabric if you had specified a border on one side but not varying colors, it would not apply the border.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #11549

### What
Check not just for non-uniform colors, but also for non-uniform sizes.

## Screenshots
| Before | After | Paper |
|--------|--------|--------|
| ![image](https://user-images.githubusercontent.com/26607885/234415769-d959e87d-a2ff-42a2-adc6-23010f207f15.png) | ![image](https://user-images.githubusercontent.com/26607885/236342496-70a974a6-2f41-4239-8d19-09ce08ae1393.png)| ![image](https://user-images.githubusercontent.com/26607885/234415792-179777b3-006c-4ae0-9221-bd1ec42466d0.png) |

## Testing
Modified pages in RNTester to cause it to repro (existing examples were either too plain or too fancy - none specifically had the repro of "set a single border other than the left border").
Also patched into [an app](https://github.com/chrisglein/artificial-chat/issues/119) and validated it there.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11561)