### PR TITLE
[0.72] Disable RestoreUseStaticGraphEvaluation for VS >= 17.6

### DIFF
--- a/change/react-native-windows-6e318099-e71b-442b-952f-ee0dce881d46.json
+++ b/change/react-native-windows-6e318099-e71b-442b-952f-ee0dce881d46.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.72] Disable RestoreUseStaticGraphEvaluation for VS >= 17.6",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -66,8 +66,9 @@
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet" Condition="'$(MSBuildProjectExtension)' == '.vcxproj'">
-    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
-    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
+    <!-- See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target -->
+    <!-- RestoreUseStaticGraphEvaluation broke in VS 17.6, see https://github.com/microsoft/react-native-windows/issues/11670 -->
+    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.6')) AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
 </Project>

--- a/vnext/PropertySheets/NuGet.Cpp.props
+++ b/vnext/PropertySheets/NuGet.Cpp.props
@@ -9,8 +9,9 @@
 
   <PropertyGroup Label="NuGet">
     <!-- Should match entry in $(ReactNativeWindowsDir)vnext\Directory.Build.props -->
-    <!--See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target-->
-    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
+    <!-- See https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#restore-target -->
+    <!-- RestoreUseStaticGraphEvaluation broke in VS 17.6, see https://github.com/microsoft/react-native-windows/issues/11670 -->
+    <RestoreUseStaticGraphEvaluation Condition="'$(BuildingInsideVisualStudio)' == 'true' AND $([MSBuild]::VersionLessThan('$(MSBuildVersion)', '17.6')) AND '$(DisableRestoreUseStaticGraphEvaluation)' != 'true'">true</RestoreUseStaticGraphEvaluation>
 
     <!-- Ensure PackageReference compatibility for any consuming projects/apps -->
     <ResolveNuGetPackages>false</ResolveNuGetPackages>


### PR DESCRIPTION
This PR backports #11681 to 0.72.

## Description

This PR disables `RestoreUseStaticGraphEvaluation` if building within Visual Studio >= 17.6, which is not working in our project.

Ideally we want `RestoreUseStaticGraphEvaluation` to improve the build speed. However this will unblock folk trying to build our code within the newest versions of Visual Studio.

This does not impact building via MSBuild (i.e. using the `run-windows` CLI command).

Resolves #11670

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Unblock building with VS >= 17.6

Resolves #11670

### What
Adds a check for the version of VS to the condition setting `RestoreUseStaticGraphEvaluation`.

## Screenshots
N/A

## Testing
Verified I can build `Microsoft.ReactNative.sln` with VS 17.6 and 17.5.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11687)