### PR TITLE
Make ScrollView and ActivityIndicator not focusable by default

### DIFF
--- a/change/react-native-windows-6dfacc4e-2515-4030-9e63-9ed1789f5f8c.json
+++ b/change/react-native-windows-6dfacc4e-2515-4030-9e63-9ed1789f5f8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make ScrollView and ActivityIndicator not focusable by default",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.cpp
@@ -25,6 +25,13 @@ void ActivityIndicatorViewManager::GetNativeProps(const winrt::Microsoft::ReactN
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"color", L"Color");
 }
 
+ShadowNode *Microsoft::ReactNative::ActivityIndicatorViewManager::createShadow() const {
+  ShadowNode *shadowNode = Super::createShadow();
+  ShadowNodeBase *shadowNodeBase = static_cast<ShadowNodeBase *>(shadowNode);
+  shadowNodeBase->IsFocusable(false);
+  return shadowNode;
+}
+
 XamlView ActivityIndicatorViewManager::CreateViewCore(
     int64_t /*tag*/,
     const winrt::Microsoft::ReactNative::JSValueObject &) {

--- a/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/ActivityIndicatorViewManager.h
@@ -15,6 +15,7 @@ class ActivityIndicatorViewManager : public ControlViewManager {
 
   const wchar_t *GetName() const override;
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
+  ShadowNode *createShadow() const override;
 
  protected:
   bool UpdateProperty(

--- a/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ScrollViewManager.cpp
@@ -100,6 +100,8 @@ void ScrollViewShadowNode::dispatchCommand(
 void ScrollViewShadowNode::createView(const winrt::Microsoft::ReactNative::JSValueObject &props) {
   Super::createView(props);
 
+  IsFocusable(false);
+
   const auto scrollViewer = GetView().as<winrt::ScrollViewer>();
   const auto scrollViewUWPImplementation = ScrollViewUWPImplementation(scrollViewer);
   scrollViewUWPImplementation.ScrollViewerSnapPointManager();


### PR DESCRIPTION
## Description

Make ScrollView and ActivityIndicator not focusable by default as this was an inadvertent change made at some point after RNW 0.68.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
In #11032 there was a change which made all ControlViewManager subclasses focusable by default. ScrollViewManager and ActivityIndicatorViewManager are two of those view managers, but both of those should not be focusable by default. Previously (e.g. in RNW 0.68) ScrollView and ActivityIndicator were not focusable by default.

### What
Make ScrollView and ActivityIndicator not focusable by default.

## Screenshots
Before all ScrollView components have a tab stop by default:

https://github.com/microsoft/react-native-windows/assets/359157/6f975c85-58ac-4358-ae8a-b37d041d238e

Before all ActivityIndicator components have a tab stop by default (note there's no focus ring but you can tell its focusing since the ScrollView is scrolling when focusing ActivityIndicators below the fold):

https://github.com/microsoft/react-native-windows/assets/359157/25b40a13-2a19-46d5-b2e3-259a674b6816

After (and in RNW 0.68) all ScrollView components don't have a tab stop by default:

https://github.com/microsoft/react-native-windows/assets/359157/a1c11fa8-0807-48cf-9a70-2a54c73a3608

After (and in RNW 0.68) all ActivityIndicator components don't have a tab stop by default:

https://github.com/microsoft/react-native-windows/assets/359157/0e9c78a4-a3ba-4fc6-9c9e-05da83b9d11f

## Testing
Tab through ScrollView and ActivityIndicator components. Ensure they don't have a tab stop by default.

CC @chiaramooney since you worked on #11032

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11675)