### PR TITLE
Promote 0.71 to legacy

### DIFF
--- a/change/@office-iss-react-native-win32-f40b1260-f10a-4a63-92f2-1b97efa0662f.json
+++ b/change/@office-iss-react-native-win32-f40b1260-f10a-4a63-92f2-1b97efa0662f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-85d7c36c-8164-484e-a503-a2aeea0d65ea.json
+++ b/change/@react-native-windows-cli-85d7c36c-8164-484e-a503-a2aeea0d65ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-be75ae98-1ec1-49ba-8cd9-20604693288d.json
+++ b/change/@react-native-windows-codegen-be75ae98-1ec1-49ba-8cd9-20604693288d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-00f0827f-505c-4e55-a8a0-f00df8dd4785.json
+++ b/change/@react-native-windows-find-repo-root-00f0827f-505c-4e55-a8a0-f00df8dd4785.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-996f94b5-fb2d-4fe0-b273-9000b36fcbef.json
+++ b/change/@react-native-windows-fs-996f94b5-fb2d-4fe0-b273-9000b36fcbef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-3d9ba78b-9864-4b2f-8323-a2935547372b.json
+++ b/change/@react-native-windows-package-utils-3d9ba78b-9864-4b2f-8323-a2935547372b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-0673ff30-f39e-4aeb-bdea-391a70bc60e4.json
+++ b/change/@react-native-windows-telemetry-0673ff30-f39e-4aeb-bdea-391a70bc60e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-01b8a6cb-d629-4574-a77e-e871ce29dd57.json
+++ b/change/react-native-windows-01b8a6cb-d629-4574-a77e-e871ce29dd57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.71 to legacy",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -82,7 +82,7 @@
     "react-native": "^0.71.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -74,7 +74,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -54,7 +54,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.9.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -36,7 +36,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.9.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -50,7 +50,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -85,7 +85,7 @@
     "react-native": "^0.71.0"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.71-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
Promote 0.71 to legacy in preparation for 0.72 promotion to latest.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11810&drop=dogfoodAlpha