### PR TITLE
Implement ScrollView props() Function on Fabric

### DIFF
--- a/change/react-native-windows-1187ae94-06f0-4d36-bb52-87f96b11cdd7.json
+++ b/change/react-native-windows-1187ae94-06f0-4d36-bb52-87f96b11cdd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update Props Function",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -219,8 +219,7 @@ void ScrollViewComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMa
 }
 void ScrollViewComponentView::prepareForRecycle() noexcept {}
 facebook::react::Props::Shared ScrollViewComponentView::props() noexcept {
-  assert(false);
-  return {};
+  return static_cast<facebook::react::Props::Shared>(m_props);
 }
 
 /*


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves bug where Fabric app's crash upon launch of Accessibility Insights due to unimplemented method. 

Resolves #11594 

### What
Implements ScrollView props() function on Fabric.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11608)