### PR TITLE
Use TurboModules for networking in MSRN

### DIFF
--- a/change/react-native-windows-2d37aae0-3bb6-4f89-8428-11cefbabf3b5.json
+++ b/change/react-native-windows-2d37aae0-3bb6-4f89-8428-11cefbabf3b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use TurboModules for networking in MSRN",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
@@ -26,6 +26,15 @@
           "NETStandard.Library": "2.0.3"
         }
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Direct",
+        "requested": "[2.8.0, )",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -43,16 +52,6 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "boost": {
-        "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
-      },
-      "Microsoft.JavaScript.Hermes": {
-        "type": "Transitive",
-        "resolved": "0.1.15",
-        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -85,23 +84,10 @@
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Transitive",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22000.194",
-        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -306,7 +292,6 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -315,11 +300,7 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
-          "Microsoft.UI.Xaml": "[2.8.0, )",
-          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
-          "ReactCommon": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "ReactCommon": "[1.0.0, )"
         }
       },
       "microsoft.reactnative.managed": {
@@ -332,8 +313,7 @@
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "Folly": "[1.0.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
@@ -26,15 +26,6 @@
           "NETStandard.Library": "2.0.3"
         }
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -52,6 +43,16 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -77,22 +78,35 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -292,6 +306,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -300,21 +315,25 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.9, )",
-          "Microsoft.ReactNative": "[1.0.0, )",
-          "NETStandard.Library": "[2.0.3, )"
+          "Microsoft.ReactNative": "[1.0.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -26,6 +26,15 @@
           "NETStandard.Library": "2.0.3"
         }
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Direct",
+        "requested": "[2.8.0, )",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -43,16 +52,6 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
-      },
-      "boost": {
-        "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
-      },
-      "Microsoft.JavaScript.Hermes": {
-        "type": "Transitive",
-        "resolved": "0.1.15",
-        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -85,23 +84,10 @@
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Transitive",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22000.194",
-        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -306,7 +292,6 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -315,11 +300,7 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
-          "Microsoft.UI.Xaml": "[2.8.0, )",
-          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
-          "ReactCommon": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "ReactCommon": "[1.0.0, )"
         }
       },
       "microsoft.reactnative.managed": {
@@ -332,8 +313,7 @@
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "Folly": "[1.0.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -26,15 +26,6 @@
           "NETStandard.Library": "2.0.3"
         }
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -52,6 +43,16 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -77,22 +78,35 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -292,6 +306,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -300,21 +315,25 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.9, )",
-          "Microsoft.ReactNative": "[1.0.0, )",
-          "NETStandard.Library": "[2.0.3, )"
+          "Microsoft.ReactNative": "[1.0.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -24,20 +24,10 @@
           "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
-      "boost": {
-        "type": "Transitive",
-        "resolved": "1.76.0",
-        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
-      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ=="
-      },
-      "Microsoft.JavaScript.Hermes": {
-        "type": "Transitive",
-        "resolved": "0.1.15",
-        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -69,24 +59,6 @@
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
-      },
-      "Microsoft.UI.Xaml": {
-        "type": "Transitive",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
-      "Microsoft.Windows.SDK.BuildTools": {
-        "type": "Transitive",
-        "resolved": "10.0.22000.194",
-        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
       },
       "NETStandard.Library": {
         "type": "Transitive",
@@ -172,7 +144,6 @@
       "folly": {
         "type": "Project",
         "dependencies": {
-          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -181,18 +152,13 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
-          "Microsoft.UI.Xaml": "[2.8.0, )",
-          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
-          "ReactCommon": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "ReactCommon": "[1.0.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )",
-          "boost": "[1.76.0, )"
+          "Folly": "[1.0.0, )"
         }
       }
     },
@@ -209,11 +175,6 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -235,11 +196,6 @@
           "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
       "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -259,11 +215,6 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -285,11 +236,6 @@
           "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
       "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -309,11 +255,6 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -335,11 +276,6 @@
           "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
-      },
       "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -359,11 +295,6 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
-      },
-      "Microsoft.Web.WebView2": {
-        "type": "Transitive",
-        "resolved": "1.0.1264.42",
-        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -24,19 +24,20 @@
           "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
-      "NETStandard.Library": {
-        "type": "Direct",
-        "requested": "[2.0.3, )",
-        "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0"
-        }
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -62,12 +63,38 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
+      },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
+      "NETStandard.Library": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
       },
       "runtime.win10-arm.Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -145,6 +172,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -153,13 +181,18 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },
@@ -176,6 +209,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -197,6 +235,11 @@
           "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -216,6 +259,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -237,6 +285,11 @@
           "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -256,6 +309,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -277,6 +335,11 @@
           "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -296,6 +359,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -23,21 +23,21 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept {
   std::vector<facebook::react::NativeModuleDescription> modules;
 
-  //TODO: Remove
-  //modules.emplace_back(
-  //    "Networking",
-  //    [props = context->Properties()]() { return Microsoft::React::CreateHttpModule(props); },
-  //    jsMessageQueue);
+  // TODO: Remove
+  // modules.emplace_back(
+  //     "Networking",
+  //     [props = context->Properties()]() { return Microsoft::React::CreateHttpModule(props); },
+  //     jsMessageQueue);
 
-  //modules.emplace_back(
-  //    Microsoft::React::GetBlobModuleName(),
-  //    [props = context->Properties()]() { return Microsoft::React::CreateBlobModule(props); },
-  //    batchingUIMessageQueue);
+  // modules.emplace_back(
+  //     Microsoft::React::GetBlobModuleName(),
+  //     [props = context->Properties()]() { return Microsoft::React::CreateBlobModule(props); },
+  //     batchingUIMessageQueue);
 
-  //modules.emplace_back(
-  //    Microsoft::React::GetFileReaderModuleName(),
-  //    [props = context->Properties()]() { return Microsoft::React::CreateFileReaderModule(props); },
-  //    batchingUIMessageQueue);
+  // modules.emplace_back(
+  //     Microsoft::React::GetFileReaderModuleName(),
+  //     [props = context->Properties()]() { return Microsoft::React::CreateFileReaderModule(props); },
+  //     batchingUIMessageQueue);
 
   return modules;
 }

--- a/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreNativeModules.cpp
@@ -23,20 +23,21 @@ std::vector<facebook::react::NativeModuleDescription> GetCoreModules(
     Mso::CntPtr<Mso::React::IReactContext> &&context) noexcept {
   std::vector<facebook::react::NativeModuleDescription> modules;
 
-  modules.emplace_back(
-      "Networking",
-      [props = context->Properties()]() { return Microsoft::React::CreateHttpModule(props); },
-      jsMessageQueue);
+  //TODO: Remove
+  //modules.emplace_back(
+  //    "Networking",
+  //    [props = context->Properties()]() { return Microsoft::React::CreateHttpModule(props); },
+  //    jsMessageQueue);
 
-  modules.emplace_back(
-      Microsoft::React::GetBlobModuleName(),
-      [props = context->Properties()]() { return Microsoft::React::CreateBlobModule(props); },
-      batchingUIMessageQueue);
+  //modules.emplace_back(
+  //    Microsoft::React::GetBlobModuleName(),
+  //    [props = context->Properties()]() { return Microsoft::React::CreateBlobModule(props); },
+  //    batchingUIMessageQueue);
 
-  modules.emplace_back(
-      Microsoft::React::GetFileReaderModuleName(),
-      [props = context->Properties()]() { return Microsoft::React::CreateFileReaderModule(props); },
-      batchingUIMessageQueue);
+  //modules.emplace_back(
+  //    Microsoft::React::GetFileReaderModuleName(),
+  //    [props = context->Properties()]() { return Microsoft::React::CreateFileReaderModule(props); },
+  //    batchingUIMessageQueue);
 
   return modules;
 }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -6,7 +6,7 @@
 #include "MsoUtils.h"
 
 #include <AppModelHelpers.h>
-#include <Base/CoreNativeModules.h>
+#include <Base/CoreNativeModules.h>//TODO: Remove
 #include <Threading/MessageDispatchQueue.h>
 #include <Threading/MessageQueueThreadFactory.h>
 #include <appModel.h>
@@ -30,7 +30,6 @@
 #include <QuirkSettings.h>
 #include <Shared/DevServerHelper.h>
 #include <Views/ViewManager.h>
-#include <base/CoreNativeModules.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include "DynamicWriter.h"
 #ifndef CORE_ABI
@@ -86,6 +85,7 @@
 #include <tuple>
 #include "ChakraRuntimeHolder.h"
 
+#include <CreateModules.h>
 #include <Utils/Helpers.h>
 #include "CrashManager.h"
 #include "JsiApi.h"
@@ -392,6 +392,11 @@ void ReactInstanceWin::LoadModules(
   registerTurboModule(
       L"Timing", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Timing>());
 #endif
+
+  registerTurboModule(
+    ::Microsoft::React::GetHttpTurboModuleName(),
+    ::Microsoft::React::GetHttpModuleProvider()
+  );
 }
 
 //! Initialize() is called from the native queue.

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -394,8 +394,23 @@ void ReactInstanceWin::LoadModules(
 #endif
 
   registerTurboModule(
+    ::Microsoft::React::GetBlobTurboModuleName(),
+    ::Microsoft::React::GetBlobModuleProvider()
+  );
+
+  registerTurboModule(
     ::Microsoft::React::GetHttpTurboModuleName(),
     ::Microsoft::React::GetHttpModuleProvider()
+  );
+
+  registerTurboModule(
+    ::Microsoft::React::GetFileReaderTurboModuleName(),
+    ::Microsoft::React::GetFileReaderModuleProvider()
+  );
+
+  registerTurboModule(
+    ::Microsoft::React::GetWebSocketTurboModuleName(),
+    ::Microsoft::React::GetWebSocketModuleProvider()
   );
 }
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -6,7 +6,7 @@
 #include "MsoUtils.h"
 
 #include <AppModelHelpers.h>
-#include <Base/CoreNativeModules.h>//TODO: Remove
+#include <Base/CoreNativeModules.h> //TODO: Remove
 #include <Threading/MessageDispatchQueue.h>
 #include <Threading/MessageQueueThreadFactory.h>
 #include <appModel.h>
@@ -393,25 +393,15 @@ void ReactInstanceWin::LoadModules(
       L"Timing", winrt::Microsoft::ReactNative::MakeTurboModuleProvider<::Microsoft::ReactNative::Timing>());
 #endif
 
-  registerTurboModule(
-    ::Microsoft::React::GetBlobTurboModuleName(),
-    ::Microsoft::React::GetBlobModuleProvider()
-  );
+  registerTurboModule(::Microsoft::React::GetBlobTurboModuleName(), ::Microsoft::React::GetBlobModuleProvider());
+
+  registerTurboModule(::Microsoft::React::GetHttpTurboModuleName(), ::Microsoft::React::GetHttpModuleProvider());
 
   registerTurboModule(
-    ::Microsoft::React::GetHttpTurboModuleName(),
-    ::Microsoft::React::GetHttpModuleProvider()
-  );
+      ::Microsoft::React::GetFileReaderTurboModuleName(), ::Microsoft::React::GetFileReaderModuleProvider());
 
   registerTurboModule(
-    ::Microsoft::React::GetFileReaderTurboModuleName(),
-    ::Microsoft::React::GetFileReaderModuleProvider()
-  );
-
-  registerTurboModule(
-    ::Microsoft::React::GetWebSocketTurboModuleName(),
-    ::Microsoft::React::GetWebSocketModuleProvider()
-  );
+      ::Microsoft::React::GetWebSocketTurboModuleName(), ::Microsoft::React::GetWebSocketModuleProvider());
 }
 
 //! Initialize() is called from the native queue.

--- a/vnext/Shared/CreateModules.h
+++ b/vnext/Shared/CreateModules.h
@@ -14,6 +14,12 @@
 #include <memory>
 
 // Forward declarations. Desktop projects can not access <React.h>
+namespace winrt::Microsoft::ReactNative
+{
+  //struct ReactContext;
+  //struct ReactModuleProvider;
+}
+
 namespace Mso::React {
 struct IReactContext;
 }
@@ -57,6 +63,7 @@ extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateFileReaderModul
 #pragma region TurboModules
 
 extern const wchar_t* GetHttpTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetHttpModuleProvider() noexcept;
 
 #pragma endregion TurboModules
 

--- a/vnext/Shared/CreateModules.h
+++ b/vnext/Shared/CreateModules.h
@@ -34,20 +34,30 @@ extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateTimingModule(
 
 namespace Microsoft::React {
 
-extern const char *GetHttpModuleName() noexcept;
+#pragma region CxxModules
+
+extern const char* GetHttpModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateHttpModule(
-    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
+  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
 
-extern const char *GetWebSocketModuleName() noexcept;
+extern const char* GetWebSocketModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule(
-    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
+  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
 
-extern const char *GetBlobModuleName() noexcept;
+extern const char* GetBlobModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateBlobModule(
-    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
+  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
 
-extern const char *GetFileReaderModuleName() noexcept;
+extern const char* GetFileReaderModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateFileReaderModule(
-    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
+  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
+
+#pragma endregion CxxModules
+
+#pragma region TurboModules
+
+extern const wchar_t* GetHttpTurboModuleName() noexcept;
+
+#pragma endregion TurboModules
 
 } // namespace Microsoft::React

--- a/vnext/Shared/CreateModules.h
+++ b/vnext/Shared/CreateModules.h
@@ -62,8 +62,17 @@ extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateFileReaderModul
 
 #pragma region TurboModules
 
+extern const wchar_t* GetBlobTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetBlobModuleProvider() noexcept;
+
 extern const wchar_t* GetHttpTurboModuleName() noexcept;
 extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetHttpModuleProvider() noexcept;
+
+extern const wchar_t* GetFileReaderTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetFileReaderModuleProvider() noexcept;
+
+extern const wchar_t* GetWebSocketTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetWebSocketModuleProvider() noexcept;
 
 #pragma endregion TurboModules
 

--- a/vnext/Shared/CreateModules.h
+++ b/vnext/Shared/CreateModules.h
@@ -14,10 +14,9 @@
 #include <memory>
 
 // Forward declarations. Desktop projects can not access <React.h>
-namespace winrt::Microsoft::ReactNative
-{
-  //struct ReactContext;
-  //struct ReactModuleProvider;
+namespace winrt::Microsoft::ReactNative {
+// struct ReactContext;
+// struct ReactModuleProvider;
 }
 
 namespace Mso::React {
@@ -42,37 +41,37 @@ namespace Microsoft::React {
 
 #pragma region CxxModules
 
-extern const char* GetHttpModuleName() noexcept;
+extern const char *GetHttpModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateHttpModule(
-  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
+    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
 
-extern const char* GetWebSocketModuleName() noexcept;
+extern const char *GetWebSocketModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateWebSocketModule(
-  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
+    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
 
-extern const char* GetBlobModuleName() noexcept;
+extern const char *GetBlobModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateBlobModule(
-  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
+    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
 
-extern const char* GetFileReaderModuleName() noexcept;
+extern const char *GetFileReaderModuleName() noexcept;
 extern std::unique_ptr<facebook::xplat::module::CxxModule> CreateFileReaderModule(
-  winrt::Windows::Foundation::IInspectable const& inspectableProperties) noexcept;
+    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept;
 
 #pragma endregion CxxModules
 
 #pragma region TurboModules
 
-extern const wchar_t* GetBlobTurboModuleName() noexcept;
-extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetBlobModuleProvider() noexcept;
+extern const wchar_t *GetBlobTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider &GetBlobModuleProvider() noexcept;
 
-extern const wchar_t* GetHttpTurboModuleName() noexcept;
-extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetHttpModuleProvider() noexcept;
+extern const wchar_t *GetHttpTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider &GetHttpModuleProvider() noexcept;
 
-extern const wchar_t* GetFileReaderTurboModuleName() noexcept;
-extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetFileReaderModuleProvider() noexcept;
+extern const wchar_t *GetFileReaderTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider &GetFileReaderModuleProvider() noexcept;
 
-extern const wchar_t* GetWebSocketTurboModuleName() noexcept;
-extern const winrt::Microsoft::ReactNative::ReactModuleProvider& GetWebSocketModuleProvider() noexcept;
+extern const wchar_t *GetWebSocketTurboModuleName() noexcept;
+extern const winrt::Microsoft::ReactNative::ReactModuleProvider &GetWebSocketModuleProvider() noexcept;
 
 #pragma endregion TurboModules
 

--- a/vnext/Shared/Modules/BlobModule.cpp
+++ b/vnext/Shared/Modules/BlobModule.cpp
@@ -4,6 +4,7 @@
 #include "BlobModule.h"
 
 #include <Modules/CxxModuleUtilities.h>
+#include <CreateModules.h>
 
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>
@@ -19,9 +20,13 @@ using winrt::Windows::Foundation::IInspectable;
 namespace msrn = winrt::Microsoft::ReactNative;
 
 namespace {
-constexpr char s_moduleName[] = "BlobModule";
+  constexpr char s_moduleName[] = "BlobModule";
+  constexpr wchar_t s_moduleNameW[] = L"BlobModule";
 
 const auto &blobKeys = IBlobResource::FieldNames();
+
+msrn::ReactModuleProvider s_moduleProvider = msrn::MakeTurboModuleProvider<Microsoft::React::BlobTurboModule>();
+
 } // namespace
 
 namespace Microsoft::React {
@@ -154,6 +159,14 @@ vector<module::CxxModule::Method> BlobModule::getMethods() {
     return std::make_unique<BlobModule>(properties);
 
   return nullptr;
+}
+
+/*extern*/ const wchar_t* GetBlobTurboModuleName() noexcept {
+  return s_moduleNameW;
+}
+
+/*extern*/ const msrn::ReactModuleProvider& GetBlobModuleProvider() noexcept {
+  return s_moduleProvider;
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/BlobModule.cpp
+++ b/vnext/Shared/Modules/BlobModule.cpp
@@ -3,8 +3,8 @@
 
 #include "BlobModule.h"
 
-#include <Modules/CxxModuleUtilities.h>
 #include <CreateModules.h>
+#include <Modules/CxxModuleUtilities.h>
 
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>
@@ -20,8 +20,8 @@ using winrt::Windows::Foundation::IInspectable;
 namespace msrn = winrt::Microsoft::ReactNative;
 
 namespace {
-  constexpr char s_moduleName[] = "BlobModule";
-  constexpr wchar_t s_moduleNameW[] = L"BlobModule";
+constexpr char s_moduleName[] = "BlobModule";
+constexpr wchar_t s_moduleNameW[] = L"BlobModule";
 
 const auto &blobKeys = IBlobResource::FieldNames();
 
@@ -161,11 +161,11 @@ vector<module::CxxModule::Method> BlobModule::getMethods() {
   return nullptr;
 }
 
-/*extern*/ const wchar_t* GetBlobTurboModuleName() noexcept {
+/*extern*/ const wchar_t *GetBlobTurboModuleName() noexcept {
   return s_moduleNameW;
 }
 
-/*extern*/ const msrn::ReactModuleProvider& GetBlobModuleProvider() noexcept {
+/*extern*/ const msrn::ReactModuleProvider &GetBlobModuleProvider() noexcept {
   return s_moduleProvider;
 }
 

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -3,6 +3,7 @@
 
 #include "FileReaderModule.h"
 
+#include <CreateModules.h>
 #include <ReactPropertyBag.h>
 #include <sstream>
 
@@ -28,6 +29,9 @@ using winrt::Windows::Foundation::IInspectable;
 
 namespace {
 constexpr char s_moduleName[] = "FileReaderModule";
+constexpr wchar_t s_moduleNameW[] = L"FileReaderModule";
+
+msrn::ReactModuleProvider s_moduleProvider = msrn::MakeTurboModuleProvider<Microsoft::React::FileReaderTurboModule>();
 } // namespace
 
 namespace Microsoft::React {
@@ -196,6 +200,14 @@ void FileReaderTurboModule::ReadAsText(
   }
 
   return nullptr;
+}
+
+/*extern*/ const wchar_t* GetFileReaderTurboModuleName() noexcept {
+  return s_moduleNameW;
+}
+
+/*extern*/ const msrn::ReactModuleProvider& GetFileReaderModuleProvider() noexcept {
+  return s_moduleProvider;
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -202,11 +202,11 @@ void FileReaderTurboModule::ReadAsText(
   return nullptr;
 }
 
-/*extern*/ const wchar_t* GetFileReaderTurboModuleName() noexcept {
+/*extern*/ const wchar_t *GetFileReaderTurboModuleName() noexcept {
   return s_moduleNameW;
 }
 
-/*extern*/ const msrn::ReactModuleProvider& GetFileReaderModuleProvider() noexcept {
+/*extern*/ const msrn::ReactModuleProvider &GetFileReaderModuleProvider() noexcept {
   return s_moduleProvider;
 }
 

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -5,8 +5,8 @@
 
 #include "HttpModule.h"
 
-#include <Modules/CxxModuleUtilities.h>
 #include <CreateModules.h>
+#include <Modules/CxxModuleUtilities.h>
 #include <ReactPropertyBag.h>
 
 // React Native
@@ -331,11 +331,11 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
   return s_moduleName;
 }
 
-/*extern*/ const wchar_t* GetHttpTurboModuleName() noexcept {
+/*extern*/ const wchar_t *GetHttpTurboModuleName() noexcept {
   return s_moduleNameW;
 }
 
-/*extern*/ const msrn::ReactModuleProvider& GetHttpModuleProvider() noexcept {
+/*extern*/ const msrn::ReactModuleProvider &GetHttpModuleProvider() noexcept {
   return s_moduleProvider;
 }
 

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -32,6 +32,7 @@ using Microsoft::React::Modules::SendEvent;
 using Microsoft::React::Networking::IHttpResource;
 
 constexpr char s_moduleName[] = "Networking";
+constexpr wchar_t s_moduleNameW[] = L"Networking";
 
 // React event names
 constexpr char completedResponse[] = "didCompleteNetworkResponse";
@@ -325,6 +326,10 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
 
 /*extern*/ const char *GetHttpModuleName() noexcept {
   return s_moduleName;
+}
+
+/*extern*/ const wchar_t* GetHttpTurboModuleName() noexcept {
+  return s_moduleNameW;
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -49,6 +49,8 @@ constexpr wchar_t receivedIncrementalDataW[] = L"didReceiveNetworkIncrementalDat
 constexpr wchar_t receivedDataProgressW[] = L"didReceiveNetworkDataProgress";
 constexpr wchar_t receivedDataW[] = L"didReceiveNetworkData";
 
+msrn::ReactModuleProvider s_moduleProvider = msrn::MakeTurboModuleProvider<Microsoft::React::HttpTurboModule>();
+
 static void SetUpHttpResource(
     shared_ptr<IHttpResource> resource,
     weak_ptr<Instance> weakReactInstance,
@@ -330,6 +332,10 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
 
 /*extern*/ const wchar_t* GetHttpTurboModuleName() noexcept {
   return s_moduleNameW;
+}
+
+/*extern*/ const msrn::ReactModuleProvider& GetHttpModuleProvider() noexcept {
+  return s_moduleProvider;
 }
 
 } // namespace Microsoft::React

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -6,6 +6,7 @@
 #include "HttpModule.h"
 
 #include <Modules/CxxModuleUtilities.h>
+#include <CreateModules.h>
 #include <ReactPropertyBag.h>
 
 // React Native

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -499,11 +499,11 @@ void WebSocketTurboModule::RemoveListeners(double /*count*/) noexcept {}
   return nullptr;
 }
 
-/*extern*/ const wchar_t* GetWebSocketTurboModuleName() noexcept {
+/*extern*/ const wchar_t *GetWebSocketTurboModuleName() noexcept {
   return s_moduleNameW;
 }
 
-/*extern*/ const msrn::ReactModuleProvider& GetWebSocketModuleProvider() noexcept {
+/*extern*/ const msrn::ReactModuleProvider &GetWebSocketModuleProvider() noexcept {
   return s_moduleProvider;
 }
 

--- a/vnext/Shared/Modules/WebSocketModule.cpp
+++ b/vnext/Shared/Modules/WebSocketModule.cpp
@@ -6,6 +6,7 @@
 #include <Modules/WebSocketModule.h>
 #include <Modules/WebSocketTurboModule.h>
 
+#include <CreateModules.h>
 #include <Modules/CxxModuleUtilities.h>
 #include <Modules/IWebSocketModuleContentHandler.h>
 #include <ReactPropertyBag.h>
@@ -50,6 +51,9 @@ using Microsoft::React::Modules::SendEvent;
 using Microsoft::React::Networking::IWebSocketResource;
 
 constexpr char s_moduleName[] = "WebSocketModule";
+constexpr wchar_t s_moduleNameW[] = L"WebSocketModule";
+
+msrn::ReactModuleProvider s_moduleProvider = msrn::MakeTurboModuleProvider<Microsoft::React::WebSocketTurboModule>();
 
 static shared_ptr<IWebSocketResource>
 GetOrCreateWebSocket(int64_t id, string &&url, weak_ptr<WebSocketModule::SharedState> weakState) {
@@ -493,6 +497,14 @@ void WebSocketTurboModule::RemoveListeners(double /*count*/) noexcept {}
     return std::make_unique<WebSocketModule>(properties);
 
   return nullptr;
+}
+
+/*extern*/ const wchar_t* GetWebSocketTurboModuleName() noexcept {
+  return s_moduleNameW;
+}
+
+/*extern*/ const msrn::ReactModuleProvider& GetWebSocketModuleProvider() noexcept {
+  return s_moduleProvider;
 }
 
 } // namespace Microsoft::React


### PR DESCRIPTION
## Description
Drops Cxx modules in favor of TurboModules for networking features (Microsoft.ReactNative only).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Why
- Usage of `CxxModule` types in Microsoft.ReactNative requires additional instantiation logic and lifetime management.\
  Now that TurboModule (`REACT_MODULE`) variants are available for networking types, MSRN should stick with a single module paradigm.
- May address #11439

### What
- Remove `Microsoft::ReactNative::GetCoreModules`.
- Define module name and provider accessors for `Http`, `WebSocket`, `Blob`, and `FileReader` modules.
