### PR TITLE
Add Fabric Snapshot Tests to CI

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -187,6 +187,32 @@ jobs:
                 buildPlatform: ${{ matrix.BuildPlatform}}
                 buildConfiguration: Debug
                 warnAsError: false
+            
+            - script: |
+                echo ##vso[task.setvariable variable=StartedFabricTests]true
+              displayName: Set StartedFabricTests
+
+            - script: yarn e2etest
+              displayName: yarn e2etest
+              workingDirectory: packages/e2e-test-app-fabric
+
+            - script: npx jest --clearCache
+              displayName: clear jest cache
+              workingDirectory: packages/e2e-test-app-fabric
+              condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+
+            - script: yarn e2etest -u
+              displayName: Update snapshots
+              workingDirectory: packages/e2e-test-app-fabric
+              condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+
+            - task: CopyFiles@2
+              displayName: Copy Fabric snapshots
+              inputs:
+                sourceFolder: packages/e2e-test-app-fabric/test/__snapshots__
+                targetFolder: $(Build.StagingDirectory)/snapshots-fabric
+                contents: "**"
+              condition: failed()
 
             - task: CopyFiles@2
               displayName: Copy RNTesterApp artifacts
@@ -201,6 +227,13 @@ jobs:
               inputs:
                 artifactName: RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
                 targetPath: $(Build.StagingDirectory)/RNTesterApp-Fabric
+              condition: failed()
+
+            - task: PublishPipelineArtifact@1
+              displayName: "Publish Artifact: Fabric Snapshots"
+              inputs:
+                artifactName: Snapshots - RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
+                targetPath: $(Build.StagingDirectory)/snapshots-fabric
               condition: failed()
 
             - template: ../templates/upload-build-logs.yml

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -9,7 +9,7 @@
     "watch": "rnw-scripts watch",
     "windows": "react-native run-windows",
     "e2etest": "react-native rnx-test --platform windows",
-    "e2etest:updateSnapshots": "jest -u",
+    "e2etest:updateSnapshots": "react-native rnx-test --platform windows -u",
     "e2etest:debug": "jest --config ./jest.debug.config.js"
   },
   "dependencies": {
@@ -36,7 +36,7 @@
     "@rnw-scripts/just-task": "2.3.15",
     "@rnw-scripts/metro-dev-config": "0.0.0",
     "@rnw-scripts/ts-config": "2.0.5",
-    "@rnx-kit/cli": "^0.16.9",
+    "@rnx-kit/cli": "^0.16.10",
     "@rnx-kit/jest-preset": "^0.1.14",
     "@types/jest": "^29.2.2",
     "@types/node": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,10 +2553,10 @@
   dependencies:
     babel-plugin-const-enum "^1.0.0"
 
-"@rnx-kit/cli@^0.16.9":
-  version "0.16.9"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.16.9.tgz#69947223ebb12f75e0a349cb4ee61e9ffb846146"
-  integrity sha512-R93xEfLj/v6fclHBFmlfBW9zulDcFV6QnkWB3ypP2GJ5bJA8kEu7nXKybgfcV/wDRqOFVj40PcBaiGP1/30XOw==
+"@rnx-kit/cli@^0.16.10":
+  version "0.16.10"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.16.10.tgz#bdddf17828b6225562021145d03d3eb71fed2034"
+  integrity sha512-k5X2e5Aw0p3QDHVi8qIHeWZBhZMnD5ETKQZ2ZyuU0/02TB4efrTZurKiHWXRsBqlM7eSxHz8+mQXUvJ23MTY1A==
   dependencies:
     "@rnx-kit/align-deps" "^2.2.2"
     "@rnx-kit/config" "^0.6.2"


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### What
Add Jest Snapshot tests on Fabric to CI. Tests will now run, and the snapshots will be published as an artifact to improve debuggability. CI behavior should match what occurs for E2E testing on Paper. 

Updated e2etest:updateSnapshots script to perform correct command for updating snapshots. Upgraded version of @rnx-kit/cli to resolve bug in package where additional command arguments were not being properly ported to Jest. 

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11968&drop=dogfoodAlpha