### PR TITLE
[Fabric] No need to assert when an unimplemented view has children added to it

### DIFF
--- a/change/react-native-windows-3c713eb8-d78f-4c25-99c0-77f22815766f.json
+++ b/change/react-native-windows-3c713eb8-d78f-4c25-99c0-77f22815766f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] No need to assert when an unimplemented view has children added to it",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -30,13 +30,11 @@ std::shared_ptr<UnimplementedNativeViewComponentView> UnimplementedNativeViewCom
 
 void UnimplementedNativeViewComponentView::mountChildComponentView(
     IComponentView &childComponentView,
-    uint32_t index) noexcept {
-}
+    uint32_t index) noexcept {}
 
 void UnimplementedNativeViewComponentView::unmountChildComponentView(
     IComponentView &childComponentView,
-    uint32_t index) noexcept {
-}
+    uint32_t index) noexcept {}
 
 void UnimplementedNativeViewComponentView::updateProps(
     facebook::react::Props::Shared const &props,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -31,13 +31,11 @@ std::shared_ptr<UnimplementedNativeViewComponentView> UnimplementedNativeViewCom
 void UnimplementedNativeViewComponentView::mountChildComponentView(
     IComponentView &childComponentView,
     uint32_t index) noexcept {
-  assert(false);
 }
 
 void UnimplementedNativeViewComponentView::unmountChildComponentView(
     IComponentView &childComponentView,
     uint32_t index) noexcept {
-  assert(false);
 }
 
 void UnimplementedNativeViewComponentView::updateProps(


### PR DESCRIPTION
## Description
We display some error UI for an unimplemented view. If that unimplemented view has children we can just ignore them, no need to assert.