### PR TITLE
Publish Guardian Artifacts to help diagnose guardian breaks

### DIFF
--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -49,6 +49,14 @@ steps:
       debugMode: false
     continueOnError: ${{ parameters.complianceWarnOnly }}
 
+  - task: PublishSecurityAnalysisLogs@3
+    displayName: 'Publish Guardian Artifacts'
+    inputs:
+      ArtifactName: CodeAnalysisLogs
+      ArtifactType: Container
+      PublishProcessedResults: false
+      AllTools: true
+
   # PostAnalysis Task (https://docs.microsoft.com/en-us/azure/security/develop/yaml-configuration#post-analysis-task)
   # Breaks the build if any of the tasks failed.
   - task: PostAnalysis@2


### PR DESCRIPTION
Current publish builds are failing a guardian check, but the build is not publishing the guardian logs, which makes it hard to work out what the actual break is.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11702)