### PR TITLE
[Fabric] Add borders to TextInput

### DIFF
--- a/change/react-native-windows-c0c1e5ac-9cf9-4281-9dd3-8e7f939c2bd4.json
+++ b/change/react-native-windows-c0c1e5ac-9cf9-4281-9dd3-8e7f939c2bd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add border to Fabric TextInput",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -853,7 +853,10 @@ std::string WindowsTextInputComponentView::GetTextFromRichEdit() const noexcept 
 
 void WindowsTextInputComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
   // m_element.FinalizeProperties();
-
+  if (m_needsBorderUpdate) {
+    m_needsBorderUpdate = false;
+    UpdateSpecialBorderLayers(m_layoutMetrics, *m_props);
+  }
   ensureDrawingSurface();
 }
 void WindowsTextInputComponentView::prepareForRecycle() noexcept {}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -852,7 +852,6 @@ std::string WindowsTextInputComponentView::GetTextFromRichEdit() const noexcept 
 }
 
 void WindowsTextInputComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept {
-  // m_element.FinalizeProperties();
   if (m_needsBorderUpdate) {
     m_needsBorderUpdate = false;
     UpdateSpecialBorderLayers(m_layoutMetrics, *m_props);


### PR DESCRIPTION
## Description
Adds borders to TextInput

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves #11573

## Screenshots

https://github.com/microsoft/react-native-windows/assets/42554868/9588e170-a841-4c30-ac2b-f649efb7237a



## Testing
tested locally
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11720)