### PR TITLE
[win32] Add support for more aria props

### DIFF
--- a/change/@office-iss-react-native-win32-30310027-6d38-47eb-8a79-91a241429ff5.json
+++ b/change/@office-iss-react-native-win32-30310027-6d38-47eb-8a79-91a241429ff5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for more aria props",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/.flowconfig
+++ b/packages/@office-iss/react-native-win32/.flowconfig
@@ -29,6 +29,7 @@
 <PROJECT_ROOT>/Libraries/Pressability/Pressability.js
 <PROJECT_ROOT>/Libraries/Pressability/HoverState.js
 <PROJECT_ROOT>/Libraries/StyleSheet/StyleSheet.js
+<PROJECT_ROOT>/Libraries/Text/TextProps.js
 <PROJECT_ROOT>/Libraries/Types/CoreEventTypes.js
 <PROJECT_ROOT>/Libraries/Utilities/DeviceInfo.js
 <PROJECT_ROOT>/Libraries/Utilities/Dimensions.js

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -423,6 +423,12 @@
     },
     {
       "type": "derived",
+      "file": "src/Libraries/Text/Text.win32.js",
+      "baseFile": "packages/react-native/Libraries/Text/Text.js",
+      "baseHash": "6aa0c6611ba260bf235610429481a638e61e5279",
+    },
+    {
+      "type": "derived",
       "file": "src/Libraries/Text/TextNativeComponent.win32.js",
       "baseFile": "packages/react-native/Libraries/Text/TextNativeComponent.js",
       "baseHash": "abcdb74e2fe1e491baaefdd0ba6369199b8032d0",

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -425,7 +425,7 @@
       "type": "derived",
       "file": "src/Libraries/Text/Text.win32.js",
       "baseFile": "packages/react-native/Libraries/Text/Text.js",
-      "baseHash": "6aa0c6611ba260bf235610429481a638e61e5279",
+      "baseHash": "6aa0c6611ba260bf235610429481a638e61e5279"
     },
     {
       "type": "derived",
@@ -433,6 +433,12 @@
       "baseFile": "packages/react-native/Libraries/Text/TextNativeComponent.js",
       "baseHash": "abcdb74e2fe1e491baaefdd0ba6369199b8032d0",
       "issue": 7074
+    },
+    {
+      "type": "derived",
+      "file": "src/Libraries/Text/TextProps.win32.js",
+      "baseFile": "packages/react-native/Libraries/Text/TextProps.js",
+      "baseHash": "7ecbe61c439e5c6f79fe5ae262f063060fa6a24f"
     },
     {
       "type": "patch",

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -35,22 +35,34 @@ const View: React.AbstractComponent<
 > = React.forwardRef(
   (
     {
+      accessibilityControls, // Win32
+      accessibilityDescribedBy, // Win32
+      accessibilityDescription, //  Win32
       accessibilityElementsHidden,
       accessibilityLabel,
       accessibilityLabelledBy,
+      accessibilityLevel, // Win32
       accessibilityLiveRegion,
+      accessibilityPositionInSet, // Win32
       accessibilityRole,
+      accessibilitySetSize, // Win32
       accessibilityState,
       accessibilityValue,
       'aria-busy': ariaBusy,
       'aria-checked': ariaChecked,
+      'aria-controls': ariaControls,
+      'aria-describedby': ariaDescribedBy, // Win32
+      'aria-description': ariaDescription, // Win32
       'aria-disabled': ariaDisabled,
       'aria-expanded': ariaExpanded,
       'aria-hidden': ariaHidden,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
+      'aria-level': ariaLevel, // Win32
       'aria-live': ariaLive,
+      'aria-posinset': ariaPosinset, // Win32
       'aria-selected': ariaSelected,
+      'aria-setsize': ariaSetsize, // Win32
       'aria-valuemax': ariaValueMax,
       'aria-valuemin': ariaValueMin,
       'aria-valuenow': ariaValueNow,
@@ -193,13 +205,19 @@ const View: React.AbstractComponent<
           return (
             <ViewNativeComponent
               {...otherProps}
+              accessibilityControls={ariaControls ?? accessibilityControls} // Win32
+              accessibilityDescribedBy={ariaDescribedBy ?? accessibilityDescribedBy} // Win32
+              accessibilityDescription={ariaDescription ?? accessibilityDescription} // Win32
               accessibilityLiveRegion={
                 ariaLive === 'off'
                   ? 'none'
                   : ariaLive ?? accessibilityLiveRegion
               }
               accessibilityLabel={ariaLabel ?? accessibilityLabel}
+              accessibilityLevel={ariaLevel ?? accessibilityLevel} // Win32
               focusable={tabIndex !== undefined ? !tabIndex : focusable}
+              accessibilityPositionInSet={ariaPosinset ?? accessibilityPositionInSet} // Win32
+              accessibilitySetSize={ariaSetsize ?? accessibilitySetSize} // Win32
               accessibilityState={_accessibilityState}
               accessibilityRole={
                 role ? getAccessibilityRoleFromRole(role) : accessibilityRole

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -206,8 +206,12 @@ const View: React.AbstractComponent<
             <ViewNativeComponent
               {...otherProps}
               accessibilityControls={ariaControls ?? accessibilityControls} // Win32
-              accessibilityDescribedBy={ariaDescribedBy ?? accessibilityDescribedBy} // Win32
-              accessibilityDescription={ariaDescription ?? accessibilityDescription} // Win32
+              accessibilityDescribedBy={
+                ariaDescribedBy ?? accessibilityDescribedBy
+              } // Win32
+              accessibilityDescription={
+                ariaDescription ?? accessibilityDescription
+              } // Win32
               accessibilityLiveRegion={
                 ariaLive === 'off'
                   ? 'none'
@@ -216,7 +220,9 @@ const View: React.AbstractComponent<
               accessibilityLabel={ariaLabel ?? accessibilityLabel}
               accessibilityLevel={ariaLevel ?? accessibilityLevel} // Win32
               focusable={tabIndex !== undefined ? !tabIndex : focusable}
-              accessibilityPositionInSet={ariaPosinset ?? accessibilityPositionInSet} // Win32
+              accessibilityPositionInSet={
+                ariaPosinset ?? accessibilityPositionInSet
+              } // Win32
               accessibilitySetSize={ariaSetsize ?? accessibilitySetSize} // Win32
               accessibilityState={_accessibilityState}
               accessibilityRole={

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
@@ -461,7 +461,7 @@ export interface AccessibilityPropsWin32 {
    * @platform win32
    */
   accessibilityDescribedBy?: string | undefined;
-  'aria-describedby': ?string;
+  'aria-describedby'?: string;
 }
 
 export type Role =

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
@@ -393,11 +393,13 @@ export interface AccessibilityPropsWin32 {
    * @platform win32
    */
   accessibilityPositionInSet?: number;
+  'aria-posinset'?: number;
   /**
    * accessibilitySetSize
    * @platform win32
    */
   accessibilitySetSize?: ?number;
+  'aria-setsize'?: number;
 
   /**
    * accessibilityDescription provides more detailed information specific to the element (i.e. last edit date, full location for a file)
@@ -406,6 +408,7 @@ export interface AccessibilityPropsWin32 {
    *
    */
   accessibilityDescription?: string;
+  'aria-description'?: string;
 
   /**
    * Tells a person using a screen reader what kind of annotation they
@@ -430,6 +433,7 @@ export interface AccessibilityPropsWin32 {
    * @platform win32
    */
   accessibilityLevel?: number;
+  'aria-level'?: number | undefined;
 
   /**
    * Identifies the ItemType property, which is a text string describing the type of the automation element.
@@ -448,6 +452,7 @@ export interface AccessibilityPropsWin32 {
    * @platform win32
    */
   accessibilityControls?: string | undefined;
+  'aria-controls'?: string;
 
   /**
    * Windows Accessibility extensions for allowing other DOM elements to label or describe a given element.
@@ -456,6 +461,7 @@ export interface AccessibilityPropsWin32 {
    * @platform win32
    */
   accessibilityDescribedBy?: string | undefined;
+  'aria-describedby': ?string;
 }
 
 export type Role =

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.js
@@ -467,8 +467,18 @@ type WindowsViewProps = $ReadOnly<{|
 
   tabIndex?: ?number,
 
-  accessibilityPosInSet?: ?number,
   accessibilitySetSize?: ?number,
+  accessibilityControls?: ?Stringish,
+  accessibilityDescribedBy?: ?Stringish,
+  accessibilityDescription?: ?Stringish,
+  accessibilityLevel?: ?number,
+  accessibilityPositionInSet?: ?number,
+  'aria-posinset'?: ?number,
+  'aria-setsize'?: ?number,
+  'aria-description'?: ?Stringish,
+  'aria-level'?: ?number,
+  'aria-controls'?: ?Stringish,
+  'aria-describedby'?: ?Stringish,
 
   /**
    * Specifies if the control should show System focus visuals

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.win32.js
@@ -1,0 +1,340 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {PressEvent} from '../Types/CoreEventTypes';
+import type {TextProps} from './TextProps';
+
+import * as PressabilityDebug from '../Pressability/PressabilityDebug';
+import usePressability from '../Pressability/usePressability';
+import flattenStyle from '../StyleSheet/flattenStyle';
+import processColor from '../StyleSheet/processColor';
+import {getAccessibilityRoleFromRole} from '../Utilities/AcessibilityMapping';
+import Platform from '../Utilities/Platform';
+import TextAncestor from './TextAncestor';
+import {NativeText, NativeVirtualText} from './TextNativeComponent';
+import * as React from 'react';
+import {useContext, useMemo, useState} from 'react';
+
+/**
+ * Text is the fundamental component for displaying text.
+ *
+ * @see https://reactnative.dev/docs/text
+ */
+const Text: React.AbstractComponent<
+  TextProps,
+  React.ElementRef<typeof NativeText | typeof NativeVirtualText>,
+> = React.forwardRef((props: TextProps, forwardedRef) => {
+  const {
+    accessible,
+    accessibilityControls, // Win32
+    accessibilityDescribedBy, // Win32
+    accessibilityDescription, // Win32
+    accessibilityLabel,
+    accessibilityLevel, // Win32
+    accessibilityPositionInSet, // Win32
+    accessibilityRole,
+    accessibilitySetSize, // Win32
+    accessibilityState,
+    allowFontScaling,
+    'aria-busy': ariaBusy,
+    'aria-checked': ariaChecked,
+    'aria-controls': ariaControls, // Win32
+    'aria-describedby': ariaDescribedBy, // Win32
+    'aria-description': ariaDescription, // Win32
+    'aria-disabled': ariaDisabled,
+    'aria-expanded': ariaExpanded,
+    'aria-label': ariaLabel,
+    'aria-level': ariaLevel, // Win32
+    'aria-posinset': ariaPosinset, // Win32
+    'aria-selected': ariaSelected,
+    'aria-setsize': ariaSetsize, // Win32
+    ellipsizeMode,
+    id,
+    nativeID,
+    onLongPress,
+    onPress,
+    onPressIn,
+    onPressOut,
+    onResponderGrant,
+    onResponderMove,
+    onResponderRelease,
+    onResponderTerminate,
+    onResponderTerminationRequest,
+    onStartShouldSetResponder,
+    pressRetentionOffset,
+    role,
+    suppressHighlighting,
+    ...restProps
+  } = props;
+
+  const [isHighlighted, setHighlighted] = useState(false);
+
+  let _accessibilityState;
+  if (
+    accessibilityState != null ||
+    ariaBusy != null ||
+    ariaChecked != null ||
+    ariaDisabled != null ||
+    ariaExpanded != null ||
+    ariaSelected != null
+  ) {
+    _accessibilityState = {
+      busy: ariaBusy ?? accessibilityState?.busy,
+      checked: ariaChecked ?? accessibilityState?.checked,
+      disabled: ariaDisabled ?? accessibilityState?.disabled,
+      expanded: ariaExpanded ?? accessibilityState?.expanded,
+      selected: ariaSelected ?? accessibilityState?.selected,
+    };
+  }
+
+  const _disabled =
+    restProps.disabled != null
+      ? restProps.disabled
+      : _accessibilityState?.disabled;
+
+  const nativeTextAccessibilityState =
+    _disabled !== _accessibilityState?.disabled
+      ? {..._accessibilityState, disabled: _disabled}
+      : _accessibilityState;
+
+  const isPressable =
+    (onPress != null ||
+      onLongPress != null ||
+      onStartShouldSetResponder != null) &&
+    _disabled !== true;
+
+  const initialized = useLazyInitialization(isPressable);
+  const config = useMemo(
+    () =>
+      initialized
+        ? {
+            disabled: !isPressable,
+            pressRectOffset: pressRetentionOffset,
+            onLongPress,
+            onPress,
+            onPressIn(event: PressEvent) {
+              setHighlighted(!suppressHighlighting);
+              onPressIn?.(event);
+            },
+            onPressOut(event: PressEvent) {
+              setHighlighted(false);
+              onPressOut?.(event);
+            },
+            onResponderTerminationRequest_DEPRECATED:
+              onResponderTerminationRequest,
+            onStartShouldSetResponder_DEPRECATED: onStartShouldSetResponder,
+          }
+        : null,
+    [
+      initialized,
+      isPressable,
+      pressRetentionOffset,
+      onLongPress,
+      onPress,
+      onPressIn,
+      onPressOut,
+      onResponderTerminationRequest,
+      onStartShouldSetResponder,
+      suppressHighlighting,
+    ],
+  );
+
+  const eventHandlers = usePressability(config);
+  const eventHandlersForText = useMemo(
+    () =>
+      eventHandlers == null
+        ? null
+        : {
+            onResponderGrant(event: PressEvent) {
+              eventHandlers.onResponderGrant(event);
+              if (onResponderGrant != null) {
+                onResponderGrant(event);
+              }
+            },
+            onResponderMove(event: PressEvent) {
+              eventHandlers.onResponderMove(event);
+              if (onResponderMove != null) {
+                onResponderMove(event);
+              }
+            },
+            onResponderRelease(event: PressEvent) {
+              eventHandlers.onResponderRelease(event);
+              if (onResponderRelease != null) {
+                onResponderRelease(event);
+              }
+            },
+            onResponderTerminate(event: PressEvent) {
+              eventHandlers.onResponderTerminate(event);
+              if (onResponderTerminate != null) {
+                onResponderTerminate(event);
+              }
+            },
+            onClick: eventHandlers.onClick,
+            onResponderTerminationRequest:
+              eventHandlers.onResponderTerminationRequest,
+            onStartShouldSetResponder: eventHandlers.onStartShouldSetResponder,
+          },
+    [
+      eventHandlers,
+      onResponderGrant,
+      onResponderMove,
+      onResponderRelease,
+      onResponderTerminate,
+    ],
+  );
+
+  // TODO: Move this processing to the view configuration.
+  const selectionColor =
+    restProps.selectionColor == null
+      ? null
+      : processColor(restProps.selectionColor);
+
+  let style = restProps.style;
+
+  if (__DEV__) {
+    if (PressabilityDebug.isEnabled() && onPress != null) {
+      style = [restProps.style, {color: 'magenta'}];
+    }
+  }
+
+  let numberOfLines = restProps.numberOfLines;
+  if (numberOfLines != null && !(numberOfLines >= 0)) {
+    console.error(
+      `'numberOfLines' in <Text> must be a non-negative number, received: ${numberOfLines}. The value will be set to 0.`,
+    );
+    numberOfLines = 0;
+  }
+
+  const hasTextAncestor = useContext(TextAncestor);
+
+  const _accessible = Platform.select({
+    ios: accessible !== false,
+    default: accessible,
+  });
+
+  // $FlowFixMe[underconstrained-implicit-instantiation]
+  style = flattenStyle(style);
+
+  if (typeof style?.fontWeight === 'number') {
+    style.fontWeight = style?.fontWeight.toString();
+  }
+
+  let _selectable = restProps.selectable;
+  if (style?.userSelect != null) {
+    _selectable = userSelectToSelectableMap[style.userSelect];
+    delete style.userSelect;
+  }
+
+  if (style?.verticalAlign != null) {
+    style.textAlignVertical =
+      verticalAlignToTextAlignVerticalMap[style.verticalAlign];
+    delete style.verticalAlign;
+  }
+
+  const _hasOnPressOrOnLongPress =
+    props.onPress != null || props.onLongPress != null;
+
+  return hasTextAncestor ? (
+    <NativeVirtualText
+      {...restProps}
+      {...eventHandlersForText}
+      accessibilityControls={ariaControls ?? accessibilityControls} // Win32
+      accessibilityDescribedBy={ariaDescribedBy ?? accessibilityDescribedBy} // Win32
+      accessibilityDescription={ariaDescription ?? accessibilityDescription} // Win32
+      accessibilityLabel={ariaLabel ?? accessibilityLabel}
+      accessibilityLevel={ariaLevel ?? accessibilityLevel} // Win32
+      accessibilityPositionInSet={ariaPosinset ?? accessibilityPositionInSet} // Win32
+      accessibilityRole={
+        role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+      }
+      accessibilitySetSize={ariaSetsize ?? accessibilitySetSize} // Win32
+      accessibilityState={_accessibilityState}
+      isHighlighted={isHighlighted}
+      isPressable={isPressable}
+      nativeID={id ?? nativeID}
+      numberOfLines={numberOfLines}
+      ref={forwardedRef}
+      selectable={_selectable}
+      selectionColor={selectionColor}
+      style={style}
+    />
+  ) : (
+    <TextAncestor.Provider value={true}>
+      <NativeText
+        {...restProps}
+        {...eventHandlersForText}
+        accessibilityControls={ariaControls ?? accessibilityControls} // Win32
+        accessibilityDescribedBy={ariaDescribedBy ?? accessibilityDescribedBy} // Win32
+        accessibilityDescription={ariaDescription ?? accessibilityDescription} // Win32
+        accessibilityLabel={ariaLabel ?? accessibilityLabel}
+        accessibilityLevel={ariaLevel ?? accessibilityLevel} // Win32
+        accessibilityPositionInSet={ariaPosinset ?? accessibilityPositionInSet} // Win32
+        accessibilityRole={
+          role ? getAccessibilityRoleFromRole(role) : accessibilityRole
+        }
+        accessibilitySetSize={ariaSetsize ?? accessibilitySetSize} // Win32
+        accessibilityState={nativeTextAccessibilityState}
+        accessible={
+          accessible == null && Platform.OS === 'android'
+            ? _hasOnPressOrOnLongPress
+            : _accessible
+        }
+        allowFontScaling={allowFontScaling !== false}
+        disabled={_disabled}
+        ellipsizeMode={ellipsizeMode ?? 'tail'}
+        isHighlighted={isHighlighted}
+        nativeID={id ?? nativeID}
+        numberOfLines={numberOfLines}
+        ref={forwardedRef}
+        selectable={_selectable}
+        selectionColor={selectionColor}
+        style={style}
+      />
+    </TextAncestor.Provider>
+  );
+});
+
+Text.displayName = 'Text';
+
+/**
+ * Switch to `deprecated-react-native-prop-types` for compatibility with future
+ * releases. This is deprecated and will be removed in the future.
+ */
+Text.propTypes = require('deprecated-react-native-prop-types').TextPropTypes;
+
+/**
+ * Returns false until the first time `newValue` is true, after which this will
+ * always return true. This is necessary to lazily initialize `Pressability` so
+ * we do not eagerly create one for every pressable `Text` component.
+ */
+function useLazyInitialization(newValue: boolean): boolean {
+  const [oldValue, setValue] = useState(newValue);
+  if (!oldValue && newValue) {
+    setValue(newValue);
+  }
+  return oldValue;
+}
+
+const userSelectToSelectableMap = {
+  auto: true,
+  text: true,
+  none: false,
+  contain: true,
+  all: true,
+};
+
+const verticalAlignToTextAlignVerticalMap = {
+  auto: 'auto',
+  top: 'top',
+  bottom: 'bottom',
+  middle: 'center',
+};
+
+module.exports = Text;

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/TextProps.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/TextProps.win32.js
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {
+  AccessibilityActionEvent,
+  AccessibilityActionInfo,
+  AccessibilityRole,
+  AccessibilityState,
+  Role,
+} from '../Components/View/ViewAccessibility';
+import type {TextStyleProp} from '../StyleSheet/StyleSheet';
+import type {
+  LayoutEvent,
+  PointerEvent,
+  PressEvent,
+  TextLayoutEvent,
+} from '../Types/CoreEventTypes';
+import type {Node} from 'react';
+
+export type PressRetentionOffset = $ReadOnly<{|
+  top: number,
+  left: number,
+  bottom: number,
+  right: number,
+|}>;
+
+type PointerEventProps = $ReadOnly<{|
+  onPointerEnter?: (event: PointerEvent) => void,
+  onPointerLeave?: (event: PointerEvent) => void,
+  onPointerMove?: (event: PointerEvent) => void,
+|}>;
+
+/**
+ * @see https://reactnative.dev/docs/text#reference
+ */
+export type TextProps = $ReadOnly<{|
+  ...PointerEventProps,
+
+  /**
+   * Indicates whether the view is an accessibility element.
+   *
+   * See https://reactnative.dev/docs/text#accessible
+   */
+  accessible?: ?boolean,
+  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  accessibilityHint?: ?Stringish,
+  accessibilityLanguage?: ?Stringish,
+  accessibilityLabel?: ?Stringish,
+  accessibilityRole?: ?AccessibilityRole,
+  accessibilityState?: ?AccessibilityState,
+  'aria-label'?: ?string,
+  accessibilityControls?: ?Stringish, // Win32
+  accessibilityDescribedBy?: ?Stringish, // Win32
+  accessibilityDescription?: ?Stringish, // Win32
+  accessibilityLevel?: ?number, // Win32
+  accessibilityPositionInSet?: ?number, // Win32
+  accessibilitySetSize?: ?number, // Win32
+
+  /**
+   * Whether font should be scaled down automatically.
+   *
+   * See https://reactnative.dev/docs/text#adjustsfontsizetofit
+   */
+  adjustsFontSizeToFit?: ?boolean,
+
+  /**
+   * Whether fonts should scale to respect Text Size accessibility settings.
+   *
+   * See https://reactnative.dev/docs/text#allowfontscaling
+   */
+  allowFontScaling?: ?boolean,
+
+  /**
+   * Set hyphenation strategy on Android.
+   *
+   */
+  android_hyphenationFrequency?: ?('normal' | 'none' | 'full'),
+
+  /**
+   * alias for accessibilityState
+   *
+   * see https://reactnative.dev/docs/accessibility#accessibilitystate
+   */
+  'aria-busy'?: ?boolean,
+  'aria-checked'?: ?boolean | 'mixed',
+  'aria-disabled'?: ?boolean,
+  'aria-expanded'?: ?boolean,
+  'aria-selected'?: ?boolean,
+  'aria-controls'?: ?Stringish, // Win32
+  'aria-describedby'?: ?Stringish, // Win32
+  'aria-description'?: ?Stringish, // Win32
+  'aria-level'?: ?number, // Win32
+  'aria-posinset'?: ?number, // Win32
+  'aria-setsize'?: ?number, // Win32
+  /**
+   * Represents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
+   * This prop is listed for cross-platform reasons and has no real effect on Android or iOS.
+   */
+  'aria-labelledby'?: ?string,
+
+  children?: ?Node,
+
+  /**
+   * When `numberOfLines` is set, this prop defines how text will be
+   * truncated.
+   *
+   * See https://reactnative.dev/docs/text#ellipsizemode
+   */
+  ellipsizeMode?: ?('clip' | 'head' | 'middle' | 'tail'),
+
+  /**
+   * Used to locate this view from native code.
+   *
+   * See https://reactnative.dev/docs/text#nativeid
+   */
+  id?: string,
+
+  /**
+   * Specifies largest possible scale a font can reach when `allowFontScaling` is enabled.
+   * Possible values:
+   * `null/undefined` (default): inherit from the parent node or the global default (0)
+   * `0`: no max, ignore parent/global default
+   * `>= 1`: sets the maxFontSizeMultiplier of this node to this value
+   */
+  maxFontSizeMultiplier?: ?number,
+
+  /**
+   * Used to locate this view from native code.
+   *
+   * See https://reactnative.dev/docs/text#nativeid
+   */
+  nativeID?: ?string,
+
+  /**
+   * Used to truncate the text with an ellipsis.
+   *
+   * See https://reactnative.dev/docs/text#numberoflines
+   */
+  numberOfLines?: ?number,
+
+  /**
+   * Invoked on mount and layout changes.
+   *
+   * See https://reactnative.dev/docs/text#onlayout
+   */
+  onLayout?: ?(event: LayoutEvent) => mixed,
+
+  /**
+   * This function is called on long press.
+   *
+   * See https://reactnative.dev/docs/text#onlongpress
+   */
+  onLongPress?: ?(event: PressEvent) => mixed,
+
+  /**
+   * This function is called on press.
+   *
+   * See https://reactnative.dev/docs/text#onpress
+   */
+  onPress?: ?(event: PressEvent) => mixed,
+  onPressIn?: ?(event: PressEvent) => mixed,
+  onPressOut?: ?(event: PressEvent) => mixed,
+  onResponderGrant?: ?(event: PressEvent) => void,
+  onResponderMove?: ?(event: PressEvent) => void,
+  onResponderRelease?: ?(event: PressEvent) => void,
+  onResponderTerminate?: ?(event: PressEvent) => void,
+  onResponderTerminationRequest?: ?() => boolean,
+  onStartShouldSetResponder?: ?() => boolean,
+  onMoveShouldSetResponder?: ?() => boolean,
+  onTextLayout?: ?(event: TextLayoutEvent) => mixed,
+
+  /**
+   * Defines how far your touch may move off of the button, before
+   * deactivating the button.
+   *
+   * See https://reactnative.dev/docs/text#pressretentionoffset
+   */
+  pressRetentionOffset?: ?PressRetentionOffset,
+
+  /**
+   * Indicates to accessibility services to treat UI component like a specific role.
+   */
+  role?: ?Role,
+
+  /**
+   * Lets the user select text.
+   *
+   * See https://reactnative.dev/docs/text#selectable
+   */
+  selectable?: ?boolean,
+  style?: ?TextStyleProp,
+
+  /**
+   * Used to locate this view in end-to-end tests.
+   *
+   * See https://reactnative.dev/docs/text#testid
+   */
+  testID?: ?string,
+
+  /**
+   * Android Only
+   */
+
+  /**
+   * Specifies the disabled state of the text view for testing purposes.
+   *
+   * See https://reactnative.dev/docs/text#disabled
+   */
+  disabled?: ?boolean,
+
+  /**
+   * The highlight color of the text.
+   *
+   * See https://reactnative.dev/docs/text#selectioncolor
+   */
+  selectionColor?: ?string,
+
+  dataDetectorType?: ?('phoneNumber' | 'link' | 'email' | 'none' | 'all'),
+
+  /**
+   * Set text break strategy on Android.
+   *
+   * See https://reactnative.dev/docs/text#textbreakstrategy
+   */
+  textBreakStrategy?: ?('balanced' | 'highQuality' | 'simple'),
+
+  /**
+   * iOS Only
+   */
+  adjustsFontSizeToFit?: ?boolean,
+
+  /**
+   * The Dynamic Type scale ramp to apply to this element on iOS.
+   */
+  dynamicTypeRamp?: ?(
+    | 'caption2'
+    | 'caption1'
+    | 'footnote'
+    | 'subheadline'
+    | 'callout'
+    | 'body'
+    | 'headline'
+    | 'title3'
+    | 'title2'
+    | 'title1'
+    | 'largeTitle'
+  ),
+
+  /**
+   * Smallest possible scale a font can reach.
+   *
+   * See https://reactnative.dev/docs/text#minimumfontscale
+   */
+  minimumFontScale?: ?number,
+
+  /**
+   * When `true`, no visual change is made when text is pressed down.
+   *
+   * See https://reactnative.dev/docs/text#supperhighlighting
+   */
+  suppressHighlighting?: ?boolean,
+
+  /**
+   * Set line break strategy on iOS.
+   *
+   * See https://reactnative.dev/docs/text.html#linebreakstrategyios
+   */
+  lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
+|}>;


### PR DESCRIPTION
Adds a few more aria alias for some additional accessibility props that we've added to win32.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11771&drop=dogfoodAlpha