### PR TITLE
Add Coding Fixes to Composition Playground

### DIFF
--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -175,7 +175,8 @@ struct CompReactPackageProvider
     : winrt::implements<CompReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {
  public: // IReactPackageProvider
   void CreatePackage(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept {
-    packageBuilder.AddTurboModule(L"DeviceInfo", winrt::Microsoft::ReactNative::MakeModuleProvider<DeviceInfo>());
+    AddAttributedModules(packageBuilder, true);
+    packageBuilder.AddModule(L"DeviceInfo", winrt::Microsoft::ReactNative::MakeModuleProvider<DeviceInfo>());
 
     CustomComponent::RegisterViewComponent(packageBuilder);
   }
@@ -521,7 +522,6 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
       windowData.get());
 
   WINRT_VERIFY(hwnd);
-  winrt::check_win32(!hwnd);
 
   windowData.release();
 
@@ -539,7 +539,7 @@ int RunPlayground(int showCmd, bool useWebDebugger) {
     }
   }
 
-  return (int)msg.wParam;
+  return static_cast<int>(msg.wParam);
 }
 
 _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR /* commandLine */, int showCmd) {

--- a/packages/playground/windows/playground-composition/Playground-Composition.vcxproj
+++ b/packages/playground/windows/playground-composition/Playground-Composition.vcxproj
@@ -84,7 +84,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
## Description

### Type of Change
- Code Edits

### Why
Adding some of the coding feedback that arose during https://github.com/microsoft/react-native-windows/pull/11407 into the Playground Composition source for consistency.

Resolves https://github.com/microsoft/react-native-windows/issues/11413