### PR TITLE
[0.71] Port @react-native-windows/codegen to 0.71-stable

### DIFF
--- a/change/@react-native-windows-codegen-ff424731-8dc6-4b44-a5d1-85240605b704.json
+++ b/change/@react-native-windows-codegen-ff424731-8dc6-4b44-a5d1-85240605b704.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support enum/union and T in Promise<T> in codegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-ff424731-8dc6-4b44-a5d1-85240605b704.json
+++ b/change/@react-native-windows-codegen-ff424731-8dc6-4b44-a5d1-85240605b704.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Support enum/union and T in Promise<T> in codegen",
   "packageName": "@react-native-windows/codegen",
   "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -40,7 +40,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.2.1",
     "prettier": "^2.4.1",
-    "react-native-tscodegen": "0.68.4",
+    "react-native-tscodegen": "0.72.0",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -7,7 +7,9 @@
 'use strict';
 
 import type {
+  NativeModuleEnumDeclaration,
   NativeModuleBaseTypeAnnotation,
+  NativeModuleUnionTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
 import {
@@ -16,10 +18,29 @@ import {
   getAnonymousAliasCppName,
 } from './AliasManaging';
 
-export function translateField(
+function translateUnionReturnType(
+  type: NativeModuleEnumDeclaration | NativeModuleUnionTypeAnnotation,
+): string {
+  const memberType = type.memberType;
+  switch (type.memberType) {
+    case 'StringTypeAnnotation':
+      return 'std::string';
+    case 'NumberTypeAnnotation':
+      return 'double';
+    case 'ObjectTypeAnnotation':
+      return '::React::JSValue';
+    default:
+      throw new Error(
+        `Unknown enum/union member type in translateReturnType: ${memberType}`,
+      );
+  }
+}
+
+export function translateFieldOrReturnType(
   type: Nullable<NativeModuleBaseTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
+  callerName: 'translateField' | 'translateReturnType',
 ): string {
   // avoid: Property 'type' does not exist on type 'never'
   const returnType = type.type;
@@ -36,10 +57,11 @@ export function translateField(
       return 'bool';
     case 'ArrayTypeAnnotation':
       if (type.elementType) {
-        return `std::vector<${translateField(
+        return `std::vector<${translateFieldOrReturnType(
           type.elementType,
           aliases,
           `${baseAliasName}_element`,
+          callerName,
         )}>`;
       } else {
         return `::React::JSValueArray`;
@@ -54,20 +76,35 @@ export function translateField(
       // (#6597)
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (name !== 'RootTag')
-        throw new Error(
-          `Unknown reserved function: ${name} in translateReturnType`,
-        );
+        throw new Error(`Unknown reserved function: ${name} in ${callerName}`);
       return 'double';
     }
     case 'TypeAliasTypeAnnotation':
       return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
-      return `std::optional<${translateField(
+      return `std::optional<${translateFieldOrReturnType(
         type.typeAnnotation,
         aliases,
         baseAliasName,
+        callerName,
       )}>`;
+    case 'EnumDeclaration':
+    case 'UnionTypeAnnotation':
+      return translateUnionReturnType(type);
     default:
-      throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
+      throw new Error(`Unhandled type in ${callerName}: ${returnType}`);
   }
+}
+
+export function translateField(
+  type: Nullable<NativeModuleBaseTypeAnnotation>,
+  aliases: AliasMap,
+  baseAliasName: string,
+): string {
+  return translateFieldOrReturnType(
+    type,
+    aliases,
+    baseAliasName,
+    'translateField',
+  );
 }

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -10,60 +10,18 @@ import type {
   NativeModuleReturnTypeAnnotation,
   Nullable,
 } from 'react-native-tscodegen';
-import {
-  AliasMap,
-  getAliasCppName,
-  getAnonymousAliasCppName,
-} from './AliasManaging';
+import {AliasMap} from './AliasManaging';
+import {translateFieldOrReturnType} from './ObjectTypes';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
 ): string {
-  // avoid: Property 'type' does not exist on type 'never'
-  const returnType = type.type;
   switch (type.type) {
     case 'VoidTypeAnnotation':
     case 'PromiseTypeAnnotation':
       return 'void';
-    case 'StringTypeAnnotation':
-      return 'std::string';
-    case 'NumberTypeAnnotation':
-    case 'FloatTypeAnnotation':
-    case 'DoubleTypeAnnotation':
-      return 'double';
-    case 'Int32TypeAnnotation':
-      return 'int';
-    case 'BooleanTypeAnnotation':
-      return 'bool';
-    case 'ArrayTypeAnnotation':
-      if (type.elementType) {
-        return `std::vector<${translateReturnType(
-          type.elementType,
-          aliases,
-          `${baseAliasName}_element`,
-        )}>`;
-      } else {
-        return '::React::JSValueArray';
-      }
-    case 'GenericObjectTypeAnnotation':
-      return '::React::JSValue';
-    case 'ObjectTypeAnnotation':
-      return getAnonymousAliasCppName(aliases, baseAliasName, type);
-    case 'ReservedTypeAnnotation': {
-      // avoid: Property 'name' does not exist on type 'never'
-      const name = type.name;
-      // (#6597)
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (name !== 'RootTag')
-        throw new Error(
-          `Unknown reserved function: ${name} in translateReturnType`,
-        );
-      return 'double';
-    }
-    case 'TypeAliasTypeAnnotation':
-      return getAliasCppName(type.name);
     case 'NullableTypeAnnotation':
       return `std::optional<${translateReturnType(
         type.typeAnnotation,
@@ -71,7 +29,12 @@ function translateReturnType(
         baseAliasName,
       )}>`;
     default:
-      throw new Error(`Unhandled type in translateReturnType: ${returnType}`);
+      return translateFieldOrReturnType(
+        type,
+        aliases,
+        baseAliasName,
+        'translateReturnType',
+      );
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9695,14 +9695,13 @@ react-native-gradle-plugin@^0.71.17:
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.71.17.tgz#cf780a27270f0a32dca8184eff91555d7627dd00"
   integrity sha512-OXXYgpISEqERwjSlaCiaQY6cTY5CH6j73gdkWpK0hedxtiWMWgH+i5TOi4hIGYitm9kQBeyDu+wim9fA8ROFJA==
 
-react-native-tscodegen@0.68.4:
-  version "0.68.4"
-  resolved "https://registry.yarnpkg.com/react-native-tscodegen/-/react-native-tscodegen-0.68.4.tgz#d8cbf523f8e20b9f0806fca8a24254a31df1f383"
-  integrity sha512-N0AEJkFyUuOkt+nA128a0MfraPETvVmW9FW0lS6iSiWCwLkUZXhZH8YuKWVOSkmREspCBg2tSqYohvGdApv63A==
+react-native-tscodegen@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/react-native-tscodegen/-/react-native-tscodegen-0.72.0.tgz#1d2b6690d0db8b590221e93c1bf9b6b810b2d57f"
+  integrity sha512-a+06vhjCBX1zZ4rhFLnpp9BAZ4iMNId1ZnaEy8Ol6WoUSOOVeTBVuju3JGj+v27k+I8NoM7bWb+OMEeJMn/qyw==
   dependencies:
     jscodeshift "0.6.4"
     nullthrows "1.1.1"
-    typescript "^4.1.5"
 
 react-native-xaml@^0.0.74:
   version "0.0.74"
@@ -11178,7 +11177,7 @@ typescript@4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
   integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
-typescript@^4.1.5, typescript@^4.4.3, typescript@^4.9.5:
+typescript@^4.4.3, typescript@^4.9.5:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
0.71.3 is used in devmain, but a new version of rnw/codegen is needed.

### What
Port @react-native-windows/codegen to 0.71-stable
 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11747)