### PR TITLE
[0.71] Fix warning compiler may not enforce left-to-right evaluation order in braced initializer list

### DIFF
--- a/change/react-native-windows-892e60c4-d492-4ae4-b4a9-6bef92849776.json
+++ b/change/react-native-windows-892e60c4-d492-4ae4-b4a9-6bef92849776.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix warning compiler may not enforce left-to-right evaluation order in braced initializer list",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -62,7 +62,7 @@
     visitor.Visit(                                                                                            \
         &TStruct::member,                                                                                     \
         attributeId,                                                                                          \
-        winrt::Microsoft::ReactNative::React##memberKind##Attribute{jsMemberName, jsModuleName});             \
+        winrt::Microsoft::ReactNative::React##memberKind##Attribute(jsMemberName, jsModuleName));             \
   }
 
 #define INTERNAL_REACT_MEMBER_3_ARGS(memberKind, member, jsMemberName) \


### PR DESCRIPTION

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11815&drop=dogfoodAlpha