### PR TITLE
Make IReactNotificationSubscription template explicit

### DIFF
--- a/change/react-native-windows-941d3b7e-ef0f-4505-bab1-8848552defd6.json
+++ b/change/react-native-windows-941d3b7e-ef0f-4505-bab1-8848552defd6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Make IReactNotificationSubscription template explicit",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
@@ -123,7 +123,8 @@ struct ReactNotificationSubscriptionView : implements<
   ReactNotificationSubscriptionView(
       weak_ref<ReactNotificationService> &&notificationService,
       IReactNotificationSubscription const &childSubscription) noexcept
-      : m_notificationService{std::move(notificationService)}, m_childSubscription{weak_ref(childSubscription)} {
+      : m_notificationService{std::move(notificationService)},
+        m_childSubscription{weak_ref<IReactNotificationSubscription>(childSubscription)} {
     childSubscription.as<IReactNotificationSubscriptionPrivate>()->SetParent(*this);
   }
 


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang doesn't seem to infer the generic type argument. Making it explicit fixes the issue.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11697)