### PR TITLE
Add cppStringType option to @rnw/codegen

### DIFF
--- a/change/@react-native-windows-cli-8ea2e77c-918e-4240-bec3-52c37a4d6a94.json
+++ b/change/@react-native-windows-cli-8ea2e77c-918e-4240-bec3-52c37a4d6a94.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add cppStringType option to @rnw/codegen",
+  "packageName": "@react-native-windows/cli",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-ca21b1e7-110a-4564-827c-6138fa6852b3.json
+++ b/change/@react-native-windows-codegen-ca21b1e7-110a-4564-827c-6138fa6852b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add cppStringType option to @rnw/codegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/codegen.ts
+++ b/packages/@react-native-windows/cli/src/codegen.ts
@@ -25,7 +25,10 @@ import {
   endTelemetrySession,
 } from './runWindows/utils/telemetryHelpers';
 
-import {CodeGenOptions as RnwCodeGenOptions, runCodeGen} from '@react-native-windows/codegen';
+import {
+  CodeGenOptions as RnwCodeGenOptions,
+  runCodeGen,
+} from '@react-native-windows/codegen';
 import {Ora} from 'ora';
 
 export class CodeGenWindows {
@@ -108,7 +111,7 @@ export class CodeGenWindows {
     ];
 
     const jsRootPathRelative = path.relative(process.cwd(), jsRootDir);
-    const options : RnwCodeGenOptions = {
+    const options: RnwCodeGenOptions = {
       files: [
         `${jsRootPathRelative}${
           jsRootPathRelative ? '/' : ''

--- a/packages/@react-native-windows/cli/src/codegen.ts
+++ b/packages/@react-native-windows/cli/src/codegen.ts
@@ -25,7 +25,7 @@ import {
   endTelemetrySession,
 } from './runWindows/utils/telemetryHelpers';
 
-import {runCodeGen} from '@react-native-windows/codegen';
+import {CodeGenOptions as RnwCodeGenOptions, runCodeGen} from '@react-native-windows/codegen';
 import {Ora} from 'ora';
 
 export class CodeGenWindows {
@@ -108,12 +108,13 @@ export class CodeGenWindows {
     ];
 
     const jsRootPathRelative = path.relative(process.cwd(), jsRootDir);
-    const options = {
+    const options : RnwCodeGenOptions = {
       files: [
         `${jsRootPathRelative}${
           jsRootPathRelative ? '/' : ''
         }**/*Native*.[jt]s`,
       ],
+      cppStringType: 'std::string',
       libraryName: projectName,
       methodOnly: false,
       modulesCxx: generators.indexOf('modulesCxx') !== -1,

--- a/packages/@react-native-windows/codegen/Document.md
+++ b/packages/@react-native-windows/codegen/Document.md
@@ -318,7 +318,7 @@ Here are a list of supported types in TurboModule.
 
 | TypeScript | Flow | C++ |
 | ---------- | ---- | --- |
-| `string` | `*` | `std::string` |
+| `string` | `*` | `std::string` or `std::wstring` according to options |
 | `number` | `*` | `double` |
 | `float (number)` | `*` | `double` |
 | `double (number)` | `*` | `double` |

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -79,6 +79,9 @@ if (
   process.exit(1);
 }
 
+// type casting is necessary here because
+// cppStringType does not become union of string literals
+// until yargs.options get improved in the future
 const changesNecessary = runCodeGen(<CodeGenOptions>argv);
 
 if (argv.test && changesNecessary) {

--- a/packages/@react-native-windows/codegen/src/Cli.ts
+++ b/packages/@react-native-windows/codegen/src/Cli.ts
@@ -6,7 +6,7 @@
  */
 
 import yargs from 'yargs';
-import {runCodeGen} from './index';
+import {CodeGenOptions, runCodeGen} from './index';
 
 const argv = yargs.options({
   file: {
@@ -58,6 +58,12 @@ const argv = yargs.options({
     required: true,
     describe: 'Used for part of the path generated within the codegen dir',
   },
+  cppStringType: {
+    choices: ['std::string', 'std::wstring'],
+    describe:
+      'C++ string type in generated code, should be "std::string" or "std::wstring"',
+    default: 'std::string',
+  },
 }).argv;
 
 if ((argv.file && argv.files) || (!argv.file && !argv.files)) {
@@ -65,7 +71,15 @@ if ((argv.file && argv.files) || (!argv.file && !argv.files)) {
   process.exit(1);
 }
 
-const changesNecessary = runCodeGen(argv);
+if (
+  argv.cppStringType !== 'std::string' &&
+  argv.cppStringType !== 'std::wstring'
+) {
+  console.error('cppStringType should be "std::string" or "std::wstring".');
+  process.exit(1);
+}
+
+const changesNecessary = runCodeGen(<CodeGenOptions>argv);
 
 if (argv.test && changesNecessary) {
   console.error(

--- a/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
+++ b/packages/@react-native-windows/codegen/src/generators/AliasGen.ts
@@ -88,14 +88,22 @@ function generateNestedAliasesInCorrectOrder(
     // nested C++ structs must be put before the current C++ struct
     // as they will be used in the current C++ struct
     // the order will be perfectly and easily ensured by doing this recursively
-    generateNestedAliasesInCorrectOrder(aliases, aliasCode, aliasOrder, options);
+    generateNestedAliasesInCorrectOrder(
+      aliases,
+      aliasCode,
+      aliasOrder,
+      options,
+    );
     // all referenced C++ structs are generated
     // put the current one following them
     aliasOrder.push(aliasName);
   }
 }
 
-export function generateAliases(aliases: AliasMap, options: CppCodegenOptions): string {
+export function generateAliases(
+  aliases: AliasMap,
+  options: CppCodegenOptions,
+): string {
   const aliasCode: AliasCodeMap = {};
   const aliasOrder: string[] = [];
   generateNestedAliasesInCorrectOrder(aliases, aliasCode, aliasOrder, options);

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -11,6 +11,9 @@ import {AliasMap, setPreferredModuleName} from './AliasManaging';
 import {createAliasMap, generateAliases} from './AliasGen';
 import {generateValidateConstants} from './ValidateConstants';
 import {generateValidateMethods} from './ValidateMethods';
+import type {CppStringTypes} from './ObjectTypes';
+
+export type {CppStringTypes} from './ObjectTypes';
 
 type FilesOutput = Map<string, string>;
 
@@ -50,7 +53,7 @@ export function createNM2Generator({
 }: {
   methodOnly: boolean;
   namespace: string;
-  cppStringType: 'std::string' | 'std::wstring';
+  cppStringType: CppStringTypes;
 }) {
   return (
     _libraryName: string,

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -46,9 +46,11 @@ struct ::_MODULE_NAME_::Spec : winrt::Microsoft::ReactNative::TurboModuleSpec {
 export function createNM2Generator({
   methodOnly,
   namespace,
+  cppStringType,
 }: {
   methodOnly: boolean;
   namespace: string;
+  cppStringType: 'std::string' | 'std::wstring';
 }) {
   return (
     _libraryName: string,

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -79,7 +79,9 @@ export function createNM2Generator({
         const aliases: AliasMap = createAliasMap(nativeModule.aliasMap);
 
         // prepare methods
-        const methods = generateValidateMethods(nativeModule, aliases, {cppStringType});
+        const methods = generateValidateMethods(nativeModule, aliases, {
+          cppStringType,
+        });
         let tuples = `
   static constexpr auto methods = std::tuple{
 ${methods[0]}
@@ -103,7 +105,9 @@ ${errors}`;
         }
 
         // generate code for structs
-        const traversedAliasedStructs = generateAliases(aliases, {cppStringType});
+        const traversedAliasedStructs = generateAliases(aliases, {
+          cppStringType,
+        });
 
         files.set(
           `Native${preferredModuleName}Spec.g.h`,

--- a/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
+++ b/packages/@react-native-windows/codegen/src/generators/GenerateNM2.ts
@@ -79,7 +79,7 @@ export function createNM2Generator({
         const aliases: AliasMap = createAliasMap(nativeModule.aliasMap);
 
         // prepare methods
-        const methods = generateValidateMethods(nativeModule, aliases);
+        const methods = generateValidateMethods(nativeModule, aliases, {cppStringType});
         let tuples = `
   static constexpr auto methods = std::tuple{
 ${methods[0]}
@@ -103,7 +103,7 @@ ${errors}`;
         }
 
         // generate code for structs
-        const traversedAliasedStructs = generateAliases(aliases);
+        const traversedAliasedStructs = generateAliases(aliases, {cppStringType});
 
         files.set(
           `Native${preferredModuleName}Spec.g.h`,

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -22,13 +22,18 @@ import {
 
 export type CppStringTypes = 'std::string' | 'std::wstring';
 
+export interface CppCodegenOptions {
+  cppStringType: CppStringTypes;
+}
+
 function translateUnionReturnType(
   type: NativeModuleEnumDeclaration | NativeModuleUnionTypeAnnotation,
+  options: CppCodegenOptions,
 ): string {
   const memberType = type.memberType;
   switch (type.memberType) {
     case 'StringTypeAnnotation':
-      return 'std::string';
+      return options.cppStringType;
     case 'NumberTypeAnnotation':
       return 'double';
     case 'ObjectTypeAnnotation':
@@ -49,12 +54,13 @@ export function translateFieldOrReturnType(
   aliases: AliasMap,
   baseAliasName: string,
   callerName: 'translateField' | 'translateReturnType',
+  options: CppCodegenOptions,
 ): string {
   // avoid: Property 'type' does not exist on type 'never'
   const returnType = type.type;
   switch (type.type) {
     case 'StringTypeAnnotation':
-      return 'std::string';
+      return options.cppStringType;
     case 'NumberTypeAnnotation':
     case 'FloatTypeAnnotation':
     case 'DoubleTypeAnnotation':
@@ -70,6 +76,7 @@ export function translateFieldOrReturnType(
           aliases,
           `${baseAliasName}_element`,
           callerName,
+          options,
         )}>`;
       } else {
         return `::React::JSValueArray`;
@@ -95,10 +102,11 @@ export function translateFieldOrReturnType(
         aliases,
         baseAliasName,
         callerName,
+        options,
       )}>`;
     case 'EnumDeclaration':
     case 'UnionTypeAnnotation':
-      return translateUnionReturnType(type);
+      return translateUnionReturnType(type, options);
     default:
       throw new Error(`Unhandled type in ${callerName}: ${returnType}`);
   }
@@ -108,11 +116,13 @@ export function translateField(
   type: Nullable<NativeModuleBaseTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ): string {
   return translateFieldOrReturnType(
     type,
     aliases,
     baseAliasName,
     'translateField',
+    options,
   );
 }

--- a/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ObjectTypes.ts
@@ -20,6 +20,8 @@ import {
   getAnonymousAliasCppName,
 } from './AliasManaging';
 
+export type CppStringTypes = 'std::string' | 'std::wstring';
+
 function translateUnionReturnType(
   type: NativeModuleEnumDeclaration | NativeModuleUnionTypeAnnotation,
 ): string {

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -72,19 +72,34 @@ function translateFunction(
     case 'spec':
       return `Callback<${param.params
         .map((p: NativeModuleParamShape) =>
-          translateSpecFunctionParam(p, aliases, `${baseAliasName}_${p.name}`, options),
+          translateSpecFunctionParam(
+            p,
+            aliases,
+            `${baseAliasName}_${p.name}`,
+            options,
+          ),
         )
         .join(', ')}>`;
     case 'template':
       return `std::function<void(${param.params
         .map((p: NativeModuleParamShape) =>
-          translateCallbackParam(p, aliases, `${baseAliasName}_${p.name}`, options),
+          translateCallbackParam(
+            p,
+            aliases,
+            `${baseAliasName}_${p.name}`,
+            options,
+          ),
         )
         .join(', ')})>`;
     default:
       return `std::function<void(${param.params
         .map((p: NativeModuleParamShape) =>
-          translateCallbackParam(p, aliases, `${baseAliasName}_${p.name}`, options),
+          translateCallbackParam(
+            p,
+            aliases,
+            `${baseAliasName}_${p.name}`,
+            options,
+          ),
         )
         .join(', ')})> const &`;
   }

--- a/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ParamTypes.ts
@@ -21,6 +21,7 @@ import {
   getAliasCppName,
   getAnonymousAliasCppName,
 } from './AliasManaging';
+import type {CppStringTypes} from './ObjectTypes';
 
 type NativeModuleParamShape = NamedShape<
   Nullable<NativeModuleParamTypeAnnotation>

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -47,7 +47,12 @@ export function translateSpecReturnType(
   baseAliasName: string,
   options: CppCodegenOptions,
 ) {
-  return translateReturnType(type, aliases, `${baseAliasName}_returnType`, options);
+  return translateReturnType(
+    type,
+    aliases,
+    `${baseAliasName}_returnType`,
+    options,
+  );
 }
 
 export function translateImplReturnType(
@@ -56,5 +61,10 @@ export function translateImplReturnType(
   baseAliasName: string,
   options: CppCodegenOptions,
 ) {
-  return translateReturnType(type, aliases, `${baseAliasName}_returnType`, options);
+  return translateReturnType(
+    type,
+    aliases,
+    `${baseAliasName}_returnType`,
+    options,
+  );
 }

--- a/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ReturnTypes.ts
@@ -11,12 +11,13 @@ import type {
   Nullable,
 } from '@react-native/codegen/lib/CodegenSchema';
 import {AliasMap} from './AliasManaging';
-import {translateFieldOrReturnType} from './ObjectTypes';
+import {CppCodegenOptions, translateFieldOrReturnType} from './ObjectTypes';
 
 function translateReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ): string {
   switch (type.type) {
     case 'VoidTypeAnnotation':
@@ -27,6 +28,7 @@ function translateReturnType(
         type.typeAnnotation,
         aliases,
         baseAliasName,
+        options,
       )}>`;
     default:
       return translateFieldOrReturnType(
@@ -34,6 +36,7 @@ function translateReturnType(
         aliases,
         baseAliasName,
         'translateReturnType',
+        options,
       );
   }
 }
@@ -42,14 +45,16 @@ export function translateSpecReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ) {
-  return translateReturnType(type, aliases, `${baseAliasName}_returnType`);
+  return translateReturnType(type, aliases, `${baseAliasName}_returnType`, options);
 }
 
 export function translateImplReturnType(
   type: Nullable<NativeModuleReturnTypeAnnotation>,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ) {
-  return translateReturnType(type, aliases, `${baseAliasName}_returnType`);
+  return translateReturnType(type, aliases, `${baseAliasName}_returnType`, options);
 }

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -75,7 +75,13 @@ function translatePossibleMethodSignatures(
   baseAliasName: string,
   options: CppCodegenOptions,
 ): string {
-  return getPossibleMethodSignatures(prop, funcType, aliases, baseAliasName, options)
+  return getPossibleMethodSignatures(
+    prop,
+    funcType,
+    aliases,
+    baseAliasName,
+    options,
+  )
     .map(sig => `"    ${sig}\\n"`)
     .join('\n          ');
 }
@@ -155,7 +161,17 @@ export function generateValidateMethods(
   options: CppCodegenOptions,
 ): [string, string] {
   const properties = nativeModule.spec.properties;
-  const traversedProperties = renderProperties(properties, aliases, false, options);
-  const traversedPropertyTuples = renderProperties(properties, aliases, true, options);
+  const traversedProperties = renderProperties(
+    properties,
+    aliases,
+    false,
+    options,
+  );
+  const traversedPropertyTuples = renderProperties(
+    properties,
+    aliases,
+    true,
+    options,
+  );
   return [traversedPropertyTuples, traversedProperties];
 }

--- a/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
+++ b/packages/@react-native-windows/codegen/src/generators/ValidateMethods.ts
@@ -12,6 +12,7 @@ import type {
   NativeModuleSchema,
 } from '@react-native/codegen/lib/CodegenSchema';
 import {AliasMap} from './AliasManaging';
+import type {CppCodegenOptions} from './ObjectTypes';
 import {translateArgs, translateSpecArgs} from './ParamTypes';
 import {translateImplReturnType, translateSpecReturnType} from './ReturnTypes';
 
@@ -27,8 +28,9 @@ function getPossibleMethodSignatures(
   funcType: NativeModuleFunctionTypeAnnotation,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ): string[] {
-  const args = translateArgs(funcType.params, aliases, baseAliasName);
+  const args = translateArgs(funcType.params, aliases, baseAliasName, options);
   if (funcType.returnTypeAnnotation.type === 'PromiseTypeAnnotation') {
     if (funcType.returnTypeAnnotation.elementType) {
       args.push(
@@ -36,6 +38,7 @@ function getPossibleMethodSignatures(
           funcType.returnTypeAnnotation.elementType,
           aliases,
           baseAliasName,
+          options,
         )}> &&result`,
       );
     } else {
@@ -50,6 +53,7 @@ function getPossibleMethodSignatures(
     funcType.returnTypeAnnotation,
     aliases,
     baseAliasName,
+    options,
   )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }`;
 
   const staticsig = `REACT_${isMethodSync(funcType) ? 'SYNC_' : ''}METHOD(${
@@ -58,6 +62,7 @@ function getPossibleMethodSignatures(
     funcType.returnTypeAnnotation,
     aliases,
     baseAliasName,
+    options,
   )} ${prop.name}(${args.join(', ')}) noexcept { /* implementation */ }`;
 
   return [sig, staticsig];
@@ -68,8 +73,9 @@ function translatePossibleMethodSignatures(
   funcType: NativeModuleFunctionTypeAnnotation,
   aliases: AliasMap,
   baseAliasName: string,
+  options: CppCodegenOptions,
 ): string {
-  return getPossibleMethodSignatures(prop, funcType, aliases, baseAliasName)
+  return getPossibleMethodSignatures(prop, funcType, aliases, baseAliasName, options)
     .map(sig => `"    ${sig}\\n"`)
     .join('\n          ');
 }
@@ -78,6 +84,7 @@ function renderProperties(
   properties: ReadonlyArray<NativeModulePropertyShape>,
   aliases: AliasMap,
   tuple: boolean,
+  options: CppCodegenOptions,
 ): string {
   // TODO: generate code for constants
   return properties
@@ -95,12 +102,14 @@ function renderProperties(
         funcType.params,
         aliases,
         propAliasName,
+        options,
       );
 
       const translatedReturnParam = translateSpecReturnType(
         funcType.returnTypeAnnotation,
         aliases,
         propAliasName,
+        options,
       );
 
       if (funcType.returnTypeAnnotation.type === 'PromiseTypeAnnotation') {
@@ -110,6 +119,7 @@ function renderProperties(
               funcType.returnTypeAnnotation.elementType,
               aliases,
               propAliasName,
+              options,
             )}>`,
           );
         } else {
@@ -132,6 +142,7 @@ function renderProperties(
             funcType,
             aliases,
             propAliasName,
+            options,
           )});`;
       }
     })
@@ -141,9 +152,10 @@ function renderProperties(
 export function generateValidateMethods(
   nativeModule: NativeModuleSchema,
   aliases: AliasMap,
+  options: CppCodegenOptions,
 ): [string, string] {
   const properties = nativeModule.spec.properties;
-  const traversedProperties = renderProperties(properties, aliases, false);
-  const traversedPropertyTuples = renderProperties(properties, aliases, true);
+  const traversedProperties = renderProperties(properties, aliases, false, options);
+  const traversedPropertyTuples = renderProperties(properties, aliases, true, options);
   return [traversedPropertyTuples, traversedProperties];
 }

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -40,15 +40,19 @@ const schemaValidator = require(path.resolve(
   'lib/SchemaValidator',
 ));
 
-interface Options {
+export interface SharedOptions {
   libraryName: string;
   methodOnly: boolean;
   modulesCxx: boolean;
-  moduleSpecName: string;
   modulesTypeScriptTypes: boolean;
   modulesWindows: boolean;
   namespace: string;
   outputDirectory: string;
+  cppStringType: 'std::string' | 'std::wstring';
+}
+
+interface Options extends SharedOptions {
+  moduleSpecName: string;
   schema: SchemaType;
 }
 
@@ -204,11 +208,12 @@ export function generate(
     libraryName,
     methodOnly,
     modulesCxx,
-    moduleSpecName,
     modulesTypeScriptTypes,
     modulesWindows,
     namespace,
     outputDirectory,
+    cppStringType,
+    moduleSpecName,
     schema,
   }: Options,
   {/*generators,*/ test}: Config,
@@ -231,6 +236,7 @@ export function generate(
   const generateNM2 = createNM2Generator({
     methodOnly,
     namespace,
+    cppStringType,
   });
 
   const generateJsiModuleH = require(path.resolve(
@@ -336,18 +342,11 @@ export function generate(
   return writeMapToFiles(generatedFiles, outputDirectory);
 }
 
-export type CodeGenOptions = {
+export interface CodeGenOptions extends SharedOptions {
   file?: string;
   files?: string[];
-  libraryName: string;
-  methodOnly: boolean;
-  modulesCxx: boolean;
-  modulesTypeScriptTypes: boolean;
-  modulesWindows: boolean;
-  namespace: string;
-  outputDirectory: string;
   test: boolean;
-};
+}
 
 export function runCodeGen(options: CodeGenOptions): boolean {
   if (!options.file && !options.files)
@@ -366,17 +365,19 @@ export function runCodeGen(options: CodeGenOptions): boolean {
     modulesWindows,
     namespace,
     outputDirectory,
+    cppStringType,
   } = options;
   return generate(
     {
       libraryName,
       methodOnly,
       modulesCxx,
-      moduleSpecName,
       modulesTypeScriptTypes,
       modulesWindows,
       namespace,
       outputDirectory,
+      cppStringType,
+      moduleSpecName,
       schema,
     },
     {generators: [], test: options.test},

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -8,6 +8,7 @@
 import path from 'path';
 import fs from '@react-native-windows/fs';
 import globby from 'globby';
+import type {CppStringTypes} from './generators/GenerateNM2';
 import {createNM2Generator} from './generators/GenerateNM2';
 import {
   generateTypeScript,
@@ -48,7 +49,7 @@ export interface SharedOptions {
   modulesWindows: boolean;
   namespace: string;
   outputDirectory: string;
-  cppStringType: 'std::string' | 'std::wstring';
+  cppStringType: CppStringTypes;
 }
 
 interface Options extends SharedOptions {


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Some people are using turbo module in devmain without using the codegen, and already have `std::wstring` everywhere. We have to support this so that to replace these code to generated code little by little.

### What
Add cppStringType option to @rnw/codegen. Cli will ensure that the value is either `std::string` (default) or `std::wstring`.

## Testing
Manual tested and see output files do get `std::wstring`.