### PR TITLE
Fix warning compiler may not enforce left-to-right evaluation order in braced initializer list

### DIFF
--- a/change/react-native-windows-34eb3554-b2c4-4faa-bfe8-1ce06c659aa3.json
+++ b/change/react-native-windows-34eb3554-b2c4-4faa-bfe8-1ce06c659aa3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix warning compiler may not enforce left-to-right evaluation order in braced initializer list",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -62,7 +62,7 @@
     visitor.Visit(                                                                                            \
         &TStruct::member,                                                                                     \
         attributeId,                                                                                          \
-        winrt::Microsoft::ReactNative::React##memberKind##Attribute{jsMemberName, jsModuleName});             \
+        winrt::Microsoft::ReactNative::React##memberKind##Attribute(jsMemberName, jsModuleName));             \
   }
 
 #define INTERNAL_REACT_MEMBER_3_ARGS(memberKind, member, jsMemberName) \


### PR DESCRIPTION

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11814&drop=dogfoodAlpha