### PR TITLE
[Fabric] Add placeholder text and textcolor

### DIFF
--- a/change/react-native-windows-f7e2bd00-47ac-4f5e-8724-81fb9f19badf.json
+++ b/change/react-native-windows-f7e2bd00-47ac-4f5e-8724-81fb9f19badf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "implement placeholder text for fabric",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -74,6 +74,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   void UpdateCharFormat() noexcept;
   void UpdateParaFormat() noexcept;
   void UpdateText(const std::string &str) noexcept;
+  void DrawPlaceholderText() noexcept;
   void OnTextUpdated() noexcept;
   void OnSelectionChanged(LONG start, LONG end) noexcept;
   std::string GetTextFromRichEdit() const noexcept;
@@ -101,6 +102,11 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   int m_cDrawBlock{0};
   bool m_needsRedraw{false};
   bool m_drawing{false};
+
+  // Used by placeholder text
+  std::string m_placeholderText;
+  bool m_firstTextUpdate{true};
+  facebook::react::SharedColor m_placeholderTextColor;
 };
 
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description
Implements placeholder and placeholder color for Fabric's textInput

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #11458, will close #11954 PR when this version gets merged in

### What
Uses TextLayout to draw Text on top of RichEdit if placeholder is needed. Redraws the RichEdit wihtout the placeholder text once the first text input is detected.

## Screenshots
https://github.com/microsoft/react-native-windows/assets/42554868/f5f7e73f-9bf6-406a-90b6-d26aa9fec183


## Testing
Tested with composition playground

## Changelog
no