### PR TITLE
Bump macos timeout

### DIFF
--- a/.ado/jobs/macos-tests.yml
+++ b/.ado/jobs/macos-tests.yml
@@ -2,7 +2,7 @@
 jobs:
   - job: MacTests
     displayName: macOS Tests
-    timeoutInMinutes: 20
+    timeoutInMinutes: 30
     variables: 
       - template: ../variables/shared.yml
       - name: BUILDSECMON_OPT_IN


### PR DESCRIPTION
While generally the macos CI task completes well before its timeout, I hit a case where it just took longer than usual.

Ex: https://dev.azure.com/ms/react-native-windows/_build/results?buildId=470103&view=logs&jobId=b8115773-854b-5a24-9853-4feb4834ad88&j=b8115773-854b-5a24-9853-4feb4834ad88

I dont see much harm in bumping the timeout some, since its by far not one of the longest tasks.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11811&drop=dogfoodAlpha