### PR TITLE
Fix bug when blur command received on node without XamlRoot

### DIFF
--- a/change/react-native-windows-3adee0f5-93e2-4451-bc8a-967121f90520.json
+++ b/change/react-native-windows-3adee0f5-93e2-4451-bc8a-967121f90520.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bug when blur command received on node without XamlRoot",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -1171,7 +1171,9 @@ void NativeUIManager::blur(int64_t reactTag) {
   if (auto shadowNode = static_cast<ShadowNodeBase *>(m_host->FindShadowNodeForTag(reactTag))) {
     // Only blur if current UI is focused to avoid problem described in PR #2687
     const auto xamlRoot = tryGetXamlRoot(shadowNode->m_rootTag);
-    if (shadowNode->GetView() == xaml::Input::FocusManager::GetFocusedElement(xamlRoot)) {
+    const auto focusedElement = xamlRoot ? xaml::Input::FocusManager::GetFocusedElement(xamlRoot)
+                                         : xaml::Input::FocusManager::GetFocusedElement();
+    if (shadowNode->GetView() == focusedElement) {
       if (auto reactControl = GetParentXamlReactControl(reactTag).get()) {
         reactControl.as<winrt::Microsoft::ReactNative::implementation::ReactRootView>()->blur(shadowNode->GetView());
       } else {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We are seeing crashes on quit when the blur command is called roughly around the same time that the React instance is being shut down. It's likely because the result of tryGetXamlRoot is null.

### What
This change falls back on the GetFocusedElement() overload without any parameters if the XamlRoot is null, as supplying a null parameter will result in a NPE.

## Testing
It's a tricky race condition to repro, but I did validate that passing a null XamlRoot value to `FocusManager::GetFocusedElement(XamlRoot)` will throw an exception.

## Changelog
Should this change be included in the release notes: _yes_

Fix for NPE when blur command is received while React instance is shutting down.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12051)