### PR TITLE
Add REACT_MODULE_NOREG which is REACT_MODULE but without auto registration

### DIFF
--- a/change/react-native-windows-ccec3086-548e-40b6-a95d-41c1ca26caff.json
+++ b/change/react-native-windows-ccec3086-548e-40b6-a95d-41c1ca26caff.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add REACT_MODULE_NOREG which is REACT_MODULE but without auto registration",
+  "packageName": "react-native-windows",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -695,6 +695,7 @@ TEST_CLASS (NativeModuleTest) {
       if (wcscmp(current->ModuleName(), L"SimpleNativeModule") == 0) {
         registered = true;
       }
+      current = current->Next();
     }
     TestCheck(registered);
   }

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/NativeModuleTest.cpp
@@ -688,6 +688,17 @@ TEST_CLASS (NativeModuleTest) {
     m_module = React::ReactNonAbiValue<SimpleNativeModule>::GetPtrUnsafe(m_moduleObject);
   }
 
+  TEST_METHOD(EnsureReactModuleAutoRegistered) {
+    bool registered = false;
+    auto current = React::ModuleRegistration::Head();
+    while (current) {
+      if (wcscmp(current->ModuleName(), L"SimpleNativeModule") == 0) {
+        registered = true;
+      }
+    }
+    TestCheck(registered);
+  }
+
   TEST_METHOD(TestMethodCall_Add) {
     m_builderMock.Call1(L"Add", std::function<void(int)>([](int result) noexcept { TestCheck(result == 8); }), 3, 5);
     TestCheck(m_builderMock.IsResolveCallbackCalled());

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -52,22 +52,26 @@
       (__VA_ARGS__, INTERNAL_REACT_MODULE_3_ARGS, INTERNAL_REACT_MODULE_2_ARGS, INTERNAL_REACT_MODULE_1_ARG, ))
 
 // Another version of REACT_MODULE but does not do auto registration
-#define INTERNAL_REACT_MODULE_NOREG_3_ARGS(moduleStruct, moduleName, eventEmitterName)                              \
-  struct moduleStruct;                                                                                              \
-  template <class TRegistry>                                                                                        \
-  constexpr void GetReactModuleInfo(moduleStruct *, TRegistry &registry) noexcept {                                 \
-    registry.RegisterModule(                                                                                        \
-        moduleName, eventEmitterName, winrt::Microsoft::ReactNative::ReactAttributeId<__COUNTER__>{});              \
+#define INTERNAL_REACT_MODULE_NOREG_3_ARGS(moduleStruct, moduleName, eventEmitterName)                 \
+  struct moduleStruct;                                                                                 \
+  template <class TRegistry>                                                                           \
+  constexpr void GetReactModuleInfo(moduleStruct *, TRegistry &registry) noexcept {                    \
+    registry.RegisterModule(                                                                           \
+        moduleName, eventEmitterName, winrt::Microsoft::ReactNative::ReactAttributeId<__COUNTER__>{}); \
   }
 
 #define INTERNAL_REACT_MODULE_NOREG_2_ARGS(moduleStruct, moduleName) \
   INTERNAL_REACT_MODULE_NOREG_3_ARGS(moduleStruct, moduleName, L"")
 
-#define INTERNAL_REACT_MODULE_NOREG_1_ARG(moduleStruct) INTERNAL_REACT_MODULE_NOREG_2_ARGS(moduleStruct, L## #moduleStruct)
+#define INTERNAL_REACT_MODULE_NOREG_1_ARG(moduleStruct) \
+  INTERNAL_REACT_MODULE_NOREG_2_ARGS(moduleStruct, L## #moduleStruct)
 
-#define INTERNAL_REACT_MODULE_NOREG(...) \
-  INTERNAL_REACT_RECOMPOSER_4(     \
-      (__VA_ARGS__, INTERNAL_REACT_MODULE_NOREG_3_ARGS, INTERNAL_REACT_MODULE_NOREG_2_ARGS, INTERNAL_REACT_MODULE_NOREG_1_ARG, ))
+#define INTERNAL_REACT_MODULE_NOREG(...)   \
+  INTERNAL_REACT_RECOMPOSER_4(             \
+      (__VA_ARGS__,                        \
+       INTERNAL_REACT_MODULE_NOREG_3_ARGS, \
+       INTERNAL_REACT_MODULE_NOREG_2_ARGS, \
+       INTERNAL_REACT_MODULE_NOREG_1_ARG, ))
 
 // Provide meta data information about struct member.
 // For each member with a 'custom attribute' macro we create a static method to provide meta data.

--- a/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ModuleRegistration.h
@@ -51,6 +51,24 @@
   INTERNAL_REACT_RECOMPOSER_4(     \
       (__VA_ARGS__, INTERNAL_REACT_MODULE_3_ARGS, INTERNAL_REACT_MODULE_2_ARGS, INTERNAL_REACT_MODULE_1_ARG, ))
 
+// Another version of REACT_MODULE but does not do auto registration
+#define INTERNAL_REACT_MODULE_NOREG_3_ARGS(moduleStruct, moduleName, eventEmitterName)                              \
+  struct moduleStruct;                                                                                              \
+  template <class TRegistry>                                                                                        \
+  constexpr void GetReactModuleInfo(moduleStruct *, TRegistry &registry) noexcept {                                 \
+    registry.RegisterModule(                                                                                        \
+        moduleName, eventEmitterName, winrt::Microsoft::ReactNative::ReactAttributeId<__COUNTER__>{});              \
+  }
+
+#define INTERNAL_REACT_MODULE_NOREG_2_ARGS(moduleStruct, moduleName) \
+  INTERNAL_REACT_MODULE_NOREG_3_ARGS(moduleStruct, moduleName, L"")
+
+#define INTERNAL_REACT_MODULE_NOREG_1_ARG(moduleStruct) INTERNAL_REACT_MODULE_NOREG_2_ARGS(moduleStruct, L## #moduleStruct)
+
+#define INTERNAL_REACT_MODULE_NOREG(...) \
+  INTERNAL_REACT_RECOMPOSER_4(     \
+      (__VA_ARGS__, INTERNAL_REACT_MODULE_NOREG_3_ARGS, INTERNAL_REACT_MODULE_NOREG_2_ARGS, INTERNAL_REACT_MODULE_NOREG_1_ARG, ))
+
 // Provide meta data information about struct member.
 // For each member with a 'custom attribute' macro we create a static method to provide meta data.
 // The member Id is generated as a ReactMemberId<__COUNTER__> type.

--- a/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
+++ b/vnext/Microsoft.ReactNative.Cxx/NativeModules.h
@@ -30,6 +30,11 @@
 #define REACT_MODULE(/* moduleStruct, [opt] moduleName, [opt] eventEmitterName */...) \
   INTERNAL_REACT_MODULE(__VA_ARGS__)(__VA_ARGS__)
 
+// REACT_MODULE_NOREG is REACT_MODULE without auto registration
+// they have the same arguments
+#define REACT_MODULE_NOREG(/* moduleStruct, [opt] moduleName, [opt] eventEmitterName */...) \
+  INTERNAL_REACT_MODULE_NOREG(__VA_ARGS__)(__VA_ARGS__)
+
 // REACT_INIT(method)
 // Arguments:
 // - method (required) - the method name the macro is attached to.

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -163,7 +163,7 @@ struct CppTurboModuleSpec : TurboModuleSpec {
   }
 };
 
-REACT_MODULE(CppTurboModule)
+REACT_MODULE_NOREG(CppTurboModule)
 struct CppTurboModule {
   using ModuleSpec = CppTurboModuleSpec;
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -558,6 +558,17 @@ struct CppTurboModulePackageProvider : winrt::implements<CppTurboModulePackagePr
 } // namespace
 
 TEST_CLASS (TurboModuleTests) {
+  TEST_METHOD(EnsureReactModuleNotAutoRegistered) {
+    bool registered = false;
+    auto current = ModuleRegistration::Head();
+    while (current) {
+      if (wcscmp(current->ModuleName(), L"CppTurboModule") == 0) {
+        registered = true;
+      }
+    }
+    TestCheck(!registered);
+  }
+
   TEST_METHOD(ExecuteSampleTurboModule) {
     TestEventService::Initialize();
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TurboModuleTests.cpp
@@ -565,6 +565,7 @@ TEST_CLASS (TurboModuleTests) {
       if (wcscmp(current->ModuleName(), L"CppTurboModule") == 0) {
         registered = true;
       }
+      current = current->Next();
     }
     TestCheck(!registered);
   }


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
`REACT_MODULE` instantiate a function to a global linked list. Such function calls `winrt::Microsoft::ReactNative::MakeModuleProvider`, forcing its implementation to load at binary startup. When auto registration is not in use, such work is unnecessary.

Resolves [Add Relevant Issue Here]

### What
Added `REACT_MODULE_NOREG`.

## Testing
- Microsoft.ReactNative.IntegrationTests
- Microsoft.ReactNative.Cxx.UnitTests

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11849&drop=dogfoodAlpha