### PR TITLE
[Win32] Always include fabric in win32 interface

### DIFF
--- a/change/react-native-windows-7d58b39d-845e-4538-940b-3ac36dc79a8c.json
+++ b/change/react-native-windows-7d58b39d-845e-4538-940b-3ac36dc79a8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add fabric APIs to win32 winmd to allow easier flighting",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -6,11 +6,9 @@
 #include "pch.h"
 #include "winrt/base.h"
 void* winrt_make_Microsoft_Internal_TestController();
-#ifdef USE_FABRIC
 void* winrt_make_Microsoft_ReactNative_CompositionRootView();
 void *winrt_make_Microsoft_ReactNative_Composition_CompositionContextHelper();
 void *winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
-#endif
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
 void* winrt_make_Microsoft_ReactNative_ReactDispatcherHelper();
@@ -45,8 +43,6 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     {
         return winrt_make_Microsoft_Internal_TestController();
     }
-
-#ifdef USE_FABRIC
     if (requal(name, L"Microsoft.ReactNative.CompositionRootView")) {
       return winrt_make_Microsoft_ReactNative_CompositionRootView();
     }
@@ -56,8 +52,6 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     if (requal(name, L"Microsoft.ReactNative.Composition.CompositionUIService")) {
       return winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
     }
-#endif
-
     if (requal(name, L"Microsoft.ReactNative.JsiRuntime"))
     {
         return winrt_make_Microsoft_ReactNative_JsiRuntime();

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
+    <IncludeFabricInterface>true</IncludeFabricInterface>
   </PropertyGroup>
   <PropertyGroup>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -1,0 +1,47 @@
+
+#include "pch.h"
+#include "CompositionContextHelper.h"
+#if __has_include("Composition.CompositionContextHelper.g.cpp")
+#include "Composition.CompositionContextHelper.g.cpp"
+#endif
+
+#include <Composition.ActivityVisual.g.h>
+#include <Composition.ScrollPositionChangedArgs.g.h>
+#include <Composition.ScrollVisual.g.h>
+#include <Composition.SpriteVisual.g.h>
+#include <Composition.SurfaceBrush.g.h>
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+ICompositionContext CompositionContextHelper::CreateContext(
+    winrt::Windows::UI::Composition::Compositor const &) noexcept {
+      return nullptr;
+}
+
+IVisual CompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &) noexcept {
+      return nullptr;
+}
+
+winrt::Windows::UI::Composition::Compositor CompositionContextHelper::InnerCompositor(
+    ICompositionContext) noexcept {
+      return nullptr;
+}
+
+winrt::Windows::UI::Composition::Visual CompositionContextHelper::InnerVisual(IVisual) noexcept {
+      return nullptr;
+}
+
+winrt::Windows::UI::Composition::DropShadow CompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
+      return nullptr;
+}
+
+winrt::Windows::UI::Composition::CompositionBrush CompositionContextHelper::InnerBrush(IBrush) noexcept {
+      return nullptr;
+}
+
+winrt::Windows::UI::Composition::ICompositionSurface CompositionContextHelper::InnerSurface(
+    ICompositionDrawingSurface) noexcept {
+      return nullptr;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -15,33 +15,32 @@ namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 ICompositionContext CompositionContextHelper::CreateContext(
     winrt::Windows::UI::Composition::Compositor const &) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 IVisual CompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
-winrt::Windows::UI::Composition::Compositor CompositionContextHelper::InnerCompositor(
-    ICompositionContext) noexcept {
-      return nullptr;
+winrt::Windows::UI::Composition::Compositor CompositionContextHelper::InnerCompositor(ICompositionContext) noexcept {
+  return nullptr;
 }
 
 winrt::Windows::UI::Composition::Visual CompositionContextHelper::InnerVisual(IVisual) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 winrt::Windows::UI::Composition::DropShadow CompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 winrt::Windows::UI::Composition::CompositionBrush CompositionContextHelper::InnerBrush(IBrush) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 winrt::Windows::UI::Composition::ICompositionSurface CompositionContextHelper::InnerSurface(
     ICompositionDrawingSurface) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#include "pch.h"
+#include "CompositionRootView.h"
+#include "CompositionRootView.g.cpp"
+#include "FocusNavigationRequest.g.cpp"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+//! This class ensures that we access ReactRootView from UI thread.
+struct CompositionReactViewInstance
+    : public winrt::implements<CompositionReactViewInstance, winrt::Microsoft::ReactNative::IReactViewInstance> {
+  CompositionReactViewInstance(
+      winrt::weak_ref<winrt::Microsoft::ReactNative::implementation::CompositionRootView> &&) noexcept {}
+
+  void InitRootView(
+      winrt::Microsoft::ReactNative::IReactContext,
+      winrt::Microsoft::ReactNative::ReactViewOptions) noexcept {}
+
+  void UpdateRootView() noexcept {}
+  void UninitRootView() noexcept {}
+};
+
+//===========================================================================
+// ReactViewInstance inline implementation
+//===========================================================================
+
+CompositionRootView::CompositionRootView() noexcept {}
+
+ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
+  return nullptr;
+}
+
+void CompositionRootView::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &) noexcept {
+}
+
+winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::RootVisual() noexcept {
+  return nullptr;
+}
+
+void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &) noexcept {
+}
+
+winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
+  return {};
+}
+
+void CompositionRootView::Size(winrt::Windows::Foundation::Size) noexcept {
+}
+
+double CompositionRootView::ScaleFactor() noexcept {
+  return 0;
+}
+
+void CompositionRootView::ScaleFactor(double) noexcept {
+}
+
+winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::GetVisual() const noexcept {
+  return nullptr;
+}
+
+std::string CompositionRootView::JSComponentName() const noexcept {
+  return {};
+}
+
+int64_t CompositionRootView::GetActualHeight() const noexcept {
+  return 0;
+}
+
+int64_t CompositionRootView::GetActualWidth() const noexcept {
+  return 0;
+}
+
+int64_t CompositionRootView::GetTag() const noexcept {
+  return 0;
+}
+
+void CompositionRootView::SetTag(int64_t) noexcept {
+}
+
+int64_t CompositionRootView::SendMessage(uint32_t, uint64_t, int64_t) noexcept {
+  return 0;
+}
+
+void CompositionRootView::OnScrollWheel(Windows::Foundation::Point, int32_t) noexcept {
+}
+
+void CompositionRootView::InitRootView(
+    winrt::Microsoft::ReactNative::IReactContext &&,
+    winrt::Microsoft::ReactNative::ReactViewOptions &&) noexcept {
+}
+
+void CompositionRootView::UpdateRootView() noexcept {
+}
+
+void CompositionRootView::UpdateRootViewInternal() noexcept {
+}
+
+void CompositionRootView::UninitRootView() noexcept {
+}
+
+void CompositionRootView::ClearLoadingUI() noexcept {}
+
+void CompositionRootView::EnsureLoadingUI() noexcept {}
+
+void CompositionRootView::ShowInstanceLoaded() noexcept {}
+
+void CompositionRootView::ShowInstanceError() noexcept {}
+
+void CompositionRootView::ShowInstanceLoading() noexcept {}
+
+Windows::Foundation::Size CompositionRootView::Measure(Windows::Foundation::Size const &) const {
+  return {};
+}
+
+Windows::Foundation::Size CompositionRootView::Arrange(Windows::Foundation::Size) const {
+  return {};
+}
+
+::Microsoft::ReactNative::RootComponentView *CompositionRootView::GetComponentView() noexcept {
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::FocusNavigationResult CompositionRootView::NavigateFocus(
+    const winrt::Microsoft::ReactNative::FocusNavigationRequest &) noexcept {
+      return nullptr;
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
-#include "CompositionRootView.h"
 #include "CompositionRootView.g.cpp"
 #include "FocusNavigationRequest.g.cpp"
+#include "CompositionRootView.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -31,29 +31,25 @@ ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
   return nullptr;
 }
 
-void CompositionRootView::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &) noexcept {
-}
+void CompositionRootView::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &) noexcept {}
 
 winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::RootVisual() noexcept {
   return nullptr;
 }
 
-void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &) noexcept {
-}
+void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &) noexcept {}
 
 winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
   return {};
 }
 
-void CompositionRootView::Size(winrt::Windows::Foundation::Size) noexcept {
-}
+void CompositionRootView::Size(winrt::Windows::Foundation::Size) noexcept {}
 
 double CompositionRootView::ScaleFactor() noexcept {
   return 0;
 }
 
-void CompositionRootView::ScaleFactor(double) noexcept {
-}
+void CompositionRootView::ScaleFactor(double) noexcept {}
 
 winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
   return nullptr;
@@ -79,29 +75,23 @@ int64_t CompositionRootView::GetTag() const noexcept {
   return 0;
 }
 
-void CompositionRootView::SetTag(int64_t) noexcept {
-}
+void CompositionRootView::SetTag(int64_t) noexcept {}
 
 int64_t CompositionRootView::SendMessage(uint32_t, uint64_t, int64_t) noexcept {
   return 0;
 }
 
-void CompositionRootView::OnScrollWheel(Windows::Foundation::Point, int32_t) noexcept {
-}
+void CompositionRootView::OnScrollWheel(Windows::Foundation::Point, int32_t) noexcept {}
 
 void CompositionRootView::InitRootView(
     winrt::Microsoft::ReactNative::IReactContext &&,
-    winrt::Microsoft::ReactNative::ReactViewOptions &&) noexcept {
-}
+    winrt::Microsoft::ReactNative::ReactViewOptions &&) noexcept {}
 
-void CompositionRootView::UpdateRootView() noexcept {
-}
+void CompositionRootView::UpdateRootView() noexcept {}
 
-void CompositionRootView::UpdateRootViewInternal() noexcept {
-}
+void CompositionRootView::UpdateRootViewInternal() noexcept {}
 
-void CompositionRootView::UninitRootView() noexcept {
-}
+void CompositionRootView::UninitRootView() noexcept {}
 
 void CompositionRootView::ClearLoadingUI() noexcept {}
 
@@ -127,7 +117,7 @@ Windows::Foundation::Size CompositionRootView::Arrange(Windows::Foundation::Size
 
 winrt::Microsoft::ReactNative::FocusNavigationResult CompositionRootView::NavigateFocus(
     const winrt::Microsoft::ReactNative::FocusNavigationRequest &) noexcept {
-      return nullptr;
+  return nullptr;
 }
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 #include "pch.h"
+
+#include "CompositionRootView.h"
+
 #include "CompositionRootView.g.cpp"
 #include "FocusNavigationRequest.g.cpp"
-#include "CompositionRootView.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include "Composition.CompositionUIService.g.cpp"
+
 #include "CompositionUIService.h"
+
+#include "Composition.CompositionUIService.g.cpp"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "CompositionUIService.h"
+#include "Composition.CompositionUIService.g.cpp"
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+void CompositionUIService::SetCompositionContext(
+    IReactPropertyBag const &,
+    ICompositionContext const &) noexcept {
+}
+
+ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &) noexcept {
+  return nullptr;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
@@ -2,15 +2,12 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include "CompositionUIService.h"
 #include "Composition.CompositionUIService.g.cpp"
+#include "CompositionUIService.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-void CompositionUIService::SetCompositionContext(
-    IReactPropertyBag const &,
-    ICompositionContext const &) noexcept {
-}
+void CompositionUIService::SetCompositionContext(IReactPropertyBag const &, ICompositionContext const &) noexcept {}
 
 ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &) noexcept {
   return nullptr;

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -521,14 +521,14 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'">
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionHwndHost.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionSwitcher.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
-    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionHwndHost.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionSwitcher.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
   </ItemGroup>
 </Project>

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -36,6 +36,11 @@
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionContextHelper_emptyimpl.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\ReactCompositionViewComponentBuilder.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl</DependentUpon>
@@ -63,8 +68,18 @@
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionRootView_emptyimpl.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionUIService.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+        <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionUIService_emptyimpl.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' != 'true'">true</ExcludedFromBuild>
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
@@ -505,15 +520,15 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactNativeHost.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
-  <ItemGroup Condition="'$(UseFabric)' == 'true'">
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionHwndHost.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionSwitcher.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
-    <Midl Condition="'$(UseFabric)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
+  <ItemGroup Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'">
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionContext.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionHwndHost.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionRootView.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionSwitcher.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
+    <Midl Condition="'$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
Currently the fabric APIs are not part of the winmd published for win32.  This means that when swapping between the dll built with fabric and without requires a rebuild in Office - which makes the barrier for testing much higher.

With this change, the interface will be included in the win32 dll, even when not building with UseFabric.  This allows us to take the same build of Office and just replace the dll to be able to start testing fabric.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11692)