### PR TITLE
[Fabric] Remove runtime classes in CompositionSwitcher

### DIFF
--- a/change/react-native-windows-335edf82-6b7e-4ed7-abbe-f639eb36e524.json
+++ b/change/react-native-windows-335edf82-6b7e-4ed7-abbe-f639eb36e524.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Remove runtime classes in CompositionSwitcher",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -138,7 +138,7 @@ struct CustomComponent : winrt::implements<CustomComponent, winrt::IInspectable>
  private:
   winrt::Windows::UI::Composition::SpotLight m_spotlight{nullptr};
 
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compContext;
 };
 

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -23,14 +23,14 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [uuid("172def51-9e1a-4e3c-841a-e5a470065acc")] // uuid needed for empty interfaces
-  [version(1)]
+  [version(0)]
   [experimental]
   interface IBrush {
   }
 
   [webhosthidden]
   [experimental]
-  runtimeclass SurfaceBrush : IBrush
+  interface ISurfaceBrush requires IBrush
   {
     void HorizontalAlignmentRatio(Single value);
     void VerticalAlignmentRatio(Single value);
@@ -67,7 +67,7 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
-  runtimeclass SpriteVisual : IVisual
+  interface ISpriteVisual requires IVisual
   {
     void Brush(IBrush brush);
     void Shadow(IDropShadow shadow);
@@ -75,17 +75,17 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
-  runtimeclass ScrollPositionChangedArgs
+  interface IScrollPositionChangedArgs
   {
     Windows.Foundation.Numerics.Vector2 Position { get; };
   }
 
   [webhosthidden]
   [experimental]
-  runtimeclass ScrollVisual : IVisual
+  interface IScrollVisual requires IVisual
   {
     void Brush(IBrush brush);
-    event Windows.Foundation.EventHandler<ScrollPositionChangedArgs> ScrollPositionChanged;
+    event Windows.Foundation.EventHandler<IScrollPositionChangedArgs> ScrollPositionChanged;
     void ContentSize(Windows.Foundation.Numerics.Vector2 size);
     Windows.Foundation.Numerics.Vector3 ScrollPosition { get; };
     void ScrollBy(Windows.Foundation.Numerics.Vector3 offset);
@@ -94,14 +94,14 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
-  runtimeclass ActivityVisual : IVisual
+  interface IActivityVisual requires IVisual
   {
     void updateColor(Windows.UI.Color color);
   }
 
   [webhosthidden]
   [uuid("a74bfffc-7f2d-432f-8291-654782ab0d52")] // uuid needed for empty interfaces
-  [version(1)]
+  [version(0)]
   [experimental]
   interface ICompositionDrawingSurface
   {
@@ -134,14 +134,14 @@ namespace Microsoft.ReactNative.Composition
       Windows.Graphics.DirectX.DirectXPixelFormat pixelFormat,
       Windows.Graphics.DirectX.DirectXAlphaMode alphaMode);
 
-    SpriteVisual CreateSpriteVisual();
-    ScrollVisual CreateScrollerVisual();
-    ActivityVisual CreateActivityVisual();
+    ISpriteVisual CreateSpriteVisual();
+    IScrollVisual CreateScrollerVisual();
+    IActivityVisual CreateActivityVisual();
     ICaretVisual CreateCaretVisual();
     IFocusVisual CreateFocusVisual();
     IDropShadow CreateDropShadow();
     IBrush CreateColorBrush(Windows.UI.Color color);
-    SurfaceBrush CreateSurfaceBrush(ICompositionDrawingSurface surface);
+    ISurfaceBrush CreateSurfaceBrush(ICompositionDrawingSurface surface);
 
     // TODO Add and hook up to rootnode - to notify the tree
     // event Windows.Foundation.EventHandler<RenderingDeviceReplacedArgs> RenderingDeviceReplaced;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
@@ -50,8 +50,8 @@ struct ActivityIndicatorComponentView : CompositionBaseComponentView {
 
   void ensureVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ActivityVisual m_ActivityIndicatorVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IActivityVisual m_ActivityIndicatorVisual{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
   facebook::react::SharedViewProps m_props;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -5,11 +5,6 @@
 #include "Composition.CompositionContextHelper.g.cpp"
 #endif
 
-#include <Composition.ActivityVisual.g.h>
-#include <Composition.ScrollPositionChangedArgs.g.h>
-#include <Composition.ScrollVisual.g.h>
-#include <Composition.SpriteVisual.g.h>
-#include <Composition.SurfaceBrush.g.h>
 #include <Windows.Graphics.Interop.h>
 #include <windows.ui.composition.interop.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
@@ -108,8 +103,11 @@ struct CompBrush
   winrt::Windows::UI::Composition::CompositionBrush m_brush;
 };
 
-struct CompSurfaceBrush
-    : winrt::Microsoft::ReactNative::Composition::implementation::SurfaceBrushT<CompSurfaceBrush, ICompositionBrush> {
+struct CompSurfaceBrush : winrt::implements<
+                              CompSurfaceBrush,
+                              winrt::Microsoft::ReactNative::Composition::ISurfaceBrush,
+                              winrt::Microsoft::ReactNative::Composition::IBrush,
+                              ICompositionBrush> {
   CompSurfaceBrush(
       const winrt::Windows::UI::Composition::Compositor &compositor,
       const winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface &drawingSurfaceInterop)
@@ -258,8 +256,12 @@ struct CompVisual : public winrt::implements<
   winrt::Windows::UI::Composition::Visual m_visual;
 };
 
-struct CompSpriteVisual : winrt::Microsoft::ReactNative::Composition::implementation::
-                              SpriteVisualT<CompSpriteVisual, ICompositionVisual, IVisualInterop> {
+struct CompSpriteVisual : winrt::implements<
+                              CompSpriteVisual,
+                              winrt::Microsoft::ReactNative::Composition::ISpriteVisual,
+                              winrt::Microsoft::ReactNative::Composition::IVisual,
+                              ICompositionVisual,
+                              IVisualInterop> {
   CompSpriteVisual(winrt::Windows::UI::Composition::SpriteVisual const &visual) : m_visual(visual) {}
 
   winrt::Windows::UI::Composition::Visual InnerVisual() const noexcept override {
@@ -368,9 +370,9 @@ struct CompSpriteVisual : winrt::Microsoft::ReactNative::Composition::implementa
   winrt::Windows::UI::Composition::SpriteVisual m_visual;
 };
 
-struct CompScrollPositionChangedArgs
-    : winrt::Microsoft::ReactNative::Composition::implementation::ScrollPositionChangedArgsT<
-          CompScrollPositionChangedArgs> {
+struct CompScrollPositionChangedArgs : winrt::implements<
+                                           CompScrollPositionChangedArgs,
+                                           winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs> {
   CompScrollPositionChangedArgs(winrt::Windows::Foundation::Numerics::float2 position) : m_position(position) {}
 
   winrt::Windows::Foundation::Numerics::float2 Position() {
@@ -381,8 +383,12 @@ struct CompScrollPositionChangedArgs
   winrt::Windows::Foundation::Numerics::float2 m_position;
 };
 
-struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implementation::
-                                ScrollVisualT<CompScrollerVisual, ICompositionVisual, IVisualInterop> {
+struct CompScrollerVisual : winrt::implements<
+                                CompScrollerVisual,
+                                winrt::Microsoft::ReactNative::Composition::IScrollVisual,
+                                winrt::Microsoft::ReactNative::Composition::IVisual,
+                                ICompositionVisual,
+                                IVisualInterop> {
   struct ScrollInteractionTrackerOwner : public winrt::implements<
                                              ScrollInteractionTrackerOwner,
                                              winrt::Windows::UI::Composition::Interactions::IInteractionTrackerOwner> {
@@ -558,7 +564,7 @@ struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implemen
 
   winrt::event_token ScrollPositionChanged(
       winrt::Windows::Foundation::EventHandler<
-          winrt::Microsoft::ReactNative::Composition::ScrollPositionChangedArgs> const &handler) {
+          winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs> const &handler) {
     return m_scrollPositionChangedEvent.add(handler);
   }
 
@@ -608,7 +614,7 @@ struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implemen
   winrt::Windows::Foundation::Numerics::float2 m_contentSize{0};
   winrt::Windows::Foundation::Numerics::float2 m_visualSize{0};
   winrt::event<
-      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::ScrollPositionChangedArgs>>
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs>>
       m_scrollPositionChangedEvent;
   winrt::Windows::UI::Composition::SpriteVisual m_visual{nullptr};
   winrt::Windows::UI::Composition::SpriteVisual m_contentVisual{nullptr};
@@ -616,8 +622,12 @@ struct CompScrollerVisual : winrt::Microsoft::ReactNative::Composition::implemen
   winrt::Windows::UI::Composition::Interactions::VisualInteractionSource m_visualInteractionSource{nullptr};
 };
 
-struct CompActivityVisual : winrt::Microsoft::ReactNative::Composition::implementation::
-                                ActivityVisualT<CompActivityVisual, ICompositionVisual, IVisualInterop> {
+struct CompActivityVisual : winrt::implements<
+                                CompActivityVisual,
+                                winrt::Microsoft::ReactNative::Composition::IActivityVisual,
+                                winrt::Microsoft::ReactNative::Composition::IVisual,
+                                ICompositionVisual,
+                                IVisualInterop> {
   CompActivityVisual(winrt::Windows::UI::Composition::SpriteVisual const &visual) : m_visual(visual) {
     auto compositor = m_visual.Compositor();
     m_contentVisual = compositor.CreateSpriteVisual();
@@ -988,15 +998,15 @@ struct CompContext : winrt::implements<
         CompositionGraphicsDevice().CreateDrawingSurface(surfaceSize, pixelFormat, alphaMode));
   }
 
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual CreateSpriteVisual() noexcept {
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual CreateSpriteVisual() noexcept {
     return winrt::make<Composition::CompSpriteVisual>(m_compositor.CreateSpriteVisual());
   }
 
-  winrt::Microsoft::ReactNative::Composition::ScrollVisual CreateScrollerVisual() noexcept {
+  winrt::Microsoft::ReactNative::Composition::IScrollVisual CreateScrollerVisual() noexcept {
     return winrt::make<Composition::CompScrollerVisual>(m_compositor.CreateSpriteVisual());
   }
 
-  winrt::Microsoft::ReactNative::Composition::ActivityVisual CreateActivityVisual() noexcept {
+  winrt::Microsoft::ReactNative::Composition::IActivityVisual CreateActivityVisual() noexcept {
     return winrt::make<Composition::CompActivityVisual>(m_compositor.CreateSpriteVisual());
   }
 
@@ -1008,7 +1018,7 @@ struct CompContext : winrt::implements<
     return winrt::make<Composition::CompBrush>(m_compositor.CreateColorBrush(color));
   }
 
-  winrt::Microsoft::ReactNative::Composition::SurfaceBrush CreateSurfaceBrush(
+  winrt::Microsoft::ReactNative::Composition::ISurfaceBrush CreateSurfaceBrush(
       const winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface &surface) noexcept {
     return winrt::make<Composition::CompSurfaceBrush>(m_compositor, surface);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -5,12 +5,6 @@
 #include "Composition.CompositionContextHelper.g.cpp"
 #endif
 
-#include <Composition.ActivityVisual.g.h>
-#include <Composition.ScrollPositionChangedArgs.g.h>
-#include <Composition.ScrollVisual.g.h>
-#include <Composition.SpriteVisual.g.h>
-#include <Composition.SurfaceBrush.g.h>
-
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 ICompositionContext CompositionContextHelper::CreateContext(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -191,16 +191,16 @@ bool CompositionBaseComponentView::ScrollWheel(facebook::react::Point pt, int32_
 }
 
 std::array<
-    winrt::Microsoft::ReactNative::Composition::SpriteVisual,
+    winrt::Microsoft::ReactNative::Composition::ISpriteVisual,
     CompositionBaseComponentView::SpecialBorderLayerCount>
 CompositionBaseComponentView::FindSpecialBorderLayers() const noexcept {
-  std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount> layers{
+  std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> layers{
       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
   if (m_numBorderVisuals) {
     for (uint8_t i = 0; i < m_numBorderVisuals; i++) {
       auto visual = Visual().GetAt(i);
-      layers[i] = visual.as<winrt::Microsoft::ReactNative::Composition::SpriteVisual>();
+      layers[i] = visual.as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>();
     }
   }
 
@@ -471,7 +471,7 @@ struct AutoDrawHelper {
 template <typename TShape>
 void SetBorderLayerPropertiesCommon(
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
-    winrt::Microsoft::ReactNative::Composition::SpriteVisual &layer,
+    winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
     TShape &shape,
     winrt::com_ptr<Composition::ICompositionDrawingSurfaceInterop> &borderTexture,
     const D2D1_RECT_F &textureRect,
@@ -560,7 +560,7 @@ void SetBorderLayerPropertiesCommon(
 template <typename TShape>
 void SetBorderLayerProperties(
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
-    winrt::Microsoft::ReactNative::Composition::SpriteVisual &layer,
+    winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
     TShape &shape,
     winrt::com_ptr<Composition::ICompositionDrawingSurfaceInterop> &borderTexture,
     const D2D1_RECT_F &textureRect,
@@ -625,7 +625,7 @@ template <typename TShape>
 void DrawAllBorderLayers(
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     std::array<
-        winrt::Microsoft::ReactNative::Composition::SpriteVisual,
+        winrt::Microsoft::ReactNative::Composition::ISpriteVisual,
         CompositionBaseComponentView::SpecialBorderLayerCount> &spBorderLayers,
     TShape &shape,
     const facebook::react::BorderWidths &borderWidths,
@@ -920,7 +920,7 @@ facebook::react::BorderMetrics resolveAndAlignBorderMetrics(
 }
 
 bool CompositionBaseComponentView::TryUpdateSpecialBorderLayers(
-    std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
+    std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
     facebook::react::LayoutMetrics const &layoutMetrics,
     const facebook::react::ViewProps &viewProps) noexcept {
   auto borderMetrics = resolveAndAlignBorderMetrics(layoutMetrics, viewProps);
@@ -1026,7 +1026,7 @@ void CompositionBaseComponentView::UpdateSpecialBorderLayers(
   if (!TryUpdateSpecialBorderLayers(spBorderLayers, layoutMetrics, viewProps)) {
     for (auto &spBorderLayer : spBorderLayers) {
       if (spBorderLayer) {
-        spBorderLayer.as<winrt::Microsoft::ReactNative::Composition::SpriteVisual>().Brush(nullptr);
+        spBorderLayer.as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>().Brush(nullptr);
       }
     }
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -70,10 +70,10 @@ struct CompositionBaseComponentView : public IComponentView,
   virtual std::string DefaultAccessibleName() const noexcept;
 
  protected:
-  std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount>
+  std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount>
   FindSpecialBorderLayers() const noexcept;
   bool TryUpdateSpecialBorderLayers(
-      std::array<winrt::Microsoft::ReactNative::Composition::SpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
+      std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
       facebook::react::LayoutMetrics const &layoutMetrics,
       const facebook::react::ViewProps &viewProps) noexcept;
   void UpdateSpecialBorderLayers(
@@ -138,7 +138,7 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
 
  private:
   facebook::react::SharedViewProps m_props;
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -85,7 +85,7 @@ struct ImageComponentView : CompositionBaseComponentView {
 
   facebook::react::SharedViewProps m_props;
 
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
   winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface m_drawingSurface;
   winrt::com_ptr<IWICBitmap> m_wicbmp;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -56,7 +56,7 @@ struct ParagraphComponentView : CompositionBaseComponentView {
   void updateTextAlignment(const std::optional<facebook::react::TextAlignment> &fbAlignment) noexcept;
 
   std::shared_ptr<facebook::react::ParagraphProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   winrt::com_ptr<::IDWriteTextLayout> m_textLayout;
   facebook::react::AttributedStringBox m_attributedStringBox;
   facebook::react::ParagraphAttributes m_paragraphAttributes;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -407,7 +407,7 @@ void ScrollViewComponentView::ensureVisual() noexcept {
         winrt::auto_revoke,
         [this](
             winrt::IInspectable const & /*sender*/,
-            winrt::Microsoft::ReactNative::Composition::ScrollPositionChangedArgs const &args) {
+            winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs const &args) {
           auto eventEmitter = GetEventEmitter();
           if (eventEmitter) {
             facebook::react::ScrollViewMetrics scrollMetrics;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -91,8 +91,8 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ScrollVisual m_scrollVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ScrollVisual::ScrollPositionChanged_revoker
+  winrt::Microsoft::ReactNative::Composition::IScrollVisual m_scrollVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IScrollVisual::ScrollPositionChanged_revoker
       m_scrollPositionChangedRevoker{};
 
   facebook::react::SharedViewProps m_props;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -55,7 +55,7 @@ struct SwitchComponentView : CompositionBaseComponentView {
   void ensureDrawingSurface() noexcept;
 
   facebook::react::Size m_contentSize;
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
   facebook::react::SharedViewProps m_props;
   winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface m_drawingSurface;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -80,7 +80,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   std::string GetTextFromRichEdit() const noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   winrt::Microsoft::ReactNative::Composition::ICaretVisual m_caretVisual{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
   winrt::Microsoft::ReactNative::Composition::ICompositionDrawingSurface m_drawingSurface{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
@@ -44,7 +44,7 @@ struct UnimplementedNativeViewComponentView : CompositionBaseComponentView {
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag);
   std::shared_ptr<facebook::react::UnimplementedNativeViewProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::SpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
 };
 
 } // namespace Microsoft::ReactNative

--- a/yarn.lock
+++ b/yarn.lock
@@ -1416,115 +1416,115 @@
     tar "^6.1.11"
     tar-stream "^2.1.4"
 
-"@esbuild/android-arm64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.16.tgz#34f562abc0015933aabd41b3d50d8d3359e30155"
-  integrity sha512-wsCqSPqLz+6Ov+OM4EthU43DyYVVyfn15S4j1bJzylDpc1r1jZFFfJQNfDuT8SlgwuqpmpJXK4uPlHGw6ve7eA==
+"@esbuild/android-arm64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.2.tgz#bc35990f412a749e948b792825eef7df0ce0e073"
+  integrity sha512-lsB65vAbe90I/Qe10OjkmrdxSX4UJDjosDgb8sZUKcg3oefEuW2OT2Vozz8ef7wrJbMcmhvCC+hciF8jY/uAkw==
 
-"@esbuild/android-arm@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.16.tgz#ef6f9aa59a79a9b9330a2e73f7eb402c6630c267"
-  integrity sha512-gCHjjQmA8L0soklKbLKA6pgsLk1byULuHe94lkZDzcO3/Ta+bbeewJioEn1Fr7kgy9NWNFy/C+MrBwC6I/WCug==
+"@esbuild/android-arm@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.19.2.tgz#edd1c8f23ba353c197f5b0337123c58ff2a56999"
+  integrity sha512-tM8yLeYVe7pRyAu9VMi/Q7aunpLwD139EY1S99xbQkT4/q2qa6eA4ige/WJQYdJ8GBL1K33pPFhPfPdJ/WzT8Q==
 
-"@esbuild/android-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.16.tgz#ed7444cb17542932c67b15e20528686853239cfd"
-  integrity sha512-ldsTXolyA3eTQ1//4DS+E15xl0H/3DTRJaRL0/0PgkqDsI0fV/FlOtD+h0u/AUJr+eOTlZv4aC9gvfppo3C4sw==
+"@esbuild/android-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.19.2.tgz#2dcdd6e6f1f2d82ea1b746abd8da5b284960f35a"
+  integrity sha512-qK/TpmHt2M/Hg82WXHRc/W/2SGo/l1thtDHZWqFq7oi24AjZ4O/CpPSu6ZuYKFkEgmZlFoa7CooAyYmuvnaG8w==
 
-"@esbuild/darwin-arm64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.16.tgz#3c5a083e6e08a50f478fa243939989d86be1c6bf"
-  integrity sha512-aBxruWCII+OtluORR/KvisEw0ALuw/qDQWvkoosA+c/ngC/Kwk0lLaZ+B++LLS481/VdydB2u6tYpWxUfnLAIw==
+"@esbuild/darwin-arm64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.19.2.tgz#55b36bc06d76f5c243987c1f93a11a80d8fc3b26"
+  integrity sha512-Ora8JokrvrzEPEpZO18ZYXkH4asCdc1DLdcVy8TGf5eWtPO1Ie4WroEJzwI52ZGtpODy3+m0a2yEX9l+KUn0tA==
 
-"@esbuild/darwin-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.16.tgz#a8f3b61bee2807131cbe28eb164ad2b0333b59f5"
-  integrity sha512-6w4Dbue280+rp3LnkgmriS1icOUZDyPuZo/9VsuMUTns7SYEiOaJ7Ca1cbhu9KVObAWfmdjUl4gwy9TIgiO5eA==
+"@esbuild/darwin-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.19.2.tgz#982524af33a6424a3b5cb44bbd52559623ad719c"
+  integrity sha512-tP+B5UuIbbFMj2hQaUr6EALlHOIOmlLM2FK7jeFBobPy2ERdohI4Ka6ZFjZ1ZYsrHE/hZimGuU90jusRE0pwDw==
 
-"@esbuild/freebsd-arm64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.16.tgz#9bdbb3f0e5f0842b21c9b8602e70c106174ac24c"
-  integrity sha512-x35fCebhe9s979DGKbVAwXUOcTmCIE32AIqB9CB1GralMIvxdnMLAw5CnID17ipEw9/3MvDsusj/cspYt2ZLNQ==
+"@esbuild/freebsd-arm64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.2.tgz#8e478a0856645265fe79eac4b31b52193011ee06"
+  integrity sha512-YbPY2kc0acfzL1VPVK6EnAlig4f+l8xmq36OZkU0jzBVHcOTyQDhnKQaLzZudNJQyymd9OqQezeaBgkTGdTGeQ==
 
-"@esbuild/freebsd-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.16.tgz#24f73956436495cc7a5a4bf06be6b661aea6a2c1"
-  integrity sha512-YM98f+PeNXF3GbxIJlUsj+McUWG1irguBHkszCIwfr3BXtXZsXo0vqybjUDFfu9a8Wr7uUD/YSmHib+EeGAFlg==
+"@esbuild/freebsd-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.2.tgz#01b96604f2540db023c73809bb8ae6cd1692d6f3"
+  integrity sha512-nSO5uZT2clM6hosjWHAsS15hLrwCvIWx+b2e3lZ3MwbYSaXwvfO528OF+dLjas1g3bZonciivI8qKR/Hm7IWGw==
 
-"@esbuild/linux-arm64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.16.tgz#244569757f9cbd912f5a595a8ad8144f8c915f13"
-  integrity sha512-XIqhNUxJiuy+zsR77+H5Z2f7s4YRlriSJKtvx99nJuG5ATuJPjmZ9n0ANgnGlPCpXGSReFpgcJ7O3SMtzIFeiQ==
+"@esbuild/linux-arm64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.19.2.tgz#7e5d2c7864c5c83ec789b59c77cd9c20d2594916"
+  integrity sha512-ig2P7GeG//zWlU0AggA3pV1h5gdix0MA3wgB+NsnBXViwiGgY77fuN9Wr5uoCrs2YzaYfogXgsWZbm+HGr09xg==
 
-"@esbuild/linux-arm@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.16.tgz#d63923c63af534032cc5ea0b2a0b3de10f8357f5"
-  integrity sha512-b5ABb+5Ha2C9JkeZXV+b+OruR1tJ33ePmv9ZwMeETSEKlmu/WJ45XTTG+l6a2KDsQtJJ66qo/hbSGBtk0XVLHw==
+"@esbuild/linux-arm@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.19.2.tgz#c32ae97bc0246664a1cfbdb4a98e7b006d7db8ae"
+  integrity sha512-Odalh8hICg7SOD7XCj0YLpYCEc+6mkoq63UnExDCiRA2wXEmGlK5JVrW50vZR9Qz4qkvqnHcpH+OFEggO3PgTg==
 
-"@esbuild/linux-ia32@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.16.tgz#a8825ccea6309f0bccfc5d87b43163ba804c2f20"
-  integrity sha512-no+pfEpwnRvIyH+txbBAWtjxPU9grslmTBfsmDndj7bnBmr55rOo/PfQmRfz7Qg9isswt1FP5hBbWb23fRWnow==
+"@esbuild/linux-ia32@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.19.2.tgz#3fc4f0fa026057fe885e4a180b3956e704f1ceaa"
+  integrity sha512-mLfp0ziRPOLSTek0Gd9T5B8AtzKAkoZE70fneiiyPlSnUKKI4lp+mGEnQXcQEHLJAcIYDPSyBvsUbKUG2ri/XQ==
 
-"@esbuild/linux-loong64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.16.tgz#f530e820fc3c61cf2206155b994aeab53b6d25be"
-  integrity sha512-Zbnczs9ZXjmo0oZSS0zbNlJbcwKXa/fcNhYQjahDs4Xg18UumpXG/lwM2lcSvHS3mTrRyCYZvJbmzYc4laRI1g==
+"@esbuild/linux-loong64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.19.2.tgz#633bcaea443f3505fb0ed109ab840c99ad3451a4"
+  integrity sha512-hn28+JNDTxxCpnYjdDYVMNTR3SKavyLlCHHkufHV91fkewpIyQchS1d8wSbmXhs1fiYDpNww8KTFlJ1dHsxeSw==
 
-"@esbuild/linux-mips64el@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.16.tgz#2d47ace539257896865d243641bd6716684a1e82"
-  integrity sha512-YMF7hih1HVR/hQVa/ot4UVffc5ZlrzEb3k2ip0nZr1w6fnYypll9td2qcoMLvd3o8j3y6EbJM3MyIcXIVzXvQQ==
+"@esbuild/linux-mips64el@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.2.tgz#e0bff2898c46f52be7d4dbbcca8b887890805823"
+  integrity sha512-KbXaC0Sejt7vD2fEgPoIKb6nxkfYW9OmFUK9XQE4//PvGIxNIfPk1NmlHmMg6f25x57rpmEFrn1OotASYIAaTg==
 
-"@esbuild/linux-ppc64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.16.tgz#d6913e7e9be9e242a6a20402800141bdbe7009f7"
-  integrity sha512-Wkz++LZ29lDwUyTSEnzDaaP5OveOgTU69q9IyIw9WqLRxM4BjTBjz9un4G6TOvehWpf/J3gYVFN96TjGHrbcNQ==
+"@esbuild/linux-ppc64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.19.2.tgz#d75798da391f54a9674f8c143b9a52d1dbfbfdde"
+  integrity sha512-dJ0kE8KTqbiHtA3Fc/zn7lCd7pqVr4JcT0JqOnbj4LLzYnp+7h8Qi4yjfq42ZlHfhOCM42rBh0EwHYLL6LEzcw==
 
-"@esbuild/linux-riscv64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.16.tgz#8f33b627389c8234fe61f4636c134f17fb1d9b09"
-  integrity sha512-LFMKZ30tk78/mUv1ygvIP+568bwf4oN6reG/uczXnz6SvFn4e2QUFpUpZY9iSJT6Qpgstrhef/nMykIXZtZWGQ==
+"@esbuild/linux-riscv64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.2.tgz#012409bd489ed1bb9b775541d4a46c5ded8e6dd8"
+  integrity sha512-7Z/jKNFufZ/bbu4INqqCN6DDlrmOTmdw6D0gH+6Y7auok2r02Ur661qPuXidPOJ+FSgbEeQnnAGgsVynfLuOEw==
 
-"@esbuild/linux-s390x@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.16.tgz#4d44c030f78962cf410f604f92fcc1505e4afdde"
-  integrity sha512-3ZC0BgyYHYKfZo3AV2/66TD/I9tlSBaW7eWTEIkrQQKfJIifKMMttXl9FrAg+UT0SGYsCRLI35Gwdmm96vlOjg==
+"@esbuild/linux-s390x@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.19.2.tgz#ece3ed75c5a150de8a5c110f02e97d315761626b"
+  integrity sha512-U+RinR6aXXABFCcAY4gSlv4CL1oOVvSSCdseQmGO66H+XyuQGZIUdhG56SZaDJQcLmrSfRmx5XZOWyCJPRqS7g==
 
-"@esbuild/linux-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.16.tgz#8846d00e16b1e93eb488c8b4dd51c946adfc236f"
-  integrity sha512-xu86B3647DihHJHv/wx3NCz2Dg1gjQ8bbf9cVYZzWKY+gsvxYmn/lnVlqDRazObc3UMwoHpUhNYaZset4X8IPA==
+"@esbuild/linux-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.19.2.tgz#dea187019741602d57aaf189a80abba261fbd2aa"
+  integrity sha512-oxzHTEv6VPm3XXNaHPyUTTte+3wGv7qVQtqaZCrgstI16gCuhNOtBXLEBkBREP57YTd68P0VgDgG73jSD8bwXQ==
 
-"@esbuild/netbsd-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.16.tgz#6514a86bd07744f3100d2813ea2fb6520d53e72e"
-  integrity sha512-uVAgpimx9Ffw3xowtg/7qQPwHFx94yCje+DoBx+LNm2ePDpQXHrzE+Sb0Si2VBObYz+LcRps15cq+95YM7gkUw==
+"@esbuild/netbsd-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.19.2.tgz#bbfd7cf9ab236a23ee3a41b26f0628c57623d92a"
+  integrity sha512-WNa5zZk1XpTTwMDompZmvQLHszDDDN7lYjEHCUmAGB83Bgs20EMs7ICD+oKeT6xt4phV4NDdSi/8OfjPbSbZfQ==
 
-"@esbuild/openbsd-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.16.tgz#ae67ce766d58aab6c0e6037f1a76f15df4a2a5fe"
-  integrity sha512-6OjCQM9wf7z8/MBi6BOWaTL2AS/SZudsZtBziXMtNI8r/U41AxS9x7jn0ATOwVy08OotwkPqGRMkpPR2wcTJXA==
+"@esbuild/openbsd-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.2.tgz#fa5c4c6ee52a360618f00053652e2902e1d7b4a7"
+  integrity sha512-S6kI1aT3S++Dedb7vxIuUOb3oAxqxk2Rh5rOXOTYnzN8JzW1VzBd+IqPiSpgitu45042SYD3HCoEyhLKQcDFDw==
 
-"@esbuild/sunos-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.16.tgz#998efe8a58374b7351ac710455051639a6ce6a05"
-  integrity sha512-ZoNkruFYJp9d1LbUYCh8awgQDvB9uOMZqlQ+gGEZR7v6C+N6u7vPr86c+Chih8niBR81Q/bHOSKGBK3brJyvkQ==
+"@esbuild/sunos-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.19.2.tgz#52a2ac8ac6284c02d25df22bb4cfde26fbddd68d"
+  integrity sha512-VXSSMsmb+Z8LbsQGcBMiM+fYObDNRm8p7tkUDMPG/g4fhFX5DEFmjxIEa3N8Zr96SjsJ1woAhF0DUnS3MF3ARw==
 
-"@esbuild/win32-arm64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.16.tgz#8de33682243508eef8d4de1816df2c05adad2b21"
-  integrity sha512-+j4anzQ9hrs+iqO+/wa8UE6TVkKua1pXUb0XWFOx0FiAj6R9INJ+WE//1/Xo6FG1vB5EpH3ko+XcgwiDXTxcdw==
+"@esbuild/win32-arm64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.19.2.tgz#719ed5870855de8537aef8149694a97d03486804"
+  integrity sha512-5NayUlSAyb5PQYFAU9x3bHdsqB88RC3aM9lKDAz4X1mo/EchMIT1Q+pSeBXNgkfNmRecLXA0O8xP+x8V+g/LKg==
 
-"@esbuild/win32-ia32@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.16.tgz#95c9f4274fb3ef9e449d464ffe3e3b7fa091503b"
-  integrity sha512-5PFPmq3sSKTp9cT9dzvI67WNfRZGvEVctcZa1KGjDDu4n3H8k59Inbk0du1fz0KrAbKKNpJbdFXQMDUz7BG4rQ==
+"@esbuild/win32-ia32@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.19.2.tgz#24832223880b0f581962c8660f8fb8797a1e046a"
+  integrity sha512-47gL/ek1v36iN0wL9L4Q2MFdujR0poLZMJwhO2/N3gA89jgHp4MR8DKCmwYtGNksbfJb9JoTtbkoe6sDhg2QTA==
 
-"@esbuild/win32-x64@0.18.16":
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.16.tgz#5be58d31d0120c68af8e38b702e6937ce764cd68"
-  integrity sha512-sCIVrrtcWN5Ua7jYXNG1xD199IalrbfV2+0k/2Zf2OyV2FtnQnMgdzgpRAbi4AWlKJj1jkX+M+fEGPQj6BQB4w==
+"@esbuild/win32-x64@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.2.tgz#1205014625790c7ff0e471644a878a65d1e34ab0"
+  integrity sha512-tcuhV7ncXBqbt/Ybf0IyrMcwVOAPDckMK9rXNHtF17UTK18OKLpg08glminN06pt2WCoALhXdLfSPbVvK/6fxw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.2.0"
@@ -2529,23 +2529,23 @@
     babel-plugin-const-enum "^1.0.0"
 
 "@rnx-kit/cli@^0.16.10":
-  version "0.16.10"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.16.10.tgz#bdddf17828b6225562021145d03d3eb71fed2034"
-  integrity sha512-k5X2e5Aw0p3QDHVi8qIHeWZBhZMnD5ETKQZ2ZyuU0/02TB4efrTZurKiHWXRsBqlM7eSxHz8+mQXUvJ23MTY1A==
+  version "0.16.13"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/cli/-/cli-0.16.13.tgz#83e50c67efb1d8965d9dc056da4d2711852936ca"
+  integrity sha512-95TnWps5ghawJMGtARG+eD4UTCOIslG97YZY/Y4yiDZKF9euGdwrdAcU0H4dfEQr5Q6Zw3AVTWLpW9LQvP6N0Q==
   dependencies:
     "@rnx-kit/align-deps" "^2.2.2"
     "@rnx-kit/config" "^0.6.2"
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/metro-plugin-cyclic-dependencies-detector" "^1.1.1"
     "@rnx-kit/metro-plugin-duplicates-checker" "^2.1.1"
-    "@rnx-kit/metro-plugin-typescript" "^0.4.1"
-    "@rnx-kit/metro-serializer" "^1.0.11"
-    "@rnx-kit/metro-serializer-esbuild" "^0.1.22"
-    "@rnx-kit/metro-service" "^3.0.4"
-    "@rnx-kit/third-party-notices" "^1.3.3"
+    "@rnx-kit/metro-plugin-typescript" "^0.4.4"
+    "@rnx-kit/metro-serializer" "^1.0.12"
+    "@rnx-kit/metro-serializer-esbuild" "^0.1.28"
+    "@rnx-kit/metro-service" "^3.1.1"
+    "@rnx-kit/third-party-notices" "^1.3.4"
     "@rnx-kit/tools-language" "^2.0.0"
     "@rnx-kit/tools-node" "^2.0.0"
-    "@rnx-kit/tools-react-native" "^1.3.1"
+    "@rnx-kit/tools-react-native" "^1.3.2"
     chalk "^4.1.0"
     find-up "^5.0.0"
     fs-extra "^10.0.0"
@@ -2579,9 +2579,9 @@
     find-up "^5.0.0"
 
 "@rnx-kit/metro-config@^1.3.5":
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-config/-/metro-config-1.3.8.tgz#ca5d4960c646f11b563ef675ff79be15d05809fd"
-  integrity sha512-jywzqKT43A4XlSNFMWEqxlqeshhdwwr6zAd+uV/Yx3HvwD7VNWMPAUlHqyVs1SAuNqnOrCQR23mI8hH8xyTQyA==
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-config/-/metro-config-1.3.9.tgz#5deefd9652ba6e553a8f1d102b200371d6ae2755"
+  integrity sha512-jAnMv11P+hknBz3fAkw0wK4ytf7ROr3kD6mwBdX6ggL2q85e3bozTm7PIymF4uI17tjgBbOGNsgZnU76Lu3SSw==
   dependencies:
     "@rnx-kit/babel-preset-metro-react-native" "^1.1.4"
     "@rnx-kit/console" "^1.0.0"
@@ -2605,51 +2605,52 @@
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/tools-node" "^2.0.0"
 
-"@rnx-kit/metro-plugin-typescript@^0.4.1":
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-typescript/-/metro-plugin-typescript-0.4.3.tgz#edd73c1afc0911a63c9371bba81766058ef4ac97"
-  integrity sha512-ehyHCHnGYlTFi7eAxAY/ZAZDzquOb/L/0LDq3asfbAQwTeF8M9+FQTCTk3R8O3gIAnoQVvhXzJ3pmD+iBiNAjg==
+"@rnx-kit/metro-plugin-typescript@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-plugin-typescript/-/metro-plugin-typescript-0.4.4.tgz#698af351134eadd4c84ceaf03a941f0c419c3602"
+  integrity sha512-cTzBrJ5FIotYCep/vSDk1mp8vf7h+VYwngSUZdtAo1MzWEd7alM6eHetdEzv0MnqxvOH5nLwhZrJBlJWXLqCBA==
   dependencies:
     "@rnx-kit/config" "^0.6.3"
     "@rnx-kit/console" "^1.0.0"
     "@rnx-kit/tools-node" "^2.0.0"
-    "@rnx-kit/tools-react-native" "^1.3.1"
-    "@rnx-kit/typescript-service" "^1.5.6"
+    "@rnx-kit/tools-react-native" "^1.3.2"
+    "@rnx-kit/typescript-service" "^1.5.7"
     semver "^7.0.0"
     typescript ">=4.7.0"
 
-"@rnx-kit/metro-serializer-esbuild@^0.1.22":
-  version "0.1.26"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-serializer-esbuild/-/metro-serializer-esbuild-0.1.26.tgz#2a4a5e2f5f1248f8f694069d934c0edc97979396"
-  integrity sha512-W0dCYRhmImgCtR4q/BZNiNj9GxHYhATI0+T6zGholkZSBsu/C0eUY8mX0w1QORYlFZRYMzbbnoDBiMr2wRge4A==
+"@rnx-kit/metro-serializer-esbuild@^0.1.28":
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-serializer-esbuild/-/metro-serializer-esbuild-0.1.28.tgz#20edbb73546b92c27bc840e91c8bdb6335e6b7c0"
+  integrity sha512-MGaFm3T7pHrsYClvwIEm0yn547ZC/rFMxJ3Bxqzx5Pl1t9WzYVzbRePgxyIsNoPjJ4y/CKQ8nDhvNmty6nwDRw==
   dependencies:
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/tools-node" "^2.0.0"
-    "@rnx-kit/tools-react-native" "^1.3.1"
-    esbuild "^0.18.0"
+    "@rnx-kit/tools-react-native" "^1.3.2"
+    esbuild "^0.19.0"
     esbuild-plugin-lodash "^1.2.0"
     fast-glob "^3.2.7"
     semver "^7.0.0"
 
-"@rnx-kit/metro-serializer@^1.0.11":
+"@rnx-kit/metro-serializer@^1.0.11", "@rnx-kit/metro-serializer@^1.0.12":
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@rnx-kit/metro-serializer/-/metro-serializer-1.0.12.tgz#c244c2f26b3470ea26734588cd956043a4677c25"
   integrity sha512-fAiY2UIeLsziZWAQ16BsljBvCACTcf6dakflnsY7/8C0MJXoo9gxImcV+r0Fgimcjm3bjmZLOcaLv8N/h0UAoA==
   dependencies:
     semver "^7.0.0"
 
-"@rnx-kit/metro-service@^3.0.4":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-service/-/metro-service-3.0.5.tgz#c7e1259eaeebda00f14ba9f9fc154b9021ae4b61"
-  integrity sha512-te9JDNtkPbEROYuW+KbYHZ2yv3QTz4LqrITU34uRUEwCtUirDR6sxaaB+p4vUO3EuahWMQpTSCeVfLggCv0Kow==
+"@rnx-kit/metro-service@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/metro-service/-/metro-service-3.1.1.tgz#af108aa9ca2b6d8bd62060fe6fecc88a5442ff1b"
+  integrity sha512-PlKcggGrc7GKZ/21/7s2+FU7IV/5jYiOmruh1Mz0UTHuVWzPJE4z1+yNu+ZM51QF6tzEvBcjhArW5L/dnbWWiQ==
   dependencies:
+    "@rnx-kit/console" "^1.0.0"
     "@rnx-kit/tools-language" "^2.0.0"
     chalk "^4.1.0"
 
-"@rnx-kit/third-party-notices@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/third-party-notices/-/third-party-notices-1.3.3.tgz#febc4609b32c95cabc00bd18546c2b96bcc89241"
-  integrity sha512-VPmrG0goSMlnlGa2aOFr4yzo6upT6KxqXeRSq5yPDnoSHuU4AeOPihWJHRw6Yw5PP+C629XbJnM5RcHEKhpZMg==
+"@rnx-kit/third-party-notices@^1.3.4":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/third-party-notices/-/third-party-notices-1.3.4.tgz#0d691a7f8b1d953791bd9963f1eae130854400af"
+  integrity sha512-L0i4ZbEBMfFwk6VhbIoJ8EgzVsadopajPnCFJig+yoVSp19eN+Snfp9Zz7BC0a7sOEY/NURzZjhcTeYzN3otCQ==
   dependencies:
     "@rnx-kit/console" "^1.0.11"
     "@rnx-kit/tools-node" "^2.0.0"
@@ -2671,27 +2672,27 @@
     pkg-dir "^5.0.0"
     pkg-up "^3.1.0"
 
-"@rnx-kit/tools-react-native@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/tools-react-native/-/tools-react-native-1.3.1.tgz#5a49723cd916e2d39b424797e4fb6457b5ae7d71"
-  integrity sha512-zip8tXSN6iV0v3LzbUjno1atJCDtC8gLrva9CN/gJRwpzkpZOlg1/aZlK0LbhvPs3P3t/3FUX5P3svMTi/fWdw==
+"@rnx-kit/tools-react-native@^1.3.1", "@rnx-kit/tools-react-native@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/tools-react-native/-/tools-react-native-1.3.2.tgz#1ef01fff23637c7124bf98ef4d8f55a49fdaf4f9"
+  integrity sha512-YZ2pMnD9AsW14CXhSgxMReDl+EEwRz+ou2ECDpljYHauPGZEHZ+5wLa5UA/HBSEU4/MBYUhrRDy1rmoiXf8oKA==
   dependencies:
     "@rnx-kit/tools-node" "^2.0.0"
 
 "@rnx-kit/tools-workspaces@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/tools-workspaces/-/tools-workspaces-0.1.3.tgz#6f9d18c5662d9e94ccc01572b33be7fdef82a443"
-  integrity sha512-3oBulRHCatRKkTYFDrRc/Bli62ATnUQ7zNheAxXdylYWGk9bR7Rdfe+SCzt3Npytljg8KOFT8kTugpGJLmaasQ==
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/tools-workspaces/-/tools-workspaces-0.1.4.tgz#79eb624b9a7f751d932f07e70bb29d3529bc2123"
+  integrity sha512-Ov+7PjXkKDqCMN3yV0nqLag76UGzAJetwagKuYYvV8/dJRiMCR2CMGRa3tnR0Fv0t0Q6AAGG5X3LvXnnqVjQgg==
   dependencies:
     fast-glob "^3.2.7"
     find-up "^5.0.0"
     read-yaml-file "^2.1.0"
     strip-json-comments "^3.1.1"
 
-"@rnx-kit/typescript-service@^1.5.6":
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/@rnx-kit/typescript-service/-/typescript-service-1.5.6.tgz#f1b608113316e21dc9998d70a5b1a44a8b6f1665"
-  integrity sha512-3Q1PpLI0oJ5XUZfr7lro72gWDBqWX6J7O6OHGibNtciE21ZaNCFLWbAzpabDz4NbZ7dcuYhr1j3JUCnNpJ7GAg==
+"@rnx-kit/typescript-service@^1.5.7":
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/@rnx-kit/typescript-service/-/typescript-service-1.5.7.tgz#c4760f0d73f273f268a5f9d71fb99976dc755f58"
+  integrity sha512-vsU8qCPsA/Ki7y+XDP8J/j5nH3qYNkJWlw/3X3bHalFu6qEtGog/E4SbIEHmHifAfnh9VhAXgbm3RZbW1liCSQ==
   dependencies:
     "@rnx-kit/tools-node" "^2.0.0"
     chalk "^4.1.0"
@@ -5572,33 +5573,33 @@ esbuild-plugin-lodash@^1.2.0:
   resolved "https://registry.yarnpkg.com/esbuild-plugin-lodash/-/esbuild-plugin-lodash-1.2.0.tgz#6395b64cbb9b23a1bee3e37fbbdd98c50bd0b53a"
   integrity sha512-8CyR67Z/VMvcJ4ABYYSaR2hhioeuoFVII1IsyPb6AwAKN57VQW8jFXyY27OwH4FGU3h3OVwwQ/GVNbo+RgpTGA==
 
-esbuild@^0.18.0:
-  version "0.18.16"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.16.tgz#bbeb058c556152bcbff4e8168e7c93020ccf09c3"
-  integrity sha512-1xLsOXrDqwdHxyXb/x/SOyg59jpf/SH7YMvU5RNSU7z3TInaASNJWNFJ6iRvLvLETZMasF3d1DdZLg7sgRimRQ==
+esbuild@^0.19.0:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.2.tgz#b1541828a89dfb6f840d38538767c6130dca2aac"
+  integrity sha512-G6hPax8UbFakEj3hWO0Vs52LQ8k3lnBhxZWomUJDxfz3rZTLqF5k/FCzuNdLx2RbpBiQQF9H9onlDDH1lZsnjg==
   optionalDependencies:
-    "@esbuild/android-arm" "0.18.16"
-    "@esbuild/android-arm64" "0.18.16"
-    "@esbuild/android-x64" "0.18.16"
-    "@esbuild/darwin-arm64" "0.18.16"
-    "@esbuild/darwin-x64" "0.18.16"
-    "@esbuild/freebsd-arm64" "0.18.16"
-    "@esbuild/freebsd-x64" "0.18.16"
-    "@esbuild/linux-arm" "0.18.16"
-    "@esbuild/linux-arm64" "0.18.16"
-    "@esbuild/linux-ia32" "0.18.16"
-    "@esbuild/linux-loong64" "0.18.16"
-    "@esbuild/linux-mips64el" "0.18.16"
-    "@esbuild/linux-ppc64" "0.18.16"
-    "@esbuild/linux-riscv64" "0.18.16"
-    "@esbuild/linux-s390x" "0.18.16"
-    "@esbuild/linux-x64" "0.18.16"
-    "@esbuild/netbsd-x64" "0.18.16"
-    "@esbuild/openbsd-x64" "0.18.16"
-    "@esbuild/sunos-x64" "0.18.16"
-    "@esbuild/win32-arm64" "0.18.16"
-    "@esbuild/win32-ia32" "0.18.16"
-    "@esbuild/win32-x64" "0.18.16"
+    "@esbuild/android-arm" "0.19.2"
+    "@esbuild/android-arm64" "0.19.2"
+    "@esbuild/android-x64" "0.19.2"
+    "@esbuild/darwin-arm64" "0.19.2"
+    "@esbuild/darwin-x64" "0.19.2"
+    "@esbuild/freebsd-arm64" "0.19.2"
+    "@esbuild/freebsd-x64" "0.19.2"
+    "@esbuild/linux-arm" "0.19.2"
+    "@esbuild/linux-arm64" "0.19.2"
+    "@esbuild/linux-ia32" "0.19.2"
+    "@esbuild/linux-loong64" "0.19.2"
+    "@esbuild/linux-mips64el" "0.19.2"
+    "@esbuild/linux-ppc64" "0.19.2"
+    "@esbuild/linux-riscv64" "0.19.2"
+    "@esbuild/linux-s390x" "0.19.2"
+    "@esbuild/linux-x64" "0.19.2"
+    "@esbuild/netbsd-x64" "0.19.2"
+    "@esbuild/openbsd-x64" "0.19.2"
+    "@esbuild/sunos-x64" "0.19.2"
+    "@esbuild/win32-arm64" "0.19.2"
+    "@esbuild/win32-ia32" "0.19.2"
+    "@esbuild/win32-x64" "0.19.2"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Description
By using `runtimeclass` in `CompositionSwitch` we prevent apps from being able to provide their own implementation of the `CompositionSwitcher`, which defeats its purpose.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12090)