### PR TITLE
Change multi_threaded_map to single_threaded_map in WinRTHttpResource

### DIFF
--- a/change/react-native-windows-2d2547a4-0134-4bab-9e67-0b4997c13e26.json
+++ b/change/react-native-windows-2d2547a4-0134-4bab-9e67-0b4997c13e26.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change multi_threaded_map to single_threaded_map in WinRTHttpResource",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -397,7 +397,7 @@ WinRTHttpResource::PerformSendRequest(HttpMethod &&method, Uri &&rtUri, IInspect
   // Ensure background thread
   co_await winrt::resume_background();
 
-  auto props = winrt::multi_threaded_map<winrt::hstring, IInspectable>();
+  auto props = winrt::single_threaded_map<winrt::hstring, IInspectable>();
   props.Insert(L"RequestArgs", coArgs);
 
   auto coRequestOp = CreateRequest(std::move(coMethod), std::move(coUri), props);


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
1. At Meta we are using an older version of CppWinRT which doesn't support `multi_threaded_map`. We can't easily upgrade CppWinRT versions because we use clang and have run into issues with coroutines with newer versions of CppWinRT.
2. Using a `multi_threaded_map` in this part of the code is not necessary. The map is only ever used on a single thread. There's a potential performance hit to using `multi_threaded_map` unnecessarily.

### What
Change `multi_threaded_map` to `single_threaded_map` in `WinRTHttpResource::PerformSendRequest`

## Testing
Ran Playground win32 with a breakpoint on this line to make sure it gets called with RNTester. It does with URL http://localhost:8081/symbolicate. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11604)