### PR TITLE
Allow apps to provide accessiblity information on non-focusable components

### DIFF
--- a/change/react-native-windows-3ef19692-9e5c-436c-8efe-c0555e8cfd84.json
+++ b/change/react-native-windows-3ef19692-9e5c-436c-8efe-c0555e8cfd84.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow apps to provide accessiblity information on non-focusable components",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -128,9 +128,8 @@ void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
 
   // If developer specifies either the accessible and focusable prop to be false
   // remove accessibility and keyboard focus for component.
-  const auto isTabStop = !node->IsDisable() && (node->IsAccessible() && node->IsFocusable());
-  const auto accessibilityView =
-      isTabStop ? xaml::Automation::Peers::AccessibilityView::Content : xaml::Automation::Peers::AccessibilityView::Raw;
+  const auto isTabStop = !node->IsDisable() && node->IsFocusable();
+  const auto accessibilityView = node->IsAccessible() ? xaml::Automation::Peers::AccessibilityView::Content : xaml::Automation::Peers::AccessibilityView::Raw;
   control.IsTabStop(isTabStop);
   xaml::Automation::AutomationProperties::SetAccessibilityView(control, accessibilityView);
 }

--- a/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ControlViewManager.cpp
@@ -125,11 +125,9 @@ void ControlViewManager::SetLayoutProps(
 
 void ControlViewManager::OnPropertiesUpdated(ShadowNodeBase *node) {
   auto control(node->GetView().as<xaml::Controls::Control>());
-
-  // If developer specifies either the accessible and focusable prop to be false
-  // remove accessibility and keyboard focus for component.
   const auto isTabStop = !node->IsDisable() && node->IsFocusable();
-  const auto accessibilityView = node->IsAccessible() ? xaml::Automation::Peers::AccessibilityView::Content : xaml::Automation::Peers::AccessibilityView::Raw;
+  const auto accessibilityView = node->IsAccessible() ? xaml::Automation::Peers::AccessibilityView::Content
+                                                      : xaml::Automation::Peers::AccessibilityView::Raw;
   control.IsTabStop(isTabStop);
   xaml::Automation::AutomationProperties::SetAccessibilityView(control, accessibilityView);
 }

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -590,15 +590,13 @@ void ViewViewManager::TryUpdateView(
 }
 
 void ViewViewManager::SyncFocusableAndAccessible(ViewShadowNode *pViewShadowNode, bool useControl) {
-  // If developer specifies either the accessible and focusable prop to be false
-  // remove keyboard focus for component.
   if (useControl) {
     const auto isFocusable = pViewShadowNode->IsFocusable();
     const auto isAccessible = pViewShadowNode->IsAccessible();
     const auto isDisabled = pViewShadowNode->IsDisable();
     const auto isTabStop = !isDisabled && isFocusable;
     const auto accessibilityView = isAccessible ? xaml::Automation::Peers::AccessibilityView::Content
-                                             : xaml::Automation::Peers::AccessibilityView::Raw;
+                                                : xaml::Automation::Peers::AccessibilityView::Raw;
     pViewShadowNode->GetControl().IsTabStop(isTabStop);
     xaml::Automation::AutomationProperties::SetAccessibilityView(pViewShadowNode->GetControl(), accessibilityView);
   }

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -591,18 +591,13 @@ void ViewViewManager::TryUpdateView(
 
 void ViewViewManager::SyncFocusableAndAccessible(ViewShadowNode *pViewShadowNode, bool useControl) {
   // If developer specifies either the accessible and focusable prop to be false
-  // remove accessibility and keyboard focus for component. Exception is made
-  // for case where a View with undefined onPress is specified, where
-  // component gains accessibility focus when either the accessible and focusable prop are true.
+  // remove keyboard focus for component.
   if (useControl) {
     const auto isFocusable = pViewShadowNode->IsFocusable();
     const auto isAccessible = pViewShadowNode->IsAccessible();
-    const auto isPressable = pViewShadowNode->OnClick();
     const auto isDisabled = pViewShadowNode->IsDisable();
-    const auto isTabStop =
-        (!isDisabled &&
-         ((isPressable && isFocusable && isAccessible) || (!isPressable && (isFocusable || isAccessible))));
-    const auto accessibilityView = isTabStop ? xaml::Automation::Peers::AccessibilityView::Content
+    const auto isTabStop = !isDisabled && isFocusable;
+    const auto accessibilityView = isAccessible ? xaml::Automation::Peers::AccessibilityView::Content
                                              : xaml::Automation::Peers::AccessibilityView::Raw;
     pViewShadowNode->GetControl().IsTabStop(isTabStop);
     xaml::Automation::AutomationProperties::SetAccessibilityView(pViewShadowNode->GetControl(), accessibilityView);

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -1513,6 +1513,12 @@ function InternalTextInput(props: Props): React.Node {
     };
   }
 
+  if (focusable && !accessible) {
+    console.warn(
+      'All focusable views should report proper accessiblity information. TextInputs marked as focusable should always be accessible.',
+    );
+  }
+
   // $FlowFixMe[underconstrained-implicit-instantiation]
   let style = flattenStyle(props.style);
 

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -183,6 +183,16 @@ const View: React.AbstractComponent<
         return updatedChildren;
       }
     };
+
+    const _focusable = tabIndex !== undefined ? !tabIndex : focusable;
+    const _accessible = importantForAccessibility === 'no-hide-descendants'
+      ? false
+      : otherProps.accessible;
+
+    if (_focusable && !_accessible) {
+      console.warn('All focusable views should report proper accessiblity information. Views marked as focusable should always be accessible.');
+    }
+
     // Windows]
 
     return (
@@ -205,7 +215,7 @@ const View: React.AbstractComponent<
                   : ariaLive ?? accessibilityLiveRegion
               }
               accessibilityLabel={ariaLabel ?? accessibilityLabel}
-              focusable={tabIndex !== undefined ? !tabIndex : focusable}
+              focusable={_focusable}
               disabled={disabled}
               accessibilityState={_accessibilityState}
               accessibilityRole={
@@ -230,11 +240,7 @@ const View: React.AbstractComponent<
               onKeyUp={_keyUp}
               onKeyUpCapture={_keyUpCapture}
               // [Windows
-              accessible={
-                importantForAccessibility === 'no-hide-descendants'
-                  ? false
-                  : otherProps.accessible
-              }
+              accessible={_accessible}
               children={
                 importantForAccessibility === 'no-hide-descendants'
                   ? childrenWithImportantForAccessibility(otherProps.children)

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -185,12 +185,15 @@ const View: React.AbstractComponent<
     };
 
     const _focusable = tabIndex !== undefined ? !tabIndex : focusable;
-    const _accessible = importantForAccessibility === 'no-hide-descendants'
-      ? false
-      : otherProps.accessible;
+    const _accessible =
+      importantForAccessibility === 'no-hide-descendants'
+        ? false
+        : otherProps.accessible;
 
     if (_focusable && !_accessible) {
-      console.warn('All focusable views should report proper accessiblity information. Views marked as focusable should always be accessible.');
+      console.warn(
+        'All focusable views should report proper accessiblity information. Views marked as focusable should always be accessible.',
+      );
     }
 
     // Windows]

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -190,7 +190,7 @@ const View: React.AbstractComponent<
         ? false
         : otherProps.accessible;
 
-    if (_focusable && !_accessible) {
+    if (_focusable === true && _accessible === false) {
       console.warn(
         'All focusable views should report proper accessiblity information. Views marked as focusable should always be accessible.',
       );


### PR DESCRIPTION
## Description
Currently accessibility information is only provided to the system if a component is both accessible and focusable.  This was done as part of some feedback from the accessibility team that all focusable controls need to provide accessible information.  But instead of just making it a requirement for something to be accessible to be focusable, it also made it a requirement that a component be focusable in order to be accessible which prevents applications from providing larger accessibility trees within a focusable component (Which we do in FURN and I'm sure other places).

This change allows the application more flexibility and replaces the previous logic that required accessibility and focusable to be linked with a warning if the developer makes a component focusable without it being accessible.

I'm also questioning the logic to stop being focusable when disabled is set.  While this is generally correct, it prevents applications from making a focusable disabled control, which seems like a limitation that we might not want. (In Office we have controls which are disabled but still focusable - just not in RN UI yet). -- I haven't removed that as part of this change though.

Related changes:
https://github.com/microsoft/react-native-windows/pull/9840
https://github.com/microsoft/react-native-windows/pull/10569

### Type of Change
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11643)