### PR TITLE
Prevent Desktop.IntegrationTests from hanging forever

### DIFF
--- a/change/react-native-windows-06fa53f8-8874-4937-a1cc-2fc3b025dc0a.json
+++ b/change/react-native-windows-06fa53f8-8874-4937-a1cc-2fc3b025dc0a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Prevent Desktop.IntegrationTests from hanging forever",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -83,7 +83,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
       std::move(jsQueue),
       std::move(nativeQueue),
       std::move(devSettings));
-  instanceWrapper->loadBundle(std::move(jsBundleFile));
+  instanceWrapper->loadBundleSync(std::move(jsBundleFile));
 
   return shared_ptr<ITestInstance>(new DesktopTestInstance(std::move(instanceWrapper)));
 }

--- a/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
+++ b/vnext/Desktop.IntegrationTests/DesktopTestRunner.cpp
@@ -83,7 +83,7 @@ shared_ptr<ITestInstance> TestRunner::GetInstance(
       std::move(jsQueue),
       std::move(nativeQueue),
       std::move(devSettings));
-  instanceWrapper->loadBundleSync(std::move(jsBundleFile));
+  instanceWrapper->loadBundle(std::move(jsBundleFile));
 
   return shared_ptr<ITestInstance>(new DesktopTestInstance(std::move(instanceWrapper)));
 }

--- a/vnext/IntegrationTests/TestRunner.cpp
+++ b/vnext/IntegrationTests/TestRunner.cpp
@@ -26,8 +26,11 @@ using std::vector;
 
 namespace Microsoft::React::Test {
 
+constexpr DWORD MarkTestSucceededEventTimeout =
+    static_cast<DWORD>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::seconds(30)).count());
+
 void TestRunner::AwaitEvent(HANDLE &event, TestResult &result) {
-  DWORD done = ::WaitForSingleObject(event, INFINITE);
+  DWORD done = ::WaitForSingleObject(event, MarkTestSucceededEventTimeout);
 
   if (WAIT_OBJECT_0 != done)
     result.Status = TestStatus::Failed;

--- a/vnext/IntegrationTests/TestRunner.cpp
+++ b/vnext/IntegrationTests/TestRunner.cpp
@@ -32,8 +32,10 @@ constexpr DWORD MarkTestSucceededEventTimeout =
 void TestRunner::AwaitEvent(HANDLE &event, TestResult &result) {
   DWORD done = ::WaitForSingleObject(event, MarkTestSucceededEventTimeout);
 
-  if (WAIT_OBJECT_0 != done)
+  if (WAIT_OBJECT_0 != done) {
     result.Status = TestStatus::Failed;
+    result.Message = L"Timeout waiting for markTestSucceeded() to be called.";
+  }
 }
 
 TestRunner::TestRunner() {}


### PR DESCRIPTION
## Description

While trying to integrate the latest RN code (see PR #11970) the `RNTesterIntegrationTests` in `React.Windows.Desktop.IntegrationTests` kept hanging and timing out.

The root issue (TBD) was a `JSError` being thrown by Chakra when the test bundle (ex. `DummyTest`) was loaded from Metro. However the bundle was loaded asynchronously, which caused that error to be swallowed and never reported. Furthermore, not knowing that the bundle load had failed, the test continued onward and attempted to start loading the app with `AppRegistry.runApplication()` (which also failed silently) and finally proceeded to wait indefinitely for the JS component to render and fire the `TestModule.markTestPassed(true)`.

To address this, this PR changes the tests to set a reasonable 30s timeout for waiting for the app to "render" (it usually completes in 2-3s).

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

To better detect failures in `RNTesterIntegrationTests`.

### What

Changes the tests to set a reasonable 30s timeout for waiting for the app to "render" (it usually completes in 2-3s).

## Screenshots
N/A

## Testing
Re-ran the tests and verified if the bundle load fails the test fails.

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12072)