### PR TITLE
[0.72] Fix integration test failures in Debug

### DIFF
--- a/packages/integration-test-app/tests/MountComponentTests.tsx
+++ b/packages/integration-test-app/tests/MountComponentTests.tsx
@@ -129,9 +129,6 @@ componentTest(
   ),
 );
 
-// Slider needs a height set to render (#5437)
-componentTest.skip('Slider', mountAndMeasure(RN.Slider));
-
 componentTest('Switch', mountAndMeasure(RN.Switch));
 
 componentTest(


### PR DESCRIPTION
This PR backports #11596 to 0.72.

This PR removes the `Slider` test case in `MountComponentTests.tsx`.

This test has been marked to skip for almost three years now (so I imagine it never worked).

Even though the test was never run, recently just the act of trying to load the `Slider` component within the JS causes an uncaught exception to be thrown in debug builds, which blocks the whole test suite from running.

Closes #11556
Closes #11562
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11609)