### PR TITLE
Default IncludeFabricInterface to true

### DIFF
--- a/change/react-native-windows-d66c1eef-4346-43c7-8451-78ebe39f062b.json
+++ b/change/react-native-windows-d66c1eef-4346-43c7-8451-78ebe39f062b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Default IncludeFabricInterface to true",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -52,6 +52,7 @@
     <UseV8>true</UseV8>
     <V8AppPlatform>win32</V8AppPlatform>
     <HermesCompileRtti>false</HermesCompileRtti>
+    <IncludeFabricInterface Condition="'$(IncludeFabricInterface)' == ''">true</IncludeFabricInterface>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>

--- a/vnext/ExperimentalFeatures.props
+++ b/vnext/ExperimentalFeatures.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(SolutionName)'=='ReactWindows-Desktop'">
     <UseFabric>false</UseFabric>
-    <IncludeFabricInterface>true</IncludeFabricInterface>
   </PropertyGroup>
   <PropertyGroup>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>


### PR DESCRIPTION
## Description
Fixes local building of Desktop solution.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Local clones of this repository will fail to build the `ReactWindows-Desktop.sln` solution.
This happens because of a missing property required to compile Fabric/Composition empty implementations (i.e. `vnext\Microsoft.ReactNative\Fabric\Composition\CompositionRootView_emptyimpl.cpp`).

### What
Set MSBuild property `IncludeFabricInterface` to `true` by default for project `React.Windows.Desktop`.

## Testing
Build solution locally.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11835&drop=dogfoodAlpha