### PR TITLE
Remove relative path from codegen include in AppearanceModule.h

### DIFF
--- a/change/react-native-windows-10f7bacb-50c1-47f3-8944-047527d3413f.json
+++ b/change/react-native-windows-10f7bacb-50c1-47f3-8944-047527d3413f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove relative path from codegen include in AppearanceModule.h",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../../codegen/NativeAppearanceSpec.g.h"
+#include "codegen/NativeAppearanceSpec.g.h"
 #include <React.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Same as #10311, but for AppearanceModule.h, which was added in #10682.

### What
Changes include to not use relative path.

## Testing

Solution builds.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11590)