### PR TITLE
Support PlatformColor fallback

### DIFF
--- a/change/react-native-windows-c23b3929-c1e6-4f1b-afe8-53051964fac7.json
+++ b/change/react-native-windows-c23b3929-c1e6-4f1b-afe8-53051964fac7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support PlatformColor fallback",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -166,10 +166,10 @@ xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {
   auto value{d.find("windowsbrush")->second};
   if (value.isArray()) {
     for (const auto &resource : value) {
-      resources.emplace_back(resource.asString());
+      resources.emplace_back(winrt::to_hstring(resource.asString()));
     }
   } else {
-    resources.emplace_back(value.asString());
+    resources.emplace_back(winrt::to_hstring(value.asString()));
   }
 
   return BrushFromColorObject(resources);

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -109,7 +109,7 @@ struct BrushCache {
     });
   }
 
-  xaml::Media::Brush BrushFromResourceName(const std::vector<winrt::hstring> resources) {
+  xaml::Media::Brush BrushFromResourceName(const std::vector<winrt::hstring> &resources) {
     for (auto resourceName : resources) {
       if (m_map.find(resourceName) != m_map.end()) {
         if (auto brush = m_map.at(resourceName)) {
@@ -154,7 +154,7 @@ xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
   return BrushFromColorObject(std::vector<winrt::hstring>{resourceName});
 }
 
-xaml::Media::Brush BrushFromColorObject(std::vector<winrt::hstring> resourceNames) {
+xaml::Media::Brush BrushFromColorObject(const std::vector<winrt::hstring> &resourceNames) {
   thread_local static BrushCache accentColorMap;
 
   return accentColorMap.BrushFromResourceName(resourceNames);

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.cpp
@@ -109,26 +109,28 @@ struct BrushCache {
     });
   }
 
-  xaml::Media::Brush BrushFromResourceName(winrt::hstring resourceName) {
-    if (m_map.find(resourceName) != m_map.end()) {
-      if (auto brush = m_map.at(resourceName)) {
-        return brush;
+  xaml::Media::Brush BrushFromResourceName(const std::vector<winrt::hstring> resources) {
+    for (auto resourceName : resources) {
+      if (m_map.find(resourceName) != m_map.end()) {
+        if (auto brush = m_map.at(resourceName)) {
+          return brush;
+        }
+
+        auto brush = BrushFromTheme(resourceName);
+        return RegisterBrush(resourceName, brush);
       }
 
-      auto brush = BrushFromTheme(resourceName);
-      return RegisterBrush(resourceName, brush);
-    }
+      const auto appResources{winrt::Application::Current().Resources()};
+      const auto boxedResourceName{winrt::box_value(resourceName)};
+      if (appResources.HasKey(boxedResourceName)) {
+        winrt::IInspectable resource{appResources.Lookup(boxedResourceName)};
 
-    const auto appResources{winrt::Application::Current().Resources()};
-    const auto boxedResourceName{winrt::box_value(resourceName)};
-    if (appResources.HasKey(boxedResourceName)) {
-      winrt::IInspectable resource{appResources.Lookup(boxedResourceName)};
-
-      if (auto brush = resource.try_as<xaml::Media::Brush>()) {
-        return RegisterBrush(resourceName, brush);
-      } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
-        auto brush = xaml::Media::SolidColorBrush(color.value());
-        return RegisterBrush(resourceName, brush);
+        if (auto brush = resource.try_as<xaml::Media::Brush>()) {
+          return RegisterBrush(resourceName, brush);
+        } else if (auto color = resource.try_as<winrt::Windows::UI::Color>()) {
+          auto brush = xaml::Media::SolidColorBrush(color.value());
+          return RegisterBrush(resourceName, brush);
+        }
       }
     }
 
@@ -149,17 +151,42 @@ struct BrushCache {
 };
 
 xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName) {
+  return BrushFromColorObject(std::vector<winrt::hstring>{resourceName});
+}
+
+xaml::Media::Brush BrushFromColorObject(std::vector<winrt::hstring> resourceNames) {
   thread_local static BrushCache accentColorMap;
 
-  return accentColorMap.BrushFromResourceName(resourceName);
+  return accentColorMap.BrushFromResourceName(resourceNames);
 }
 
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d) {
-  return BrushFromColorObject(winrt::to_hstring(d.find("windowsbrush")->second.asString()));
+  std::vector<winrt::hstring> resources;
+
+  auto value{d.find("windowsbrush")->second};
+  if (value.isArray()) {
+    for (const auto &resource : value) {
+      resources.emplace_back(resource.asString());
+    }
+  } else {
+    resources.emplace_back(value.asString());
+  }
+
+  return BrushFromColorObject(resources);
 }
 
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v) {
-  return BrushFromColorObject(winrt::to_hstring(v["windowsbrush"].AsString()));
+  std::vector<winrt::hstring> resources;
+
+  if (v["windowsbrush"].Type() == winrt::Microsoft::ReactNative::JSValueType::Array) {
+    for (const auto &resource : v["windowsbrush"].AsArray()) {
+      resources.emplace_back(winrt::to_hstring(resource.AsString()));
+    }
+  } else {
+    resources.emplace_back(winrt::to_hstring(v["windowsbrush"].AsString()));
+  }
+
+  return BrushFromColorObject(resources);
 }
 
 winrt::Color ColorFromNumber(DWORD argb) noexcept {

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -21,7 +21,7 @@ struct JSValue;
 namespace Microsoft::ReactNative {
 
 xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName);
-xaml::Media::Brush BrushFromColorObject(std::vector<winrt::hstring> resourceNames);
+xaml::Media::Brush BrushFromColorObject(const std::vector<winrt::hstring> &resourceNames);
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v);
 xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);

--- a/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ValueUtils.h
@@ -21,6 +21,7 @@ struct JSValue;
 namespace Microsoft::ReactNative {
 
 xaml::Media::Brush BrushFromColorObject(winrt::hstring resourceName);
+xaml::Media::Brush BrushFromColorObject(std::vector<winrt::hstring> resourceNames);
 xaml::Media::Brush BrushFromColorObject(const folly::dynamic &d);
 xaml::Media::Brush BrushFromColorObject(const winrt::Microsoft::ReactNative::JSValue &v);
 xaml::Media::SolidColorBrush SolidBrushFromColor(winrt::Windows::UI::Color color);

--- a/vnext/src/Libraries/StyleSheet/PlatformColorValueTypes.windows.js
+++ b/vnext/src/Libraries/StyleSheet/PlatformColorValueTypes.windows.js
@@ -19,7 +19,7 @@ export opaque type NativeColorValue = {
 
 export const PlatformColor = (...names: Array<string>): ColorValue => {
   // We don't support fallback colors right now, so no point in sending more than the first color across the bridge
-  return {windowsbrush: names[0]};
+  return {windowsbrush: names};
 };
 
 export const normalizeColorObject = (


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Feature parity. PlatformColor is supposed to accept fallback colors: https://reactnative.dev/docs/platformcolor

Resolves #8513 

### What
1. Change PlatformColorValueTypes to pass on the array of string over to the native side instead of just taking the first element.
2. If a resource is not found, try the rest of the resources in the array before falling back to transparent.  

## Screenshots
```jsx
<Button title='SystemAccentColor' color={PlatformColor('SystemAccentColor')}/>
<Button title='FakeSystemColor, SystemAccentColor' color={PlatformColor('FakeSystemColor', 'SystemAccentColor')}/>
```
![image](https://github.com/microsoft/react-native-windows/assets/1422161/a547f542-7eeb-4d78-9ea3-cc61df8ffe32)
