### PR TITLE
Fix Utils.cpp not compiling on Clang

### DIFF
--- a/change/react-native-windows-3a401d81-c522-4d5f-b004-cc3b57ca8b7f.json
+++ b/change/react-native-windows-3a401d81-c522-4d5f-b004-cc3b57ca8b7f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Utils.cpp not compiling on Clang",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/compilerAdapters/compilerFeatures.h
+++ b/vnext/Mso/compilerAdapters/compilerFeatures.h
@@ -20,7 +20,7 @@
 
 // Check if compiler supports UUID
 #ifndef COMPILER_SUPPORTS_UUID
-#if defined(__clang__) || defined(__GNUC__)
+#if (defined(__APPLE__) && defined(__clang__)) || defined(__GNUC__)
 #define COMPILER_SUPPORTS_UUID 0
 #elif defined(_MSC_VER)
 #define COMPILER_SUPPORTS_UUID 1


### PR DESCRIPTION
## Description

Fix Utils.cpp not compiling on Clang

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
RNW's Utils.cpp does not compile with Clang. It produces this error:
```
In file included from Utils.cpp:9:
In file included from windows10sdk\10.0.18362.0\Include\10.0.18362.0/um\ShlObj.h:110:
In file included from windows10sdk\10.0.18362.0\Include\10.0.18362.0/um\shobjidl.h:767:
windows10sdk\10.0.18362.0\Include\10.0.18362.0/um/shobjidl_core.h:27522:83: error: template argument for template type parameter must be a type
    HRESULT hr = CoCreateInstance(CLSID_ShellLibrary, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&plib));
                                                                                  ^~~~~~~~~~~~~~~~~~~
windows10sdk\10.0.18362.0\Include\10.0.18362.0/um\combaseapi.h:207:39: note: expanded from macro 'IID_PPV_ARGS'
#define IID_PPV_ARGS(ppType) __uuidof(**(ppType)), IID_PPV_ARGS_Helper(ppType)
                             ~~~~~~~~~^~~~~~~~~~~
guid/msoGuidDetails.h:104:58: note: expanded from macro '__uuidof'
#define __uuidof(type) ::Mso::Details::GuidUtils::GuidOf<type>::Value
                                                         ^~~~
guid/msoGuidDetails.h:133:20: note: template parameter is declared here
template <typename T>
```

It seems that when using Clang, instead of using its [builtin `__uuidof` operator](https://clang.llvm.org/docs/UsersManual.html#microsoft-extensions), RNW defines a `__uuidof` shim. This shim only works with passing a type to `__uuidof`, while in the real `_uuidof(expression)`:
> [The expression can be a type name, pointer, reference, or array of that type, a template specialized on these types, or a variable of these types](https://learn.microsoft.com/en-us/cpp/cpp/uuidof-operator?view=msvc-170#remarks)

It doesn't make sense to use this `__uuidof` shim on Windows where Clang enables its `__uuidof` operator by default.

### What
If we detect we're compiling with Clang and not on an Apple machine, we now set `COMPILER_SUPPORTS_UUID=1` which allows Utils.cpp to compile. I added the Apple check since the Mso files may be getting compiled under macOS where Clang by default won't have `__uuidof` unless you pass `-fms-extensions`.

## Testing
RNW builds with Clang after this change. Also confirmed RNW still builds with MSVC.

CC @vmoroz since you added the Mso library to RNW.