### PR TITLE
Be more explicit when using winrt::Windows types, to avoid conflicts with WinAppSDK

### DIFF
--- a/change/react-native-windows-630e2ba2-a26a-4722-b93c-bfb489443e93.json
+++ b/change/react-native-windows-630e2ba2-a26a-4722-b93c-bfb489443e93.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Be more explicit when using winrt::Windows types, to avoid conflicts with WinAppSDK",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.cpp
@@ -112,7 +112,7 @@ void JsiHostObjectWrapper::SetProperty(
   throw;
 }
 
-Windows::Foundation::Collections::IVector<JsiPropertyIdRef> JsiHostObjectWrapper::GetPropertyIds(
+winrt::Windows::Foundation::Collections::IVector<JsiPropertyIdRef> JsiHostObjectWrapper::GetPropertyIds(
     JsiRuntime const &runtime) try {
   JsiAbiRuntime *rt{JsiAbiRuntime::GetFromJsiRuntime(runtime)};
   auto names = m_hostObject->getPropertyNames(*rt);

--- a/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSI/JsiAbiApi.h
@@ -46,7 +46,7 @@ struct JsiHostObjectWrapper : implements<JsiHostObjectWrapper, IJsiHostObject> {
 
   JsiValueRef GetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name);
   void SetProperty(JsiRuntime const &runtime, JsiPropertyIdRef const &name, JsiValueRef const &value);
-  Windows::Foundation::Collections::IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime const &runtime);
+  winrt::Windows::Foundation::Collections::IVector<JsiPropertyIdRef> GetPropertyIds(JsiRuntime const &runtime);
 
   std::shared_ptr<facebook::jsi::HostObject> const &HostObjectSharedPtr() noexcept;
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactHandleHelper.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactHandleHelper.h
@@ -27,7 +27,7 @@ auto TestHandle(int *) -> void;
 
 template <class T>
 inline constexpr bool HasHandleV =
-    std::is_base_of_v<Windows::Foundation::IInspectable, std::decay_t<decltype(Internal::TestHandle<T>(0))>>;
+    std::is_base_of_v<winrt::Windows::Foundation::IInspectable, std::decay_t<decltype(Internal::TestHandle<T>(0))>>;
 
 // True if two types with Handle() have the same handle.
 template <class T, std::enable_if_t<HasHandleV<T>, int> = 0>

--- a/vnext/Microsoft.ReactNative.Cxx/ReactNonAbiValue.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactNonAbiValue.h
@@ -44,7 +44,7 @@ struct ReactNonAbiValue : implements<ReactNonAbiValue<T>, IReactNonAbiValue> {
 // a new instance of implementation::ReactNonAbiValue. The std::in_place allows to disambiguate the calls to
 // other constructors.
 template <class T>
-struct ReactNonAbiValue : Windows::Foundation::IInspectable {
+struct ReactNonAbiValue : winrt::Windows::Foundation::IInspectable {
   // Create a new instance of implementation::ReactNonAbiValue with args and keep a ref-counted pointer to it.
   template <class... TArgs>
   ReactNonAbiValue(std::in_place_t, TArgs &&...args) noexcept

--- a/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
@@ -129,15 +129,16 @@ struct ReactNotificationArgs : ReactNotificationArgsBase {
 };
 
 template <class THandle, class TData>
-inline constexpr bool IsValidHandlerV =
-    std::is_invocable_v<THandle, winrt::Windows::Foundation::IInspectable const &, ReactNotificationArgs<TData> const &>;
+inline constexpr bool IsValidHandlerV = std::
+    is_invocable_v<THandle, winrt::Windows::Foundation::IInspectable const &, ReactNotificationArgs<TData> const &>;
 
 struct ReactNotificationService {
   // Notification data result type is either T or std::optional<T>.
   // T is returned for types inherited from IInspectable.
   // The std::optional<T> is returned for all other types.
   template <class T>
-  using ResultType = std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
+  using ResultType =
+      std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
 
   // Create a new empty instance of ReactNotificationService.
   ReactNotificationService(std::nullptr_t = nullptr) noexcept {}
@@ -165,7 +166,7 @@ struct ReactNotificationService {
               notificationId.Handle(),
               dispatcher.Handle(),
               [handler = std::forward<THandler>(handler)](
-                winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
+                  winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
                 handler(sender, ReactNotificationArgs<TData>{args});
               })
         : nullptr;
@@ -192,7 +193,7 @@ struct ReactNotificationService {
               notificationId.Handle(),
               dispatcher.Handle(),
               [handler = std::forward<THandler>(handler)](
-                winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
+                  winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
                 handler(sender, ReactNotificationArgs<TData>{args});
               })
         : nullptr;
@@ -211,7 +212,7 @@ struct ReactNotificationService {
   static void SendNotification(
       IReactNotificationService const &handle,
       ReactNotificationId<TData> const &notificationId,
-    ::winrt::Windows::Foundation::IInspectable const &sender,
+      ::winrt::Windows::Foundation::IInspectable const &sender,
       TValue &&value) noexcept {
     if (handle) {
       handle.SendNotification(
@@ -222,7 +223,7 @@ struct ReactNotificationService {
   static void SendNotification(
       IReactNotificationService const &handle,
       ReactNotificationId<void> const &notificationId,
-    winrt::Windows::Foundation::IInspectable const &sender) noexcept {
+      winrt::Windows::Foundation::IInspectable const &sender) noexcept {
     if (handle) {
       handle.SendNotification(notificationId.Handle(), sender, nullptr);
     }
@@ -279,14 +280,14 @@ struct ReactNotificationService {
   template <class TData, class TValue, std::enable_if_t<!std::is_void_v<TData>, int> = 0>
   void SendNotification(
       ReactNotificationId<TData> const &notificationId,
-    winrt::Windows::Foundation::IInspectable const &sender,
+      winrt::Windows::Foundation::IInspectable const &sender,
       TValue &&value) const noexcept {
     SendNotification(m_handle, notificationId, sender, std::forward<TValue>(value));
   }
 
   void SendNotification(
       ReactNotificationId<void> const &notificationId,
-    winrt::Windows::Foundation::IInspectable const &sender) const noexcept {
+      winrt::Windows::Foundation::IInspectable const &sender) const noexcept {
     SendNotification(m_handle, notificationId, sender);
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactNotificationService.h
@@ -130,14 +130,14 @@ struct ReactNotificationArgs : ReactNotificationArgsBase {
 
 template <class THandle, class TData>
 inline constexpr bool IsValidHandlerV =
-    std::is_invocable_v<THandle, Windows::Foundation::IInspectable const &, ReactNotificationArgs<TData> const &>;
+    std::is_invocable_v<THandle, winrt::Windows::Foundation::IInspectable const &, ReactNotificationArgs<TData> const &>;
 
 struct ReactNotificationService {
   // Notification data result type is either T or std::optional<T>.
   // T is returned for types inherited from IInspectable.
   // The std::optional<T> is returned for all other types.
   template <class T>
-  using ResultType = std::conditional_t<std::is_base_of_v<Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
+  using ResultType = std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
 
   // Create a new empty instance of ReactNotificationService.
   ReactNotificationService(std::nullptr_t = nullptr) noexcept {}
@@ -165,7 +165,7 @@ struct ReactNotificationService {
               notificationId.Handle(),
               dispatcher.Handle(),
               [handler = std::forward<THandler>(handler)](
-                  Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
+                winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
                 handler(sender, ReactNotificationArgs<TData>{args});
               })
         : nullptr;
@@ -192,7 +192,7 @@ struct ReactNotificationService {
               notificationId.Handle(),
               dispatcher.Handle(),
               [handler = std::forward<THandler>(handler)](
-                  Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
+                winrt::Windows::Foundation::IInspectable const &sender, IReactNotificationArgs const &args) noexcept {
                 handler(sender, ReactNotificationArgs<TData>{args});
               })
         : nullptr;
@@ -211,7 +211,7 @@ struct ReactNotificationService {
   static void SendNotification(
       IReactNotificationService const &handle,
       ReactNotificationId<TData> const &notificationId,
-      Windows::Foundation::IInspectable const &sender,
+    ::winrt::Windows::Foundation::IInspectable const &sender,
       TValue &&value) noexcept {
     if (handle) {
       handle.SendNotification(
@@ -222,7 +222,7 @@ struct ReactNotificationService {
   static void SendNotification(
       IReactNotificationService const &handle,
       ReactNotificationId<void> const &notificationId,
-      Windows::Foundation::IInspectable const &sender) noexcept {
+    winrt::Windows::Foundation::IInspectable const &sender) noexcept {
     if (handle) {
       handle.SendNotification(notificationId.Handle(), sender, nullptr);
     }
@@ -279,14 +279,14 @@ struct ReactNotificationService {
   template <class TData, class TValue, std::enable_if_t<!std::is_void_v<TData>, int> = 0>
   void SendNotification(
       ReactNotificationId<TData> const &notificationId,
-      Windows::Foundation::IInspectable const &sender,
+    winrt::Windows::Foundation::IInspectable const &sender,
       TValue &&value) const noexcept {
     SendNotification(m_handle, notificationId, sender, std::forward<TValue>(value));
   }
 
   void SendNotification(
       ReactNotificationId<void> const &notificationId,
-      Windows::Foundation::IInspectable const &sender) const noexcept {
+    winrt::Windows::Foundation::IInspectable const &sender) const noexcept {
     SendNotification(m_handle, notificationId, sender);
   }
 

--- a/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
@@ -165,7 +165,8 @@ struct ReactPropertyBag {
   // T is returned for types inherited from IInspectable.
   // The std::optional<T> is returned for all other types.
   template <class T>
-  using ResultType = std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
+  using ResultType =
+      std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
 
   // Create a new empty instance of ReactPropertyBag.
   ReactPropertyBag(std::nullptr_t = nullptr) noexcept {}

--- a/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
+++ b/vnext/Microsoft.ReactNative.Cxx/ReactPropertyBag.h
@@ -165,7 +165,7 @@ struct ReactPropertyBag {
   // T is returned for types inherited from IInspectable.
   // The std::optional<T> is returned for all other types.
   template <class T>
-  using ResultType = std::conditional_t<std::is_base_of_v<Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
+  using ResultType = std::conditional_t<std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>, T, std::optional<T>>;
 
   // Create a new empty instance of ReactPropertyBag.
   ReactPropertyBag(std::nullptr_t = nullptr) noexcept {}
@@ -186,7 +186,7 @@ struct ReactPropertyBag {
   // Get property value by property name.
   template <class T>
   static ResultType<T> Get(IReactPropertyBag const &handle, ReactPropertyId<T> const &propertyId) noexcept {
-    Windows::Foundation::IInspectable propertyValue = handle ? handle.Get(propertyId.Handle()) : nullptr;
+    winrt::Windows::Foundation::IInspectable propertyValue = handle ? handle.Get(propertyId.Handle()) : nullptr;
     return FromObject<T>(propertyValue);
   }
 
@@ -197,7 +197,7 @@ struct ReactPropertyBag {
       IReactPropertyBag const &handle,
       ReactPropertyId<T> const &propertyId,
       TCreateValue const &createValue) noexcept {
-    Windows::Foundation::IInspectable propertyValue = handle
+    winrt::Windows::Foundation::IInspectable propertyValue = handle
         ? handle.GetOrCreate(propertyId.Handle(), [&createValue]() noexcept { return ToObject<T>(createValue()); })
         : nullptr;
     return FromObject<T>(propertyValue);
@@ -247,7 +247,7 @@ struct ReactPropertyBag {
 
   // Box value to an ABI-safe object.
   template <class T, class TValue, std::enable_if_t<!IsReactNonAbiValueV<T> || std::is_same_v<T, TValue>, int> = 0>
-  static Windows::Foundation::IInspectable ToObject(TValue const &value) noexcept {
+  static winrt::Windows::Foundation::IInspectable ToObject(TValue const &value) noexcept {
     // We box WinRT types and return IInspectable-inherited values as-is.
     // The ReactNonAbiValue<U> is treated as IInspectable-inherited value if TValue=='ReactNonAbiValue<U>'.
     return box_value(value);
@@ -255,7 +255,7 @@ struct ReactPropertyBag {
 
   // Box value to an ABI-safe object.
   template <class T, class TValue, std::enable_if_t<IsReactNonAbiValueV<T> && !std::is_same_v<T, TValue>, int> = 0>
-  static Windows::Foundation::IInspectable ToObject(TValue &&value) noexcept {
+  static winrt::Windows::Foundation::IInspectable ToObject(TValue &&value) noexcept {
     // Create ReactNonAbiValue<U> with newly allocated wrapper for U and pass TValue as an argument to the U
     // constructor. For example, we can pass TValue=='const char*' to U=='std::string' where
     // T=='ReactNonAbiValue<std::string>'.
@@ -264,33 +264,33 @@ struct ReactPropertyBag {
 
   // Box value to an ABI-safe object.
   template <class T>
-  static Windows::Foundation::IInspectable ToObject(std::optional<T> const &value) noexcept {
+  static winrt::Windows::Foundation::IInspectable ToObject(std::optional<T> const &value) noexcept {
     return value ? ToObject<T>(*value) : nullptr;
   }
 
   // Unbox value from an ABI-safe object.
   template <class T>
-  static auto FromObject(Windows::Foundation::IInspectable const &obj) noexcept {
+  static auto FromObject(winrt::Windows::Foundation::IInspectable const &obj) noexcept {
     // The code mostly borrowed from the winrt::unbox_value_or implementation to return
     // empty std::optional in case if obj is null or has a wrong type.
-    if constexpr (std::is_base_of_v<Windows::Foundation::IInspectable, T>) {
+    if constexpr (std::is_base_of_v<winrt::Windows::Foundation::IInspectable, T>) {
       return obj.try_as<T>();
 #ifndef __APPLE__
     } else if constexpr (impl::has_category_v<T>) {
       if (obj) {
 #ifdef WINRT_IMPL_IUNKNOWN_DEFINED
         if constexpr (std::is_same_v<T, GUID>) {
-          if (auto temp = obj.try_as<Windows::Foundation::IReference<guid>>()) {
+          if (auto temp = obj.try_as<winrt::Windows::Foundation::IReference<guid>>()) {
             return std::optional<T>{temp.Value()};
           }
         }
 #endif
-        if (auto temp = obj.try_as<Windows::Foundation::IReference<T>>()) {
+        if (auto temp = obj.try_as<winrt::Windows::Foundation::IReference<T>>()) {
           return std::optional<T>{temp.Value()};
         }
 
         if constexpr (std::is_enum_v<T>) {
-          if (auto temp = obj.try_as<Windows::Foundation::IReference<std::underlying_type_t<T>>>()) {
+          if (auto temp = obj.try_as<winrt::Windows::Foundation::IReference<std::underlying_type_t<T>>>()) {
             return std::optional<T>{static_cast<T>(temp.Value())};
           }
         }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -303,7 +303,8 @@ void CompositionRootView::ShowInstanceLoading() noexcept {
   // TODO: Show loading UI here
 }
 
-winrt::Windows::Foundation::Size CompositionRootView::Measure(winrt::Windows::Foundation::Size const &availableSize) const {
+winrt::Windows::Foundation::Size CompositionRootView::Measure(
+    winrt::Windows::Foundation::Size const &availableSize) const {
   winrt::Windows::Foundation::Size size{0.0f, 0.0f};
 
   if (m_isInitialized && m_rootTag != -1) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -191,7 +191,7 @@ int64_t CompositionRootView::SendMessage(uint32_t msg, uint64_t wParam, int64_t 
   return 0;
 }
 
-void CompositionRootView::OnScrollWheel(Windows::Foundation::Point point, int32_t delta) noexcept {
+void CompositionRootView::OnScrollWheel(winrt::Windows::Foundation::Point point, int32_t delta) noexcept {
   if (m_rootTag == -1)
     return;
 
@@ -303,8 +303,8 @@ void CompositionRootView::ShowInstanceLoading() noexcept {
   // TODO: Show loading UI here
 }
 
-Windows::Foundation::Size CompositionRootView::Measure(Windows::Foundation::Size const &availableSize) const {
-  Windows::Foundation::Size size{0.0f, 0.0f};
+winrt::Windows::Foundation::Size CompositionRootView::Measure(winrt::Windows::Foundation::Size const &availableSize) const {
+  winrt::Windows::Foundation::Size size{0.0f, 0.0f};
 
   if (m_isInitialized && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
@@ -336,7 +336,7 @@ Windows::Foundation::Size CompositionRootView::Measure(Windows::Foundation::Size
   return size;
 }
 
-Windows::Foundation::Size CompositionRootView::Arrange(Windows::Foundation::Size finalSize) const {
+winrt::Windows::Foundation::Size CompositionRootView::Arrange(winrt::Windows::Foundation::Size finalSize) const {
   if (m_isInitialized && m_rootTag != -1) {
     if (auto fabricuiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(
             winrt::Microsoft::ReactNative::ReactPropertyBag(m_context.Properties()))) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -59,8 +59,8 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   double ScaleFactor() noexcept;
   void ScaleFactor(double value) noexcept;
 
-  Windows::Foundation::Size Measure(Windows::Foundation::Size const &availableSize) const;
-  Windows::Foundation::Size Arrange(Windows::Foundation::Size finalSize) const;
+  winrt::Windows::Foundation::Size Measure(winrt::Windows::Foundation::Size const &availableSize) const;
+  winrt::Windows::Foundation::Size Arrange(winrt::Windows::Foundation::Size finalSize) const;
 
   winrt::Microsoft::ReactNative::FocusNavigationResult NavigateFocus(
       const winrt::Microsoft::ReactNative::FocusNavigationRequest &request) noexcept;
@@ -70,7 +70,7 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   IInspectable GetUiaProvider() noexcept;
 
   int64_t SendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept;
-  void OnScrollWheel(Windows::Foundation::Point point, int32_t delta) noexcept;
+  void OnScrollWheel(winrt::Windows::Foundation::Point point, int32_t delta) noexcept;
 
  public: // ICompositionRootView
   winrt::Microsoft::ReactNative::Composition::IVisual GetVisual() const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -37,60 +37,60 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
       // Accent colors
       // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uicolortype?view=winrt-22621
       static std::
-          unordered_map<std::string, ui::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
+          unordered_map<std::string, winrt::Windows::UI::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
               s_uiColorTypes = {
-                  {"Accent", ui::ViewManagement::UIColorType::Accent},
-                  {"AccentDark1", ui::ViewManagement::UIColorType::AccentDark1},
-                  {"AccentDark2", ui::ViewManagement::UIColorType::AccentDark2},
-                  {"AccentDark3", ui::ViewManagement::UIColorType::AccentDark3},
-                  {"AccentLight1", ui::ViewManagement::UIColorType::AccentLight1},
-                  {"AccentLight2", ui::ViewManagement::UIColorType::AccentLight2},
-                  {"AccentLight3", ui::ViewManagement::UIColorType::AccentLight3},
-                  {"Background", ui::ViewManagement::UIColorType::Background},
-                  {"Complement", ui::ViewManagement::UIColorType::Complement},
-                  {"Foreground", ui::ViewManagement::UIColorType::Foreground}};
+                  {"Accent", winrt::Windows::UI::ViewManagement::UIColorType::Accent},
+                  {"AccentDark1", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark1},
+                  {"AccentDark2", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark2},
+                  {"AccentDark3", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark3},
+                  {"AccentLight1", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight1},
+                  {"AccentLight2", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight2},
+                  {"AccentLight3", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight3},
+                  {"Background", winrt::Windows::UI::ViewManagement::UIColorType::Background},
+                  {"Complement", winrt::Windows::UI::ViewManagement::UIColorType::Complement},
+                  {"Foreground", winrt::Windows::UI::ViewManagement::UIColorType::Foreground}};
 
       auto uiColor = s_uiColorTypes.find(platformColor);
       if (uiColor != s_uiColorTypes.end()) {
-        auto uiSettings{ui::ViewManagement::UISettings()};
+        auto uiSettings{ winrt::Windows::UI::ViewManagement::UISettings()};
         return uiSettings.GetColorValue(uiColor->second);
       }
 
       // UI element colors
       // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uielementtype?view=winrt-22621
       static std::
-          unordered_map<std::string, ui::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
+          unordered_map<std::string, winrt::Windows::UI::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
               s_uiElementTypes = {
-                  {"AccentColor", ui::ViewManagement::UIElementType::AccentColor},
-                  {"ActiveCaption", ui::ViewManagement::UIElementType::ActiveCaption},
-                  {"Background", ui::ViewManagement::UIElementType::Background},
-                  {"ButtonFace", ui::ViewManagement::UIElementType::ButtonFace},
-                  {"ButtonText", ui::ViewManagement::UIElementType::ButtonText},
-                  {"CaptionText", ui::ViewManagement::UIElementType::CaptionText},
-                  {"GrayText", ui::ViewManagement::UIElementType::GrayText},
-                  {"Highlight", ui::ViewManagement::UIElementType::Highlight},
-                  {"HighlightText", ui::ViewManagement::UIElementType::HighlightText},
-                  {"Hotlight", ui::ViewManagement::UIElementType::Hotlight},
-                  {"InactiveCaption", ui::ViewManagement::UIElementType::InactiveCaption},
-                  {"InactiveCaptionText", ui::ViewManagement::UIElementType::InactiveCaptionText},
-                  {"NonTextHigh", ui::ViewManagement::UIElementType::NonTextHigh},
-                  {"NonTextLow", ui::ViewManagement::UIElementType::NonTextLow},
-                  {"NonTextMedium", ui::ViewManagement::UIElementType::NonTextMedium},
-                  {"NonTextMediumHigh", ui::ViewManagement::UIElementType::NonTextMediumHigh},
-                  {"NonTextMediumLow", ui::ViewManagement::UIElementType::NonTextMediumLow},
-                  {"OverlayOutsidePopup", ui::ViewManagement::UIElementType::OverlayOutsidePopup},
-                  {"PageBackground", ui::ViewManagement::UIElementType::PageBackground},
-                  {"PopupBackground", ui::ViewManagement::UIElementType::PopupBackground},
-                  {"TextContrastWithHigh", ui::ViewManagement::UIElementType::TextContrastWithHigh},
-                  {"TextHigh", ui::ViewManagement::UIElementType::TextHigh},
-                  {"TextLow", ui::ViewManagement::UIElementType::TextLow},
-                  {"TextMedium", ui::ViewManagement::UIElementType::TextMedium},
-                  {"Window", ui::ViewManagement::UIElementType::Window},
-                  {"WindowText", ui::ViewManagement::UIElementType::WindowText}};
+                  {"AccentColor", winrt::Windows::UI::ViewManagement::UIElementType::AccentColor},
+                  {"ActiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::ActiveCaption},
+                  {"Background", winrt::Windows::UI::ViewManagement::UIElementType::Background},
+                  {"ButtonFace", winrt::Windows::UI::ViewManagement::UIElementType::ButtonFace},
+                  {"ButtonText", winrt::Windows::UI::ViewManagement::UIElementType::ButtonText},
+                  {"CaptionText", winrt::Windows::UI::ViewManagement::UIElementType::CaptionText},
+                  {"GrayText", winrt::Windows::UI::ViewManagement::UIElementType::GrayText},
+                  {"Highlight", winrt::Windows::UI::ViewManagement::UIElementType::Highlight},
+                  {"HighlightText", winrt::Windows::UI::ViewManagement::UIElementType::HighlightText},
+                  {"Hotlight", winrt::Windows::UI::ViewManagement::UIElementType::Hotlight},
+                  {"InactiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaption},
+                  {"InactiveCaptionText", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaptionText},
+                  {"NonTextHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextHigh},
+                  {"NonTextLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextLow},
+                  {"NonTextMedium", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMedium},
+                  {"NonTextMediumHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumHigh},
+                  {"NonTextMediumLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumLow},
+                  {"OverlayOutsidePopup", winrt::Windows::UI::ViewManagement::UIElementType::OverlayOutsidePopup},
+                  {"PageBackground", winrt::Windows::UI::ViewManagement::UIElementType::PageBackground},
+                  {"PopupBackground", winrt::Windows::UI::ViewManagement::UIElementType::PopupBackground},
+                  {"TextContrastWithHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextContrastWithHigh},
+                  {"TextHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextHigh},
+                  {"TextLow", winrt::Windows::UI::ViewManagement::UIElementType::TextLow},
+                  {"TextMedium", winrt::Windows::UI::ViewManagement::UIElementType::TextMedium},
+                  {"Window", winrt::Windows::UI::ViewManagement::UIElementType::Window},
+                  {"WindowText", winrt::Windows::UI::ViewManagement::UIElementType::WindowText}};
 
       auto uiElement = s_uiElementTypes.find(platformColor);
       if (uiElement != s_uiElementTypes.end()) {
-        auto uiSettings{ui::ViewManagement::UISettings()};
+        auto uiSettings{ winrt::Windows::UI::ViewManagement::UISettings()};
         return uiSettings.UIElementColor(uiElement->second);
       }
 
@@ -102,7 +102,7 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
       // are needed, they should be taken from that section (not "Dark" or "HighContrast").
       // For control-specific values, they will be in a theme resource file for that control. Example:
       // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-      static std::unordered_map<std::string, ui::Color, std::hash<std::string_view>, std::equal_to<>> s_xamlBrushes = {
+      static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>> s_xamlBrushes = {
           {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
           {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
           {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
@@ -171,11 +171,11 @@ xaml::Media::Brush SharedColor::AsWindowsBrush() const {
 
 SharedColor colorFromComponents(ColorComponents components) {
   float ratio = 255;
-  return {ui::ColorHelper::FromArgb(
-      (int)round(components.alpha * ratio) & 0xff,
-      (int)round(components.red * ratio) & 0xff,
-      (int)round(components.green * ratio) & 0xff,
-      (int)round(components.blue * ratio) & 0xff)};
+  return winrt::Windows::UI::Color{
+      static_cast<uint8_t>((int)round(components.alpha * ratio) & 0xff),
+      static_cast<uint8_t>((int)round(components.red * ratio) & 0xff),
+      static_cast<uint8_t>((int)round(components.green * ratio) & 0xff),
+      static_cast<uint8_t>((int)round(components.blue * ratio) & 0xff)};
 }
 
 ColorComponents colorComponentsFromColor(SharedColor const &sharedColor) {

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/graphics/Color.cpp
@@ -36,61 +36,67 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
 
       // Accent colors
       // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uicolortype?view=winrt-22621
-      static std::
-          unordered_map<std::string, winrt::Windows::UI::ViewManagement::UIColorType, std::hash<std::string_view>, std::equal_to<>>
-              s_uiColorTypes = {
-                  {"Accent", winrt::Windows::UI::ViewManagement::UIColorType::Accent},
-                  {"AccentDark1", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark1},
-                  {"AccentDark2", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark2},
-                  {"AccentDark3", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark3},
-                  {"AccentLight1", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight1},
-                  {"AccentLight2", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight2},
-                  {"AccentLight3", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight3},
-                  {"Background", winrt::Windows::UI::ViewManagement::UIColorType::Background},
-                  {"Complement", winrt::Windows::UI::ViewManagement::UIColorType::Complement},
-                  {"Foreground", winrt::Windows::UI::ViewManagement::UIColorType::Foreground}};
+      static std::unordered_map<
+          std::string,
+          winrt::Windows::UI::ViewManagement::UIColorType,
+          std::hash<std::string_view>,
+          std::equal_to<>>
+          s_uiColorTypes = {
+              {"Accent", winrt::Windows::UI::ViewManagement::UIColorType::Accent},
+              {"AccentDark1", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark1},
+              {"AccentDark2", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark2},
+              {"AccentDark3", winrt::Windows::UI::ViewManagement::UIColorType::AccentDark3},
+              {"AccentLight1", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight1},
+              {"AccentLight2", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight2},
+              {"AccentLight3", winrt::Windows::UI::ViewManagement::UIColorType::AccentLight3},
+              {"Background", winrt::Windows::UI::ViewManagement::UIColorType::Background},
+              {"Complement", winrt::Windows::UI::ViewManagement::UIColorType::Complement},
+              {"Foreground", winrt::Windows::UI::ViewManagement::UIColorType::Foreground}};
 
       auto uiColor = s_uiColorTypes.find(platformColor);
       if (uiColor != s_uiColorTypes.end()) {
-        auto uiSettings{ winrt::Windows::UI::ViewManagement::UISettings()};
+        auto uiSettings{winrt::Windows::UI::ViewManagement::UISettings()};
         return uiSettings.GetColorValue(uiColor->second);
       }
 
       // UI element colors
       // https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.uielementtype?view=winrt-22621
-      static std::
-          unordered_map<std::string, winrt::Windows::UI::ViewManagement::UIElementType, std::hash<std::string_view>, std::equal_to<>>
-              s_uiElementTypes = {
-                  {"AccentColor", winrt::Windows::UI::ViewManagement::UIElementType::AccentColor},
-                  {"ActiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::ActiveCaption},
-                  {"Background", winrt::Windows::UI::ViewManagement::UIElementType::Background},
-                  {"ButtonFace", winrt::Windows::UI::ViewManagement::UIElementType::ButtonFace},
-                  {"ButtonText", winrt::Windows::UI::ViewManagement::UIElementType::ButtonText},
-                  {"CaptionText", winrt::Windows::UI::ViewManagement::UIElementType::CaptionText},
-                  {"GrayText", winrt::Windows::UI::ViewManagement::UIElementType::GrayText},
-                  {"Highlight", winrt::Windows::UI::ViewManagement::UIElementType::Highlight},
-                  {"HighlightText", winrt::Windows::UI::ViewManagement::UIElementType::HighlightText},
-                  {"Hotlight", winrt::Windows::UI::ViewManagement::UIElementType::Hotlight},
-                  {"InactiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaption},
-                  {"InactiveCaptionText", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaptionText},
-                  {"NonTextHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextHigh},
-                  {"NonTextLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextLow},
-                  {"NonTextMedium", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMedium},
-                  {"NonTextMediumHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumHigh},
-                  {"NonTextMediumLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumLow},
-                  {"OverlayOutsidePopup", winrt::Windows::UI::ViewManagement::UIElementType::OverlayOutsidePopup},
-                  {"PageBackground", winrt::Windows::UI::ViewManagement::UIElementType::PageBackground},
-                  {"PopupBackground", winrt::Windows::UI::ViewManagement::UIElementType::PopupBackground},
-                  {"TextContrastWithHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextContrastWithHigh},
-                  {"TextHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextHigh},
-                  {"TextLow", winrt::Windows::UI::ViewManagement::UIElementType::TextLow},
-                  {"TextMedium", winrt::Windows::UI::ViewManagement::UIElementType::TextMedium},
-                  {"Window", winrt::Windows::UI::ViewManagement::UIElementType::Window},
-                  {"WindowText", winrt::Windows::UI::ViewManagement::UIElementType::WindowText}};
+      static std::unordered_map<
+          std::string,
+          winrt::Windows::UI::ViewManagement::UIElementType,
+          std::hash<std::string_view>,
+          std::equal_to<>>
+          s_uiElementTypes = {
+              {"AccentColor", winrt::Windows::UI::ViewManagement::UIElementType::AccentColor},
+              {"ActiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::ActiveCaption},
+              {"Background", winrt::Windows::UI::ViewManagement::UIElementType::Background},
+              {"ButtonFace", winrt::Windows::UI::ViewManagement::UIElementType::ButtonFace},
+              {"ButtonText", winrt::Windows::UI::ViewManagement::UIElementType::ButtonText},
+              {"CaptionText", winrt::Windows::UI::ViewManagement::UIElementType::CaptionText},
+              {"GrayText", winrt::Windows::UI::ViewManagement::UIElementType::GrayText},
+              {"Highlight", winrt::Windows::UI::ViewManagement::UIElementType::Highlight},
+              {"HighlightText", winrt::Windows::UI::ViewManagement::UIElementType::HighlightText},
+              {"Hotlight", winrt::Windows::UI::ViewManagement::UIElementType::Hotlight},
+              {"InactiveCaption", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaption},
+              {"InactiveCaptionText", winrt::Windows::UI::ViewManagement::UIElementType::InactiveCaptionText},
+              {"NonTextHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextHigh},
+              {"NonTextLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextLow},
+              {"NonTextMedium", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMedium},
+              {"NonTextMediumHigh", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumHigh},
+              {"NonTextMediumLow", winrt::Windows::UI::ViewManagement::UIElementType::NonTextMediumLow},
+              {"OverlayOutsidePopup", winrt::Windows::UI::ViewManagement::UIElementType::OverlayOutsidePopup},
+              {"PageBackground", winrt::Windows::UI::ViewManagement::UIElementType::PageBackground},
+              {"PopupBackground", winrt::Windows::UI::ViewManagement::UIElementType::PopupBackground},
+              {"TextContrastWithHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextContrastWithHigh},
+              {"TextHigh", winrt::Windows::UI::ViewManagement::UIElementType::TextHigh},
+              {"TextLow", winrt::Windows::UI::ViewManagement::UIElementType::TextLow},
+              {"TextMedium", winrt::Windows::UI::ViewManagement::UIElementType::TextMedium},
+              {"Window", winrt::Windows::UI::ViewManagement::UIElementType::Window},
+              {"WindowText", winrt::Windows::UI::ViewManagement::UIElementType::WindowText}};
 
       auto uiElement = s_uiElementTypes.find(platformColor);
       if (uiElement != s_uiElementTypes.end()) {
-        auto uiSettings{ winrt::Windows::UI::ViewManagement::UISettings()};
+        auto uiSettings{winrt::Windows::UI::ViewManagement::UISettings()};
         return uiSettings.UIElementColor(uiElement->second);
       }
 
@@ -102,37 +108,38 @@ winrt::Windows::UI::Color ResolvePlatformColor(Color const *const color) {
       // are needed, they should be taken from that section (not "Dark" or "HighContrast").
       // For control-specific values, they will be in a theme resource file for that control. Example:
       // https://github.com/microsoft/microsoft-ui-xaml/blob/9052972906c8a0a1b6cb5d5c61b27d6d27cd7f11/dev/CommonStyles/Button_themeresources.xaml
-      static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>> s_xamlBrushes = {
-          {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
-          {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
-          {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
-          {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
-          {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
-          {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
-          {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
-          {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
-          {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
-          {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
-          // Arguably only the control-agnostic platform colors should be respected, and
-          // Button should be updated to use those instead, assuming that still holds up
-          // in high contrast and such.
-          {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
-          {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
-          {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-          {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
-          {"ButtonBorderBrush",
-           {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
-          {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
-          {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
-          {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
-          {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
-          {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
-          {"ButtonBorderBrushPointerOver",
-           {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to ControlStrokeColorOnAccentDefault
-          {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
-      };
+      static std::unordered_map<std::string, winrt::Windows::UI::Color, std::hash<std::string_view>, std::equal_to<>>
+          s_xamlBrushes = {
+              {"SolidBackgroundFillColorBase", {0xFF, 0xF3, 0xF3, 0xF3}},
+              {"ControlFillColorDefault", {0xB3, 0xFF, 0xFF, 0xFF}},
+              {"ControlFillColorSecondary", {0x80, 0xF9, 0xF9, 0xF9}},
+              {"ControlFillColorTertiary", {0x4D, 0xF9, 0xF9, 0xF9}},
+              {"ControlFillColorDisabled", {0x4D, 0xF9, 0xF9, 0xF9}},
+              {"ControlFillColorTransparent", {0x00, 0xFF, 0xFF, 0xFF}},
+              {"ControlStrokeColorDefault", {0x0F, 0x00, 0x00, 0x00}},
+              {"ControlStrokeColorSecondary", {0x29, 0x00, 0x00, 0x00}},
+              {"ControlStrokeColorOnAccentSecondary", {0x66, 0x00, 0x00, 0x00}},
+              {"TextFillColorPrimary", {0xE4, 0x00, 0x00, 0x00}},
+              {"TextFillColorSecondary", {0x9E, 0x00, 0x00, 0x00}},
+              {"TextFillColorDisabled", {0x5C, 0x00, 0x00, 0x00}},
+              // Arguably only the control-agnostic platform colors should be respected, and
+              // Button should be updated to use those instead, assuming that still holds up
+              // in high contrast and such.
+              {"ButtonBackgroundPressed", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorTertiary
+              {"ButtonForegroundPressed", {0x9E, 0x00, 0x00, 0x00}}, // TextFillColorSecondary
+              {"ButtonForegroundPointerOver", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+              {"ButtonBackground", {0xB3, 0xFF, 0xFF, 0xFF}}, // ControlFillColorDefault
+              {"ButtonBorderBrush",
+               {0x29, 0x00, 0x00, 0x00}}, // from ControlStrokeColorSecondary to ControlStrokeColorDefault
+              {"ButtonForeground", {0xE4, 0x00, 0x00, 0x00}}, // TextFillColorPrimary
+              {"ButtonBackgroundDisabled", {0x4D, 0xF9, 0xF9, 0xF9}}, // ControlFillColorDisabled
+              {"ButtonBorderBrushDisabled", {0x0F, 0x00, 0x00, 0x00}}, // ControlStrokeColorDefault
+              {"ButtonForegroundDisabled", {0x5C, 0x00, 0x00, 0x00}}, // TextFillColorDisabled
+              {"ButtonBackgroundPointerOver", {0x80, 0xF9, 0xF9, 0xF9}}, // ControlFillColorSecondary
+              {"ButtonBorderBrushPointerOver", {0x66, 0x00, 0x00, 0x00}}, // from ControlStrokeColorOnAccentSecondary to
+                                                                          // ControlStrokeColorOnAccentDefault
+              {"ButtonBorderBrushPressed", {0x00, 0xFF, 0xFF, 0xFF}}, // ControlFillColorTransparent
+          };
 
       auto result = s_xamlBrushes.find(platformColor);
       if (result != s_xamlBrushes.end()) {

--- a/vnext/Microsoft.ReactNative/IReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/IReactContext.cpp
@@ -100,7 +100,7 @@ IReactDispatcher ReactContext::JSDispatcher() noexcept {
   return Properties().Get(ReactDispatcherHelper::JSDispatcherProperty()).try_as<IReactDispatcher>();
 }
 
-Windows::Foundation::IInspectable ReactContext::JSRuntime() noexcept {
+winrt::Windows::Foundation::IInspectable ReactContext::JSRuntime() noexcept {
   return m_context->JsiRuntime();
 }
 

--- a/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
+++ b/vnext/Microsoft.ReactNative/IReactNotificationService.cpp
@@ -16,8 +16,8 @@ MSO_GUID(IReactNotificationSubscriptionPrivate, "09437980-3508-4690-930c-7c310e2
 struct IReactNotificationSubscriptionPrivate : ::IUnknown {
   virtual void SetParent(IReactNotificationSubscription const &parentSubscription) noexcept = 0;
   virtual void CallHandler(
-      Windows::Foundation::IInspectable const &sender,
-      Windows::Foundation::IInspectable const &data) noexcept = 0;
+      winrt::Windows::Foundation::IInspectable const &sender,
+      winrt::Windows::Foundation::IInspectable const &data) noexcept = 0;
 };
 
 // The Notification subscription class.

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -167,7 +167,8 @@ void ApplyArguments(ReactNative::ReactNativeHost const &host, std::wstring const
 /// <param name="e">Details about the launch request and process.</param>
 void ReactApplication::OnCreate(winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
   bool isPrelaunchActivated = false;
-  if (auto prelaunchActivatedArgs = e.try_as<winrt::Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
+  if (auto prelaunchActivatedArgs =
+          e.try_as<winrt::Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
     isPrelaunchActivated = prelaunchActivatedArgs.PrelaunchActivated();
   }
 
@@ -192,7 +193,8 @@ void ReactApplication::OnCreate(winrt::Windows::ApplicationModel::Activation::IA
 
     rootFrame.NavigationFailed({this, &ReactApplication::OnNavigationFailed});
 
-    if (e.PreviousExecutionState() == winrt::Windows::ApplicationModel::Activation::ApplicationExecutionState::Terminated) {
+    if (e.PreviousExecutionState() ==
+        winrt::Windows::ApplicationModel::Activation::ApplicationExecutionState::Terminated) {
       // Restore the saved session state only when appropriate, scheduling the
       // final launch steps after the restore is complete
     }

--- a/vnext/Microsoft.ReactNative/ReactApplication.cpp
+++ b/vnext/Microsoft.ReactNative/ReactApplication.cpp
@@ -105,9 +105,9 @@ void ReactApplication::BundleAppId(hstring const &value) noexcept {
   InstanceSettings().BundleAppId(value);
 }
 
-void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
-  if (e.Kind() == Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
-    auto protocolActivatedEventArgs{e.as<Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
+void ReactApplication::OnActivated(winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
+  if (e.Kind() == winrt::Windows::ApplicationModel::Activation::ActivationKind::Protocol) {
+    auto protocolActivatedEventArgs{e.as<winrt::Windows::ApplicationModel::Activation::ProtocolActivatedEventArgs>()};
     ::Microsoft::ReactNative::LinkingManager::OpenUri(protocolActivatedEventArgs.Uri());
   }
   this->OnCreate(e);
@@ -115,7 +115,7 @@ void ReactApplication::OnActivated(Windows::ApplicationModel::Activation::IActiv
 
 void ReactApplication::OnLaunched(activation::LaunchActivatedEventArgs const &e_) {
   base_type::OnLaunched(e_);
-  Windows::ApplicationModel::Activation::LaunchActivatedEventArgs e =
+  winrt::Windows::ApplicationModel::Activation::LaunchActivatedEventArgs e =
 #ifdef USE_WINUI3
       e_.UWPLaunchActivatedEventArgs();
 #else
@@ -165,9 +165,9 @@ void ApplyArguments(ReactNative::ReactNativeHost const &host, std::wstring const
 /// specific file.
 /// </summary>
 /// <param name="e">Details about the launch request and process.</param>
-void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
+void ReactApplication::OnCreate(winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const &e) {
   bool isPrelaunchActivated = false;
-  if (auto prelaunchActivatedArgs = e.try_as<Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
+  if (auto prelaunchActivatedArgs = e.try_as<winrt::Windows::ApplicationModel::Activation::IPrelaunchActivatedEventArgs>()) {
     isPrelaunchActivated = prelaunchActivatedArgs.PrelaunchActivated();
   }
 
@@ -192,7 +192,7 @@ void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivate
 
     rootFrame.NavigationFailed({this, &ReactApplication::OnNavigationFailed});
 
-    if (e.PreviousExecutionState() == Windows::ApplicationModel::Activation::ApplicationExecutionState::Terminated) {
+    if (e.PreviousExecutionState() == winrt::Windows::ApplicationModel::Activation::ApplicationExecutionState::Terminated) {
       // Restore the saved session state only when appropriate, scheduling the
       // final launch steps after the restore is complete
     }
@@ -222,7 +222,7 @@ void ReactApplication::OnCreate(Windows::ApplicationModel::Activation::IActivate
 /// <param name="e">Details about the suspend request.</param>
 void ReactApplication::OnSuspending(
     [[maybe_unused]] IInspectable const &sender,
-    [[maybe_unused]] Windows::ApplicationModel::SuspendingEventArgs const &e) {
+    [[maybe_unused]] winrt::Windows::ApplicationModel::SuspendingEventArgs const &e) {
   // Save application state and stop any background activity
 }
 

--- a/vnext/Microsoft.ReactNative/ReactApplication.h
+++ b/vnext/Microsoft.ReactNative/ReactApplication.h
@@ -81,7 +81,7 @@ struct ReactApplication : NoDefaultCtorReactApplication_base<ReactApplication, x
   ReactNative::ReactInstanceSettings InstanceSettings() noexcept;
   void InstanceSettings(ReactNative::ReactInstanceSettings const &value) noexcept;
 
-  Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
+  winrt::Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
 
   ReactNative::ReactNativeHost Host() noexcept;
 
@@ -94,9 +94,9 @@ struct ReactApplication : NoDefaultCtorReactApplication_base<ReactApplication, x
   hstring BundleAppId() noexcept;
   void BundleAppId(hstring const &value) noexcept;
 
-  void OnActivated(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
+  void OnActivated(winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
   void OnLaunched(activation::LaunchActivatedEventArgs const &e);
-  void OnSuspending(IInspectable const &, Windows::ApplicationModel::SuspendingEventArgs const &);
+  void OnSuspending(IInspectable const &, winrt::Windows::ApplicationModel::SuspendingEventArgs const &);
   void OnNavigationFailed(IInspectable const &, xaml::Navigation::NavigationFailedEventArgs const &);
 
   using AppLaunchedDelegate = winrt::delegate<void(
@@ -129,7 +129,7 @@ struct ReactApplication : NoDefaultCtorReactApplication_base<ReactApplication, x
   winrt::Microsoft::ReactNative::ReactInstanceSettings m_instanceSettings{nullptr};
   winrt::Microsoft::ReactNative::ReactNativeHost m_host{nullptr};
 
-  void OnCreate(Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
+  void OnCreate(winrt::Windows::ApplicationModel::Activation::IActivatedEventArgs const &e);
 
   AppLaunchedDelegate m_launched;
   AppViewCreatedDelegate m_viewCreated;

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -60,11 +60,11 @@ struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
       Mso::React::IReactViewHost &viewHost,
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
-  Windows::Foundation::IAsyncAction ReloadViewInstance() noexcept;
-  Windows::Foundation::IAsyncAction ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
-  Windows::Foundation::IAsyncAction UnloadViewInstance() noexcept;
-  Windows::Foundation::IAsyncAction AttachViewInstance(IReactViewInstance viewInstance) noexcept;
-  Windows::Foundation::IAsyncAction DetachViewInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction ReloadViewInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
+  winrt::Windows::Foundation::IAsyncAction UnloadViewInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction AttachViewInstance(IReactViewInstance viewInstance) noexcept;
+  winrt::Windows::Foundation::IAsyncAction DetachViewInstance() noexcept;
   winrt::Microsoft::ReactNative::ReactNativeHost ReactNativeHost() noexcept;
 
  private:

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -61,7 +61,8 @@ struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {
       const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher);
 
   winrt::Windows::Foundation::IAsyncAction ReloadViewInstance() noexcept;
-  winrt::Windows::Foundation::IAsyncAction ReloadViewInstanceWithOptions(ReactNative::ReactViewOptions options) noexcept;
+  winrt::Windows::Foundation::IAsyncAction ReloadViewInstanceWithOptions(
+      ReactNative::ReactViewOptions options) noexcept;
   winrt::Windows::Foundation::IAsyncAction UnloadViewInstance() noexcept;
   winrt::Windows::Foundation::IAsyncAction AttachViewInstance(IReactViewInstance viewInstance) noexcept;
   winrt::Windows::Foundation::IAsyncAction DetachViewInstance() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -160,7 +160,7 @@ template <typename argsT>
 winrt::event_token subscribeToNotifications(
     IReactNotificationService const &notifications,
     IReactPropertyName const &property,
-  winrt::Windows::Foundation::EventHandler<argsT> const &handler) {
+    winrt::Windows::Foundation::EventHandler<argsT> const &handler) {
   auto subscription = notifications.Subscribe(
       property,
       nullptr,
@@ -185,7 +185,7 @@ void unsubscribeFromNotifications(winrt::event_token const &token) {
 }
 
 winrt::event_token ReactInstanceSettings::InstanceCreated(
-  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
         &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceCreatedEventName(), handler);
 }
@@ -195,7 +195,8 @@ void ReactInstanceSettings::InstanceCreated(winrt::event_token const &token) noe
 }
 
 winrt::event_token ReactInstanceSettings::InstanceLoaded(
-  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const &handler) noexcept {
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const
+        &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceLoadedEventName(), handler);
 }
 
@@ -204,7 +205,7 @@ void ReactInstanceSettings::InstanceLoaded(winrt::event_token const &token) noex
 }
 
 winrt::event_token ReactInstanceSettings::InstanceDestroyed(
-  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
         &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceDestroyedEventName(), handler);
 }

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.cpp
@@ -160,7 +160,7 @@ template <typename argsT>
 winrt::event_token subscribeToNotifications(
     IReactNotificationService const &notifications,
     IReactPropertyName const &property,
-    Windows::Foundation::EventHandler<argsT> const &handler) {
+  winrt::Windows::Foundation::EventHandler<argsT> const &handler) {
   auto subscription = notifications.Subscribe(
       property,
       nullptr,
@@ -185,7 +185,7 @@ void unsubscribeFromNotifications(winrt::event_token const &token) {
 }
 
 winrt::event_token ReactInstanceSettings::InstanceCreated(
-    Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
+  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
         &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceCreatedEventName(), handler);
 }
@@ -195,7 +195,7 @@ void ReactInstanceSettings::InstanceCreated(winrt::event_token const &token) noe
 }
 
 winrt::event_token ReactInstanceSettings::InstanceLoaded(
-    Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const &handler) noexcept {
+  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceLoadedEventName(), handler);
 }
 
@@ -204,7 +204,7 @@ void ReactInstanceSettings::InstanceLoaded(winrt::event_token const &token) noex
 }
 
 winrt::event_token ReactInstanceSettings::InstanceDestroyed(
-    Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
+  winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
         &handler) noexcept {
   return subscribeToNotifications(Notifications(), InstanceDestroyedEventName(), handler);
 }

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -147,17 +147,17 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   void JSIEngineOverride(JSIEngine value) noexcept;
 
   winrt::event_token InstanceCreated(
-    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
           &handler) noexcept;
   void InstanceCreated(winrt::event_token const &token) noexcept;
 
   winrt::event_token InstanceLoaded(
-    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const
           &handler) noexcept;
   void InstanceLoaded(winrt::event_token const &token) noexcept;
 
   winrt::event_token InstanceDestroyed(
-    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
+      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
           &handler) noexcept;
   void InstanceDestroyed(winrt::event_token const &token) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
+++ b/vnext/Microsoft.ReactNative/ReactInstanceSettings.h
@@ -53,7 +53,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
 
   IReactNotificationService Notifications() noexcept;
 
-  Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
+  winrt::Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
 
   //! This controls the availability of various developer support functionality including
   //! RedBox, and the Developer Menu
@@ -147,17 +147,17 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
   void JSIEngineOverride(JSIEngine value) noexcept;
 
   winrt::event_token InstanceCreated(
-      Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceCreatedEventArgs> const
           &handler) noexcept;
   void InstanceCreated(winrt::event_token const &token) noexcept;
 
   winrt::event_token InstanceLoaded(
-      Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceLoadedEventArgs> const
           &handler) noexcept;
   void InstanceLoaded(winrt::event_token const &token) noexcept;
 
   winrt::event_token InstanceDestroyed(
-      Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
+    winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::InstanceDestroyedEventArgs> const
           &handler) noexcept;
   void InstanceDestroyed(winrt::event_token const &token) noexcept;
 
@@ -174,7 +174,7 @@ struct ReactInstanceSettings : ReactInstanceSettingsT<ReactInstanceSettings> {
  private:
   IReactPropertyBag m_properties{ReactPropertyBagHelper::CreatePropertyBag()};
   IReactNotificationService m_notifications{ReactNotificationServiceHelper::CreateNotificationService()};
-  Windows::Foundation::Collections::IVector<IReactPackageProvider> m_packageProviders{
+  ::winrt::Windows::Foundation::Collections::IVector<IReactPackageProvider> m_packageProviders{
       single_threaded_vector<IReactPackageProvider>()};
   hstring m_javaScriptBundleFile{};
   hstring m_bundleAppId{};
@@ -223,7 +223,7 @@ inline IReactNotificationService ReactInstanceSettings::Notifications() noexcept
   return m_notifications;
 }
 
-inline Windows::Foundation::Collections::IVector<IReactPackageProvider>
+inline winrt::Windows::Foundation::Collections::IVector<IReactPackageProvider>
 ReactInstanceSettings::PackageProviders() noexcept {
   return m_packageProviders;
 }

--- a/vnext/Microsoft.ReactNative/ReactNativeHost.h
+++ b/vnext/Microsoft.ReactNative/ReactNativeHost.h
@@ -20,15 +20,15 @@ struct ReactNativeHost : ReactNativeHostT<ReactNativeHost> {
   static ReactNative::ReactNativeHost FromContext(ReactNative::IReactContext const &reactContext) noexcept;
 
   // property PackageProviders
-  Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
+  winrt::Windows::Foundation::Collections::IVector<IReactPackageProvider> PackageProviders() noexcept;
 
   // property InstanceSettings
   ReactNative::ReactInstanceSettings InstanceSettings() noexcept;
   void InstanceSettings(ReactNative::ReactInstanceSettings const &value) noexcept;
 
-  Windows::Foundation::IAsyncAction LoadInstance() noexcept;
-  Windows::Foundation::IAsyncAction ReloadInstance() noexcept;
-  Windows::Foundation::IAsyncAction UnloadInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction LoadInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction ReloadInstance() noexcept;
+  winrt::Windows::Foundation::IAsyncAction UnloadInstance() noexcept;
 
  public:
   Mso::React::IReactHost *ReactHost() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -430,8 +430,8 @@ void ReactRootView::ReactViewHost(Mso::React::IReactViewHost *viewHost) noexcept
   }
 }
 
-Windows::Foundation::Size ReactRootView::MeasureOverride(Windows::Foundation::Size const &availableSize) const {
-  Windows::Foundation::Size size{0.0f, 0.0f};
+winrt::Windows::Foundation::Size ReactRootView::MeasureOverride(winrt::Windows::Foundation::Size const &availableSize) const {
+  winrt::Windows::Foundation::Size size{0.0f, 0.0f};
 
   for (xaml::UIElement child : Children()) {
     child.Measure(availableSize);
@@ -445,7 +445,7 @@ Windows::Foundation::Size ReactRootView::MeasureOverride(Windows::Foundation::Si
   return size;
 }
 
-Windows::Foundation::Size ReactRootView::ArrangeOverride(Windows::Foundation::Size finalSize) const {
+winrt::Windows::Foundation::Size ReactRootView::ArrangeOverride(winrt::Windows::Foundation::Size finalSize) const {
   for (xaml::UIElement child : Children()) {
     child.Arrange(winrt::Rect(0, 0, finalSize.Width, finalSize.Height));
   }

--- a/vnext/Microsoft.ReactNative/ReactRootView.cpp
+++ b/vnext/Microsoft.ReactNative/ReactRootView.cpp
@@ -430,7 +430,8 @@ void ReactRootView::ReactViewHost(Mso::React::IReactViewHost *viewHost) noexcept
   }
 }
 
-winrt::Windows::Foundation::Size ReactRootView::MeasureOverride(winrt::Windows::Foundation::Size const &availableSize) const {
+winrt::Windows::Foundation::Size ReactRootView::MeasureOverride(
+    winrt::Windows::Foundation::Size const &availableSize) const {
   winrt::Windows::Foundation::Size size{0.0f, 0.0f};
 
   for (xaml::UIElement child : Children()) {

--- a/vnext/Microsoft.ReactNative/ReactRootView.h
+++ b/vnext/Microsoft.ReactNative/ReactRootView.h
@@ -60,8 +60,8 @@ struct ReactRootView : ReactRootViewT<ReactRootView>, ::Microsoft::ReactNative::
   void UpdateRootView() noexcept;
   void UninitRootView() noexcept;
 
-  Windows::Foundation::Size MeasureOverride(Windows::Foundation::Size const &availableSize) const;
-  Windows::Foundation::Size ArrangeOverride(Windows::Foundation::Size finalSize) const;
+  winrt::Windows::Foundation::Size MeasureOverride(winrt::Windows::Foundation::Size const &availableSize) const;
+  winrt::Windows::Foundation::Size ArrangeOverride(winrt::Windows::Foundation::Size finalSize) const;
 
   void blur(::Microsoft::ReactNative::XamlView const &xamlView) noexcept;
 

--- a/vnext/Microsoft.ReactNative/ReactSupport.h
+++ b/vnext/Microsoft.ReactNative/ReactSupport.h
@@ -8,6 +8,6 @@
 namespace winrt::Microsoft::ReactNative {
 
 // Convert a WinRT IInspectable into a folly::dynamic object
-folly::dynamic ConvertToDynamic(Windows::Foundation::IInspectable const &object);
+folly::dynamic ConvertToDynamic(winrt::Windows::Foundation::IInspectable const &object);
 
 } // namespace winrt::Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
@@ -81,8 +81,8 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   static xaml::DependencyProperty AccessibilityActionsProperty();
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-      Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
-  static Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
+    winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
+  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
@@ -81,9 +81,9 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
   static xaml::DependencyProperty AccessibilityActionsProperty();
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-    winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
-  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
-      xaml::UIElement const &element);
+      winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
+  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
+  GetAccessibilityActions(xaml::UIElement const &element);
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
   static xaml::DependencyProperty AccessibilityActionEventHandlerProperty();
   static void SetAccessibilityActionEventHandler(

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
@@ -242,7 +242,8 @@ DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(xaml::UIElement 
 xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
   static xaml::DependencyProperty s_AccessibilityActionsProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityActions",
-      winrt::xaml_typename<winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(),
+      winrt::xaml_typename<
+          winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(),
       dynamicAutomationTypeName,
       winrt::PropertyMetadata(nullptr));
 
@@ -251,13 +252,14 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProper
 
 void DynamicAutomationProperties::SetAccessibilityActions(
     xaml::UIElement const &element,
-  winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value) {
+    winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value) {
   return element.SetValue(AccessibilityActionsProperty(), winrt::box_value(value));
 }
 
 winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
 DynamicAutomationProperties::GetAccessibilityActions(xaml::UIElement const &element) {
-  return winrt::unbox_value<winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(
+  return winrt::unbox_value<
+      winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(
       element.GetValue(AccessibilityActionsProperty()));
 }
 

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
@@ -242,7 +242,7 @@ DynamicAutomationProperties::GetAccessibilityInvokeEventHandler(xaml::UIElement 
 xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProperty() {
   static xaml::DependencyProperty s_AccessibilityActionsProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityActions",
-      winrt::xaml_typename<Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(),
+      winrt::xaml_typename<winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(),
       dynamicAutomationTypeName,
       winrt::PropertyMetadata(nullptr));
 
@@ -251,13 +251,13 @@ xaml::DependencyProperty DynamicAutomationProperties::AccessibilityActionsProper
 
 void DynamicAutomationProperties::SetAccessibilityActions(
     xaml::UIElement const &element,
-    Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value) {
+  winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value) {
   return element.SetValue(AccessibilityActionsProperty(), winrt::box_value(value));
 }
 
-Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
+winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
 DynamicAutomationProperties::GetAccessibilityActions(xaml::UIElement const &element) {
-  return winrt::unbox_value<Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(
+  return winrt::unbox_value<winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>>(
       element.GetValue(AccessibilityActionsProperty()));
 }
 

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
@@ -73,9 +73,9 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
 
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-      Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
+    winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
 
-  static Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
+  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
       xaml::UIElement const &element);
 
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
@@ -73,10 +73,10 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
 
   static void SetAccessibilityActions(
       xaml::UIElement const &element,
-    winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
+      winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> const &value);
 
-  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction> GetAccessibilityActions(
-      xaml::UIElement const &element);
+  static winrt::Windows::Foundation::Collections::IVector<Microsoft::ReactNative::AccessibilityAction>
+  GetAccessibilityActions(xaml::UIElement const &element);
 
   static void DispatchAccessibilityAction(xaml::UIElement const &element, std::wstring_view const &actionName);
 

--- a/vnext/Microsoft.ReactNative/XamlHelper.cpp
+++ b/vnext/Microsoft.ReactNative/XamlHelper.cpp
@@ -19,7 +19,7 @@ xaml::Media::Brush XamlHelper::BrushFrom(JSValueArgWriter const &valueProvider) 
   return ::Microsoft::ReactNative::IsValidColorValue(value) ? ::Microsoft::ReactNative::BrushFrom(value) : nullptr;
 }
 
-Windows::UI::Color XamlHelper::ColorFrom(JSValueArgWriter const &valueProvider) noexcept {
+winrt::Windows::UI::Color XamlHelper::ColorFrom(JSValueArgWriter const &valueProvider) noexcept {
   auto value = GetFollyDynamicFromValueProvider(valueProvider);
   return ::Microsoft::ReactNative::ColorFrom(value);
 }

--- a/vnext/Microsoft.ReactNative/XamlHelper.h
+++ b/vnext/Microsoft.ReactNative/XamlHelper.h
@@ -15,7 +15,7 @@ struct XamlHelper : XamlHelperT<XamlHelper> {
   XamlHelper() = default;
 
   static xaml::Media::Brush BrushFrom(JSValueArgWriter const &valueProvider) noexcept;
-  static Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
+  static winrt::Windows::UI::Color ColorFrom(JSValueArgWriter const &valueProvider) noexcept;
 
   static xaml::DependencyProperty ReactTagProperty() noexcept;
   static int64_t GetReactTag(xaml::DependencyObject const &dependencyObject) noexcept;


### PR DESCRIPTION
## Description
When linking in WinAppSDK, there is a namespace conflict with winrt::Microsoft::Windows and winrt::Windows, which causes various build errors.

This makes our code more explicitly use winrt::Windows where appropriate.

Also modified the fabric color.cpp to always use winrt::Windows::UI, not winrt::Microsoft::UI even when USE_WINUI3 is set, since the ViewManagement functionality does not exist in Microsoft::UI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12114)