### PR TITLE
Component Governance Updates 5/8/23

### DIFF
--- a/change/@rnw-scripts-doxysaurus-7a64cc60-7a5b-4c0b-8b9e-53447f0f76e8.json
+++ b/change/@rnw-scripts-doxysaurus-7a64cc60-7a5b-4c0b-8b9e-53447f0f76e8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Component Governance Updates 5/8/23",
+  "packageName": "@rnw-scripts/doxysaurus",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "**/@react-native/repo-config/ws": "^6.2.2",
     "**/@react-native/tester/ws": "^6.2.2",
     "**/detox/ws": "^5.2.3",
+    "xml2js": "^0.5.0",
     "z-schema": "^5.0.2"
   },
   "resolutions.justification": {

--- a/packages/@rnw-scripts/doxysaurus/package.json
+++ b/packages/@rnw-scripts/doxysaurus/package.json
@@ -26,7 +26,7 @@
     "github-slugger": "^1.3.0",
     "mustache": "^4.0.1",
     "source-map-support": "^0.5.19",
-    "xml2js": "^0.4.23",
+    "xml2js": "^0.5.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12368,10 +12368,10 @@ xml-parser@^1.2.1:
   dependencies:
     debug "^2.2.0"
 
-xml2js@^0.4.19, xml2js@^0.4.23:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
-  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+xml2js@^0.4.19, xml2js@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.5.0.tgz#d9440631fbb2ed800203fad106f2724f62c493b7"
+  integrity sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
@@ -12422,9 +12422,9 @@ yaml@^1.10.0:
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
-  integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.2.tgz#ec551ef37326e6d42872dad1970300f8eb83a073"
+  integrity sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==
 
 yargs-parser@^18.1.2, yargs-parser@^18.1.3:
   version "18.1.3"


### PR DESCRIPTION
## Description

* Updated to `xml2js@0.5.0`
* Updated to `yaml@2.2.2`

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves Component Governance alerts.

### What
Updates package versions.

## Screenshots
N/A

## Testing
N/A
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11575)