### PR TITLE
[Win32] Remove flow usage from saveAssetPlugin codeflow

### DIFF
--- a/change/@office-iss-react-native-win32-fe0fc9d1-3124-4ae6-b15a-7c456cee835d.json
+++ b/change/@office-iss-react-native-win32-fe0fc9d1-3124-4ae6-b15a-7c456cee835d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove flow usage from saveAssetPlugin codeflow",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/assetPaths.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/assetPaths.js
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT License.
  *
- * @flow strict-local
+ * Dont use flow here, since this file is used by saveAssetPlugin.js which will run without flow transform
  * @format
  */
 
@@ -12,7 +12,7 @@
 // https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 // Assets in nested node_modules (common when using pnpm) - end up creating very long paths
 // Using this function we shorten longer paths to prevent paths from hitting the path limit
-function ensureShortPath(str: string): string {
+function ensureShortPath(str) {
   if (str.length < 40) return str;
 
   const assetsPrefix = 'assets/';


### PR DESCRIPTION
## Description
assetPaths.js is imported by saveAssetPlugin.js which is loaded by the bundler as a node JS file.  So it need to be free of flow annotations, otherwise it'll fail to run.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12080)