### PR TITLE
Fix BinSkim warnings for Desktop

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -192,11 +192,7 @@ jobs:
                   InputType: 'Basic'
                   Function: 'analyze'
                   TargetPattern: 'guardianGlob'
-                  # Scanning v8jsi.dll in x64/x86 only, because PDBs are stripped in ARM64
-                  ${{ if ne(matrix.BuildPlatform, 'ARM64') }}:
-                    AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\\React.Windows.Desktop.DLL\*.dll'
-                  ${{ else }}:
-                    AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\\React.Windows.Desktop.DLL\react-native-win32.dll'
+                  AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\React.Windows.Desktop.DLL\react-native-win32.dll'
                   AnalyzeVerbose: true
                   toolVersion: 'Latest'
               continueOnError: true


### PR DESCRIPTION
BinSkim has been throwing warnings for Desktop ever since the upgrade to BinSkim@4. Particularly this is from scanning the Hermes and V8 dlls.

However both are sourced from their own Microsoft-owned repos and only consumed here via published NuGets. BinSkim should be running on those repos (if required) not here in RNW.

This PR updates the pipeline to only test the binaries built by this pipeline.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11816&drop=dogfoodAlpha