### PR TITLE
Update Guardian tasks to v2

### DIFF
--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -51,7 +51,7 @@ steps:
 
   # PostAnalysis Task (https://docs.microsoft.com/en-us/azure/security/develop/yaml-configuration#post-analysis-task)
   # Breaks the build if any of the tasks failed.
-  - task: PostAnalysis@1
+  - task: PostAnalysis@2
     displayName: "⚖️ Compliance Pre-Build Analysis"
     inputs:
       AllTools: false


### PR DESCRIPTION
## Description

Updates Guardian pre-build analysis tasks to v2.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Guardian v1 deprecation.

## Screenshots
N/A

## Testing
Ran compliance pipeline to confirm it still works.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11658)