### PR TITLE
[0.71] Add aria-required and aria-multiselectable to accessibilityState on win32

### DIFF
--- a/change/@office-iss-react-native-win32-7fd6b7f9-9ded-4985-87b5-70b02f87b6c1.json
+++ b/change/@office-iss-react-native-win32-7fd6b7f9-9ded-4985-87b5-70b02f87b6c1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix a11yState and add support for aria-required and -multiselectable",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "krsiler@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Accessibility/AccessibilityExampleWin32.tsx
@@ -181,7 +181,7 @@ class MultiSelectionExample extends React.Component<{}, IMultiSelectionExampleSt
 
   public render() {
     return (
-      <ViewWin32 accessible accessibilityRole="tablist" accessibilityState={{multiselectable: true}}>
+      <ViewWin32 accessible accessibilityRole="tablist" aria-required aria-multiselectable>
         <SelectionItemComponent
           value={1}
           color="#aee8fcff"

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/Pressable/Pressable.win32.js
@@ -74,6 +74,8 @@ type Props = $ReadOnly<{|
   'aria-disabled'?: ?boolean,
   'aria-expanded'?: ?boolean,
   'aria-selected'?: ?boolean,
+  'aria-multiselectable'?: ?boolean, // Win32
+  'aria-required'?: ?boolean, // Win32
   /**
    * A value indicating whether the accessibility elements contained within
    * this accessibility element are hidden.
@@ -257,6 +259,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
     'aria-label': ariaLabel,
+    'aria-multiselectable': ariaMultiselectable, // Win32
+    'aria-required': ariaRequired, // Win32
     'aria-selected': ariaSelected,
     cancelable,
     children,
@@ -297,6 +301,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
     checked: ariaChecked ?? accessibilityState?.checked,
     disabled: ariaDisabled ?? accessibilityState?.disabled,
     expanded: ariaExpanded ?? accessibilityState?.expanded,
+    multiselectable: ariaMultiselectable ?? accessibilityState?.multiselectable, // Win32
+    required: ariaRequired ?? accessibilityState?.required, // Win32
     selected: ariaSelected ?? accessibilityState?.selected,
   };
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.js
@@ -1101,6 +1101,8 @@ function InternalTextInput(props: Props): React.Node {
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
     'aria-selected': ariaSelected,
+    'aria-multiselectable': ariaMultiselectable, // Win32
+    'aria-required': ariaRequired, // Win32
     accessibilityState,
     id,
     tabIndex,
@@ -1491,6 +1493,8 @@ function InternalTextInput(props: Props): React.Node {
     ariaChecked != null ||
     ariaDisabled != null ||
     ariaExpanded != null ||
+    ariaMultiselectable != null ||
+    ariaRequired != null ||
     ariaSelected != null
   ) {
     _accessibilityState = {
@@ -1498,6 +1502,9 @@ function InternalTextInput(props: Props): React.Node {
       checked: ariaChecked ?? accessibilityState?.checked,
       disabled: ariaDisabled ?? accessibilityState?.disabled,
       expanded: ariaExpanded ?? accessibilityState?.expanded,
+      multiselectable:
+        ariaMultiselectable ?? accessibilityState?.multiselectable, // Win32
+      required: ariaRequired ?? accessibilityState?.required, // Win32
       selected: ariaSelected ?? accessibilityState?.selected,
     };
   }

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -50,6 +50,8 @@ const View: React.AbstractComponent<
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       'aria-live': ariaLive,
+      'aria-multiselectable': ariaMultiselectable, // Win32
+      'aria-required': ariaRequired, // Win32
       'aria-selected': ariaSelected,
       'aria-valuemax': ariaValueMax,
       'aria-valuemin': ariaValueMin,
@@ -76,6 +78,8 @@ const View: React.AbstractComponent<
       ariaChecked != null ||
       ariaDisabled != null ||
       ariaExpanded != null ||
+      ariaMultiselectable != null ||
+      ariaRequired != null ||
       ariaSelected != null
     ) {
       _accessibilityState = {
@@ -83,6 +87,9 @@ const View: React.AbstractComponent<
         checked: ariaChecked ?? accessibilityState?.checked,
         disabled: ariaDisabled ?? accessibilityState?.disabled,
         expanded: ariaExpanded ?? accessibilityState?.expanded,
+        multiselectable:
+          ariaMultiselectable ?? accessibilityState?.multiselectable, // Win32
+        required: ariaRequired ?? accessibilityState?.required, // Win32
         selected: ariaSelected ?? accessibilityState?.selected,
       };
     }

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.d.ts
@@ -57,6 +57,8 @@ export interface AccessibilityProps
   'aria-checked'?: boolean | 'mixed' | undefined;
   'aria-disabled'?: boolean | undefined;
   'aria-expanded'?: boolean | undefined;
+  'aria-multiselectable'?: boolean | undefined; // Win32
+  'aria-required'?: boolean | undefined; // Win32
   'aria-selected'?: boolean | undefined;
 
   /**

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewAccessibility.win32.js
@@ -152,6 +152,8 @@ export type AccessibilityState = {
   checked?: ?boolean | 'mixed',
   busy?: boolean,
   expanded?: boolean,
+  multiselectable?: boolean, // Win32
+  required?: boolean, // Win32
   ...
 };
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/ViewPropTypes.win32.js
@@ -467,6 +467,8 @@ type WindowsViewProps = $ReadOnly<{|
 
   accessibilityPosInSet?: ?number,
   accessibilitySetSize?: ?number,
+  'aria-multiselectable'?: ?boolean,
+  'aria-required'?: ?boolean,
 
   /**
    * Specifies if the control should show System focus visuals

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/Image.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/Image.win32.js
@@ -170,6 +170,8 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
+    'aria-multiselectable': ariaMultiselectable, // Win32
+    'aria-required': ariaRequired, // Win32
     'aria-selected': ariaSelected,
     height,
     src,
@@ -182,6 +184,9 @@ const BaseImage = (props: ImagePropsType, forwardedRef) => {
     checked: ariaChecked ?? props.accessibilityState?.checked,
     disabled: ariaDisabled ?? props.accessibilityState?.disabled,
     expanded: ariaExpanded ?? props.accessibilityState?.expanded,
+    multiselectable:
+      ariaMultiselectable ?? props.accessibilityState?.multiselectable, // Win32
+    required: ariaRequired ?? props.accessibilityState?.required, // Win32
     selected: ariaSelected ?? props.accessibilityState?.selected,
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;


### PR DESCRIPTION
## Description
Backport of #12046 

### Type of Change
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12061)