### PR TITLE
[react-native-windows-init] Fix cli to work with workspaces

### DIFF
--- a/change/react-native-windows-init-af32cca8-44f8-41f9-8da0-93bbd2510923.json
+++ b/change/react-native-windows-init-af32cca8-44f8-41f9-8da0-93bbd2510923.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[react-native-windows-init] Fix cli to work with workspaces",
+  "packageName": "react-native-windows-init",
+  "email": "donadeldev@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -37,10 +37,19 @@ import {
 
 import requireGenerateWindows from './requireGenerateWindows';
 
-const npmConfReg = execSync('npm config get registry').toString().trim();
-const NPM_REGISTRY_URL = validUrl.isUri(npmConfReg)
-  ? npmConfReg
-  : 'http://registry.npmjs.org';
+let NPM_REGISTRY_URL = 'http://registry.npmjs.org';
+try {
+  const npmConfReg = execSync('npm config get registry').toString().trim();
+  if (validUrl.isUri(npmConfReg)) {
+    NPM_REGISTRY_URL = npmConfReg;
+  }
+} catch (error: any) {
+  // Ignore workspace errors as `npm config` does not support it
+  const stderr = error?.stderr?.toString() || '';
+  if (!stderr.includes('ENOWORKSPACES')) {
+    throw error;
+  }
+}
 
 // Causes the type-checker to ensure the options object is a valid yargs options object
 function initOptions<T extends Record<string, yargs.Options>>(options: T): T {


### PR DESCRIPTION
## Description

### Type of Change 

- Bug fix (non-breaking change which fixes an issue)
 
### Why

The current react-native-windows-init script does not work inside a monorepo that uses workspaces because 
the `npm config get registry` command is not supported in workspaces.

<img width="571" alt="image" src="https://github.com/microsoft/react-native-windows/assets/11707729/c911f60a-61ce-4711-b92b-225511ebd060">

### What

This PR wraps the `execSync('npm config get registry')` call into a try catch so errors related to `ENOWORKSPACES` get ignored, defaulting `NPM_REGISTRY_URL` to `http://registry.npmjs.org`

## Screenshots

<img width="325" alt="image" src="https://github.com/microsoft/react-native-windows/assets/11707729/a2e70072-2fa7-4af6-b870-dbe05ded91b3">


## Testing

Run cli locally inside a repo that uses workspaces
 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11713)