### PR TITLE
Properly detect the correct machine architecture in CLI

### DIFF
--- a/change/@react-native-windows-cli-89b5d265-8b1d-40b6-9cda-1449d039d1b2.json
+++ b/change/@react-native-windows-cli-89b5d265-8b1d-40b6-9cda-1449d039d1b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Properly detect the correct machine architecture",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-39db57fb-a779-4bd5-93bd-edfa4aed719b.json
+++ b/change/@react-native-windows-telemetry-39db57fb-a779-4bd5-93bd-edfa4aed719b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Properly detect the correct machine architecture",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-632430bc-c96b-4bf3-b20e-26f62b73e43f.json
+++ b/change/react-native-windows-init-632430bc-c96b-4bf3-b20e-26f62b73e43f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Properly detect the correct machine architecture",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -205,6 +205,10 @@ async function runWindowsInternal(
 ) {
   const verbose = options.logging === true;
 
+  if (verbose) {
+    newInfo('Verbose: ON');
+  }
+
   // Get the solution file
   let slnFile: string | null;
   runWindowsPhase = 'FindSolution';

--- a/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindows.ts
@@ -205,10 +205,6 @@ async function runWindowsInternal(
 ) {
   const verbose = options.logging === true;
 
-  if (verbose) {
-    newInfo('Verbose: ON');
-  }
-
   // Get the solution file
   let slnFile: string | null;
   runWindowsPhase = 'FindSolution';

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -72,7 +72,7 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--arch [string]',
     description: 'The build architecture (ARM64, x86, x64)',
-    default: deviceArchitecture() === 'arm64' ? 'ARM64' : deviceArchitecture(),
+    default: parseBuildArch(deviceArchitecture()),
     parse: parseBuildArch,
   },
   {

--- a/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/runWindowsOptions.ts
@@ -4,8 +4,8 @@
  * @format
  */
 
-import os from 'os';
 import {CommandOption} from '@react-native-community/cli-types';
+import {deviceArchitecture} from '@react-native-windows/telemetry';
 
 export type BuildArch = 'x86' | 'x64' | 'ARM64';
 export type BuildConfig = 'Debug' | 'DebugBundle' | 'Release' | 'ReleaseBundle';
@@ -72,12 +72,7 @@ export const runWindowsOptions: CommandOption[] = [
   {
     name: '--arch [string]',
     description: 'The build architecture (ARM64, x86, x64)',
-    default:
-      os.arch() === 'ia32'
-        ? 'x86'
-        : os.arch() === 'arm64'
-        ? 'ARM64'
-        : os.arch(),
+    default: deviceArchitecture() === 'arm64' ? 'ARM64' : deviceArchitecture(),
     parse: parseBuildArch,
   },
   {

--- a/packages/@react-native-windows/cli/src/runWindows/utils/telemetryHelpers.ts
+++ b/packages/@react-native-windows/cli/src/runWindows/utils/telemetryHelpers.ts
@@ -23,7 +23,11 @@ import {
   OptionSanitizer,
   configToProjectInfo,
   getProjectFileFromConfig,
+  deviceArchitecture,
+  nodeArchitecture,
 } from '@react-native-windows/telemetry';
+
+import {newInfo, newWarn} from './commandWithProgress';
 
 /**
  * Calculates a the default values of a given react-native CLI command's options.
@@ -89,11 +93,25 @@ export async function startTelemetrySession(
   defaultOptions: CommanderOptionsType,
   optionSanitizer: OptionSanitizer,
 ) {
+  const verbose = options.logging === true;
+
   if (!options.telemetry) {
-    if (options.logging) {
-      console.log('Telemetry is disabled');
+    if (verbose) {
+      newInfo('Telemetry is disabled');
     }
     return;
+  }
+
+  if (verbose) {
+    newInfo(
+      `Running ${nodeArchitecture()} node on a ${deviceArchitecture()} machine`,
+    );
+  }
+
+  if (deviceArchitecture() !== nodeArchitecture()) {
+    newWarn(
+      'This version of node was built for a different architecture than this machine and may cause unintended behavior',
+    );
   }
 
   await Telemetry.setup();

--- a/packages/@react-native-windows/telemetry/src/index.ts
+++ b/packages/@react-native-windows/telemetry/src/index.ts
@@ -11,6 +11,8 @@ export {
   CommandEndInfo,
 } from './telemetry';
 
+export {deviceArchitecture, nodeArchitecture} from './utils/basePropUtils';
+
 export {CodedError, CodedErrorType, CodedErrors} from './utils/errorUtils';
 
 export {

--- a/packages/@react-native-windows/telemetry/src/telemetry.ts
+++ b/packages/@react-native-windows/telemetry/src/telemetry.ts
@@ -175,6 +175,8 @@ export class Telemetry {
       await basePropUtils.deviceId();
     Telemetry.client!.commonProperties.deviceArchitecture =
       basePropUtils.deviceArchitecture();
+    Telemetry.client!.commonProperties.nodeArchitecture =
+      basePropUtils.nodeArchitecture();
     Telemetry.client!.commonProperties.devicePlatform =
       basePropUtils.devicePlatform();
     Telemetry.client!.commonProperties.deviceLocale =

--- a/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
+++ b/packages/@react-native-windows/telemetry/src/test/basePropUtils.test.ts
@@ -25,6 +25,13 @@ test('deviceArchitecture() is valid', () => {
   expect(value).not.toBeNull();
 });
 
+test('nodeArchitecture() is valid', () => {
+  const value = basePropUtils.nodeArchitecture();
+  expect(value).toBeDefined();
+  expect(value).not.toBe('');
+  expect(value).not.toBeNull();
+});
+
 test('devicePlatform() is valid', () => {
   const value = basePropUtils.devicePlatform();
   expect(value).toBeDefined();

--- a/packages/react-native-windows-init/src/Cli.ts
+++ b/packages/react-native-windows-init/src/Cli.ts
@@ -27,6 +27,8 @@ import {
   getProjectFileFromConfig,
   OptionSanitizer,
   YargsOptionsType,
+  deviceArchitecture,
+  nodeArchitecture,
 } from '@react-native-windows/telemetry';
 
 /**
@@ -382,11 +384,25 @@ async function startTelemetrySession(
   args: string[],
   options: YargsOptionsType,
 ) {
+  const verbose = options.verbose === true;
+
   if (!options.telemetry) {
-    if (options.verbose) {
+    if (verbose) {
       console.log('Telemetry is disabled');
     }
     return;
+  }
+
+  if (verbose) {
+    console.log(
+      `Running ${nodeArchitecture()} node on a ${deviceArchitecture()} machine`,
+    );
+  }
+
+  if (deviceArchitecture() !== nodeArchitecture()) {
+    console.warn(
+      'This version of node was built for a different architecture than this machine and may cause unintended behavior',
+    );
   }
 
   // Setup telemetry, but don't get NPM package version info right away as


### PR DESCRIPTION
## Description

Node's `process.arch` and `os.arch()` methods both return the architecture that the node binaries were built for, not the architecture of the machine they're running.

This can cause issues with the various hardware virtualization layers, specifically when running 32-bit Node on 64-bit machines.

Closes: #11977

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We keep hitting issues when users run the 32-bit Node on 64-bit Windows configuration.

Closes: #11977

### What

This PR:
* Updates and exports the `deviceArchitecture()` API in the `@react-native-windows/telemetry` library, which now correctly detects when x86 Node is being used on an x64 machine
* Adds and exports a new `nodeArchitecture()` method, which is also now recorded in telemetry
* Updates the `react-native-windows-init` and `@react-native-windows/cli` commands to warn the user if there's a mismatch
* Fixes an issue where querying for a registry key would fail due to querying the wrong registry because of the SysWOW64 redirection

## Screenshots
N/A

## Testing

Updated the telemetry tests with a new test for `nodeArchitecture`.

## Changelog
Should this change be included in the release notes: Yes

Properly detect the correct machine architecture for 32-bit Node on 64-bit Windows scenarios
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11978&drop=dogfoodAlpha