### PR TITLE
Use Upstream TopClick Type Instead of Windows-Specific Type

### DIFF
--- a/change/react-native-windows-7ea54908-7e23-47a6-ab07-01bb80c23987.json
+++ b/change/react-native-windows-7ea54908-7e23-47a6-ab07-01bb80c23987.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use Bubbling TopClick",
+  "packageName": "react-native-windows",
+  "email": "34109996+chiaramooney@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewViewManager.cpp
@@ -243,11 +243,6 @@ void ViewViewManager::GetExportedCustomDirectEventTypeConstants(
     const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
   Super::GetExportedCustomDirectEventTypeConstants(writer);
 
-  writer.WritePropertyName(L"topClick");
-  writer.WriteObjectBegin();
-  winrt::Microsoft::ReactNative::WriteProperty(writer, L"registrationName", L"onClick");
-  writer.WriteObjectEnd();
-
   writer.WritePropertyName(L"topAccessibilityTap");
   writer.WriteObjectBegin();
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"registrationName", L"onAccessibilityTap");

--- a/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
+++ b/vnext/src/Libraries/NativeComponent/BaseViewConfig.windows.js
@@ -83,16 +83,13 @@ const bubblingEventTypes = {
       captured: 'onTouchEndCapture',
     },
   },
-
   // Experimental/Work in Progress Pointer Events (not yet ready for use)
-  /*[Windows
   topClick: {
     phasedRegistrationNames: {
       captured: 'onClickCapture',
       bubbled: 'onClick',
     },
   },
-  Windows] */
   topPointerCancel: {
     phasedRegistrationNames: {
       captured: 'onPointerCancelCapture',
@@ -201,9 +198,6 @@ const directEventTypes = {
   },
   topMouseLeave: {
     registrationName: 'onMouseLeave',
-  },
-  topClick: {
-    registrationName: 'onClick',
   },
   // Windows]
 };


### PR DESCRIPTION
## Description

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Use new upstream TopClick type instead of the Windows-specific TopClick type we originally implemented. This change results in Windows matching the Win32/iOS/Android behavior. Code now registers onClick as a bubbling event.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11969&drop=dogfoodAlpha