### PR TITLE
Set yoga to maintain all legacy behavior unless specifically opted into

### DIFF
--- a/change/react-native-windows-942f3fb6-3a51-4255-836f-e221c64edee8.json
+++ b/change/react-native-windows-942f3fb6-3a51-4255-836f-e221c64edee8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Set yoga to maintain all legacy behavior unless specifically opted into",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -153,9 +153,10 @@ NativeUIManager::NativeUIManager(winrt::Microsoft::ReactNative::ReactContext con
   m_yogaConfig = YGConfigNew();
   if (React::implementation::QuirkSettings::GetUseWebFlexBasisBehavior(m_context.Properties()))
     YGConfigSetExperimentalFeatureEnabled(m_yogaConfig, YGExperimentalFeatureWebFlexBasis, true);
+  auto errata = YGErrataAll;
   if (React::implementation::QuirkSettings::GetMatchAndroidAndIOSStretchBehavior(m_context.Properties()))
-    YGConfigSetErrata(m_yogaConfig, YGErrataStretchFlexBasis);
-
+    errata &= ~YGErrataStretchFlexBasis;
+  YGConfigSetErrata(m_yogaConfig, errata);
 #if defined(_DEBUG)
   YGConfigSetLogger(m_yogaConfig, &YogaLog);
 


### PR DESCRIPTION
https://github.com/microsoft/react-native-windows/pull/11623 accidently opted into all future yoga conformance changes.  This changes it so we only opt into the one we meant to.