### PR TITLE
Fix VS Code Direct Debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,11 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
+            "name": "Attach to RNW App (Hermes Direct Debug w/ Metro)",
+            "port": 8081,
             "request": "attach",
-            "name": "Attach to react-native direct debugger",
-            "protocol": "inspector",
-            "port": 9229
-          },
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node",
+        }
     ]
 }


### PR DESCRIPTION
This PR changes the launch config for VS Code so we can attach to an in-repo app with direct debugging through Metro.

Tested working with e2e-test-app with Hermes enabled.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11820&drop=dogfoodAlpha