### PR TITLE
[0.72] Fix AV in LinkingManagerModule when resolving promise with nullptr

### DIFF
--- a/change/react-native-windows-c7574db8-26ae-4cd1-b76c-b9c712abc2bb.json
+++ b/change/react-native-windows-c7574db8-26ae-4cd1-b76c-b9c712abc2bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Fix AV in LinkingManagerModule when resolving promise with nullptr",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/LinkingManagerModule.cpp
@@ -113,7 +113,7 @@ void LinkingManager::HandleOpenUri(winrt::hstring const &uri) noexcept {
   if (s_initialUri) {
     result.Resolve(to_string(s_initialUri.AbsoluteUri()));
   } else {
-    result.Resolve(nullptr);
+    result.Resolve("");
   }
 }
 


### PR DESCRIPTION
This PR backports #11812 to 0.72.

* Fix AV in LinkingManagerModule when resolving promise with nullptr

This bug was discovered while testing SampleAppCpp, and causes the app to crash after loading the bundle from metro.