### PR TITLE
[0.72] Fix V8 Node API Task Runner implementation (#10966)

### DIFF
--- a/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
+++ b/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix V8 Node API task runner implementation",
+  "packageName": "react-native-windows",
+  "email": "vmoroz@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
+++ b/change/react-native-windows-cafebabf-5714-4f76-9359-584cca01febc.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fix V8 Node API task runner implementation",
   "packageName": "react-native-windows",
-  "email": "vmoroz@users.noreply.github.com",
+  "email": "vmorozov@microsoft.com",
   "dependentChangeType": "patch"
 }

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -24,7 +24,7 @@
     <EnableDevServerHBCBundles Condition="'$(EnableDevServerHBCBundles)' == ''">false</EnableDevServerHBCBundles>
 
     <UseV8 Condition="'$(UseV8)' == ''">false</UseV8>
-    <V8Version Condition="'$(V8Version)' == ''">0.71.2</V8Version>
+    <V8Version Condition="'$(V8Version)' == ''">0.71.3</V8Version>
     <V8PackageName>ReactNative.V8Jsi.Windows</V8PackageName>
     <V8PackageName Condition="'$(V8AppPlatform)' != 'win32'">$(V8PackageName).UWP</V8PackageName>
   </PropertyGroup>

--- a/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
+++ b/vnext/Shared/JSI/NapiJsiV8RuntimeHolder.h
@@ -24,14 +24,6 @@ class NapiJsiV8RuntimeHolder : public Microsoft::JSI::RuntimeHolderLazyInit {
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;
 
  private:
-  static void __cdecl ScheduleTaskCallback(
-      napi_env env,
-      napi_ext_task_callback taskCb,
-      void *taskData,
-      uint32_t delayMs,
-      napi_finalize finalizeCb,
-      void *finalizeHint);
-
   void InitRuntime() noexcept;
   napi_ext_script_cache InitScriptCache(
       std::unique_ptr<facebook::jsi::PreparedScriptStore> &&preparedScriptStore) noexcept;


### PR DESCRIPTION
Cherry pick PR #10966. Original PR description:

## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

We see that application crashes when we do direct debugging with V8 engine that accessed through the Node-API.
The issue is that current task runner (V8 dispatcher queue) implementation lifetime is bound to the `napi_env` object, and any task posted to that queue is crashing. The correct implementation of the task runner must be independent from the `napi_env`.

### What

In [this v8-jsi PR](https://github.com/microsoft/v8-jsi/pull/153) we change the task runner API and the implementation.
In this PR we do the corresponding changes to the `NapiJsiV8RuntimeHolder.cpp` that implements the task runner on top of the JS message queue. The new `NapiTaskRunner` and `NapiTask` do not have dependency on the `napi_env` and can be deleted at any time by `v8-jsi.dll` as it is being done with the current task runner implemented for JSI.

## Testing

Note that we start the PR from 0.68 branch and the corresponding v8-jsi 0.65 branch to match the versions used in Office apps.
Both PRs were manually tested against Office code, and we do not observe the crash anymore while doing the direct debugging.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11572)