### PR TITLE
[Fabric] Add accessibilityHint support to UIA tree

### DIFF
--- a/change/react-native-windows-3f730a0d-eb08-4507-891a-a3662c57a804.json
+++ b/change/react-native-windows-3f730a0d-eb08-4507-891a-a3662c57a804.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "added accessibilityHint support",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -283,14 +283,13 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
       break;
     }
 
-     case UIA_HelpTextPropertyId: {
+    case UIA_HelpTextPropertyId: {
       pRetVal->vt = VT_BSTR;
       auto helpText = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
       pRetVal->bstrVal = SysAllocString(helpText.c_str());
       hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
       break;
     }
-
   }
 
   return hr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -282,6 +282,15 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
       pRetVal->boolVal = (props->accessible && props->accessibilityRole != "none") ? VARIANT_TRUE : VARIANT_FALSE;
       break;
     }
+
+     case UIA_HelpTextPropertyId: {
+      pRetVal->vt = VT_BSTR;
+      auto helpText = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
+      pRetVal->bstrVal = SysAllocString(helpText.c_str());
+      hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
+      break;
+    }
+
   }
 
   return hr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1097,6 +1097,9 @@ void CompositionBaseComponentView::updateAccessibilityProps(
 
   winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
       provider, UIA_ControlTypePropertyId, oldViewProps.accessibilityRole, newViewProps.accessibilityRole);
+
+  winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+      provider, UIA_HelpTextPropertyId, oldViewProps.accessibilityHint, newViewProps.accessibilityHint);
 }
 
 void CompositionBaseComponentView::updateBorderLayoutMetrics(


### PR DESCRIPTION
## Description

Note: this is the same change that was made in https://github.com/microsoft/react-native-windows/pull/12036, which was reverted here: https://github.com/microsoft/react-native-windows/pull/12057

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Add accessibilityHint support and information to UIA Tree HelpText property for improved accessibility information.

### What
Added code to update HelpText UIA field with property value passed in to the accessibilityHint prop. Previously, when the accessibilityHint prop was populated, the HelpText field in the UIA tree would remain empty.

## Screenshots
Before: 
![image](https://github.com/microsoft/react-native-windows/assets/30995198/8d89ea30-d551-40f7-8855-40563dc56fe2)
After:
![image](https://github.com/microsoft/react-native-windows/assets/30995198/9128b95d-e078-4f7d-8008-8c013c7568fa)

As can be seen the HelpText property is updated within the UIA tree when setting the accessibilityHint prop

## Testing
Tested that HelpText UIA field is not populated when accessibilityHint is set before code change, and that HelpText UIA field is populated after code change. Used `accessible.tsx` sample page in playground for testing
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12058)