### PR TITLE
[0.71] [Win32] Export additional TS types for back compat

### DIFF
--- a/change/@office-iss-react-native-win32-733be819-9ae8-47c0-8e54-1620c7609496.json
+++ b/change/@office-iss-react-native-win32-733be819-9ae8-47c0-8e54-1620c7609496.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Export additional TS types for back compat",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
@@ -5,9 +5,15 @@
 *        need to also be added to index.win32.js
 */
 
+import {IViewWin32Props as IViewWin32PropsOnly} from './Components/View/ViewPropTypes.win32';
+import { AccessibilityPropsWin32 } from '@office-iss/react-native-win32/Libraries/Components/View/ViewAccessibility.win32';
+export { AccessibilityPropsWin32 } from '@office-iss/react-native-win32/Libraries/Components/View/ViewAccessibility.win32';
+export type IViewWin32Props = IViewWin32PropsOnly & AccessibilityPropsWin32;
 export {ViewWin32} from './Components/View/ViewWin32';
-export {IViewWin32Props} from './Components/View/ViewPropTypes.win32';
-export {TextWin32TextStyle, ITextWin32Props } from './Components/Text/TextWin32.Props';
+export {IKeyboardEvent, IHandledKeyboardEvent} from './Components/View/ViewPropTypes.win32';
+import {ITextWin32Props as ITextWin32PropsOnly} from './Components/Text/TextWin32.Props';
+export type ITextWin32Props = ITextWin32PropsOnly & AccessibilityPropsWin32;
+export {TextWin32TextStyle } from './Components/Text/TextWin32.Props';
 export {TextWin32} from './Components/Text/TextWin32';
 export {IButtonWin32Props, IButtonWin32Style} from './Components/Button/ButtonWin32.Props';
 export {ButtonWin32} from './Components/Button/ButtonWin32';


### PR DESCRIPTION
Basically the types being exported from RNWin32 wouldn't be the specific win32 types unless you are using some new TS magic which most people won't be yet.  ViewProps extends AccessiblityProps, but AccessibilityProps has a .win32 override that is what you really want.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11588)