### PR TITLE
Fix dependency script to install missing components for VS Preview

### DIFF
--- a/change/react-native-windows-6c630b6e-c0af-460a-8d41-8dc1fdeedc57.json
+++ b/change/react-native-windows-6c630b6e-c0af-460a-8d41-8dc1fdeedc57.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix dependency script to install missing components for VS Preview",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

The dependency script could detect that a Preview install meets the version requirement, but when it came to installing any missing VS components, would fail to remember to use the Preview install.

Best case it would try to install a stable version and add the components to that instead.

This does not solve the problem of not being able to install Preview builds with Choco.

Closes #11665

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
So that users who have a VS Preview installed don't get another VS build installed - just add components to the existing installed preview.

Closes #11665

### What
Updated the dep script.

## Screenshots
N/A

## Testing
Tested with 17.7 Preview installed and bumping the version number.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11667)