### PR TITLE
Fix AV in LinkingManagerModule when resolving promise with nullptr

### DIFF
--- a/change/react-native-windows-c7574db8-26ae-4cd1-b76c-b9c712abc2bb.json
+++ b/change/react-native-windows-c7574db8-26ae-4cd1-b76c-b9c712abc2bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix AV in LinkingManagerModule when resolving promise with nullptr",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -113,7 +113,7 @@ void LinkingManager::HandleOpenUri(winrt::hstring const &uri) noexcept {
   if (s_initialUri) {
     result.Resolve(to_string(s_initialUri.AbsoluteUri()));
   } else {
-    result.Resolve(nullptr);
+    result.Resolve("");
   }
 }
 


### PR DESCRIPTION
## Description

This bug was discovered while testing SampleAppCpp, and causes the app to crash after loading the bundle from metro.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Fix crash.

### What
Replace call to `promise.Resolve(nullptr)` with `promise.Resolve("")`.

## Screenshots
N/A

## Testing
Verified SampleAppCpp can now launch.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11812&drop=dogfoodAlpha