### PR TITLE
Get StructInfo<T>::FieldMap lazy initialized

### DIFF
--- a/change/react-native-windows-bd63ab24-bc97-4f58-9566-b4f9ffa47214.json
+++ b/change/react-native-windows-bd63ab24-bc97-4f58-9566-b4f9ffa47214.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Get StructInfo<T>::FieldMap lazy initialized",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueReader.h
@@ -409,7 +409,7 @@ inline void ReadValue(IJSValueReader const &reader, /*out*/ JSValueArray &value)
 template <class T, std::enable_if_t<!std::is_void_v<decltype(GetStructInfo(static_cast<T *>(nullptr)))>, int>>
 inline void ReadValue(IJSValueReader const &reader, /*out*/ T &value) noexcept {
   if (reader.ValueType() == JSValueType::Object) {
-    const auto &fieldMap = StructInfo<T>::FieldMap;
+    const auto &fieldMap = StructInfo<T>::GetFieldMap();
     hstring propertyName;
     while (reader.GetNextObjectProperty(/*out*/ propertyName)) {
       auto it = fieldMap.find(std::wstring_view(propertyName));

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueWriter.h
@@ -234,7 +234,7 @@ inline void WriteCustomDirectEventTypeConstant(IJSValueWriter const &writer, std
 template <class T, std::enable_if_t<!std::is_void_v<decltype(GetStructInfo(static_cast<T *>(nullptr)))>, int>>
 inline void WriteValue(IJSValueWriter const &writer, T const &value) noexcept {
   writer.WriteObjectBegin();
-  for (const auto &fieldEntry : StructInfo<T>::FieldMap) {
+  for (const auto &fieldEntry : StructInfo<T>::GetFieldMap()) {
     writer.WritePropertyName(fieldEntry.first);
     fieldEntry.second.WriteField(writer, &value);
   }

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -113,11 +113,12 @@ void FieldWriter(IJSValueWriter const &writer, const void *obj, const uintptr_t 
 
 template <class T>
 struct StructInfo {
-  static const FieldMap FieldMap;
+  static const FieldMap& GetFieldMap()
+  {
+    static const FieldMap fieldMap = GetStructInfo(static_cast<T *>(nullptr));
+    return fieldMap;
+  }
 };
-
-template <class T>
-/*static*/ const FieldMap StructInfo<T>::FieldMap = GetStructInfo(static_cast<T *>(nullptr));
 
 template <int I>
 using ReactFieldId = std::integral_constant<int, I>;

--- a/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
+++ b/vnext/Microsoft.ReactNative.Cxx/StructInfo.h
@@ -113,8 +113,7 @@ void FieldWriter(IJSValueWriter const &writer, const void *obj, const uintptr_t 
 
 template <class T>
 struct StructInfo {
-  static const FieldMap& GetFieldMap()
-  {
+  static const FieldMap &GetFieldMap() {
     static const FieldMap fieldMap = GetStructInfo(static_cast<T *>(nullptr));
     return fieldMap;
   }

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -69,7 +69,7 @@ struct CppTurboModuleSpec : TurboModuleSpec {
 
       Method<void(int, int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"divideCallbacks"},
       Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateAsyncCallbacks"},
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateAsyncCallbacks"},                                                                                                                                                                                         
       Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{
           INDEX(c2),
           L"negateDispatchQueueCallbacks"},

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -69,7 +69,7 @@ struct CppTurboModuleSpec : TurboModuleSpec {
 
       Method<void(int, int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"divideCallbacks"},
       Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateCallbacks"},
-      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateAsyncCallbacks"},                                                                                                                                                                                         
+      Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{INDEX(c2), L"negateAsyncCallbacks"},
       Method<void(int, Callback<int>, Callback<std::string const &>) noexcept>{
           INDEX(c2),
           L"negateDispatchQueueCallbacks"},


### PR DESCRIPTION
## Description

### Type of Change
- New feature

### Why
Get StructInfo<T>::FieldMap is initialized when the binary is loading, it would heavily affect performance when a binary has many modules. It should be initialized only at the first accessing.

### What
Change `StructInfo<T>::FieldMap` to a function and perform lazy initialization inside.

## Screenshots
N/A

## Testing
Tested in `Microsoft.ReactNative.IntegrationTests`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11718)