### PR TITLE
Point Desktop.IntegrationTests::HttpResourceIntegrationTests to a non-rate limited API

### DIFF
--- a/change/react-native-windows-9fc1928b-a45e-406c-96d8-6f034b72083d.json
+++ b/change/react-native-windows-9fc1928b-a45e-406c-96d8-6f034b72083d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Point Desktop.IntegrationTests::HttpResourceIntegrationTests to a non-rate limited API",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
+++ b/vnext/Desktop.IntegrationTests/HttpResourceIntegrationTests.cpp
@@ -169,7 +169,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
   }
 
   TEST_METHOD(RequestGetExplicitUserAgentSucceeds) {
-    string url = "https://api.github.com/repos/microsoft/react-native-xaml";
+    string url = "https://api.github.com/rate_limit";
 
     promise<void> rcPromise;
     string error;
@@ -206,7 +206,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
   }
 
   TEST_METHOD(RequestGetImplicitUserAgentSucceeds) {
-    string url = "https://api.github.com/repos/microsoft/react-native-windows";
+    string url = "https://api.github.com/rate_limit";
 
     promise<void> rcPromise;
     string error;
@@ -246,7 +246,7 @@ TEST_CLASS (HttpResourceIntegrationTest) {
 
   TEST_METHOD(RequestGetMissingUserAgentFails) {
     // string url = "http://localhost:" + std::to_string(s_port);
-    string url = "https://api.github.com/repos/microsoft/react-native-macos";
+    string url = "https://api.github.com/rate_limit";
 
     promise<void> rcPromise;
     string error;


### PR DESCRIPTION
## Description

There are three tests in `Desktop.Integration`'s `HttpResourceIntegrationTests` which verify that requests against a server that requires a `User-Agent` will succeed with the header present and fail when it's missing.

To do this we're using a standard unauthenticated GitHub API endpoint.

However, we can also hit rate limiting on this endpoint, causing the tests to fail. This PR improves the stability of those tests by instead hitting an API with the same Header requirement, but without rate limiting.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Stop good PRs from failing due to rate limiting causing tests to fail sporadically.

### What

Instead of hitting random GitHub API endpoints (and getting caught in unauthenticated rate limiting), instead change to calling the `/rate_limit` API, which has no rate limit itself.

## Screenshots
N/A

## Testing

Ran integration tests.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12056)