### PR TITLE
[Win32] [0.71] Add missing eventPhase on INativeKeyboardEvent

### DIFF
--- a/.ado/templates/run-compliance-prebuild.yml
+++ b/.ado/templates/run-compliance-prebuild.yml
@@ -51,7 +51,7 @@ steps:
 
   # PostAnalysis Task (https://docs.microsoft.com/en-us/azure/security/develop/yaml-configuration#post-analysis-task)
   # Breaks the build if any of the tasks failed.
-  - task: PostAnalysis@1
+  - task: PostAnalysis@2
     displayName: "⚖️ Compliance Pre-Build Analysis"
     inputs:
       AllTools: false

--- a/change/@office-iss-react-native-win32-e33cc16a-01b8-485d-b3dc-017ba9f1c528.json
+++ b/change/@office-iss-react-native-win32-e33cc16a-01b8-485d-b3dc-017ba9f1c528.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add missing eventPhase on INativeKeyboardEvent",
+  "comment": "Add missing eventPhase on IHandledKeyboardEvent",
   "packageName": "@office-iss/react-native-win32",
   "email": "30809111+acoates-ms@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@office-iss-react-native-win32-e33cc16a-01b8-485d-b3dc-017ba9f1c528.json
+++ b/change/@office-iss-react-native-win32-e33cc16a-01b8-485d-b3dc-017ba9f1c528.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add missing eventPhase on INativeKeyboardEvent",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
@@ -184,12 +184,24 @@ export type Cursor =
   | 'we-resize'
   | 'text';
 
+export namespace EventPhase {
+  export const None = 0;
+  export const Capturing = 1;
+  export const AtTarget = 2;
+  export const Bubbling = 3;
+}
+
 export interface INativeKeyboardEvent {
   altKey: boolean;
   ctrlKey: boolean;
   metaKey: boolean;
   shiftKey: boolean;
   key: string;
+  eventPhase:
+    | EventPhase.None
+    | EventPhase.Capturing
+    | EventPhase.AtTarget
+    | EventPhase.Bubbling;
 }
 export type IKeyboardEvent = NativeSyntheticEvent<INativeKeyboardEvent>;
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
@@ -197,11 +197,6 @@ export interface INativeKeyboardEvent {
   metaKey: boolean;
   shiftKey: boolean;
   key: string;
-  eventPhase:
-    | EventPhase.None
-    | EventPhase.Capturing
-    | EventPhase.AtTarget
-    | EventPhase.Bubbling;
 }
 export type IKeyboardEvent = NativeSyntheticEvent<INativeKeyboardEvent>;
 
@@ -215,7 +210,13 @@ type PartiallyRequired<T, Keys extends keyof T = keyof T> = Pick<
 export type IHandledKeyboardEvent = PartiallyRequired<
   INativeKeyboardEvent,
   'key'
->;
+> & {
+  eventPhase:
+    | EventPhase.None
+    | EventPhase.Capturing
+    | EventPhase.AtTarget
+    | EventPhase.Bubbling;
+};
 // Win32]
 
 export interface ViewPropsWin32 {

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.d.ts
@@ -211,7 +211,7 @@ export type IHandledKeyboardEvent = PartiallyRequired<
   INativeKeyboardEvent,
   'key'
 > & {
-  eventPhase:
+  eventPhase?:
     | EventPhase.None
     | EventPhase.Capturing
     | EventPhase.AtTarget

--- a/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/platform-types.d.ts
@@ -10,7 +10,7 @@ import { AccessibilityPropsWin32 } from '@office-iss/react-native-win32/Librarie
 export { AccessibilityPropsWin32 } from '@office-iss/react-native-win32/Libraries/Components/View/ViewAccessibility.win32';
 export type IViewWin32Props = IViewWin32PropsOnly & AccessibilityPropsWin32;
 export {ViewWin32} from './Components/View/ViewWin32';
-export {IKeyboardEvent, IHandledKeyboardEvent} from './Components/View/ViewPropTypes.win32';
+export {IKeyboardEvent, IHandledKeyboardEvent, EventPhase} from './Components/View/ViewPropTypes.win32';
 import {ITextWin32Props as ITextWin32PropsOnly} from './Components/Text/TextWin32.Props';
 export type ITextWin32Props = ITextWin32PropsOnly & AccessibilityPropsWin32;
 export {TextWin32TextStyle } from './Components/Text/TextWin32.Props';


### PR DESCRIPTION
Add missing type.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11714)