### PR TITLE
Updated accessibilityRole and accessibilityLevel logic for different heading level announcements

### DIFF
--- a/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextViewManager.cpp
@@ -314,16 +314,22 @@ bool TextViewManager::UpdateProperty(
       auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateString(value);
 
       textBlock.SetValue(winrt::AutomationProperties::LocalizedControlTypeProperty(), boxedValue);
-      if (role == "header") {
-        xaml::Automation::AutomationProperties::SetHeadingLevel(
-            textBlock, winrt::Peers::AutomationHeadingLevel::Level2);
-      } else {
+      if (role != "header") {
         textBlock.ClearValue(winrt::AutomationProperties::HeadingLevelProperty());
       }
     } else if (propertyValue.IsNull()) {
       textBlock.ClearValue(winrt::AutomationProperties::LocalizedControlTypeProperty());
       textBlock.ClearValue(winrt::AutomationProperties::HeadingLevelProperty());
     }
+  } else if (propertyName == "accessibilityLevel") {
+    if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Double ||
+          propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Int64) {
+            auto value = static_cast<int>(propertyValue.AsDouble());
+            auto boxedValue = winrt::Windows::Foundation::PropertyValue::CreateInt32(value);
+            textBlock.SetValue(winrt::AutomationProperties::HeadingLevelProperty(), boxedValue);
+          } else if (propertyValue.IsNull()) {
+            textBlock.ClearValue(winrt::AutomationProperties::HeadingLevelProperty());
+          }
   } else {
     return Super::UpdateProperty(nodeToUpdate, propertyName, propertyValue);
   }


### PR DESCRIPTION
## Description
Changed logic to `accessibilityRole` and `accessibilityLevel` property checks so that value of heading level property is set via accessibilityLevel prop rather than defaulting to setting 'heading, level 2'.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)


### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves #11847

### What
Removed logic from 'accessibilityRole' check that sets heading level to level 2 by default, and added check for the 'accessibilityLevel' prop to set level based on prop value.

## Screenshots
N/A

## Testing
Tested on playground with a basic `<Text>` component as a header and checked Narrator announcement. 

Component tested on:
```
<View
  accessible={true} accessibilityLevel={4}>
  <Text accessibilityRole='header' accessibilityLevel={1}>This is text</Text>
</View>
```