### PR TITLE
Define WebSocket TurboModule

### DIFF
--- a/change/react-native-windows-9dd4df7c-d51b-4cc3-9da4-0be4e2ff6e8c.json
+++ b/change/react-native-windows-9dd4df7c-d51b-4cc3-9da4-0be4e2ff6e8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Define WebSocket TurboModule",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/BlobModule.cpp
+++ b/vnext/Shared/Modules/BlobModule.cpp
@@ -41,6 +41,7 @@ using winrt::Windows::Foundation::Uri;
 using winrt::Windows::Security::Cryptography::CryptographicBuffer;
 
 namespace fs = std::filesystem;
+namespace msrn = winrt::Microsoft::ReactNative;
 
 namespace {
 constexpr char moduleName[] = "BlobModule";
@@ -283,6 +284,25 @@ void BlobWebSocketModuleContentHandler::ProcessMessage(vector<uint8_t> &&message
   params[dataKey] = std::move(blob);
   params[typeKey] = blobKey;
 }
+
+void BlobWebSocketModuleContentHandler::ProcessMessage(
+    string &&message,
+    msrn::JSValueObject &params) noexcept /*override*/
+{
+  params[dataKey] = std::move(message);
+}
+
+void BlobWebSocketModuleContentHandler::ProcessMessage(
+    vector<uint8_t> &&message,
+    msrn::JSValueObject &params) noexcept /*override*/
+{
+  auto blob = msrn::JSValueObject{
+      {offsetKey, 0}, {sizeKey, message.size()}, {blobIdKey, m_blobPersistor->StoreMessage(std::move(message))}};
+
+  params[dataKey] = std::move(blob);
+  params[typeKey] = blobKey;
+}
+
 #pragma endregion IWebSocketModuleContentHandler
 
 void BlobWebSocketModuleContentHandler::Register(int64_t socketID) noexcept {

--- a/vnext/Shared/Modules/BlobModule.h
+++ b/vnext/Shared/Modules/BlobModule.h
@@ -59,6 +59,11 @@ class BlobWebSocketModuleContentHandler final : public IWebSocketModuleContentHa
 
   void ProcessMessage(std::vector<uint8_t> &&message, folly::dynamic &params) override;
 
+  void ProcessMessage(std::string &&message, winrt::Microsoft::ReactNative::JSValueObject &params) noexcept override;
+
+  void ProcessMessage(std::vector<uint8_t> &&message, winrt::Microsoft::ReactNative::JSValueObject &params) noexcept
+      override;
+
 #pragma endregion IWebSocketModuleContentHandler
 
   void Register(int64_t socketID) noexcept;

--- a/vnext/Shared/Modules/CxxModuleUtilities.cpp
+++ b/vnext/Shared/Modules/CxxModuleUtilities.cpp
@@ -18,10 +18,10 @@ void SendEvent(weak_ptr<Instance> weakReactInstance, string &&eventName, dynamic
   }
 }
 
-void SendEvent(msrn::ReactContext const& reactContext,
-  std::wstring_view&& eventName,
-  msrn::JSValueObject&& args) noexcept
-{
+void SendEvent(
+    msrn::ReactContext const &reactContext,
+    std::wstring_view &&eventName,
+    msrn::JSValueObject &&args) noexcept {
   reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", std::move(eventName), std::move(args));
 }
 

--- a/vnext/Shared/Modules/CxxModuleUtilities.cpp
+++ b/vnext/Shared/Modules/CxxModuleUtilities.cpp
@@ -3,6 +3,8 @@
 
 #include "CxxModuleUtilities.h"
 
+namespace msrn = winrt::Microsoft::ReactNative;
+
 using facebook::react::Instance;
 using folly::dynamic;
 using std::string;
@@ -14,6 +16,13 @@ void SendEvent(weak_ptr<Instance> weakReactInstance, string &&eventName, dynamic
   if (auto instance = weakReactInstance.lock()) {
     instance->callJSFunction("RCTDeviceEventEmitter", "emit", dynamic::array(std::move(eventName), std::move(args)));
   }
+}
+
+void SendEvent(msrn::ReactContext const& reactContext,
+  std::wstring_view&& eventName,
+  msrn::JSValueObject&& args) noexcept
+{
+  reactContext.EmitJSEvent(L"RCTDeviceEventEmitter", std::move(eventName), std::move(args));
 }
 
 } // namespace Microsoft::React::Modules

--- a/vnext/Shared/Modules/CxxModuleUtilities.h
+++ b/vnext/Shared/Modules/CxxModuleUtilities.h
@@ -24,8 +24,8 @@ void SendEvent(
     folly::dynamic &&args);
 
 void SendEvent(
-  winrt::Microsoft::ReactNative::ReactContext const& reactContext,
-  std::wstring_view&& eventName,
-  winrt::Microsoft::ReactNative::JSValueObject&& args) noexcept;
+    winrt::Microsoft::ReactNative::ReactContext const &reactContext,
+    std::wstring_view &&eventName,
+    winrt::Microsoft::ReactNative::JSValueObject &&args) noexcept;
 
 } // namespace Microsoft::React::Modules

--- a/vnext/Shared/Modules/CxxModuleUtilities.h
+++ b/vnext/Shared/Modules/CxxModuleUtilities.h
@@ -9,6 +9,9 @@
 // React Native
 #include <cxxreact/Instance.h>
 
+// React Native Windows
+#include <ReactContext.h>
+
 // Standard Library
 #include <memory>
 #include <string>
@@ -19,5 +22,10 @@ void SendEvent(
     std::weak_ptr<facebook::react::Instance> weakReactInstance,
     std::string &&eventName,
     folly::dynamic &&args);
+
+void SendEvent(
+  winrt::Microsoft::ReactNative::ReactContext const& reactContext,
+  std::wstring_view&& eventName,
+  winrt::Microsoft::ReactNative::JSValueObject&& args) noexcept;
 
 } // namespace Microsoft::React::Modules

--- a/vnext/Shared/Modules/IWebSocketModuleContentHandler.h
+++ b/vnext/Shared/Modules/IWebSocketModuleContentHandler.h
@@ -6,6 +6,9 @@
 // React Native
 #include <folly/dynamic.h>
 
+// React Native Windows
+#include <JSValue.h>
+
 // Standard Library
 #include <string>
 #include <vector>
@@ -21,6 +24,12 @@ struct IWebSocketModuleContentHandler {
   virtual void ProcessMessage(std::string &&message, folly::dynamic &params) = 0;
 
   virtual void ProcessMessage(std::vector<uint8_t> &&message, folly::dynamic &params) = 0;
+
+  virtual void ProcessMessage(std::string &&message, winrt::Microsoft::ReactNative::JSValueObject &params) noexcept = 0;
+
+  virtual void ProcessMessage(
+      std::vector<uint8_t> &&message,
+      winrt::Microsoft::ReactNative::JSValueObject &params) noexcept = 0;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -476,7 +476,7 @@ void WebSocketTurboModule::Ping(double socketID) noexcept {
 }
 
 // See react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
-void WebSocketTurboModule::AddListener(string&& /*eventName*/) noexcept {}
+void WebSocketTurboModule::AddListener(string && /*eventName*/) noexcept {}
 
 void WebSocketTurboModule::RemoveListeners(double /*count*/) noexcept {}
 

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -395,8 +395,7 @@ void WebSocketTurboModule::Connect(
     string &&url,
     msrn::JSValueArray &&protocols,
     msrn::JSValueObject &&options,
-    int64_t id,
-    msrn::ReactPromise<string> &&result) noexcept {
+    int64_t id) noexcept {
   IWebSocketResource::Protocols rcProtocols;
   for (const auto &protocol : protocols) {
     rcProtocols.push_back(protocol.AsString());
@@ -424,6 +423,54 @@ void WebSocketTurboModule::Connect(
 
   if (auto rc = weakRc.lock()) {
     rc->Connect(std::move(url), rcProtocols, rcOptions);
+  }
+}
+
+void WebSocketTurboModule::Close(int64_t code, string&& reason, int64_t id) noexcept {
+  auto rcItr = m_resourceMap.find(id);
+  if (rcItr == m_resourceMap.cend()) {
+    return;//TODO: Send error instead?
+  }
+
+  weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
+  if (auto rc = weakRc.lock()) {
+    rc->Close(static_cast<IWebSocketResource::CloseCode>(code), std::move(reason));
+  }
+}
+
+void WebSocketTurboModule::Send(string&& message, int64_t id) noexcept {
+  auto rcItr = m_resourceMap.find(id);
+  if (rcItr == m_resourceMap.cend()) {
+    return;//TODO: Send error instead?
+  }
+
+  weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
+  if (auto rc = weakRc.lock()) {
+    rc->Send(std::move(message));
+  }
+}
+
+void WebSocketTurboModule::SendBinary(string&& base64String, int64_t id) noexcept {
+  auto rcItr = m_resourceMap.find(id);
+  if (rcItr == m_resourceMap.cend()) {
+    return;//TODO: Send error instead?
+  }
+
+  weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
+  if (auto rc = weakRc.lock()) {
+    rc->SendBinary(std::move(base64String));
+  }
+}
+
+void WebSocketTurboModule::Ping(int64_t id) noexcept {
+  auto rcItr = m_resourceMap.find(id);
+  if (rcItr == m_resourceMap.cend()) {
+    return;//TODO: Send error instead?
+  }
+
+  weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
+  if (auto rc = weakRc.lock()) {
+    rc->Ping();
   }
 }
 

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -370,6 +370,20 @@ shared_ptr<IWebSocketResource> WebSocketTurboModule::CreateResource(int64_t id, 
     SendEvent(context, L"websocketMessage", std::move(args));
   });
 
+  rc->SetOnClose([id, context = m_context](IWebSocketResource::CloseCode code, const string &reason) {
+    auto args = msrn::JSValueObject{{"id", id}, {"code", static_cast<uint16_t>(code)}, {"reason", reason}};
+
+    SendEvent(context, L"websocketClosed", std::move(args));
+  });
+
+  rc->SetOnError([id, context = m_context](const IWebSocketResource::Error &err) {
+    auto errorObj = msrn::JSValueObject{{"id", id}, {"message", err.Message}};
+
+    SendEvent(context, L"websocketFailed", std::move(errorObj));
+  });
+
+  m_resourceMap.emplace(id, rc);
+
   return rc;
 }
 

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -475,6 +475,11 @@ void WebSocketTurboModule::Ping(double socketID) noexcept {
   }
 }
 
+// See react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.java
+void WebSocketTurboModule::AddListener(string&& /*eventName*/) noexcept {}
+
+void WebSocketTurboModule::RemoveListeners(double /*count*/) noexcept {}
+
 #pragma endregion WebSocketTurboModule
 
 /*extern*/ const char *GetWebSocketModuleName() noexcept {

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -383,7 +383,7 @@ shared_ptr<IWebSocketResource> WebSocketTurboModule::CreateResource(int64_t id, 
     SendEvent(context, L"websocketFailed", std::move(errorObj));
   });
 
-  m_resourceMap.emplace(id, rc);
+  m_resourceMap.emplace(static_cast<double>(id), rc);
 
   return rc;
 }
@@ -414,12 +414,11 @@ void WebSocketTurboModule::Connect(
   }
 
   weak_ptr<IWebSocketResource> weakRc;
-  auto id = static_cast<int64_t>(socketID);
-  auto rcItr = m_resourceMap.find(id);
+  auto rcItr = m_resourceMap.find(socketID);
   if (rcItr != m_resourceMap.cend()) {
     weakRc = (*rcItr).second;
   } else {
-    weakRc = CreateResource(id, string{url});
+    weakRc = CreateResource(static_cast<int64_t>(socketID), string{url});
   }
 
   if (auto rc = weakRc.lock()) {
@@ -428,7 +427,7 @@ void WebSocketTurboModule::Connect(
 }
 
 void WebSocketTurboModule::Close(double code, string &&reason, double socketID) noexcept {
-  auto rcItr = m_resourceMap.find(static_cast<int64_t>(socketID));
+  auto rcItr = m_resourceMap.find(socketID);
   if (rcItr == m_resourceMap.cend()) {
     return; // TODO: Send error instead?
   }
@@ -440,7 +439,7 @@ void WebSocketTurboModule::Close(double code, string &&reason, double socketID) 
 }
 
 void WebSocketTurboModule::Send(string &&message, double forSocketID) noexcept {
-  auto rcItr = m_resourceMap.find(static_cast<int64_t>(forSocketID));
+  auto rcItr = m_resourceMap.find(forSocketID);
   if (rcItr == m_resourceMap.cend()) {
     return; // TODO: Send error instead?
   }
@@ -452,7 +451,7 @@ void WebSocketTurboModule::Send(string &&message, double forSocketID) noexcept {
 }
 
 void WebSocketTurboModule::SendBinary(string &&base64String, double forSocketID) noexcept {
-  auto rcItr = m_resourceMap.find(static_cast<int64_t>(forSocketID));
+  auto rcItr = m_resourceMap.find(forSocketID);
   if (rcItr == m_resourceMap.cend()) {
     return; // TODO: Send error instead?
   }
@@ -464,7 +463,7 @@ void WebSocketTurboModule::SendBinary(string &&base64String, double forSocketID)
 }
 
 void WebSocketTurboModule::Ping(double socketID) noexcept {
-  auto rcItr = m_resourceMap.find(static_cast<int64_t>(socketID));
+  auto rcItr = m_resourceMap.find(socketID);
   if (rcItr == m_resourceMap.cend()) {
     return; // TODO: Send error instead?
   }

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -398,18 +398,17 @@ void WebSocketTurboModule::Connect(
     ReactNativeSpecs::WebSocketModuleSpec_connect_options &&options,
     double socketID) noexcept {
   IWebSocketResource::Protocols rcProtocols;
-  for (const auto& protocol : protocols.value_or(vector<string>{})) {
+  for (const auto &protocol : protocols.value_or(vector<string>{})) {
     rcProtocols.push_back(protocol);
   }
 
   IWebSocketResource::Options rcOptions;
-  auto& optHeaders = options.headers;
-  if (optHeaders.has_value())
-  {
-    auto& headersVal = optHeaders.value();
-    for (const auto& headerVal : headersVal.AsArray()) {
+  auto &optHeaders = options.headers;
+  if (optHeaders.has_value()) {
+    auto &headersVal = optHeaders.value();
+    for (const auto &headerVal : headersVal.AsArray()) {
       // Each header JSValueObject should only contain one key-value pair
-      const auto& entry = *headerVal.AsObject().cbegin();
+      const auto &entry = *headerVal.AsObject().cbegin();
       rcOptions.emplace(winrt::to_hstring(entry.first), entry.second.AsString());
     }
   }
@@ -419,9 +418,8 @@ void WebSocketTurboModule::Connect(
   auto rcItr = m_resourceMap.find(id);
   if (rcItr != m_resourceMap.cend()) {
     weakRc = (*rcItr).second;
-  }
-  else {
-    weakRc = CreateResource(id, string{ url });
+  } else {
+    weakRc = CreateResource(id, string{url});
   }
 
   if (auto rc = weakRc.lock()) {
@@ -429,10 +427,10 @@ void WebSocketTurboModule::Connect(
   }
 }
 
-void WebSocketTurboModule::Close(int64_t code, string&& reason, int64_t id) noexcept {
-  auto rcItr = m_resourceMap.find(id);
+void WebSocketTurboModule::Close(double code, string &&reason, double socketID) noexcept {
+  auto rcItr = m_resourceMap.find(static_cast<int64_t>(socketID));
   if (rcItr == m_resourceMap.cend()) {
-    return;//TODO: Send error instead?
+    return; // TODO: Send error instead?
   }
 
   weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
@@ -441,10 +439,10 @@ void WebSocketTurboModule::Close(int64_t code, string&& reason, int64_t id) noex
   }
 }
 
-void WebSocketTurboModule::Send(string&& message, int64_t id) noexcept {
-  auto rcItr = m_resourceMap.find(id);
+void WebSocketTurboModule::Send(string &&message, double forSocketID) noexcept {
+  auto rcItr = m_resourceMap.find(static_cast<int64_t>(forSocketID));
   if (rcItr == m_resourceMap.cend()) {
-    return;//TODO: Send error instead?
+    return; // TODO: Send error instead?
   }
 
   weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
@@ -453,10 +451,10 @@ void WebSocketTurboModule::Send(string&& message, int64_t id) noexcept {
   }
 }
 
-void WebSocketTurboModule::SendBinary(string&& base64String, int64_t id) noexcept {
-  auto rcItr = m_resourceMap.find(id);
+void WebSocketTurboModule::SendBinary(string &&base64String, double forSocketID) noexcept {
+  auto rcItr = m_resourceMap.find(static_cast<int64_t>(forSocketID));
   if (rcItr == m_resourceMap.cend()) {
-    return;//TODO: Send error instead?
+    return; // TODO: Send error instead?
   }
 
   weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;
@@ -465,10 +463,10 @@ void WebSocketTurboModule::SendBinary(string&& base64String, int64_t id) noexcep
   }
 }
 
-void WebSocketTurboModule::Ping(int64_t id) noexcept {
-  auto rcItr = m_resourceMap.find(id);
+void WebSocketTurboModule::Ping(double socketID) noexcept {
+  auto rcItr = m_resourceMap.find(static_cast<int64_t>(socketID));
   if (rcItr == m_resourceMap.cend()) {
-    return;//TODO: Send error instead?
+    return; // TODO: Send error instead?
   }
 
   weak_ptr<IWebSocketResource> weakRc = (*rcItr).second;

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -4,6 +4,7 @@
 #include "pch.h"
 
 #include <Modules/WebSocketModule.h>
+#include <Modules/WebSocketTurboModule.h>
 
 #include <Modules/CxxModuleUtilities.h>
 #include <Modules/IWebSocketModuleContentHandler.h>
@@ -18,6 +19,8 @@
 
 // Standard Library
 #include <iomanip>
+
+namespace msrn = winrt::Microsoft::ReactNative;
 
 using namespace facebook::xplat;
 
@@ -42,7 +45,7 @@ using Microsoft::React::WebSocketModule;
 using Microsoft::React::Modules::SendEvent;
 using Microsoft::React::Networking::IWebSocketResource;
 
-constexpr char moduleName[] = "WebSocketModule";
+constexpr char s_moduleName[] = "WebSocketModule";
 
 static shared_ptr<IWebSocketResource>
 GetOrCreateWebSocket(int64_t id, string &&url, weak_ptr<WebSocketModule::SharedState> weakState) {
@@ -179,7 +182,7 @@ void WebSocketModule::SetResourceFactory(
 }
 
 string WebSocketModule::getName() {
-  return moduleName;
+  return s_moduleName;
 }
 
 std::map<string, dynamic> WebSocketModule::getConstants() {
@@ -312,8 +315,16 @@ void WebSocketModuleProxy::SendBinary(std::string &&base64String, int64_t id) no
 
 #pragma endregion WebSocketModuleProxy
 
+#pragma region WebSocketTurboModule
+
+void WebSocketTurboModule::Initialize(msrn::ReactContext const& reactContext) noexcept {
+
+}
+
+#pragma endregion WebSocketTurboModule
+
 /*extern*/ const char *GetWebSocketModuleName() noexcept {
-  return moduleName;
+  return s_moduleName;
 }
 
 /*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule(

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -413,7 +413,18 @@ void WebSocketTurboModule::Connect(
     }
   }
 
-  // TODO
+  weak_ptr<IWebSocketResource> weakRc;
+  auto rcItr = m_resourceMap.find(id);
+  if (rcItr != m_resourceMap.cend()) {
+    weakRc = (*rcItr).second;
+  }
+  else {
+    weakRc = CreateResource(id, string{ url });
+  }
+
+  if (auto rc = weakRc.lock()) {
+    rc->Connect(std::move(url), rcProtocols, rcOptions);
+  }
 }
 
 #pragma endregion WebSocketTurboModule

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -46,7 +46,7 @@ struct WebSocketTurboModule {
   std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;
 
   winrt::Microsoft::ReactNative::ReactContext m_context;
-  std::unordered_map<int64_t, std::shared_ptr<Networking::IWebSocketResource>> m_resourceMap;
+  std::unordered_map<double, std::shared_ptr<Networking::IWebSocketResource>> m_resourceMap;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -3,17 +3,16 @@
 
 #pragma once
 
-// #include <NativeFileReaderModuleSpec.g.h>
-
 #include <Modules/IWebSocketModuleProxy.h>
-#include <NativeModules.h>
 #include <Networking/IWebSocketResource.h>
+#include <NativeModules.h>
+#include <NativeWebSocketModuleSpec.g.h>
 
 namespace Microsoft::React {
 
 REACT_MODULE(WebSocketTurboModule, L"WebSocketModule")
 struct WebSocketTurboModule {
-  // using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
+  //using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
 
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -24,17 +24,25 @@ struct WebSocketTurboModule {
     ReactNativeSpecs::WebSocketModuleSpec_connect_options&& options,
     double socketID) noexcept;
 
-  REACT_METHOD(Close, L"close")
+  REACT_METHOD(close) void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }
+  //REACT_METHOD(Close, L"close")
   void Close(int64_t code, std::string &&url, int64_t id) noexcept;
 
-  REACT_METHOD(Send, L"send")
+  REACT_METHOD(send) void send(std::string message, double forSocketID) noexcept { /* implementation */ }
+  //REACT_METHOD(Send, L"send")
   void Send(std::string&& message, int64_t id) noexcept;
 
-  REACT_METHOD(SendBinary, L"sendBinary")
+  REACT_METHOD(sendBinary) void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }
+  //REACT_METHOD(SendBinary, L"sendBinary")
   void SendBinary(std::string &&base64String, int64_t id) noexcept;
 
-  REACT_METHOD(Ping, L"ping")
+  REACT_METHOD(ping) void ping(double socketID) noexcept { /* implementation */ }
+  //REACT_METHOD(Ping, L"ping")
   void Ping(int64_t id) noexcept;
+
+  //TODO:
+  REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }
+  REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }
 
  private:
   std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -23,8 +23,19 @@ struct WebSocketTurboModule {
       std::string &&url,
       winrt::Microsoft::ReactNative::JSValueArray &&protocols,
       winrt::Microsoft::ReactNative::JSValueObject &&options,
-      int64_t id,
-      winrt::Microsoft::ReactNative::ReactPromise<std::string> &&result) noexcept;
+      int64_t id) noexcept;
+
+  REACT_METHOD(Close, L"close")
+  void Close(int64_t code, std::string &&url, int64_t id) noexcept;
+
+  REACT_METHOD(Send, L"send")
+  void Send(std::string&& message, int64_t id) noexcept;
+
+  REACT_METHOD(SendBinary, L"sendBinary")
+  void SendBinary(std::string &&base64String, int64_t id) noexcept;
+
+  REACT_METHOD(Ping, L"ping")
+  void Ping(int64_t id) noexcept;
 
  private:
   std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -36,11 +36,11 @@ struct WebSocketTurboModule {
   REACT_METHOD(Ping, L"ping")
   void Ping(double socketID) noexcept;
 
-  // TODO:
-  REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */
-  }
-  REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */
-  }
+  REACT_METHOD(AddListener, L"addListener")
+  void AddListener(std::string &&eventName) noexcept;
+
+  REACT_METHOD(RemoveListeners, L"removeListeners")
+  void RemoveListeners(double count) noexcept;
 
  private:
   std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+//#include <NativeFileReaderModuleSpec.g.h>
+
+#include <Modules/IWebSocketModuleProxy.h>
+#include <Networking/IWebSocketResource.h>
+#include <NativeModules.h>
+
+namespace Microsoft::React {
+
+REACT_MODULE(WebSocketTurboModule, L"WebSocketModule")
+struct WebSocketTurboModule {
+  //using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
+
+  REACT_INIT(Initialize)
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const& reactContext) noexcept;
+
+  //REACT_METHOD(Connect, L"connect")
+  //void Connect(std::string &&url, winrt::Microsoft::ReactNative::JSValueArray &&protocols)
+};
+
+} // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -18,8 +18,18 @@ struct WebSocketTurboModule {
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const& reactContext) noexcept;
 
-  //REACT_METHOD(Connect, L"connect")
-  //void Connect(std::string &&url, winrt::Microsoft::ReactNative::JSValueArray &&protocols)
+  REACT_METHOD(Connect, L"connect")
+  void Connect(std::string&& url,
+    winrt::Microsoft::ReactNative::JSValueArray&& protocols,
+    winrt::Microsoft::ReactNative::JSValueObject&& options,
+    int64_t id,
+    winrt::Microsoft::ReactNative::ReactPromise<std::string>&& result) noexcept;
+
+private:
+  std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string&& url) noexcept;
+
+  winrt::Microsoft::ReactNative::ReactContext m_context;
+  std::unordered_map<int64_t, std::shared_ptr<Networking::IWebSocketResource>> m_resourceMap;
 };
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -12,17 +12,17 @@ namespace Microsoft::React {
 
 REACT_MODULE(WebSocketTurboModule, L"WebSocketModule")
 struct WebSocketTurboModule {
-  //using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
+  using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
 
   REACT_INIT(Initialize)
   void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
   REACT_METHOD(Connect, L"connect")
   void Connect(
-      std::string &&url,
-      winrt::Microsoft::ReactNative::JSValueArray &&protocols,
-      winrt::Microsoft::ReactNative::JSValueObject &&options,
-      int64_t id) noexcept;
+    std::string&& url,
+    std::optional<std::vector<std::string>> protocols,
+    ReactNativeSpecs::WebSocketModuleSpec_connect_options&& options,
+    double socketID) noexcept;
 
   REACT_METHOD(Close, L"close")
   void Close(int64_t code, std::string &&url, int64_t id) noexcept;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -3,30 +3,31 @@
 
 #pragma once
 
-//#include <NativeFileReaderModuleSpec.g.h>
+// #include <NativeFileReaderModuleSpec.g.h>
 
 #include <Modules/IWebSocketModuleProxy.h>
-#include <Networking/IWebSocketResource.h>
 #include <NativeModules.h>
+#include <Networking/IWebSocketResource.h>
 
 namespace Microsoft::React {
 
 REACT_MODULE(WebSocketTurboModule, L"WebSocketModule")
 struct WebSocketTurboModule {
-  //using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
+  // using ModuleSpec = ReactNativeSpecs::WebSocketModuleSpec;
 
   REACT_INIT(Initialize)
-  void Initialize(winrt::Microsoft::ReactNative::ReactContext const& reactContext) noexcept;
+  void Initialize(winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
   REACT_METHOD(Connect, L"connect")
-  void Connect(std::string&& url,
-    winrt::Microsoft::ReactNative::JSValueArray&& protocols,
-    winrt::Microsoft::ReactNative::JSValueObject&& options,
-    int64_t id,
-    winrt::Microsoft::ReactNative::ReactPromise<std::string>&& result) noexcept;
+  void Connect(
+      std::string &&url,
+      winrt::Microsoft::ReactNative::JSValueArray &&protocols,
+      winrt::Microsoft::ReactNative::JSValueObject &&options,
+      int64_t id,
+      winrt::Microsoft::ReactNative::ReactPromise<std::string> &&result) noexcept;
 
-private:
-  std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string&& url) noexcept;
+ private:
+  std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;
 
   winrt::Microsoft::ReactNative::ReactContext m_context;
   std::unordered_map<int64_t, std::shared_ptr<Networking::IWebSocketResource>> m_resourceMap;

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <Modules/IWebSocketModuleProxy.h>
-#include <Networking/IWebSocketResource.h>
-#include <NativeModules.h>
 #include <NativeWebSocketModuleSpec.g.h>
+#include <Modules/IWebSocketModuleProxy.h>
+#include <NativeModules.h>
+#include <Networking/IWebSocketResource.h>
 
 namespace Microsoft::React {
 
@@ -19,30 +19,28 @@ struct WebSocketTurboModule {
 
   REACT_METHOD(Connect, L"connect")
   void Connect(
-    std::string&& url,
-    std::optional<std::vector<std::string>> protocols,
-    ReactNativeSpecs::WebSocketModuleSpec_connect_options&& options,
-    double socketID) noexcept;
+      std::string &&url,
+      std::optional<std::vector<std::string>> protocols,
+      ReactNativeSpecs::WebSocketModuleSpec_connect_options &&options,
+      double socketID) noexcept;
 
-  REACT_METHOD(close) void close(double code, std::string reason, double socketID) noexcept { /* implementation */ }
-  //REACT_METHOD(Close, L"close")
-  void Close(int64_t code, std::string &&url, int64_t id) noexcept;
+  REACT_METHOD(Close, L"close")
+  void Close(double code, std::string &&reason, double socketID) noexcept;
 
-  REACT_METHOD(send) void send(std::string message, double forSocketID) noexcept { /* implementation */ }
-  //REACT_METHOD(Send, L"send")
-  void Send(std::string&& message, int64_t id) noexcept;
+  REACT_METHOD(Send, L"send")
+  void Send(std::string &&message, double forSocketID) noexcept;
 
-  REACT_METHOD(sendBinary) void sendBinary(std::string base64String, double forSocketID) noexcept { /* implementation */ }
-  //REACT_METHOD(SendBinary, L"sendBinary")
-  void SendBinary(std::string &&base64String, int64_t id) noexcept;
+  REACT_METHOD(SendBinary, L"sendBinary")
+  void SendBinary(std::string &&base64String, double forSocketID) noexcept;
 
-  REACT_METHOD(ping) void ping(double socketID) noexcept { /* implementation */ }
-  //REACT_METHOD(Ping, L"ping")
-  void Ping(int64_t id) noexcept;
+  REACT_METHOD(Ping, L"ping")
+  void Ping(double socketID) noexcept;
 
-  //TODO:
-  REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */ }
-  REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */ }
+  // TODO:
+  REACT_METHOD(addListener) void addListener(std::string eventName) noexcept { /* implementation */
+  }
+  REACT_METHOD(removeListeners) void removeListeners(double count) noexcept { /* implementation */
+  }
 
  private:
   std::shared_ptr<Networking::IWebSocketResource> CreateResource(int64_t id, std::string &&url) noexcept;

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -325,6 +325,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\IWebSocketModuleProxy.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\HttpModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\NetworkingModule.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\WebSocketTurboModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IHttpResource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IRedirectEventSource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IWebSocketResource.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -726,6 +726,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\JsiApi.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\V8RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)SafeLoadLibrary.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\WebSocketTurboModule.h">
+      <Filter>Header Files\Modules</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp">


### PR DESCRIPTION
## Description

Implements `REACT_MODULE` variant of `WebSocket`.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
In the long term, we want all modules to be `REACT_MODULE`.

Blob-related modules are not essential for all React Native scenarios.
Thus, we should be able to lazy-load them as turbo-modules instead of instantiating them by default with every React instance.

### What
- Defined `Microsoft::React::WebSocketTurboModule`.
- Added the following methods to `Microsoft::React::IWebSocketModuleContentHandler`:
  - `ProcessMessage(std::string &&message, winrt::Microsoft::ReactNative::JSValueObject &params)`
  - `ProcessMessage(std::vector<uint8_t> &&message, winrt::Microsoft::ReactNative::JSValueObject &params)`

Addresses #11790

Note, the TurboModule variant is currently not enabled. This PR only implements it.

## Testing
- **PENDING**

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11802&drop=dogfoodAlpha