### PR TITLE
Fixes Flex Gap Extra Spacing when Children Determine Parent's Main Axis Size

### DIFF
--- a/change/react-native-windows-34076042-6abe-4d4a-8cdd-c76c0fd2685b.json
+++ b/change/react-native-windows-34076042-6abe-4d4a-8cdd-c76c0fd2685b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Revert 10863",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-4312d17c-cd6d-4960-bcd1-5b3e1950953f.json
+++ b/change/react-native-windows-4312d17c-cd6d-4960-bcd1-5b3e1950953f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Backport Yoga Fix",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
@@ -100,8 +100,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2302.1002-2d4bf1df",
-        "contentHash": "4skpllUPEBkww7FN7iacP7NWrZlEGDNg83qIuFjKn4Sl8JpJQZqfUTrXcvh6tb4mHXkmwFoKhLw4Rc5Op7f+8w=="
+        "resolved": "0.71.1",
+        "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -310,7 +310,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2302.1002-2d4bf1df, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -100,8 +100,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2302.1002-2d4bf1df",
-        "contentHash": "4skpllUPEBkww7FN7iacP7NWrZlEGDNg83qIuFjKn4Sl8JpJQZqfUTrXcvh6tb4mHXkmwFoKhLw4Rc5Op7f+8w=="
+        "resolved": "0.71.1",
+        "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -310,7 +310,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2302.1002-2d4bf1df, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -85,8 +85,8 @@
       },
       "ReactNative.Hermes.Windows": {
         "type": "Transitive",
-        "resolved": "0.0.0-2302.1002-2d4bf1df",
-        "contentHash": "4skpllUPEBkww7FN7iacP7NWrZlEGDNg83qIuFjKn4Sl8JpJQZqfUTrXcvh6tb4mHXkmwFoKhLw4Rc5Op7f+8w=="
+        "resolved": "0.71.1",
+        "contentHash": "q38h/Gkw8d0pfUqIhRCd1j/XLhpQY4Hm7kSQthZUzetEST34acbR883/Eh+DKt4FVz9a0lh5kiAfP7piO768SA=="
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -176,7 +176,7 @@
           "Microsoft.UI.Xaml": "[2.7.0, )",
           "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
           "ReactCommon": "[1.0.0, )",
-          "ReactNative.Hermes.Windows": "[0.0.0-2302.1002-2d4bf1df, )",
+          "ReactNative.Hermes.Windows": "[0.71.1, )",
           "boost": "[1.76.0, )"
         }
       },

--- a/vnext/ReactCommon/Yoga.cpp
+++ b/vnext/ReactCommon/Yoga.cpp
@@ -2540,6 +2540,11 @@ static void YGJustifyMainAxis(
     const YGNodeRef child = node->getChild(i);
     const YGStyle &childStyle = child->getStyle();
     const YGLayout childLayout = child->getLayout();
+    const bool isLastChild = i == collectedFlexItemsValues.endOfLineIndex - 1;
+    // remove the gap if it is the last element of the line
+    if (isLastChild) {
+      betweenMainDim -= gap;
+    }
     if (childStyle.display() == YGDisplayNone) {
       continue;
     }


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #11442 

Fixes flex gap extra spacing when children determine parent's main axis size.

This was fixed in Yoga with https://github.com/facebook/yoga/commit/ba27f9d1ecfa7518019845b84b035d3d4a2a665, backported to RN 0.71.0-rc.5 with https://github.com/facebook/react-native/commit/a0ee98dfeec1a75e649a935b733c70ae2cc1628d before we released.

### What
Backports upstream change into v0.71. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11611)