### PR TITLE
[Fabric] Fix y-position of TextInput's caret

### DIFF
--- a/change/react-native-windows-fae51559-4d2b-4ea7-bfa4-81a7a18a3108.json
+++ b/change/react-native-windows-fae51559-4d2b-4ea7-bfa4-81a7a18a3108.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix y-position of caret",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -145,8 +145,8 @@ RECT CompositionBaseComponentView::getClientRect() const noexcept {
     rc = m_parent->getClientRect();
   }
 
-  rc.left = static_cast<LONG>(m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor);
-  rc.top = static_cast<LONG>(m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor);
+  rc.left += static_cast<LONG>(m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor);
+  rc.top += static_cast<LONG>(m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor);
   rc.right = rc.left + static_cast<LONG>(m_layoutMetrics.frame.size.width * m_layoutMetrics.pointScaleFactor);
   rc.bottom = rc.top + static_cast<LONG>(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
   return rc;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -145,8 +145,8 @@ RECT CompositionBaseComponentView::getClientRect() const noexcept {
     rc = m_parent->getClientRect();
   }
 
-  rc.left += static_cast<LONG>(m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor);
-  rc.top += static_cast<LONG>(m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor);
+  rc.left = static_cast<LONG>(m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor);
+  rc.top = static_cast<LONG>(m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor);
   rc.right = rc.left + static_cast<LONG>(m_layoutMetrics.frame.size.width * m_layoutMetrics.pointScaleFactor);
   rc.bottom = rc.top + static_cast<LONG>(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
   return rc;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -252,7 +252,7 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
 
   //@cmember Retrieves the coordinates of a window's client area
   HRESULT TxGetClientRect(LPRECT prc) override {
-    *prc = m_outer->getClientRect();
+    *prc = m_outer->m_rcClient;
     return S_OK;
   }
 
@@ -950,8 +950,8 @@ void WindowsTextInputComponentView::ensureDrawingSurface() noexcept {
         winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
         winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
 
-    auto rcClient = getClientRect();
-    winrt::check_hresult(m_textServices->OnTxInPlaceActivate(&rcClient));
+    m_rcClient = getClientRect();
+    winrt::check_hresult(m_textServices->OnTxInPlaceActivate(&m_rcClient));
 
     LRESULT lresult;
     winrt::check_hresult(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -170,10 +170,9 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
       return false;
     }
 
-    // the y-position of the caret is constant
     m_outer->m_caretVisual.Position(
         {x - (m_outer->m_layoutMetrics.frame.origin.x * m_outer->m_layoutMetrics.pointScaleFactor),
-         m_outer->m_layoutMetrics.contentInsets.top * m_outer->m_layoutMetrics.pointScaleFactor});
+         y - (m_outer->m_layoutMetrics.frame.origin.y * m_outer->m_layoutMetrics.pointScaleFactor)});
     return true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -170,9 +170,10 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
       return false;
     }
 
+    // the y-position of the caret is constant
     m_outer->m_caretVisual.Position(
         {x - (m_outer->m_layoutMetrics.frame.origin.x * m_outer->m_layoutMetrics.pointScaleFactor),
-         y - (m_outer->m_layoutMetrics.frame.origin.y * m_outer->m_layoutMetrics.pointScaleFactor)});
+         m_outer->m_layoutMetrics.contentInsets.top * m_outer->m_layoutMetrics.pointScaleFactor});
     return true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -92,6 +92,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   unsigned int m_imgWidth{0}, m_imgHeight{0};
   std::shared_ptr<facebook::react::WindowsTextInputProps const> m_props;
   std::shared_ptr<facebook::react::WindowsTextInputShadowNode::ConcreteState const> m_state;
+  RECT m_rcClient;
   int m_mostRecentEventCount{0};
   int m_nativeEventCount{0};
   bool m_comingFromJS{false};


### PR DESCRIPTION
## Description
Fixes the y-position of TextInput's caret when located within a ScrollView. The ScrollViewComponent adds extra space via the getClientRect after TextInput gets initially drawn. This uses the correct RECT that is set when TextInput is drawn.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves #11486

## Screenshots
Before

https://github.com/microsoft/react-native-windows/assets/42554868/75771d62-2545-4500-b854-fca3f3144c78


After

https://github.com/microsoft/react-native-windows/assets/42554868/7f8412e2-c488-4bc9-a9dc-4fedd011f60a



## Testing
Tested locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11717)