### PR TITLE
Fix codegenConfig.windows.separateDataTypes default value

### DIFF
--- a/change/@react-native-windows-cli-321ad683-84dc-4ae2-bf92-5d21bde36768.json
+++ b/change/@react-native-windows-cli-321ad683-84dc-4ae2-bf92-5d21bde36768.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix codegenConfig.windows.separateDataTypes default value",
+  "packageName": "@react-native-windows/cli",
+  "email": "53799235+ZihanChen-MSFT@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/codegen.ts
+++ b/packages/@react-native-windows/cli/src/codegen.ts
@@ -111,7 +111,7 @@ export class CodeGenWindows {
       }
     }
 
-    let separateDataTypes = true;
+    let separateDataTypes = false;
     if (pkgJson.codegenConfig.windows.separateDataTypes !== undefined) {
       switch (pkgJson.codegenConfig.windows.separateDataTypes) {
         case true:

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -41,7 +41,7 @@
     "jsSrcsDir": "src",
     "windows": {
       "namespace": "SampleLibraryCodegen",
-      "separateDataFiles": true
+      "separateDataTypes": true
     }
   },
   "engines": {


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
The default value should be `false`.
Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12032)