### PR TITLE
Disable SBOM signing on CI/PRs

### DIFF
--- a/.ado/variables/shared.yml
+++ b/.ado/variables/shared.yml
@@ -6,7 +6,7 @@ variables:
   skipComponentGovernanceDetection: true
   
   # SBOM signing only works on microsoft ADO
-  Packaging.EnableSBOMSigning: ${{ startsWith(variables['System.CollectionUri'], "https://dev.azure.com/microsoft") }}
+  Packaging.EnableSBOMSigning: ${{ startsWith(variables['System.CollectionUri'], 'https://dev.azure.com/microsoft') }}
   
   # Enables `chalk` to show colored output to Azure Pipelines
   FORCE_COLOR: 3

--- a/.ado/variables/shared.yml
+++ b/.ado/variables/shared.yml
@@ -5,6 +5,9 @@ variables:
   runCodesignValidationInjection: false
   skipComponentGovernanceDetection: true
   
+  # SBOM signing only works on microsoft ADO
+  Packaging.EnableSBOMSigning: ${{ startsWith(variables['System.CollectionUri'], "https://dev.azure.com/microsoft") }}
+  
   # Enables `chalk` to show colored output to Azure Pipelines
   FORCE_COLOR: 3
 


### PR DESCRIPTION
## Description

Our SBOM manifests can only be signed when running pipelines in the internal ADO for publishing official builds. This PR changes the config not not sign the manifests for PR/CI.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Unblock PRs.

### What
Added variable to only enable signing when on the right ADO instance.

## Screenshots
N/A

## Testing
N/A

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11657)