### PR TITLE
[Fabric] Add colored emojis to TextInput and Text

### DIFF
--- a/change/react-native-windows-94dfd5a6-f3d9-472b-b3f9-a1d25de3296b.json
+++ b/change/react-native-windows-94dfd5a6-f3d9-472b-b3f9-a1d25de3296b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add colored fonts",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -462,7 +462,8 @@ void ParagraphComponentView::DrawText() noexcept {
             static_cast<FLOAT>((offset.x + m_layoutMetrics.contentInsets.left) / m_layoutMetrics.pointScaleFactor),
             static_cast<FLOAT>((offset.y + m_layoutMetrics.contentInsets.top) / m_layoutMetrics.pointScaleFactor)),
         m_textLayout.get(),
-        brush.get());
+        brush.get(),
+        D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
 
     // restore dpi to old state
     d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -762,6 +762,10 @@ void WindowsTextInputComponentView::UpdateText(const std::string &str) noexcept 
       EM_SETTEXTEX, reinterpret_cast<WPARAM>(&stt), reinterpret_cast<LPARAM>(str.c_str()), &res));
 
   winrt::check_hresult(m_textServices->TxSendMessage(EM_EXGETSEL, 0, reinterpret_cast<LPARAM>(&cr), &res));
+
+  // enable colored emojis
+  winrt::check_hresult(
+      m_textServices->TxSendMessage(EM_SETTYPOGRAPHYOPTIONS, 0x1000 | 0x2000, 0x1000 | 0x2000, nullptr));
 }
 
 void WindowsTextInputComponentView::updateLayoutMetrics(


### PR DESCRIPTION
## Description
Add colored emojis to TextInput and Text in Fabric

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #11764

### What
Added flags to both textinput and text

## Screenshots
![image](https://github.com/microsoft/react-native-windows/assets/42554868/5275a2ee-0bc4-4333-8d3e-39c2e8bf5730)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11906&drop=dogfoodAlpha