### PR TITLE
Fix missing import in ViewExample.windows.js

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples/View/ViewExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/View/ViewExample.windows.js
@@ -18,6 +18,7 @@ const {
   TouchableWithoutFeedback,
   View,
   Platform,
+  Alert,
 } = require('react-native');
 
 class ViewBorderStyleExample extends React.Component<


### PR DESCRIPTION
## Description

Fix missing import in ViewExample.windows.js.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
In https://github.com/microsoft/react-native-windows/pull/10764 some calls to Alert were introduced in ViewExample.windows.js but I'm not sure how it worked as it's missing an import for Alert. I'm not sure how to test accessibility actions, but to ensure this is actually an issue I added a separate `onPress={() => Alert.alert('Alert')}` call to that file and verified that when I press I get an error:
![Screenshot 2023-05-17 at 11 24 34 AM](https://github.com/microsoft/react-native-windows/assets/359157/af2b25a7-b3e4-48a8-bef9-5d693417448b)

### What
Add missing import.

## Testing
In RNTester, go to View example and trigger an Alert call and confirm no error:

![Screenshot 2023-05-17 at 11 26 22 AM](https://github.com/microsoft/react-native-windows/assets/359157/177712c1-236f-46be-bf73-6c9e2186e5e8)

CC @chiaramooney
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11622)