### PR TITLE
Attempt AddNetworkingHandler if HTTP module was not ready

### DIFF
--- a/change/react-native-windows-1c549950-1146-4bb2-b48f-ed2c578f8237.json
+++ b/change/react-native-windows-1c549950-1146-4bb2-b48f-ed2c578f8237.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Attempt AddNetworkingHandler if HTTP module was not ready",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -26,7 +26,6 @@ TEST_MODULE_INITIALIZE(InitModule) {
   using Microsoft::React::SetRuntimeOptionBool;
 
   SetRuntimeOptionBool("WebSocket.AcceptSelfSigned", true);
-  SetRuntimeOptionBool("Blob.EnableModule", true);
 
   // WebSocketJSExecutor can't register native log hooks.
   SetRuntimeOptionBool("RNTester.UseWebDebugger", false);

--- a/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.IntegrationTests/packages.lock.json
@@ -26,15 +26,6 @@
           "NETStandard.Library": "2.0.3"
         }
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -52,6 +43,16 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -77,22 +78,35 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -292,6 +306,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -300,21 +315,25 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.9, )",
-          "Microsoft.ReactNative": "[1.0.0, )",
-          "NETStandard.Library": "[2.0.3, )"
+          "Microsoft.ReactNative": "[1.0.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed.UnitTests/packages.lock.json
@@ -26,15 +26,6 @@
           "NETStandard.Library": "2.0.3"
         }
       },
-      "Microsoft.UI.Xaml": {
-        "type": "Direct",
-        "requested": "[2.8.0, )",
-        "resolved": "2.8.0",
-        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
-        "dependencies": {
-          "Microsoft.Web.WebView2": "1.0.1264.42"
-        }
-      },
       "MSTest.TestAdapter": {
         "type": "Direct",
         "requested": "[2.2.10, )",
@@ -52,6 +43,16 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -77,22 +78,35 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.NETCore.Targets": {
         "type": "Transitive",
         "resolved": "1.0.1",
         "contentHash": "rkn+fKobF/cbWfnnfBOQHKVKIOpxMZBvlSHkqDWgBpwGDcLRduvs3D9OLGeV6GWGvVwNlVi2CBbTjuPmtHvyNw=="
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
       "Microsoft.Web.WebView2": {
         "type": "Transitive",
         "resolved": "1.0.1264.42",
         "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -292,6 +306,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -300,21 +315,25 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "microsoft.reactnative.managed": {
         "type": "Project",
         "dependencies": {
           "Microsoft.NETCore.UniversalWindowsPlatform": "[6.2.9, )",
-          "Microsoft.ReactNative": "[1.0.0, )",
-          "NETStandard.Library": "[2.0.3, )"
+          "Microsoft.ReactNative": "[1.0.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },

--- a/vnext/Microsoft.ReactNative.Managed/packages.lock.json
+++ b/vnext/Microsoft.ReactNative.Managed/packages.lock.json
@@ -24,10 +24,20 @@
           "Microsoft.SourceLink.Common": "1.0.0"
         }
       },
+      "boost": {
+        "type": "Transitive",
+        "resolved": "1.76.0",
+        "contentHash": "p+w3YvNdXL8Cu9Fzrmexssu0tZbWxuf6ywsQqHjDlKFE5ojXHof1HIyMC3zDLfLnh80dIeFcEUAuR2Asg/XHRA=="
+      },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "z2fpmmt+1Jfl+ZnBki9nSP08S1/tbEOxFdsK1rSR+LBehIJz1Xv9/6qOOoGNqlwnAGGVGis1Oj6S8Kt9COEYlQ=="
+      },
+      "Microsoft.JavaScript.Hermes": {
+        "type": "Transitive",
+        "resolved": "0.1.15",
+        "contentHash": "My/u5RvxoymtwWokoweU6iVpuP79w271UjadcmSNqnQ9ESIv00tlVP4sHnIiN3t2lJNDeciyE1EVF4swGPECKQ=="
       },
       "Microsoft.Net.Native.Compiler": {
         "type": "Transitive",
@@ -53,17 +63,35 @@
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "2.1.0",
-        "contentHash": "ok+RPAtESz/9MUXeIEz6Lv5XAGQsaNmEYXMsgVALj4D7kqC8gveKWXWXbufLySR2fWrwZf8smyN5RmHu0e4BHA=="
+        "contentHash": "GmkKfoyerqmsHMn7OZj0AKpcBabD+GaafqphvX2Mw406IwiJRy1pKcKqdCfKJfYmkRyJ6+e+RaUylgdJoDa1jQ=="
       },
       "Microsoft.SourceLink.Common": {
         "type": "Transitive",
         "resolved": "1.0.0",
         "contentHash": "G8DuQY8/DK5NN+3jm5wcMcd9QYD90UV7MiLmdljSJixi3U/vNaeBKmmXUqI4DJCOeWizIUEh4ALhSt58mR+5eg=="
       },
+      "Microsoft.UI.Xaml": {
+        "type": "Transitive",
+        "resolved": "2.8.0",
+        "contentHash": "vxdHxTr63s5KVtNddMFpgvjBjUH50z7seq/5jLWmmSuf8poxg+sXrywkofUdE8ZstbpO9y3FL/IXXUcPYbeesA==",
+        "dependencies": {
+          "Microsoft.Web.WebView2": "1.0.1264.42"
+        }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
+      "Microsoft.Windows.SDK.BuildTools": {
+        "type": "Transitive",
+        "resolved": "10.0.22000.194",
+        "contentHash": "4L0P3zqut466SIqT3VBeLTNUQTxCBDOrTRymRuROCRJKazcK7ibLz9yAO1nKWRt50ttCj39oAa2Iuz9ZTDmLlg=="
+      },
       "NETStandard.Library": {
         "type": "Transitive",
         "resolved": "2.0.3",
-        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "contentHash": "548M6mnBSJWxsIlkQHfbzoYxpiYFXZZSL00p4GHYv8PkiqFBnnT68mW5mGEsA/ch9fDO9GkPgkFQpWiXZN7mAQ==",
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
@@ -144,6 +172,7 @@
       "folly": {
         "type": "Project",
         "dependencies": {
+          "boost": "[1.76.0, )",
           "fmt": "[1.0.0, )"
         }
       },
@@ -152,13 +181,18 @@
         "dependencies": {
           "Common": "[1.0.0, )",
           "Folly": "[1.0.0, )",
-          "ReactCommon": "[1.0.0, )"
+          "Microsoft.JavaScript.Hermes": "[0.1.15, )",
+          "Microsoft.UI.Xaml": "[2.8.0, )",
+          "Microsoft.Windows.SDK.BuildTools": "[10.0.22000.194, )",
+          "ReactCommon": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       },
       "reactcommon": {
         "type": "Project",
         "dependencies": {
-          "Folly": "[1.0.0, )"
+          "Folly": "[1.0.0, )",
+          "boost": "[1.76.0, )"
         }
       }
     },
@@ -175,6 +209,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -196,6 +235,11 @@
           "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-arm-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -215,6 +259,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -236,6 +285,11 @@
           "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-x64.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -255,6 +309,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
@@ -276,6 +335,11 @@
           "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
       },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
+      },
       "runtime.win10-x86.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",
         "resolved": "6.2.9",
@@ -295,6 +359,11 @@
           "NETStandard.Library": "2.0.3",
           "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
         }
+      },
+      "Microsoft.Web.WebView2": {
+        "type": "Transitive",
+        "resolved": "1.0.1264.42",
+        "contentHash": "7OBUTkzQ5VI/3gb0ufi5U4zjuCowAJwQg2li0zXXzqkM+S1kmOlivTy1R4jAW+gY5Vyg510M+qMAESCQUjrfgA=="
       },
       "runtime.win10-x86-aot.Microsoft.NETCore.UniversalWindowsPlatform": {
         "type": "Transitive",

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -314,7 +314,7 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
 }
 
 /*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateHttpModule(
-  IInspectable const& inspectableProperties) noexcept {
+    IInspectable const &inspectableProperties) noexcept {
   return std::make_unique<HttpModule>(inspectableProperties);
 }
 

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -331,6 +331,11 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
   return s_moduleName;
 }
 
+/*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateHttpModule(
+  IInspectable const& inspectableProperties) noexcept {
+  return std::make_unique<HttpModule>(inspectableProperties);
+}
+
 /*extern*/ const wchar_t *GetHttpTurboModuleName() noexcept {
   return s_moduleNameW;
 }

--- a/vnext/Shared/Modules/HttpModule.cpp
+++ b/vnext/Shared/Modules/HttpModule.cpp
@@ -237,6 +237,8 @@ std::map<string, dynamic> HttpModule::getConstants() {
 
 // clang-format off
 std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods() {
+  // See CxxNativeModule::lazyInit()
+  SetUpHttpResource(m_resource, getInstance(), m_inspectableProperties);
 
   return
   {
@@ -249,12 +251,6 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
           return;
         }
 
-        auto resource = holder->Module->m_resource;
-        if (!holder->Module->m_isResourceSetup)
-        {
-          SetUpHttpResource(resource, holder->Module->getInstance(), holder->Module->m_inspectableProperties);
-          holder->Module->m_isResourceSetup = true;
-        }
         holder->Module->m_requestId++;
 
         auto params = facebook::xplat::jsArgAsObject(args, 0);
@@ -263,7 +259,7 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
           headers.emplace(header.first.getString(), header.second.getString());
         }
 
-        resource->SendRequest(
+        holder->Module->m_resource->SendRequest(
           params["method"].asString(),
           params["url"].asString(),
           holder->Module->m_requestId,
@@ -289,14 +285,7 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
           return;
         }
 
-        auto resource = holder->Module->m_resource;
-        if (!holder->Module->m_isResourceSetup)
-        {
-          SetUpHttpResource(resource, holder->Module->getInstance(), holder->Module->m_inspectableProperties);
-          holder->Module->m_isResourceSetup = true;
-        }
-
-        resource->AbortRequest(facebook::xplat::jsArgAsInt(args, 0));
+        holder->Module->m_resource->AbortRequest(facebook::xplat::jsArgAsInt(args, 0));
       }
     },
     {
@@ -309,14 +298,7 @@ std::vector<facebook::xplat::module::CxxModule::Method> HttpModule::getMethods()
           return;
         }
 
-        auto resource = holder->Module->m_resource;
-        if (!holder->Module->m_isResourceSetup)
-        {
-          SetUpHttpResource(resource, holder->Module->getInstance(), holder->Module->m_inspectableProperties);
-          holder->Module->m_isResourceSetup = true;
-        }
-
-        resource->ClearCookies();
+        holder->Module->m_resource->ClearCookies();
       }
     }
   };

--- a/vnext/Shared/Modules/HttpModule.h
+++ b/vnext/Shared/Modules/HttpModule.h
@@ -84,7 +84,6 @@ class HttpModule : public facebook::xplat::module::CxxModule {
 
   std::shared_ptr<Networking::IHttpResource> m_resource;
   std::shared_ptr<ModuleHolder> m_holder;
-  bool m_isResourceSetup{false};
   int64_t m_requestId{0};
 
   // Property bag high level reference.

--- a/vnext/Shared/Networking/DefaultBlobResource.cpp
+++ b/vnext/Shared/Networking/DefaultBlobResource.cpp
@@ -145,8 +145,13 @@ void DefaultBlobResource::AddNetworkingHandler() noexcept /*override*/ {
       httpHandler->AddRequestBodyHandler(m_requestBodyHandler);
       httpHandler->AddResponseHandler(m_responseHandler);
     }
+  } else {
+    // #11439 - The absence of HttpModule.Proxy may be caused by a module initialization race condition.
+    // Best-effort approach to set up the request/response handlers by exposing this interface to dependents
+    // (i.e. IHttpResource).
+    auto propId = msrn::ReactPropertyId<msrn::ReactNonAbiValue<weak_ptr<IBlobResource>>>{L"Blob.Resource"};
+    m_propertyBag.Set(propId, weak_ptr<IBlobResource>(shared_from_this()));
   }
-  // TODO: else emit error?
 }
 
 void DefaultBlobResource::AddWebSocketHandler(int64_t id) noexcept /*override*/ {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -555,16 +555,16 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
       nativeQueue));
 
   modules.push_back(std::make_unique<CxxNativeModule>(
-    m_innerInstance,
-    Microsoft::React::GetBlobModuleName(),
-    [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
-    nativeQueue));
+      m_innerInstance,
+      Microsoft::React::GetBlobModuleName(),
+      [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
+      nativeQueue));
 
   modules.push_back(std::make_unique<CxxNativeModule>(
-    m_innerInstance,
-    Microsoft::React::GetFileReaderModuleName(),
-    [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
-    nativeQueue));
+      m_innerInstance,
+      Microsoft::React::GetFileReaderModuleName(),
+      [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
+      nativeQueue));
 
   modules.push_back(std::make_unique<CxxNativeModule>(
       m_innerInstance,

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -26,7 +26,6 @@
 #include <cxxreact/ModuleRegistry.h>
 
 #include <Modules/ExceptionsManagerModule.h>
-#include <Modules/HttpModule.h>
 #include <Modules/PlatformConstantsModule.h>
 #include <Modules/SourceCodeModule.h>
 #include <Modules/StatusBarManagerModule.h>
@@ -67,15 +66,6 @@ using namespace Microsoft::JSI;
 
 using std::make_shared;
 using winrt::Microsoft::ReactNative::ReactPropertyBagHelper;
-
-namespace Microsoft::React {
-
-/*extern*/ std::unique_ptr<facebook::xplat::module::CxxModule> CreateHttpModule(
-    winrt::Windows::Foundation::IInspectable const &inspectableProperties) noexcept {
-  return std::make_unique<HttpModule>(inspectableProperties);
-}
-
-} // namespace Microsoft::React
 
 namespace facebook {
 namespace react {

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -565,13 +565,7 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
     Microsoft::React::GetFileReaderModuleName(),
     [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
     nativeQueue));
-#endif
 
-  // TODO: This is not included for UWP because we have a different module which
-  // is added later. However, this one is designed
-  //  so that we can base a UWP version on it. We need to do that but is not high
-  //  priority.
-#if (defined(_MSC_VER) && !defined(WINRT))
   modules.push_back(std::make_unique<CxxNativeModule>(
       m_innerInstance,
       "Timing",


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Under certain conditions (i.e. setting `UseWebDebugger` to `false`, Blob method `addNetworkingHandler` would be call prematurely.

Resolves #11439

### What
If the Blob module HTTP resource dependency is not initialized when `addNetworkingHandler` is called, expose the underlying Blob resource using the property bag and re-invoke that Blob method once the HTTP resource is ready.

## Testing
Applied changes to sample MSRN apps (i.e. `react-native-gallery`).
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11926&drop=dogfoodAlpha