### PR TITLE
[Fabric] Fix borders for Image and Switch

### DIFF
--- a/change/react-native-windows-5cf81a32-9afd-461e-b345-5ca54e898dcc.json
+++ b/change/react-native-windows-5cf81a32-9afd-461e-b345-5ca54e898dcc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] fix border for Image and Switch",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -183,7 +183,12 @@ void ImageComponentView::updateLayoutMetrics(
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
 }
 
-void ImageComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {}
+void ImageComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
+  if (m_needsBorderUpdate) {
+    m_needsBorderUpdate = false;
+    UpdateSpecialBorderLayers(m_layoutMetrics, *m_props);
+  }
+}
 
 void ImageComponentView::OnRenderingDeviceLost() noexcept {
   // Draw the text again

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -84,6 +84,11 @@ void SwitchComponentView::updateLayoutMetrics(
 
 void SwitchComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
   ensureDrawingSurface();
+
+  if (m_needsBorderUpdate) {
+    m_needsBorderUpdate = false;
+    UpdateSpecialBorderLayers(m_layoutMetrics, *m_props);
+  }
 }
 
 void SwitchComponentView::Draw() noexcept {


### PR DESCRIPTION
Borders were not being drawn for Image and Switch fabric components. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11574)