### PR TITLE
[Fabric] Add accessible Prop Functionality to Remove/Add Elements from Content Tree

### DIFF
--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -247,6 +247,16 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
       pRetVal->boolVal = !props->accessibilityState.disabled ? VARIANT_TRUE : VARIANT_FALSE;
       break;
     }
+    case UIA_IsContentElementPropertyId: {
+      pRetVal->vt = VT_BOOL;
+      pRetVal->boolVal = props->accessible ? VARIANT_TRUE : VARIANT_FALSE;
+      break;
+    }
+    case UIA_IsControlElementPropertyId: {
+      pRetVal->vt = VT_BOOL;
+      pRetVal->boolVal = props->accessible ? VARIANT_TRUE : VARIANT_FALSE;
+      break;
+    }
   }
 
   return hr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1057,6 +1057,12 @@ void CompositionBaseComponentView::updateAccessibilityProps(
       provider, UIA_NamePropertyId, oldViewProps.accessibilityLabel, newViewProps.accessibilityLabel);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      provider, UIA_IsContentElementPropertyId, oldViewProps.accessible, newViewProps.accessible);
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      provider, UIA_IsControlElementPropertyId, oldViewProps.accessible, newViewProps.accessible);
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       provider,
       UIA_IsEnabledPropertyId,
       !oldViewProps.accessibilityState.disabled,


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Move closer to accessibility baseline on Fabric. 

### What
Add accessible prop functionality to Fabric. When an element sets accessible to false, the element should be removed from the UIA tree. When an element sets accessible to true, the element should exist in the UIA tree.

## Testing
Focusable | Accessible | Result
-- | -- | --
T | T | All properties are   true. Element can gain focus and is in the UIA tree.
T | F | Element can gain   keyboard focus, but is not in UIA tree. Yellow box error should be thrown.
F | T | Element cannot   gain keyboard focus, but is in the UIA tree.
F | F | All properties   false. Element cannot gain focus and is not in the UIA tree.