### PR TITLE
Adds ABIViewManager interface for 3p popup content

### DIFF
--- a/change/react-native-windows-128e7062-7261-4842-8249-a892f9541277.json
+++ b/change/react-native-windows-128e7062-7261-4842-8249-a892f9541277.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds ABIViewManager interface for 3p popup content",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ABIViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.cpp
@@ -19,13 +19,19 @@ class ABIShadowNode : public ::Microsoft::ReactNative::ShadowNodeBase {
   using Super = ShadowNodeBase;
 
  public:
-  ABIShadowNode(bool needsForceLayout) : m_needsForceLayout(needsForceLayout) {}
+  ABIShadowNode(bool needsForceLayout, bool isWindowed)
+      : m_needsForceLayout(needsForceLayout), m_isWindowed{isWindowed} {}
   bool NeedsForceLayout() override {
     return m_needsForceLayout;
   }
 
+  bool IsWindowed() override {
+    return m_isWindowed;
+  }
+
  private:
   bool m_needsForceLayout;
+  bool m_isWindowed;
 };
 
 ABIViewManager::ABIViewManager(
@@ -43,6 +49,7 @@ ABIViewManager::ABIViewManager(
       m_viewManagerWithChildren{viewManager.try_as<IViewManagerWithChildren>()},
       m_viewManagerWithPointerEvents{viewManager.try_as<IViewManagerWithPointerEvents>()},
       m_viewManagerWithDropViewInstance{viewManager.try_as<IViewManagerWithDropViewInstance>()},
+      m_viewManagerWithWindowedContent{viewManager.try_as<IViewManagerWithWindowedContent>()},
       m_viewManagerWithOnLayout{viewManager.try_as<IViewManagerWithOnLayout>()} {
   if (m_viewManagerWithReactContext) {
     m_viewManagerWithReactContext.ReactContext(winrt::make<implementation::ReactContext>(Mso::Copy(reactContext)));
@@ -257,7 +264,8 @@ void ABIViewManager::SetLayoutProps(
 
 ::Microsoft::ReactNative::ShadowNode *ABIViewManager::createShadow() const {
   return new ABIShadowNode(
-      m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout());
+      m_viewManagerRequiresNativeLayout && m_viewManagerRequiresNativeLayout.RequiresNativeLayout(),
+      m_viewManagerWithWindowedContent && m_viewManagerWithWindowedContent.IsWindowed());
 }
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/ABIViewManager.h
+++ b/vnext/Microsoft.ReactNative/ABIViewManager.h
@@ -93,6 +93,7 @@ class ABIViewManager : public ::Microsoft::ReactNative::FrameworkElementViewMana
   IViewManagerWithPointerEvents m_viewManagerWithPointerEvents;
   IViewManagerWithDropViewInstance m_viewManagerWithDropViewInstance;
   IViewManagerWithOnLayout m_viewManagerWithOnLayout;
+  IViewManagerWithWindowedContent m_viewManagerWithWindowedContent;
 
   winrt::Windows::Foundation::Collections::IMapView<winrt::hstring, ViewManagerPropertyType> m_nativeProps;
 };

--- a/vnext/Microsoft.ReactNative/IViewManager.idl
+++ b/vnext/Microsoft.ReactNative/IViewManager.idl
@@ -117,4 +117,18 @@ namespace Microsoft.ReactNative
         "without a corresponding `onLayout` event in JavaScript.")
     void OnLayout(XAML_NAMESPACE.FrameworkElement view, Single left, Single top, Single width, Single height);
   };
-} // namespace Microsoft.ReactNative
+
+  [webhosthidden]
+  DOC_STRING(
+    "Experimental interface enabling view managers to accurately measure content "
+    "that is rendered outside of the @ReactRootView, e.g., in a Popup."
+  )
+  interface IViewManagerWithWindowedContent {
+    DOC_STRING(
+        "When true, ensures that content is measured against the first native ancestor in "
+        "the sub-tree(s) attached to components created by this @IViewManager.")
+    Boolean IsWindowed {
+      get;
+    };
+  };
+  } // namespace Microsoft.ReactNative


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
We discovered a bug where a custom component that hoists it's children into a popup has issues with Pressable. Specifically, Pressable calls UIManager.measure to test whether a pointer is still in the hit box for the first responder after pointerDown on each pointerMove.

### What
FlyoutViewManager works around this by returning `true` from `ShadowNodeBase::IsWindowed()`. There is no affordance for this in ABIViewManager. This change introduces an interface to support it.

## Testing
Verifying privately in our project that this can be used to solve the issue. Better testing would be to add a custom component to PlaygroundNativeModules 😬

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11821&drop=dogfoodAlpha