### PR TITLE
[0.71] Fix a bunch of properties on Text

### DIFF
--- a/change/react-native-windows-74728d8a-1ece-4904-9a2f-2d682cd92eb7.json
+++ b/change/react-native-windows-74728d8a-1ece-4904-9a2f-2d682cd92eb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix a bunch of properties on Text",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -212,6 +212,7 @@ const Text: React.AbstractComponent<
 
   const _accessible = Platform.select({
     ios: accessible !== false,
+    windows: accessible !== false,
     default: accessible,
   });
 
@@ -228,24 +229,16 @@ const Text: React.AbstractComponent<
     return (
       <NativeVirtualText
         {...restProps}
+        accessibilityState={_accessibilityState}
         {...eventHandlersForText}
-        disabled={_disabled}
-        selectable={_selectable}
-        accessible={
-          accessible == null && Platform.OS === 'android'
-            ? _hasOnPressOrOnLongPress
-            : _accessible
-        }
         accessibilityLabel={ariaLabel ?? accessibilityLabel}
-        accessibilityState={nativeTextAccessibilityState}
         accessibilityRole={
           role ? getAccessibilityRoleFromRole(role) : accessibilityRole
         }
-        allowFontScaling={allowFontScaling !== false}
-        ellipsizeMode={ellipsizeMode ?? 'tail'}
         isHighlighted={isHighlighted}
-        nativeID={id ?? nativeID}
         isPressable={isPressable}
+        selectable={_selectable}
+        nativeID={id ?? nativeID}
         numberOfLines={numberOfLines}
         selectionColor={selectionColor}
         style={flattenedStyle}
@@ -297,10 +290,23 @@ const Text: React.AbstractComponent<
             <NativeText
               {...textPropsLessStyle}
               {...eventHandlersForText}
-              accessible={accessible !== false}
+              disabled={_disabled}
+              selectable={_selectable}
+              accessible={
+                accessible == null && Platform.OS === 'android'
+                  ? _hasOnPressOrOnLongPress
+                  : _accessible
+              }
+              accessibilityLabel={ariaLabel ?? accessibilityLabel}
+              accessibilityState={nativeTextAccessibilityState}
+              accessibilityRole={
+                role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+              }
               allowFontScaling={allowFontScaling !== false}
               ellipsizeMode={ellipsizeMode ?? 'tail'}
               isHighlighted={isHighlighted}
+              nativeID={id ?? nativeID}
+              numberOfLines={numberOfLines}
               selectionColor={selectionColor}
               style={((rest: any): TextStyleProp)}
               ref={forwardedRef}
@@ -314,12 +320,25 @@ const Text: React.AbstractComponent<
           <NativeText
             {...restProps}
             {...eventHandlersForText}
-            accessible={accessible !== false}
+            disabled={_disabled}
+            selectable={_selectable}
+            accessible={
+              accessible == null && Platform.OS === 'android'
+                ? _hasOnPressOrOnLongPress
+                : _accessible
+            }
+            accessibilityLabel={ariaLabel ?? accessibilityLabel}
+            accessibilityState={nativeTextAccessibilityState}
+            accessibilityRole={
+              role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+            }
             allowFontScaling={allowFontScaling !== false}
             ellipsizeMode={ellipsizeMode ?? 'tail'}
             isHighlighted={isHighlighted}
+            nativeID={id ?? nativeID}
+            numberOfLines={numberOfLines}
             selectionColor={selectionColor}
-            style={style}
+            style={flattenedStyle}
             ref={forwardedRef}
           />
         </TextAncestor.Provider>


### PR DESCRIPTION
## Description
At some point we lost a bunch of properties on Text -- including accessibilityLabel.  This should light up those properties again.

During various RN merges - we brought in changes that extracted more props out of "restProps", but didn't merge in addition property sets on the components, so we lost the values of a bunch of properties.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11603)