### PR TITLE
[0.71] Fix BinSkim warnings for Desktop

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -188,11 +188,7 @@ jobs:
                   InputType: 'Basic'
                   Function: 'analyze'
                   TargetPattern: 'guardianGlob'
-                  # Scanning v8jsi.dll in x64/x86 only, because PDBs are stripped in ARM64
-                  ${{ if ne(matrix.BuildPlatform, 'ARM64') }}:
-                    AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\\React.Windows.Desktop.DLL\*.dll'
-                  ${{ else }}:
-                    AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\\React.Windows.Desktop.DLL\react-native-win32.dll'
+                  AnalyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\React.Windows.Desktop.DLL\react-native-win32.dll'
                   AnalyzeVerbose: true
                   toolVersion: 'Latest'
               continueOnError: true


### PR DESCRIPTION
This PR backports #11816 to 0.71.

BinSkim has been throwing warnings for Desktop ever since the upgrade to BinSkim@4. Particularly this is from scanning the Hermes and V8 dlls.

However both are sourced from their own Microsoft-owned repos and only consumed here via published NuGets. BinSkim should be running on those repos (if required) not here in RNW.

This PR updates the pipeline to only test the binaries built by this pipeline.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12041)