### PR TITLE
Fix fetch failing with certain custom user agents

### DIFF
--- a/change/react-native-windows-9dd9ab69-35af-4ed6-b752-8660632e6fc6.json
+++ b/change/react-native-windows-9dd9ab69-35af-4ed6-b752-8660632e6fc6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix fetch failing with certain custom user agents",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -147,6 +147,14 @@ IAsyncOperation<HttpRequestMessage> WinRTHttpResource::CreateRequest(
         }
         co_return nullptr;
       }
+    } else if (boost::iequals(name.c_str(), "User-Agent")) {
+      bool success = request.Headers().TryAppendWithoutValidation(to_hstring(name), to_hstring(value));
+      if (!success) {
+        if (self->m_onError) {
+          self->m_onError(reqArgs->RequestId, "Failed to append User-Agent", false);
+        }
+        co_return nullptr;
+      }
     } else {
       try {
         request.Headers().Append(to_hstring(name), to_hstring(value));


### PR DESCRIPTION
## Description

Fix fetch failing with certain custom user agents.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Previously in PR https://github.com/microsoft/react-native-windows/pull/10279 there was a fix to skip user agent HTTP header validation, but then we lost that fix in https://github.com/microsoft/react-native-windows/pull/10534. This PR re-adds that fix.

### What
As we did previously, skip user agent HTTP header validation.

## Screenshots
Made a fetch request with header `'User-Agent': "CustomAgent [CustomAgentData/1;MoreCustomAgentData/2]"`.

Before it fails:
![before](https://github.com/microsoft/react-native-windows/assets/359157/24ddfe4d-415a-45d2-b1b9-8463ed582173)

After it succeeds:
<img width="1988" alt="after" src="https://github.com/microsoft/react-native-windows/assets/359157/cd1531f5-1443-4241-920d-8e6bbc2cb7a2">


## Testing
I used the following test case for screenshots above: https://github.com/lyahdav/react-native-windows/commit/c4e4bd87298d7111f8b2740f426da044cfc8ed12
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11775&drop=dogfoodAlpha