### PR TITLE
[WIP] Add Control Type Information to UIA Tree

### DIFF
--- a/change/react-native-windows-ed4b1594-95cb-4689-a8de-053a7e2e31dc.json
+++ b/change/react-native-windows-ed4b1594-95cb-4689-a8de-053a7e2e31dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add Support for ControlType Specification",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -126,4 +126,8 @@ bool ActivityIndicatorComponentView::focusable() const noexcept {
   return false;
 }
 
+std::string ActivityIndicatorComponentView::DefaultControlType() const noexcept {
+  return "progressbar";
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
@@ -40,6 +40,7 @@ struct ActivityIndicatorComponentView : CompositionBaseComponentView {
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  virtual std::string DefaultControlType() const noexcept;
 
  private:
   ActivityIndicatorComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -135,7 +135,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPatternProvider(PATTE
 long GetControlType(const std::string &role) noexcept {
   if (role == "adjustable") {
     return UIA_SliderControlTypeId;
-  } else if (role == "group"  || role == "search" || role == "radiogroup" || role == "timer" || role.empty()) {
+  } else if (role == "group" || role == "search" || role == "radiogroup" || role == "timer" || role.empty()) {
     return UIA_GroupControlTypeId;
   } else if (role == "button" || role == "imagebutton" || role == "switch" || role == "togglebutton") {
     return UIA_ButtonControlTypeId;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -135,7 +135,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPatternProvider(PATTE
 long GetControlType(const std::string &role) noexcept {
   if (role == "adjustable") {
     return UIA_SliderControlTypeId;
-  } else if (role == "group" || role == "search" || role == "radiogroup" || role == "timer" || role.empty()) {
+  } else if (role == "group" || role == "radiogroup" || role == "timer" || role.empty()) {
     return UIA_GroupControlTypeId;
   } else if (role == "button" || role == "imagebutton" || role == "switch" || role == "togglebutton") {
     return UIA_ButtonControlTypeId;
@@ -182,6 +182,10 @@ long GetControlType(const std::string &role) noexcept {
     return UIA_TabItemControlTypeId;
   } else if (role == "tablist") {
     return UIA_TabControlTypeId;
+  } else if (role == "text") {
+    return UIA_TextControlTypeId;
+  } else if (role == "textinput" || role == "searchbox" || role == "search") {
+    return UIA_EditControlTypeId;
   } else if (role == "toolbar") {
     return UIA_ToolBarControlTypeId;
   } else if (role == "tree") {
@@ -205,12 +209,16 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
   if (props == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
 
+  auto baseView = std::static_pointer_cast<::Microsoft::ReactNative::CompositionBaseComponentView>(strongView);
+  if (baseView == nullptr)
+    return UIA_E_ELEMENTNOTAVAILABLE;
+
   auto hr = S_OK;
 
   switch (propertyId) {
     case UIA_ControlTypePropertyId: {
       pRetVal->vt = VT_I4;
-      auto role = props->accessibilityRole;
+      auto role = props->accessibilityRole == "" ? baseView.get()->DefaultControlType() : props->accessibilityRole;
       pRetVal->lVal = GetControlType(role);
       break;
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -135,7 +135,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPatternProvider(PATTE
 long GetControlType(const std::string &role) noexcept {
   if (role == "adjustable") {
     return UIA_SliderControlTypeId;
-  } else if (role == "group" || role == "radiogroup" || role == "timer" || role.empty()) {
+  } else if (role == "group"  || role == "search" || role == "radiogroup" || role == "timer" || role.empty()) {
     return UIA_GroupControlTypeId;
   } else if (role == "button" || role == "imagebutton" || role == "switch" || role == "togglebutton") {
     return UIA_ButtonControlTypeId;
@@ -184,7 +184,7 @@ long GetControlType(const std::string &role) noexcept {
     return UIA_TabControlTypeId;
   } else if (role == "text") {
     return UIA_TextControlTypeId;
-  } else if (role == "textinput" || role == "searchbox" || role == "search") {
+  } else if (role == "textinput" || role == "searchbox") {
     return UIA_EditControlTypeId;
   } else if (role == "toolbar") {
     return UIA_ToolBarControlTypeId;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -182,8 +182,6 @@ long GetControlType(const std::string &role) noexcept {
     return UIA_TabItemControlTypeId;
   } else if (role == "tablist") {
     return UIA_TabControlTypeId;
-  } else if (role == "text") {
-    return UIA_TextControlTypeId;
   } else if (role == "textinput" || role == "searchbox") {
     return UIA_EditControlTypeId;
   } else if (role == "toolbar") {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1091,6 +1091,9 @@ void CompositionBaseComponentView::updateAccessibilityProps(
       UIA_IsEnabledPropertyId,
       !oldViewProps.accessibilityState.disabled,
       !newViewProps.accessibilityState.disabled);
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      provider, UIA_ControlTypePropertyId, oldViewProps.accessibilityRole, newViewProps.accessibilityRole);
 }
 
 void CompositionBaseComponentView::updateBorderLayoutMetrics(
@@ -1210,6 +1213,10 @@ facebook::react::SharedTouchEventEmitter CompositionBaseComponentView::touchEven
 
 bool CompositionBaseComponentView::focusable() const noexcept {
   return false;
+}
+
+std::string CompositionBaseComponentView::DefaultControlType() const noexcept {
+  return "group";
 }
 
 CompositionViewComponentView::CompositionViewComponentView(
@@ -1411,6 +1418,10 @@ winrt::Microsoft::ReactNative::Composition::IVisual CompositionViewComponentView
 
 bool CompositionViewComponentView::focusable() const noexcept {
   return m_props->focusable;
+}
+
+std::string CompositionViewComponentView::DefaultControlType() const noexcept {
+  return "group";
 }
 
 IComponentView *lastDeepChild(IComponentView &view) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -66,6 +66,8 @@ struct CompositionBaseComponentView : public IComponentView,
 
   winrt::IInspectable EnsureUiaProvider() noexcept override;
 
+  virtual std::string DefaultControlType() const noexcept;
+
  protected:
   std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount>
   FindSpecialBorderLayers() const noexcept;
@@ -116,6 +118,7 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
   void finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept override;
   void prepareForRecycle() noexcept override;
   bool focusable() const noexcept override;
+  std::string DefaultControlType() const noexcept override;
 
   facebook::react::Props::Shared props() noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -409,6 +409,10 @@ bool ImageComponentView::focusable() const noexcept {
   return m_props->focusable;
 }
 
+std::string ImageComponentView::DefaultControlType() const noexcept {
+  return "image";
+}
+
 std::shared_ptr<ImageComponentView> ImageComponentView::Create(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -53,6 +53,7 @@ struct ImageComponentView : CompositionBaseComponentView {
       const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
   bool focusable() const noexcept override;
+  virtual std::string DefaultControlType() const noexcept;
 
  private:
   ImageComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -474,6 +474,10 @@ void ParagraphComponentView::DrawText() noexcept {
   }
 }
 
+std::string ParagraphComponentView::DefaultControlType() const noexcept {
+  return "text";
+}
+
 winrt::Microsoft::ReactNative::Composition::IVisual ParagraphComponentView::Visual() const noexcept {
   return m_visual;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -42,6 +42,7 @@ struct ParagraphComponentView : CompositionBaseComponentView {
   facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
 
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  virtual std::string DefaultControlType() const noexcept;
 
  private:
   ParagraphComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -460,4 +460,8 @@ winrt::Microsoft::ReactNative::Composition::IVisual ScrollViewComponentView::Vis
   return m_visual;
 }
 
+ std::string ScrollViewComponentView::DefaultControlType() const noexcept {
+  return "scrollbar";
+ }
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -460,8 +460,8 @@ winrt::Microsoft::ReactNative::Composition::IVisual ScrollViewComponentView::Vis
   return m_visual;
 }
 
- std::string ScrollViewComponentView::DefaultControlType() const noexcept {
+std::string ScrollViewComponentView::DefaultControlType() const noexcept {
   return "scrollbar";
- }
+}
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -79,6 +79,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept override;
 
   void StartBringIntoView(BringIntoViewOptions &&args) noexcept override;
+  virtual std::string DefaultControlType() const noexcept;
 
  private:
   ScrollViewComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -266,4 +266,8 @@ bool SwitchComponentView::focusable() const noexcept {
   return m_props->focusable;
 }
 
+std::string SwitchComponentView::DefaultControlType() const noexcept {
+  return "switch";
+}
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -42,6 +42,7 @@ struct SwitchComponentView : CompositionBaseComponentView {
       const noexcept override;
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
   int64_t sendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept override;
+  std::string DefaultControlType() const noexcept override;
 
  private:
   SwitchComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -594,6 +594,10 @@ bool WindowsTextInputComponentView::focusable() const noexcept {
   return m_props->focusable;
 }
 
+std::string WindowsTextInputComponentView::DefaultControlType() const noexcept {
+  return "textinput";
+}
+
 void WindowsTextInputComponentView::updateProps(
     facebook::react::Props::Shared const &props,
     facebook::react::Props::Shared const &oldProps) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -52,6 +52,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
   bool focusable() const noexcept override;
+  std::string DefaultControlType() const noexcept override;
 
  private:
   WindowsTextInputComponentView(


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)


### Why
Add Control Type information to UIA tree to improve accessibility information. 

### What
- Added update for control type information upon fast refresh. 
- Added ability to specify for Text and Edit control types.
- Added DefaultControlType property to all core components to give components a default role. Previously all controls defaulted to Group control type. Now controls default to the following types:
| Component | Control Type |
| -- | -- | 
| View/View-based Controls (Pressable, Touchable*) | Group |
| Button | Button |
| Text | Text |
| Image | Image | 
| Switch | Button | 
| ScrollView | ScrollBar |
| TextInput | Edit | 
| ActivityIndicator | ProgressView | 


## Testing
Tested all controls and confirmed correct types appear in AccessibilityInsights tool. Types can be altered by the developer using the `accessibilityRole` or `role` props and will update upon fast refresh. Control type will return to default value if `accessibilityRole` or `role` is not specified. 
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11876&drop=dogfoodAlpha