### PR TITLE
Fix updating snapshot tests on pipeline

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -93,6 +93,7 @@ jobs:
             - script: npx jest --clearCache
               displayName: clear jest cache
               workingDirectory: packages/e2e-test-app
+              condition: and(failed(), eq(variables.StartedTests, 'true'))
 
             - script: yarn e2etest -u
               displayName: Update snapshots

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -90,6 +90,10 @@ jobs:
               displayName: yarn e2etest
               workingDirectory: packages/e2e-test-app
 
+            - script: npx jest --clearCache
+              displayName: clear jest cache
+              workingDirectory: packages/e2e-test-app
+
             - script: yarn e2etest -u
               displayName: Update snapshots
               workingDirectory: packages/e2e-test-app

--- a/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
@@ -47,7 +47,7 @@ exports[`ViewTests Views can adjust backface visibility 1`] = `
           "Left": 83,
           "Margin": "0,0,0,0",
           "Padding": "0,0,0,0",
-          "Text": "Front",
+          "Text": "Testing a failing snapshot test",
           "Top": 90,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",

--- a/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
@@ -47,7 +47,7 @@ exports[`ViewTests Views can adjust backface visibility 1`] = `
           "Left": 83,
           "Margin": "0,0,0,0",
           "Padding": "0,0,0,0",
-          "Text": "Testing a failing snapshot test",
+          "Text": "Front",
           "Top": 90,
           "VerticalAlignment": "Stretch",
           "Visibility": "Visible",


### PR DESCRIPTION
## Description
Added work around from #10982 into the e2e-test pipeline to get updated snapshots

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Before this change, you could not update the snapshots via the pipeline, this allows the pipeline to publish new snapshots

### What
Clear the jest cache before trying to update the snapshots

## Screenshots
**Before**
![image](https://github.com/microsoft/react-native-windows/assets/42554868/7ed5b786-dd94-4743-b5ae-9e4be6f32a71)
**After**
![image](https://github.com/microsoft/react-native-windows/assets/42554868/c4cc48d9-d1c2-4356-8032-aa3af41b150f)


## Testing
Tested via pipline

## Changelog
No
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11937&drop=dogfoodAlpha