### PR TITLE
[Fabric]: Scroll Scrollviews to bring focused items into view

### DIFF
--- a/change/react-native-windows-9f19f41a-f08e-48ba-becf-7867ac8521f5.json
+++ b/change/react-native-windows-9f19f41a-f08e-48ba-becf-7867ac8521f5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: Scroll Scrollviews to bring focused items into view",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -27,6 +27,17 @@ DEFINE_ENUM_FLAG_OPERATORS(RNComponentViewUpdateMask);
 
 struct RootComponentView;
 
+struct BringIntoViewOptions {
+  bool AnimationDesired{false};
+  // NaN will bring the element fully into view aligned to the nearest edge of the viewport
+  float HorizontalAlignmentRatio{std::numeric_limits<float>::quiet_NaN()};
+  float HorizontalOffset{0};
+  std::optional<facebook::react::Rect> TargetRect;
+  // NaN will bring the element fully into view aligned to the nearest edge of the viewport
+  float VerticalAlignmentRatio{std::numeric_limits<float>::quiet_NaN()};
+  float VerticalOffset{0};
+};
+
 struct IComponentView {
   virtual std::vector<facebook::react::ComponentDescriptorProvider>
   supplementalComponentDescriptorProviders() noexcept = 0;
@@ -68,6 +79,8 @@ struct IComponentView {
       bool ignorePointerEvents = false) const noexcept = 0;
   virtual int64_t sendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept = 0;
   virtual winrt::IInspectable EnsureUiaProvider() noexcept = 0;
+  // Notify up the tree to bring the rect into view by scrolling as needed
+  virtual void StartBringIntoView(BringIntoViewOptions &&args) noexcept = 0;
 };
 
 // Run fn on all nodes of the component view tree starting from this one until fn returns true

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -97,6 +97,24 @@ void CompositionBaseComponentView::onFocusGained() noexcept {
       UiaRaiseAutomationEvent(spProviderSimple.get(), UIA_AutomationFocusChangedEventId);
     }
   }
+
+  StartBringIntoView({});
+}
+
+void CompositionBaseComponentView::StartBringIntoView(BringIntoViewOptions &&options) noexcept {
+  if (!options.TargetRect) {
+    // Default to bring the entire of this component into view
+    options.TargetRect = {
+        {0, 0},
+        {m_layoutMetrics.frame.size.width * m_layoutMetrics.pointScaleFactor,
+         m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor}};
+  }
+
+  if (m_parent) {
+    options.TargetRect->origin.y += m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor;
+    options.TargetRect->origin.x += m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor;
+    m_parent->StartBringIntoView(std::move(options));
+  }
 }
 
 void CompositionBaseComponentView::updateEventEmitter(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -59,6 +59,8 @@ struct CompositionBaseComponentView : public IComponentView,
 
   virtual void OnRenderingDeviceLost() noexcept;
 
+  void StartBringIntoView(BringIntoViewOptions &&args) noexcept override;
+
   comp::CompositionPropertySet EnsureCenterPointPropertySet() noexcept;
   void EnsureTransformMatrixFacade() noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -78,6 +78,8 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   // void OnPointerDown(const winrt::Windows::UI::Input::PointerPoint &pp) noexcept override;
   bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept override;
 
+  void StartBringIntoView(BringIntoViewOptions &&args) noexcept override;
+
  private:
   ScrollViewComponentView(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,


### PR DESCRIPTION
When keyboarding around, if focus moves to a component outside of the current viewport of a scrollview, it should scroll into view.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11805&drop=dogfoodAlpha