### PR TITLE
Fix a bunch of properties on Text

### DIFF
--- a/change/react-native-windows-dd0239d5-4995-4d68-9d8a-6e4333066157.json
+++ b/change/react-native-windows-dd0239d5-4995-4d68-9d8a-6e4333066157.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix a bunch of properties on Text",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Text/Text.windows.js
+++ b/vnext/src/Libraries/Text/Text.windows.js
@@ -208,6 +208,7 @@ const Text: React.AbstractComponent<
 
   const _accessible = Platform.select({
     ios: accessible !== false,
+    windows: accessible !== false,
     default: accessible,
   });
 
@@ -242,18 +243,13 @@ const Text: React.AbstractComponent<
         accessibilityRole={
           role ? getAccessibilityRoleFromRole(role) : accessibilityRole
         }
-        accessibilityState={nativeTextAccessibilityState}
-        accessible={
-          accessible == null && Platform.OS === 'android'
-            ? _hasOnPressOrOnLongPress
-            : _accessible
-        }
+        accessibilityState={_accessibilityState}
         allowFontScaling={allowFontScaling !== false}
         disabled={_disabled}
         ellipsizeMode={ellipsizeMode ?? 'tail'}
         isHighlighted={isHighlighted}
-        nativeID={id ?? nativeID}
         isPressable={isPressable}
+        nativeID={id ?? nativeID}
         numberOfLines={numberOfLines}
         ref={forwardedRef}
         selectable={_selectable}
@@ -307,13 +303,26 @@ const Text: React.AbstractComponent<
             <NativeText
               {...textPropsLessStyle}
               {...eventHandlersForText}
-              accessible={accessible !== false}
+              accessibilityLabel={ariaLabel ?? accessibilityLabel}
+              accessibilityRole={
+                role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+              }
+              accessibilityState={nativeTextAccessibilityState}
+              accessible={
+                accessible == null && Platform.OS === 'android'
+                  ? _hasOnPressOrOnLongPress
+                  : _accessible
+              }
               allowFontScaling={allowFontScaling !== false}
+              disabled={_disabled}
               ellipsizeMode={ellipsizeMode ?? 'tail'}
               isHighlighted={isHighlighted}
+              nativeID={id ?? nativeID}
+              numberOfLines={numberOfLines}
+              ref={forwardedRef}
+              selectable={_selectable}
               selectionColor={selectionColor}
               style={((rest: any): TextStyleProp)}
-              ref={forwardedRef}
             />
           </TextAncestor.Provider>
         </View>
@@ -324,13 +333,26 @@ const Text: React.AbstractComponent<
           <NativeText
             {...restProps}
             {...eventHandlersForText}
-            accessible={accessible !== false}
+            accessibilityLabel={ariaLabel ?? accessibilityLabel}
+            accessibilityRole={
+              role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+            }
+            accessibilityState={nativeTextAccessibilityState}
+            accessible={
+              accessible == null && Platform.OS === 'android'
+                ? _hasOnPressOrOnLongPress
+                : _accessible
+            }
             allowFontScaling={allowFontScaling !== false}
+            disabled={_disabled}
             ellipsizeMode={ellipsizeMode ?? 'tail'}
             isHighlighted={isHighlighted}
+            nativeID={id ?? nativeID}
+            numberOfLines={numberOfLines}
+            ref={forwardedRef}
+            selectable={_selectable}
             selectionColor={selectionColor}
             style={style}
-            ref={forwardedRef}
           />
         </TextAncestor.Provider>
       );


### PR DESCRIPTION
At some point we lost a bunch of properties on Text -- including accessibilityLabel. This should light up those properties again.

During various RN merges - we brought in changes that extracted more props out of "restProps", but didn't merge in addition property sets on the components, so we lost the values of a bunch of properties.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11605)