### PR TITLE
[0.72] Enable using newer CppWinRT versions that use WINRT_IMPL_LoadLibraryExW

### DIFF
--- a/change/react-native-windows-a293bfbd-cd92-48c4-8758-bcff78656d4a.json
+++ b/change/react-native-windows-a293bfbd-cd92-48c4-8758-bcff78656d4a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Enable using newer CppWinRT versions that use WINRT_IMPL_LoadLibraryExW",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/CppWinRTIncludes.h
+++ b/vnext/Microsoft.ReactNative.Cxx/CppWinRTIncludes.h
@@ -51,3 +51,8 @@ using namespace Windows::Foundation::Collections;
 #define _QUOTE(x) L#x
 #define QUOTE(x) _QUOTE(x)
 #define XAML_NAMESPACE_STR QUOTE(XAML_NAMESPACE)
+
+#ifdef CPPWINRT_USE_LOADLIBRARYEXW
+#define WINRT_IMPL_LoadLibraryW(name) \
+  WINRT_IMPL_LoadLibraryExW(name, nullptr, 0x00001000 /* LOAD_LIBRARY_SEARCH_DEFAULT_DIRS */)
+#endif

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Cpp.Dependencies.props
@@ -14,4 +14,13 @@
     <CppWinRTVersion Condition="'$(CppWinRTVersion)' == '' Or $([MSBuild]::VersionLessThan('$(CppWinRTVersion)', '2.0.211028.7'))">2.0.211028.7</CppWinRTVersion>
   </PropertyGroup>
 
+  <ItemDefinitionGroup Label="CppWinRT">
+    <ClCompile>
+      <PreprocessorDefinitions Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(CppWinRTVersion)', '2.0.230524.3'))">
+        CPPWINRT_USE_LOADLIBRARYEXW;
+        %(PreprocessorDefinitions)
+      </PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
 </Project>


### PR DESCRIPTION
This PR backports #11953 to RNW 0.72.

## Description

CppWinRT >= 2.0.230524.3 no longer expose the `WINRT_IMPL_LoadLibraryW` method for loading libraries, instead preferring a new `WINRT_IMPL_LoadLibraryExW`. See https://github.com/microsoft/cppwinrt/pull/1293.

This PR fixes our usage of `WINRT_IMPL_LoadLibraryW` by detecting newer versions of CppWinRT and using the new API when available.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Customers who tried to specify newer versions of CppWinRT hit build errors due to the use of the deprecated API.

Closes https://github.com/microsoft/react-native-windows/issues/11795

### What
Created a macro to re-define the old API which calls the new API with the same behavior, as seen in the PR which deprecated the API in the first place.

## Screenshots
N/A

## Testing
Verified able to build against the latest [Microsoft.Windows.CppWinRT 2.0.230706.1](https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.230706.1).

## Changelog
Should this change be included in the release notes: yes

Customers who specify their own version of Microsoft.Windows.CppWinRT can now use versions >= 2.0.230524.3.
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11986&drop=dogfoodAlpha