### PR TITLE
[Fabric] Fix textinput crashing when app is minimized

### DIFF
--- a/change/react-native-windows-4240d9b5-be72-42a8-8e2a-c71d5a1ff72b.json
+++ b/change/react-native-windows-4240d9b5-be72-42a8-8e2a-c71d5a1ff72b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix fabric textinput crashing on minimized",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -798,9 +798,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   unsigned int newWidth = static_cast<unsigned int>(layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor);
   unsigned int newHeight = static_cast<unsigned int>(layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor);
 
-  bool isMinimized =
-      layoutMetrics.frame.size.width <= (layoutMetrics.contentInsets.left + layoutMetrics.contentInsets.right);
-  if (!isMinimized && (newWidth != m_imgWidth || newHeight != m_imgHeight)) {
+  if (newWidth != m_imgWidth || newHeight != m_imgHeight) {
     m_drawingSurface = nullptr; // Invalidate surface if we get a size change that is not the app being minimized
   }
 
@@ -1018,7 +1016,9 @@ void WindowsTextInputComponentView::DrawText() noexcept {
     return;
   }
 
-  if (!m_drawingSurface)
+  bool isZeroSized =
+      m_layoutMetrics.frame.size.width <= (m_layoutMetrics.contentInsets.left + m_layoutMetrics.contentInsets.right);
+  if (!m_drawingSurface || isZeroSized)
     return;
 
   // Begin our update of the surface pixels. If this is our first update, we are required

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -799,8 +799,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   unsigned int newHeight = static_cast<unsigned int>(layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor);
 
   bool isMinimized =
-      layoutMetrics.frame.size.width <= (layoutMetrics.contentInsets.left + layoutMetrics.contentInsets.top +
-                                         layoutMetrics.contentInsets.bottom + layoutMetrics.contentInsets.right);
+      layoutMetrics.frame.size.width <= (layoutMetrics.contentInsets.left + layoutMetrics.contentInsets.right);
   if (!isMinimized && (newWidth != m_imgWidth || newHeight != m_imgHeight)) {
     m_drawingSurface = nullptr; // Invalidate surface if we get a size change that is not the app being minimized
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -799,7 +799,7 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   unsigned int newHeight = static_cast<unsigned int>(layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor);
 
   if (newWidth != m_imgWidth || newHeight != m_imgHeight) {
-    m_drawingSurface = nullptr; // Invalidate surface if we get a size change that is not the app being minimized
+    m_drawingSurface = nullptr; // Invalidate surface if we get a size change
   }
 
   m_imgWidth = newWidth;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -798,8 +798,11 @@ void WindowsTextInputComponentView::updateLayoutMetrics(
   unsigned int newWidth = static_cast<unsigned int>(layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor);
   unsigned int newHeight = static_cast<unsigned int>(layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor);
 
-  if (newWidth != m_imgWidth || newHeight != m_imgHeight) {
-    m_drawingSurface = nullptr; // Invalidate surface if we get a size change
+  bool isMinimized =
+      layoutMetrics.frame.size.width <= (layoutMetrics.contentInsets.left + layoutMetrics.contentInsets.top +
+                                         layoutMetrics.contentInsets.bottom + layoutMetrics.contentInsets.right);
+  if (!isMinimized && (newWidth != m_imgWidth || newHeight != m_imgHeight)) {
+    m_drawingSurface = nullptr; // Invalidate surface if we get a size change that is not the app being minimized
   }
 
   m_imgWidth = newWidth;


### PR DESCRIPTION
## Description
Fixes issue where TextInput would crash when the app is minimized.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #12040

### What
Excludes invalidating the drawingSurface if the app is minimized. Finds out if the app is minimized by calculating if the content width is less than the borders/padding (ie there's no content).

## Testing
Tested with playground

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12059)