### PR TITLE
Fabric Text components use their text value as the accessibility name by default

### DIFF
--- a/change/react-native-windows-78dd7222-aaf1-4762-984e-be7cb6c503c5.json
+++ b/change/react-native-windows-78dd7222-aaf1-4762-984e-be7cb6c503c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Components can provide a default accessible name Text component falls back to the content if accessibleLabel isn't set",
+  "packageName": "react-native-windows",
+  "email": "26607885+chrisglein@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -248,7 +248,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     case UIA_NamePropertyId: {
       pRetVal->vt = VT_BSTR;
       auto wideName = ::Microsoft::Common::Unicode::Utf8ToUtf16(
-        props->accessibilityLabel.empty() ? baseView->DefaultAccessibleName() : props->accessibilityLabel);
+          props->accessibilityLabel.empty() ? baseView->DefaultAccessibleName() : props->accessibilityLabel);
       pRetVal->bstrVal = SysAllocString(wideName.c_str());
       hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
       break;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -234,7 +234,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
   switch (propertyId) {
     case UIA_ControlTypePropertyId: {
       pRetVal->vt = VT_I4;
-      auto role = props->accessibilityRole == "" ? baseView.get()->DefaultControlType() : props->accessibilityRole;
+      auto role = props->accessibilityRole.empty() ? baseView->DefaultControlType() : props->accessibilityRole;
       pRetVal->lVal = GetControlType(role);
       break;
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -247,7 +247,8 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
     }
     case UIA_NamePropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto wideName = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityLabel);
+      auto wideName = ::Microsoft::Common::Unicode::Utf8ToUtf16(
+        props->accessibilityLabel.empty() ? baseView->DefaultAccessibleName() : props->accessibilityLabel);
       pRetVal->bstrVal = SysAllocString(wideName.c_str());
       hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
       break;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1072,7 +1072,10 @@ void CompositionBaseComponentView::updateAccessibilityProps(
       provider, UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-      provider, UIA_NamePropertyId, oldViewProps.accessibilityLabel, newViewProps.accessibilityLabel);
+    provider,
+    UIA_NamePropertyId,
+    oldViewProps.accessibilityLabel,
+    newViewProps.accessibilityLabel.empty() ? DefaultAccessibleName() : newViewProps.accessibilityLabel);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       provider,
@@ -1217,6 +1220,10 @@ bool CompositionBaseComponentView::focusable() const noexcept {
 
 std::string CompositionBaseComponentView::DefaultControlType() const noexcept {
   return "group";
+}
+
+std::string CompositionBaseComponentView::DefaultAccessibleName() const noexcept {
+  return "";
 }
 
 CompositionViewComponentView::CompositionViewComponentView(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1072,10 +1072,10 @@ void CompositionBaseComponentView::updateAccessibilityProps(
       provider, UIA_IsKeyboardFocusablePropertyId, oldViewProps.focusable, newViewProps.focusable);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
-    provider,
-    UIA_NamePropertyId,
-    oldViewProps.accessibilityLabel,
-    newViewProps.accessibilityLabel.empty() ? DefaultAccessibleName() : newViewProps.accessibilityLabel);
+      provider,
+      UIA_NamePropertyId,
+      oldViewProps.accessibilityLabel,
+      newViewProps.accessibilityLabel.empty() ? DefaultAccessibleName() : newViewProps.accessibilityLabel);
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       provider,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -67,6 +67,7 @@ struct CompositionBaseComponentView : public IComponentView,
   winrt::IInspectable EnsureUiaProvider() noexcept override;
 
   virtual std::string DefaultControlType() const noexcept;
+  virtual std::string DefaultAccessibleName() const noexcept;
 
  protected:
   std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -46,7 +46,7 @@ void ParagraphComponentView::updateProps(
   if (oldViewProps.textAttributes.foregroundColor != newViewProps.textAttributes.foregroundColor) {
     m_requireRedraw = true;
   }
-  if (oldViewProps.textAttributes.opacity != newViewProps.textAttributes.opacity) {
+if (oldViewProps.textAttributes.opacity != newViewProps.textAttributes.opacity) {
     m_requireRedraw = true;
   }
 
@@ -54,6 +54,7 @@ void ParagraphComponentView::updateProps(
     updateTextAlignment(newViewProps.textAttributes.alignment);
   }
 
+  updateAccessibilityProps(oldViewProps, newViewProps);
   updateBorderProps(oldViewProps, newViewProps);
 
   m_props = std::static_pointer_cast<facebook::react::ParagraphProps const>(props);
@@ -477,6 +478,10 @@ void ParagraphComponentView::DrawText() noexcept {
 
 std::string ParagraphComponentView::DefaultControlType() const noexcept {
   return "text";
+}
+
+std::string ParagraphComponentView::DefaultAccessibleName() const noexcept {
+  return m_attributedStringBox.getValue().getString();
 }
 
 winrt::Microsoft::ReactNative::Composition::IVisual ParagraphComponentView::Visual() const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -46,7 +46,7 @@ void ParagraphComponentView::updateProps(
   if (oldViewProps.textAttributes.foregroundColor != newViewProps.textAttributes.foregroundColor) {
     m_requireRedraw = true;
   }
-if (oldViewProps.textAttributes.opacity != newViewProps.textAttributes.opacity) {
+  if (oldViewProps.textAttributes.opacity != newViewProps.textAttributes.opacity) {
     m_requireRedraw = true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -42,7 +42,8 @@ struct ParagraphComponentView : CompositionBaseComponentView {
   facebook::react::SharedTouchEventEmitter touchEventEmitterAtPoint(facebook::react::Point pt) noexcept override;
 
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
-  virtual std::string DefaultControlType() const noexcept;
+  virtual std::string DefaultControlType() const noexcept override;
+  virtual std::string DefaultAccessibleName() const noexcept override;
 
  private:
   ParagraphComponentView(


### PR DESCRIPTION
## Description
Text components were showing in the accessibility tree but not with any value. This change has `UIA_NamePropertyId` default to the text value but can be overriden by `accessibilityLabel`. 

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Text components were showing in the accessibility tree but not with any value.

Resolves #12030

### What
Added a virtual `DefaultAccessibleName()` that enables individual Fabric components to provide a fallback if `accessibilityLabel` isn't specified. Then `ParagraphComponentView` overrides this to provide its string value.

## Screenshots
Add any relevant screen captures here from before or after your changes. 
| Before | After |
|--------|--------|
| ![image](https://github.com/microsoft/react-native-windows/assets/26607885/4f95ce31-d0e4-40fe-aa4d-b2e1bb0f7178)| ![image](https://github.com/microsoft/react-native-windows/assets/26607885/55d59c10-0767-4eb4-adf0-18f6e82a1325)|

## Testing
- Tested first in the Artifical Chat app
- Then tested in PlaygroundComposition on the Text test page to ensure that 1. Names started showing up, and 2. `accessibilityLabel` was still respected if specified.

## Changelog
Yes? This is somewhere between bug fix (expected behavior not working) and feature (it wasn't working before).

Fabric Text components use their text value as the accessibility name by default (if `accessibilityLabel` is not specified
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12039)