### PR TITLE
Allow disabling Blob Cxx module

### DIFF
--- a/change/react-native-windows-8d9e88e3-ce8b-46b7-a11e-af04d9f3d59d.json
+++ b/change/react-native-windows-8d9e88e3-ce8b-46b7-a11e-af04d9f3d59d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Allow disabling Blob Cxx module",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -223,5 +223,12 @@ TEST_CLASS (RNTesterIntegrationTests) {
     Assert::AreEqual(TestStatus::Passed, result.Status, result.Message.c_str());
   }
 
+  BEGIN_TEST_METHOD_ATTRIBUTE(Fetch)
+    END_TEST_METHOD_ATTRIBUTE()
+    TEST_METHOD(Fetch) {
+    auto result = m_runner.RunTest("IntegrationTests/FetchTest", "FetchTest");
+    Assert::AreEqual(TestStatus::Passed, result.Status, result.Message.c_str());
+  }
+
 #pragma endregion Extended Tests
 };

--- a/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/RNTesterIntegrationTests.cpp
@@ -224,8 +224,8 @@ TEST_CLASS (RNTesterIntegrationTests) {
   }
 
   BEGIN_TEST_METHOD_ATTRIBUTE(Fetch)
-    END_TEST_METHOD_ATTRIBUTE()
-    TEST_METHOD(Fetch) {
+  END_TEST_METHOD_ATTRIBUTE()
+  TEST_METHOD(Fetch) {
     auto result = m_runner.RunTest("IntegrationTests/FetchTest", "FetchTest");
     Assert::AreEqual(TestStatus::Passed, result.Status, result.Message.c_str());
   }

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -554,17 +554,20 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
       },
       nativeQueue));
 
-  modules.push_back(std::make_unique<CxxNativeModule>(
-      m_innerInstance,
-      Microsoft::React::GetBlobModuleName(),
-      [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
-      nativeQueue));
+  // Use in case the host app provides its a non-Blob-compatilbe HTTP module.
+  if (!Microsoft::React::GetRuntimeOptionBool("Blob.DisableModule")) {
+    modules.push_back(std::make_unique<CxxNativeModule>(
+        m_innerInstance,
+        Microsoft::React::GetBlobModuleName(),
+        [transitionalProps]() { return Microsoft::React::CreateBlobModule(transitionalProps); },
+        nativeQueue));
 
-  modules.push_back(std::make_unique<CxxNativeModule>(
-      m_innerInstance,
-      Microsoft::React::GetFileReaderModuleName(),
-      [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
-      nativeQueue));
+    modules.push_back(std::make_unique<CxxNativeModule>(
+        m_innerInstance,
+        Microsoft::React::GetFileReaderModuleName(),
+        [transitionalProps]() { return Microsoft::React::CreateFileReaderModule(transitionalProps); },
+        nativeQueue));
+  }
 
   modules.push_back(std::make_unique<CxxNativeModule>(
       m_innerInstance,

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -158,6 +158,10 @@
     },
     {
       "type": "platform",
+      "file": "src/IntegrationTests/FetchTest.js"
+    },
+    {
+      "type": "platform",
       "file": "src/IntegrationTests/LoggingTest.js"
     },
     {

--- a/vnext/src/IntegrationTests/FetchTest.js
+++ b/vnext/src/IntegrationTests/FetchTest.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ * @format
+ * @flow
+ */
+import React, { useEffect, useState } from 'react';
+import { Button, Text, View } from 'react-native';
+
+const { TestModule } = ReactNative.NativeModules;
+
+const FetchTest = () => {
+  const [content, setContent] = useState('NOTHING');
+  const [reqId, setReqId] = useState(0);
+  const uri =
+    'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
+    //'http://localhost:5555';
+
+  const doFetch = async () => {
+    var response = await fetch(uri);
+    var text = await response.text();
+    setReqId(reqId + 1);
+    setContent(text);
+  };
+
+  useEffect(() => {
+    doFetch().catch(console.error);
+    TestModule.markTestPassed(true);
+  }, []);
+
+  return (
+    <View />
+  );
+
+//  return (
+//    <View
+//      style={{
+//        flex: 1,
+//        justifyContent: 'flex-start',
+//        alignItems: 'stretch',
+//      }}>
+//      <Text>Response {reqId}:</Text>
+//      <Text>[{content}]</Text>
+//      <Button onPress={doFetch} title="Reload" />
+//    </View>
+//  );
+};
+
+export default FetchTest;

--- a/vnext/src/IntegrationTests/FetchTest.js
+++ b/vnext/src/IntegrationTests/FetchTest.js
@@ -18,25 +18,32 @@ const uri =
   'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
 const expectedContent = 'enableScripts: false';
 
-class FetchTest extends React.Component {
-  constructor() {
-    super();
-    this.state = {data: 'NONE'};
-  }
+type State = {
+  uri: string,
+  expected: string,
+  content: string,
+};
+
+class FetchTest extends React.Component<{...}, State> {
+  state: State = {
+    uri: 'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml',
+    expected: 'enableScripts: false',
+    content: '',
+  };
 
   async componentDidMount() {
     const response = await fetch(uri);
     const text = await response.text();
-    this.setState({data: text});
+    this.setState({content: text});
 
-    if (this.state.data === expectedContent) {
+    if (this.state.content === expectedContent) {
       TestModule.markTestPassed(true);
     } else {
       TestModule.markTestPassed(false);
     }
   }
 
-  render() {
+  render(): React.Node {
     return <View />;
   }
 }

--- a/vnext/src/IntegrationTests/FetchTest.js
+++ b/vnext/src/IntegrationTests/FetchTest.js
@@ -10,37 +10,34 @@
 const React = require('react');
 const ReactNative = require('react-native');
 
-const { AppRegistry, View } = ReactNative;
+const {AppRegistry, View} = ReactNative;
 
-const { TestModule } = ReactNative.NativeModules;
+const {TestModule} = ReactNative.NativeModules;
 
-const uri = 'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
+const uri =
+  'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
 const expectedContent = 'enableScripts: false';
 
 class FetchTest extends React.Component {
-
   constructor() {
     super();
-    this.state = { data: 'NONE' };
+    this.state = {data: 'NONE'};
   }
 
   async componentDidMount() {
     const response = await fetch(uri);
     const text = await response.text();
-    this.setState({ data: text });
+    this.setState({data: text});
 
     if (this.state.data === expectedContent) {
       TestModule.markTestPassed(true);
     } else {
       TestModule.markTestPassed(false);
     }
-
   }
 
   render() {
-    return (
-      <View />
-    );
+    return <View />;
   }
 }
 

--- a/vnext/src/IntegrationTests/FetchTest.js
+++ b/vnext/src/IntegrationTests/FetchTest.js
@@ -4,46 +4,46 @@
  * @format
  * @flow
  */
-import React, { useEffect, useState } from 'react';
-import { Button, Text, View } from 'react-native';
+
+'use strict';
+
+const React = require('react');
+const ReactNative = require('react-native');
+
+const { AppRegistry, View } = ReactNative;
 
 const { TestModule } = ReactNative.NativeModules;
 
-const FetchTest = () => {
-  const [content, setContent] = useState('NOTHING');
-  const [reqId, setReqId] = useState(0);
-  const uri =
-    'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
-    //'http://localhost:5555';
+const uri = 'https://raw.githubusercontent.com/microsoft/react-native-windows/main/.yarnrc.yml';
+const expectedContent = 'enableScripts: false';
 
-  const doFetch = async () => {
-    var response = await fetch(uri);
-    var text = await response.text();
-    setReqId(reqId + 1);
-    setContent(text);
-  };
+class FetchTest extends React.Component {
 
-  useEffect(() => {
-    doFetch().catch(console.error);
-    TestModule.markTestPassed(true);
-  }, []);
+  constructor() {
+    super();
+    this.state = { data: 'NONE' };
+  }
 
-  return (
-    <View />
-  );
+  async componentDidMount() {
+    const response = await fetch(uri);
+    const text = await response.text();
+    this.setState({ data: text });
 
-//  return (
-//    <View
-//      style={{
-//        flex: 1,
-//        justifyContent: 'flex-start',
-//        alignItems: 'stretch',
-//      }}>
-//      <Text>Response {reqId}:</Text>
-//      <Text>[{content}]</Text>
-//      <Button onPress={doFetch} title="Reload" />
-//    </View>
-//  );
-};
+    if (this.state.data === expectedContent) {
+      TestModule.markTestPassed(true);
+    } else {
+      TestModule.markTestPassed(false);
+    }
 
-export default FetchTest;
+  }
+
+  render() {
+    return (
+      <View />
+    );
+  }
+}
+
+AppRegistry.registerComponent('FetchTest', () => FetchTest);
+
+module.exports = FetchTest;


### PR DESCRIPTION
## Description
Allows disabling the Blob module in Desktop apps.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Host apps that override the RNW-provided HTTP module will encounter issues if they don't provide Blob support, due to the inter-dependency between both modules.

### What
Introduces runtime option `Blob.DisableModule`.

## Testing
Added `RNTesterIntegrationTests::Fetch`.

 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11979&drop=dogfoodAlpha