### PR TITLE
[0.72] Fix os.arch for x86/arm64

### DIFF
--- a/change/@react-native-windows-cli-e0d0ac4b-9d62-43e2-bcd9-1169b0c8c681.json
+++ b/change/@react-native-windows-cli-e0d0ac4b-9d62-43e2-bcd9-1169b0c8c681.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.72] fix x86 node invocation",
+  "packageName": "@react-native-windows/cli",
+  "email": "asklar@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -72,7 +72,12 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--arch [string]',
     description: 'The build architecture (ARM64, x86, x64)',
-    default: os.arch(),
+    default:
+      os.arch() === 'ia32'
+        ? 'x86'
+        : os.arch() === 'arm64'
+        ? 'ARM64'
+        : os.arch(),
     parse: parseBuildArch,
   },
   {


### PR DESCRIPTION
This PR backports #11659 to 0.72.

* Update runWindowsOptions.ts

os.arch returns ia32 and arm64 for x86 and ARM64 respectively
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11671)