### PR TITLE
Add option to load ship bundles from metro

### DIFF
--- a/change/react-native-windows-85fcf5fc-0b8b-4e5c-8f5b-08a4bbcfaa0d.json
+++ b/change/react-native-windows-85fcf5fc-0b8b-4e5c-8f5b-08a4bbcfaa0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add option to load ship bundles from metro",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactContextTest.cpp
@@ -110,6 +110,10 @@ struct ReactContextStub : implements<ReactContextStub, IReactContext> {
   hstring BundleAppId() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }
+  
+  bool RequestDevBundle() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
 
   LoadingState LoadingState() noexcept {
     VerifyElseCrashSz(false, "Not implemented");

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/ReactModuleBuilderMock.h
@@ -198,6 +198,10 @@ struct ReactContextMock : implements<ReactContextMock, IReactContext> {
     VerifyElseCrashSz(false, "Not implemented");
   }
 
+  bool RequestDevBundle() noexcept {
+    VerifyElseCrashSz(false, "Not implemented");
+  }
+
   LoadingState LoadingState() noexcept {
     VerifyElseCrashSz(false, "Not implemented");
   }

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/ReactModuleBuilderMock.cs
@@ -326,6 +326,9 @@ namespace Microsoft.ReactNative.Managed.UnitTests
     public ushort SourceBundlePort => throw new NotImplementedException();
 
     public bool RequestInlineSourceMap => throw new NotImplementedException();
+  
+    public bool RequestDevBundle => throw new NotImplementedException();
+
   }
 
   class ReactContextMock : IReactContext

--- a/vnext/Microsoft.ReactNative.Managed/ReactSettingsSnapshot.cs
+++ b/vnext/Microsoft.ReactNative.Managed/ReactSettingsSnapshot.cs
@@ -32,6 +32,8 @@ namespace Microsoft.ReactNative.Managed
 
     public bool UseWebDebugger => IsValid ? Handle.UseWebDebugger : false;
 
+    public bool RequestDevBundle => IsValid ? Handle.RequestDevBundle : null;
+
     public IReactSettingsSnapshot Handle { get; }
 
     public bool IsValid => Handle != null;

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -65,6 +65,10 @@ hstring ReactSettingsSnapshot::BundleAppId() const noexcept {
   return winrt::to_hstring(m_settings->BundleAppId());
 }
 
+bool  ReactSettingsSnapshot::RequestDevBundle() const noexcept {
+  return m_settings->RequestDevBundle();
+}
+
 Mso::React::IReactSettingsSnapshot const &ReactSettingsSnapshot::GetInner() const noexcept {
   return *m_settings;
 }

--- a/vnext/Microsoft.ReactNative/IReactContext.h
+++ b/vnext/Microsoft.ReactNative/IReactContext.h
@@ -24,6 +24,7 @@ struct ReactSettingsSnapshot : winrt::implements<ReactSettingsSnapshot, IReactSe
   bool RequestInlineSourceMap() const noexcept;
   hstring JavaScriptBundleFile() const noexcept;
   hstring BundleAppId() const noexcept;
+  bool RequestDevBundle() const noexcept;
 
  public:
   // Internal accessor for within the Microsoft.ReactNative dll to allow calling into internal methods

--- a/vnext/Microsoft.ReactNative/IReactContext.idl
+++ b/vnext/Microsoft.ReactNative/IReactContext.idl
@@ -125,6 +125,12 @@ namespace Microsoft.ReactNative
       "at the time when the React instance was created.\n"
       "The name of the app passed to the packager server via the 'app' query parameter.")
     String BundleAppId { get; };
+
+    DOC_STRING(
+      "A read-only snapshot of the @ReactInstanceSettings.RequestDevBundle property value "
+      "at the time when the React instance was created.\n"
+      "When querying the bundle server for a bundle, should it request the dev bundle or release bundle.")
+    Boolean RequestDevBundle { get; };
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
@@ -100,6 +100,13 @@ std::string ReactSettingsSnapshot::BundleAppId() const noexcept {
   return {};
 }
 
+bool ReactSettingsSnapshot::RequestDevBundle() const noexcept {
+  if (auto instance = m_reactInstance.GetStrongPtr()) {
+    return instance->RequestDevBundle();
+  }
+  return {};
+}
+
 JSIEngine ReactSettingsSnapshot::JsiEngine() const noexcept {
   if (auto instance = m_reactInstance.GetStrongPtr()) {
     return instance->JsiEngine();

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.h
@@ -30,6 +30,7 @@ class ReactSettingsSnapshot final : public Mso::UnknownObject<IReactSettingsSnap
   bool RequestInlineSourceMap() const noexcept override;
   std::string JavaScriptBundleFile() const noexcept override;
   std::string BundleAppId() const noexcept override;
+  bool RequestDevBundle() const noexcept override;
   bool UseDeveloperSupport() const noexcept override;
   JSIEngine JsiEngine() const noexcept override;
 

--- a/vnext/Microsoft.ReactNative/ReactHost/React.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/React.h
@@ -105,6 +105,7 @@ struct IReactSettingsSnapshot : IUnknown {
   virtual bool RequestInlineSourceMap() const noexcept = 0;
   virtual std::string JavaScriptBundleFile() const noexcept = 0;
   virtual std::string BundleAppId() const noexcept = 0;
+  virtual bool RequestDevBundle() const noexcept = 0;
   virtual bool UseDeveloperSupport() const noexcept = 0;
   virtual JSIEngine JsiEngine() const noexcept = 0;
 };
@@ -152,6 +153,7 @@ struct ReactDevOptions {
   std::string SourceBundleName; // Bundle name without any extension (e.g. "index.win32"). Default: "index.{PLATFORM}"
   std::string SourceBundleExtension; // Bundle name extension. Default: ".bundle".
   std::string BundleAppId; // Bundle app id. Default: "".
+  bool DevBundle{true}; // When requesting bundle from bundle server, query for dev bundle or release bundle
 
   //! Module name used for loading the debug bundle.
   //! e.g. The modules name registered in the jsbundle via AppRegistry.registerComponent('ModuleName', () =>

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -451,6 +451,7 @@ void ReactInstanceWin::Initialize() noexcept {
           devSettings->debuggerAttachCallback = GetDebuggerAttachCallback();
           devSettings->enableDefaultCrashHandler = m_options.EnableDefaultCrashHandler();
           devSettings->bundleAppId = BundleAppId();
+          devSettings->devBundle = RequestDevBundle();
           devSettings->showDevMenuCallback = [weakThis]() noexcept {
             if (auto strongThis = weakThis.GetStrongPtr()) {
               strongThis->m_uiQueue->Post(
@@ -1164,6 +1165,10 @@ std::string ReactInstanceWin::JavaScriptBundleFile() const noexcept {
 
 std::string ReactInstanceWin::BundleAppId() const noexcept {
   return m_options.DeveloperSettings.BundleAppId;
+}
+
+bool ReactInstanceWin::RequestDevBundle() const noexcept {
+  return m_options.DeveloperSettings.DevBundle;
 }
 
 bool ReactInstanceWin::UseDeveloperSupport() const noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -80,6 +80,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   bool RequestInlineSourceMap() const noexcept;
   std::string JavaScriptBundleFile() const noexcept;
   std::string BundleAppId() const noexcept;
+  bool RequestDevBundle() const noexcept;
   bool UseDeveloperSupport() const noexcept;
   JSIEngine JsiEngine() const noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -66,6 +66,10 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   hstring BundleAppId() noexcept;
   void BundleAppId(hstring const &value) noexcept;
 
+  //! When querying the bundle server for a bundle, should it request the dev bundle or release bundle
+  bool RequestDevBundle() noexcept;
+  void RequestDevBundle(bool value) noexcept;
+
   //! Should the instance run in a remote environment such as within a browser
   //! By default, this is using a browser navigated to  http://localhost:8081/debugger-ui served
   //! by Metro/Haul. Debugging will start as soon as the React Native instance is loaded.
@@ -174,6 +178,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
       single_threaded_vector<IReactPackageProvider>()};
   hstring m_javaScriptBundleFile{};
   hstring m_bundleAppId{};
+  bool m_devBundle{};
   bool m_enableJITCompilation{true};
   bool m_enableByteCodeCaching{false};
   hstring m_byteCodeFileUri{};
@@ -237,6 +242,14 @@ inline hstring ReactInstanceSettings::BundleAppId() noexcept {
 
 inline void ReactInstanceSettings::BundleAppId(hstring const &value) noexcept {
   m_bundleAppId = value;
+}
+
+inline bool ReactInstanceSettings::RequestDevBundle() noexcept {
+  return m_devBundle;
+}
+
+inline void ReactInstanceSettings::RequestDevBundle(bool value) noexcept {
+  m_devBundle = value;
 }
 
 inline bool ReactInstanceSettings::EnableJITCompilation() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.idl
@@ -112,6 +112,10 @@ namespace Microsoft.ReactNative
     String BundleAppId { get; set; };
 
     DOC_STRING(
+      "When querying the bundle server for a bundle, should it request the dev bundle or release bundle.")
+    Boolean RequestDevBundle { get; set; };
+
+    DOC_STRING(
       "Controls whether the instance JavaScript runs in a remote environment such as within a browser.\n"
       "By default, this is using a browser navigated to http://localhost:8081/debugger-ui served by Metro/Haul.\n"
       "Debugging will start as soon as the react native instance is loaded.")

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.cpp
@@ -151,6 +151,7 @@ IAsyncAction ReactNativeHost::ReloadInstance() noexcept {
   reactOptions.DeveloperSettings.SourceBundlePort = m_instanceSettings.SourceBundlePort();
   reactOptions.DeveloperSettings.RequestInlineSourceMap = m_instanceSettings.RequestInlineSourceMap();
   reactOptions.DeveloperSettings.BundleAppId = to_string(m_instanceSettings.BundleAppId());
+  reactOptions.DeveloperSettings.DevBundle = m_instanceSettings.RequestDevBundle();
 
   reactOptions.ByteCodeFileUri = to_string(m_instanceSettings.ByteCodeFileUri());
   reactOptions.EnableByteCodeCaching = m_instanceSettings.EnableByteCodeCaching();

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -95,6 +95,9 @@ struct DevSettings {
 
   bool inlineSourceMap{true};
 
+  // When querying the bundle server for a bundle, should it request the dev bundle or release bundle
+  bool devBundle{true};
+
   bool enableDefaultCrashHandler{false};
 };
 

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -448,7 +448,7 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
           m_devSettings->platformName,
           m_devSettings->bundleAppId,
-          true /* dev */,
+          m_devSettings->devBundle,
           m_devSettings->useFastRefresh,
           m_devSettings->inlineSourceMap,
           hermesBytecodeVersion);
@@ -470,8 +470,8 @@ void InstanceImpl::loadBundleInternal(std::string &&jsBundleRelativePath, bool s
           m_devSettings->debugBundlePath.empty() ? jsBundleRelativePath : m_devSettings->debugBundlePath,
           m_devSettings->platformName,
           m_devSettings->bundleAppId,
-          /*dev*/ true,
-          /*hot*/ false,
+          m_devSettings->devBundle,
+          m_devSettings->useFastRefresh,
           m_devSettings->inlineSourceMap,
           hermesBytecodeVersion);
 
@@ -607,7 +607,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
             m_devSettings->debugBundlePath,
             m_devSettings->platformName,
             m_devSettings->bundleAppId,
-            true /*dev*/,
+            m_devSettings->devBundle,
             m_devSettings->useFastRefresh,
             m_devSettings->inlineSourceMap,
             hermesBytecodeVersion)

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -270,6 +270,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxErrorFrameInfo.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxErrorInfo.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\TurboModulesProvider.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\ActivityIndicatorComponentView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -678,9 +679,6 @@
       <Filter>Header Files\Fabric\Composition</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\SwitchComponentView.h">
-      <Filter>Header Files\Fabric\Composition</Filter>
-    </ClInclude>
-    <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\ActivityIndicatorComponentView.h">
       <Filter>Header Files\Fabric\Composition</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\TextInput\WindowsTextInputComponentView.h">


### PR DESCRIPTION
## Description
Currently whenever RNW loads a bundle from the bundle server, it will always request the dev bundle.  In some cases developers may want to work against a release bundle.  This adds a new option to specify that RNW should request a release bundle from the bundle server.
