### PR TITLE
@rnw/cli add package.json:codegenConfig.windows.outputDirectory

### DIFF
--- a/change/@react-native-windows-cli-4c7dac7a-f8f1-4115-8416-0f071e245477.json
+++ b/change/@react-native-windows-cli-4c7dac7a-f8f1-4115-8416-0f071e245477.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add package.json:codegenConfig.windows.outputDirectory",
+  "packageName": "@react-native-windows/cli",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/codegen.ts
+++ b/packages/@react-native-windows/cli/src/codegen.ts
@@ -123,6 +123,8 @@ export class CodeGenWindows {
     const jsRootDir = pkgJson.codegenConfig.jsSrcsDir
       ? path.join(this.root, pkgJson.codegenConfig.jsSrcsDir)
       : this.root;
+    const codegenOutputDir =
+      pkgJson.codegenConfig.windows.outputDirectory ?? 'codegen';
 
     const generators = pkgJson.codegenConfig.windows.generators ?? [
       'modulesWindows',
@@ -143,7 +145,7 @@ export class CodeGenWindows {
         generators.indexOf('modulesTypeScriptTypes') !== -1,
       modulesWindows: generators.indexOf('modulesWindows') !== -1,
       namespace: projectNamespace,
-      outputDirectory: path.join(this.root, 'codegen'),
+      outputDirectory: path.join(this.root, codegenOutputDir),
       test: !!this.options.check,
     };
 


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Before this pull request, `@rnw/cli` calls `@rnw/codegen` and write all generated C++ files to `codegen` folder. But in devmain we have a default list of writable folders names which doesn't include `codegen`. And I believe allowing users to choose a name is necessary, even if we could workaround the issue in devmain.

### What
In `package.json`

```json
  "codegenConfig": {
    "name": "SampleApp",
    "type": "modules",
    "jsSrcsDir": "src",
    "windows": {
      "namespace": "SampleLibraryCodegen",
      "outputDirectory": "dist" // new configuration
    }
  },
```

## Testing
Manual tested
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11891&drop=dogfoodAlpha