### PR TITLE
Use correct data types in FileReaderTurboModule::ReadAs*

### DIFF
--- a/change/react-native-windows-ea809b99-bf6d-4902-9c4f-5b35c6a7996f.json
+++ b/change/react-native-windows-ea809b99-bf6d-4902-9c4f-5b35c6a7996f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use correct data types in FileReaderTurboModule::ReadAs*",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -126,21 +126,26 @@ void FileReaderTurboModule::Initialize(msrn::ReactContext const &reactContext) n
 }
 
 ///
-/// <param name="args">
-/// Array of arguments passed from the JavaScript layer.
-/// [0]  - dynamic blob object { blobId, offset, size[, type] }
+/// <param name="data">
+/// Blob object with the following fields:
+/// - blobId
+/// - offset
+/// - size
+/// - type (optional)
+/// </param>
+/// <param name="result">
+/// Either resolves or rejects the current method with a given text message.
 /// </param>
 ///
 void FileReaderTurboModule::ReadAsDataUrl(msrn::JSValue &&data, msrn::ReactPromise<string> &&result) noexcept {
-  auto &array = data.AsArray();
-  auto &blob = data[0].AsObject();
+  auto &blob = data.AsObject();
   auto blobId = blob["blobId"].AsString();
   auto offset = blob["offset"].AsInt64();
   auto size = blob["size"].AsInt64();
 
   auto typeItr = blob.find("type");
   string type{};
-  if (typeItr == blob.end()) { // TODO: .items() ?
+  if (typeItr == blob.end()) {
     type = "application/octet-stream";
   } else {
     type = (*typeItr).second.AsString();
@@ -155,20 +160,26 @@ void FileReaderTurboModule::ReadAsDataUrl(msrn::JSValue &&data, msrn::ReactPromi
       [&result](string &&message) { result.Reject(winrt::to_hstring(std::move(message)).c_str()); });
 }
 
-/// TODO: update (folly not used)
-///  <param name="args">
-///  Array of arguments passed from the JavaScript layer.
-///  [0]  - dynamic blob object { blobId, offset, size }
-///  [1]  - string encoding
-///  </param>
+///
+/// <param name="data">
+/// Blob object with the following fields:
+/// - blobId
+/// - offset
+/// - size
+/// - type (optional)
+/// </param>
+/// <param name="encoding">
+/// Text encoding to proces data with.
+/// </param>
+/// <param name="result">
+/// Either resolves or rejects the current method with a given text message.
+/// </param>
 ///
 void FileReaderTurboModule::ReadAsText(
     msrn::JSValue &&data,
     string &&encoding,
     msrn::ReactPromise<string> &&result) noexcept {
-  auto &args = data.AsArray();
-  auto &blob = args[0].AsObject();
-
+  auto &blob = data.AsObject();
   auto blobId = blob["blobId"].AsString();
   auto offset = blob["offset"].AsInt64();
   auto size = blob["size"].AsInt64();


### PR DESCRIPTION
## Description
Fixes FileReader turbo module's argument handling.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Invoking `FileReaderTurboModule::ReadAs*` will trigger an invalid pointer error and crash the host process.

### What
Interprets the `data` `JSValue` argument as `JSValueObject`.

## Testing
Manual testing in a custom React Native Gallery instance.