### PR TITLE
Add configConfig.windows.cppStringType in package.json for @rnw/codegen

### DIFF
--- a/change/@react-native-windows-cli-f40b1069-5931-47af-94ce-0c0c056f6d1f.json
+++ b/change/@react-native-windows-cli-f40b1069-5931-47af-94ce-0c0c056f6d1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add configConfig.windows.cppStringType in package.json for @rnw/codegen",
+  "packageName": "@react-native-windows/cli",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-14224062-151e-446d-a3a2-1107be08b0c4.json
+++ b/change/@react-native-windows-codegen-14224062-151e-446d-a3a2-1107be08b0c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add configConfig.windows.cppStringType in package.json for @rnw/codegen",
+  "packageName": "@react-native-windows/codegen",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/codegen.ts
+++ b/packages/@react-native-windows/cli/src/codegen.ts
@@ -27,6 +27,7 @@ import {
 
 import {
   CodeGenOptions as RnwCodeGenOptions,
+  CppStringTypes,
   runCodeGen,
 } from '@react-native-windows/codegen';
 import {Ora} from 'ora';
@@ -93,6 +94,23 @@ export class CodeGenWindows {
       );
     }
 
+    let cppStringType: CppStringTypes = 'std::string';
+    if (pkgJson.codegenConfig.windows.cppStringType) {
+      switch (pkgJson.codegenConfig.windows.cppStringType) {
+        case 'std::string':
+        case 'std::wstring':
+          cppStringType = pkgJson.codegenConfig.windows.cppStringType;
+          break;
+        default:
+          throw new CodedError(
+            'InvalidCodegenConfig',
+            `Value of ${chalk.bold(
+              'codegenConfig.windows.cppStringType',
+            )} package.json should be either 'std::string' or 'std::wstring'`,
+          );
+      }
+    }
+
     if (!pkgJson.codegenConfig.name) {
       throw new CodedError(
         'InvalidCodegenConfig',
@@ -117,7 +135,7 @@ export class CodeGenWindows {
           jsRootPathRelative ? '/' : ''
         }**/*Native*.[jt]s`,
       ],
-      cppStringType: 'std::string',
+      cppStringType,
       libraryName: projectName,
       methodOnly: false,
       modulesCxx: generators.indexOf('modulesCxx') !== -1,

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -17,6 +17,8 @@ import {
 import type {SchemaType} from '@react-native/codegen/lib/CodegenSchema';
 import type {Parser} from '@react-native/codegen/lib/parsers/parser';
 
+export type {CppStringTypes} from './generators/GenerateNM2';
+
 // Load @react-native/codegen from react-native
 const rnPath = path.dirname(require.resolve('react-native/package.json'));
 const rncodegenPath = path.dirname(


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The previous pull request allow `@rnw/codegen` to generate `std::wstring` instead of `std::string` via command-line argument. This pull request add the corresponding entry in `package.json`.

## Testing
Manually tested
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11848&drop=dogfoodAlpha