### PR TITLE
Fix PR change check

### DIFF
--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -30,7 +30,7 @@ jobs:
         displayName: Build @rnw-scripts/beachball-config
 
       - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
-        - script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "##vso[task.logissue type=error]Run `yarn change` from root of repo to generate a change file."
+        - script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "##vso[task.logissue type=error]Run \"yarn change\" from root of repo to generate a change file."
           displayName: Check for change files
 
       - script: npx beachball bump --branch origin/$(BeachBallBranchName) --yes --verbose


### PR DESCRIPTION
## Description

This PR fixes the problem where we're no longer getting the correct error when a PR is missing a change file.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

So it's clear why the PR is failing (missing change file).

Closes #11610

### What

Fixed the escaping of ther `yarn change` command in the error output so bash re-adds it properly

## Screenshots
N/A

## Testing
Ran a PR with this change without the change file.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11612)