### PR TITLE
fix: fix RNW not being detected on case-sensitive file systems

### DIFF
--- a/change/@react-native-windows-codegen-f9e05d99-29f5-408d-8d40-89d1fb7359b4.json
+++ b/change/@react-native-windows-codegen-f9e05d99-29f5-408d-8d40-89d1fb7359b4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix RNW not being detected on case-sensitive file systems",
+  "packageName": "@react-native-windows/codegen",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -40,7 +40,7 @@ function getParser(isTypeScript: boolean): Parser {
 
 const schemaValidator = require(path.resolve(
   rncodegenPath,
-  'lib/schemaValidator',
+  'lib/SchemaValidator',
 ));
 
 export interface SharedOptions {


### PR DESCRIPTION
## Description

Metro fails to create a Windows bundle on non-Windows platforms:

```
error Invalid platform "windows" selected.
info Available platforms are: "ios", "android", "macos", "native". If you are trying to bundle for an out-of-tree platform, it may not be installed.
```

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Windows is not detected on case-sensitive file systems because it fails to import `react-native-codegen/lib/schemaValidator.js`. The filename is PascalCased.

### What

Capitalizing the 's' in `schemaValidator.js` fixes the issue.

## Testing

Cherry-picked from `main`: 0e9e464c8b9f73e941e502efcce11be1aeb5b663
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11919&drop=dogfoodAlpha