### PR TITLE
[Fabric] Add basic PlatformColor support

### DIFF
--- a/change/react-native-windows-9bada428-fb94-4baf-8e6f-c00637c09a13.json
+++ b/change/react-native-windows-9bada428-fb94-4baf-8e6f-c00637c09a13.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add basic PlatformColor support",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1196,7 +1196,7 @@ void CompositionViewComponentView::updateProps(
 
   if (oldViewProps.backgroundColor != newViewProps.backgroundColor) {
     if (newViewProps.backgroundColor) {
-      m_visual.Brush(m_compContext.CreateColorBrush((*newViewProps.backgroundColor).m_color));
+      m_visual.Brush(m_compContext.CreateColorBrush(newViewProps.backgroundColor.AsWindowsColor()));
     } else {
       m_visual.Brush(nullptr);
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -149,7 +149,7 @@ void ScrollViewComponentView::updateProps(
 
   if (!oldProps || oldViewProps.backgroundColor != newViewProps.backgroundColor) {
     if (newViewProps.backgroundColor) {
-      m_scrollVisual.Brush(m_compContext.CreateColorBrush((*newViewProps.backgroundColor).m_color));
+      m_scrollVisual.Brush(m_compContext.CreateColorBrush(newViewProps.backgroundColor.AsWindowsColor()));
     } else {
       m_scrollVisual.Brush(m_compContext.CreateColorBrush({0, 0, 0, 0}));
     }

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -17,7 +17,6 @@ bool isColorMeaningful(SharedColor const &color) noexcept {
 
 winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
   if (!color->m_platformColor.empty()) {
-
 #ifndef CORE_ABI
     // If XAML is loaded, look in application resources
     if (xaml::TryGetCurrentApplication()) {
@@ -30,7 +29,8 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
 
     // Accent colors
     // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uicolortype?view=winrt-22621
-    static std::unordered_map<std::string, ui::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
+    static std::
+        unordered_map<std::string, ui::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
             s_uiColorTypes = {
                 {"Accent", ui::ViewManagement::UIColorType::Accent},
                 {"AccentDark1", ui::ViewManagement::UIColorType::AccentDark1},
@@ -51,7 +51,8 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
 
     // UI element colors
     // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uielementtype?view=winrt-22621
-    static std::unordered_map<std::string, ui::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
+    static std::
+        unordered_map<std::string, ui::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
             s_uiElementTypes = {
                 {"AccentColor", ui::ViewManagement::UIElementType::AccentColor},
                 {"ActiveCaption", ui::ViewManagement::UIElementType::ActiveCaption},
@@ -94,38 +95,37 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
     // are needed, they should be taken from that section (not "Dark" or "HighContrast").
     // For control-specific values, they will be in a theme resource file for that control. Example:
     // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-    static std::unordered_map<std::string, ui::Color, std::hash<std::string_view>, std::equal_to<>>
-        s_xamlBrushes = {
-            {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
-            {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
-            {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
-            {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
-            {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
-            {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
-            {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
-            {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
-            {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
-            {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
-            {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
-            {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
-            // Arguably only the control-agnostic platform colors should be respected, and
-            // Button should be updated to use those instead, assuming that still holds up
-            // in high contrast and such.
-            {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
-            {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
-            {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-            {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
-            {"ButtonBorderBrush",
-             {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
-            {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-            {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
-            {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
-            {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
-            {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
-            {"ButtonBorderBrushPointerOver",
-             {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
-            {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
-        };
+    static std::unordered_map<std::string, ui::Color, std::hash<std::string_view>, std::equal_to<>> s_xamlBrushes = {
+        {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
+        {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
+        {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
+        {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
+        {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
+        {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
+        {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
+        {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
+        {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
+        {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
+        {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
+        {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
+        // Arguably only the control-agnostic platform colors should be respected, and
+        // Button should be updated to use those instead, assuming that still holds up
+        // in high contrast and such.
+        {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
+        {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
+        {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+        {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
+        {"ButtonBorderBrush",
+         {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
+        {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+        {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
+        {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
+        {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
+        {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
+        {"ButtonBorderBrushPointerOver",
+         {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
+        {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
+    };
 
     auto result = s_xamlBrushes.find(color->m_platformColor);
     if (result != s_xamlBrushes.end()) {

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -3,6 +3,7 @@
 
 #include "Color.h"
 #include <Utils/ValueUtils.h>
+#include <XamlUtils.h>
 
 namespace facebook::react {
 
@@ -15,49 +16,119 @@ bool isColorMeaningful(SharedColor const &color) noexcept {
 }
 
 winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
-  // Issue #11489. These are all the light-theme values. Which is better than no values.
-  // Where did these values come from? WinUI's common theme resources:
-  // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
-  // Specifically these are pulled from the "Light" ResourceDictionary. If any additional values
-  // are needed, they should be taken from that section (not "Dark" or "HighContrast").
-  // For control-specific values, they will be in a theme resource file for that control. Example:
-  // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-  static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>>
-      s_windowsColors = {
-          {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
-          {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
-          {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
-          {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
-          {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
-          {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
-          {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
-          {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
-          {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
-          // Arguably only the control-agnostic platform colors should be respected, and
-          // Button should be updated to use those instead, assuming that still holds up
-          // in high contrast and such.
-          {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
-          {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
-          {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-          {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
-          {"ButtonBorderBrush",
-           {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
-          {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-          {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
-          {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
-          {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
-          {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
-          {"ButtonBorderBrushPointerOver",
-           {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
-          {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
-      };
-
   if (!color->m_platformColor.empty()) {
-    auto result = s_windowsColors.find(color->m_platformColor);
-    if (result != s_windowsColors.end()) {
+
+#ifndef CORE_ABI
+    // If XAML is loaded, look in application resources
+    if (xaml::TryGetCurrentApplication()) {
+      xaml::Media::Brush brush{Microsoft::ReactNative::BrushFromColorObject(winrt::to_hstring(color->m_platformColor))};
+      if (auto scb{brush.try_as<xaml::Media::SolidColorBrush>()}) {
+        return scb.Color();
+      }
+    }
+#endif // CORE_ABI
+
+    // Accent colors
+    // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uicolortype?view=winrt-22621
+    static std::unordered_map<std::string, ui::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
+            s_uiColorTypes = {
+                {"Accent", ui::ViewManagement::UIColorType::Accent},
+                {"AccentDark1", ui::ViewManagement::UIColorType::AccentDark1},
+                {"AccentDark2", ui::ViewManagement::UIColorType::AccentDark2},
+                {"AccentDark3", ui::ViewManagement::UIColorType::AccentDark3},
+                {"AccentLight1", ui::ViewManagement::UIColorType::AccentLight1},
+                {"AccentLight2", ui::ViewManagement::UIColorType::AccentLight2},
+                {"AccentLight3", ui::ViewManagement::UIColorType::AccentLight3},
+                {"Background", ui::ViewManagement::UIColorType::Background},
+                {"Complement", ui::ViewManagement::UIColorType::Complement},
+                {"Foreground", ui::ViewManagement::UIColorType::Foreground}};
+
+    auto uiColor = s_uiColorTypes.find(color->m_platformColor);
+    if (uiColor != s_uiColorTypes.end()) {
+      auto uiSettings{ui::ViewManagement::UISettings()};
+      return uiSettings.GetColorValue(uiColor->second);
+    }
+
+    // UI element colors
+    // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uielementtype?view=winrt-22621
+    static std::unordered_map<std::string, ui::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
+            s_uiElementTypes = {
+                {"AccentColor", ui::ViewManagement::UIElementType::AccentColor},
+                {"ActiveCaption", ui::ViewManagement::UIElementType::ActiveCaption},
+                {"Background", ui::ViewManagement::UIElementType::Background},
+                {"ButtonFace", ui::ViewManagement::UIElementType::ButtonFace},
+                {"ButtonText", ui::ViewManagement::UIElementType::ButtonText},
+                {"CaptionText", ui::ViewManagement::UIElementType::CaptionText},
+                {"GrayText", ui::ViewManagement::UIElementType::GrayText},
+                {"Highlight", ui::ViewManagement::UIElementType::Highlight},
+                {"HighlightText", ui::ViewManagement::UIElementType::HighlightText},
+                {"Hotlight", ui::ViewManagement::UIElementType::Hotlight},
+                {"InactiveCaption", ui::ViewManagement::UIElementType::InactiveCaption},
+                {"InactiveCaptionText", ui::ViewManagement::UIElementType::InactiveCaptionText},
+                {"NonTextHigh", ui::ViewManagement::UIElementType::NonTextHigh},
+                {"NonTextLow", ui::ViewManagement::UIElementType::NonTextLow},
+                {"NonTextMedium", ui::ViewManagement::UIElementType::NonTextMedium},
+                {"NonTextMediumHigh", ui::ViewManagement::UIElementType::NonTextMediumHigh},
+                {"NonTextMediumLow", ui::ViewManagement::UIElementType::NonTextMediumLow},
+                {"OverlayOutsidePopup", ui::ViewManagement::UIElementType::OverlayOutsidePopup},
+                {"PageBackground", ui::ViewManagement::UIElementType::PageBackground},
+                {"PopupBackground", ui::ViewManagement::UIElementType::PopupBackground},
+                {"TextContrastWithHigh", ui::ViewManagement::UIElementType::TextContrastWithHigh},
+                {"TextHigh", ui::ViewManagement::UIElementType::TextHigh},
+                {"TextLow", ui::ViewManagement::UIElementType::TextLow},
+                {"TextMedium", ui::ViewManagement::UIElementType::TextMedium},
+                {"Window", ui::ViewManagement::UIElementType::Window},
+                {"WindowText", ui::ViewManagement::UIElementType::WindowText}};
+
+    auto uiElement = s_uiElementTypes.find(color->m_platformColor);
+    if (uiElement != s_uiElementTypes.end()) {
+      auto uiSettings{ui::ViewManagement::UISettings()};
+      return uiSettings.UIElementColor(uiElement->second);
+    }
+
+    // Fallback light-theme XAML brushes
+    // Issue #11489. These are all the light-theme values. Which is better than no values.
+    // Where did these values come from? WinUI's common theme resources:
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/7a33ad772d77d908aa6b316ec24e6d2eb3ebf571/dev/CommonStyles/Common_themeresources_any.xaml
+    // Specifically these are pulled from the "Light" ResourceDictionary. If any additional values
+    // are needed, they should be taken from that section (not "Dark" or "HighContrast").
+    // For control-specific values, they will be in a theme resource file for that control. Example:
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
+    static std::unordered_map<std::string, ui::Color, std::hash<std::string_view>, std::equal_to<>>
+        s_xamlBrushes = {
+            {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
+            {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
+            {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
+            {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
+            {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
+            {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
+            {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
+            {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
+            {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
+            {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
+            {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
+            {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
+            // Arguably only the control-agnostic platform colors should be respected, and
+            // Button should be updated to use those instead, assuming that still holds up
+            // in high contrast and such.
+            {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
+            {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
+            {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+            {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
+            {"ButtonBorderBrush",
+             {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
+            {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+            {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
+            {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
+            {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
+            {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
+            {"ButtonBorderBrushPointerOver",
+             {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
+            {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
+        };
+
+    auto result = s_xamlBrushes.find(color->m_platformColor);
+    if (result != s_xamlBrushes.end()) {
       return result->second;
     }
   }

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -3,7 +3,10 @@
 
 #include "Color.h"
 #include <Utils/ValueUtils.h>
+
+#ifndef CORE_ABI
 #include <XamlUtils.h>
+#endif // CORE_ABI
 
 namespace facebook::react {
 

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -8,6 +8,8 @@
 #include <XamlUtils.h>
 #endif // CORE_ABI
 
+#include <winrt/Windows.UI.ViewManagement.h>
+
 namespace facebook::react {
 
 bool isColorMeaningful(SharedColor const &color) noexcept {


### PR DESCRIPTION
Adding accent and system ui element colors. If XAML is loaded, we fall back to Paper/XAML brushes. 

Next iteration will add color cache and redraw when system colors change while app is running. 

![image](https://github.com/microsoft/react-native-windows/assets/1422161/b2910d5a-3d04-4bc3-acdc-0cd19b8a74e6)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11710)