### PR TITLE
[Win32] Webpack assets do not prefix paths with /, which causes a lost char in asset path

### DIFF
--- a/change/@office-iss-react-native-win32-e8c0b2fd-503a-492b-a0e8-9bea3e698b51.json
+++ b/change/@office-iss-react-native-win32-e8c0b2fd-503a-492b-a0e8-9bea3e698b51.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Webpack assets do not prefix paths with /, which causes a lost char in asset path",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/resolveAssetSource.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/resolveAssetSource.win32.js
@@ -90,9 +90,13 @@ class AssetResolverLateScaleResolution {
   }
 
   _getBasePath(local: boolean) {
+    let basePath = this._resolver.asset.httpServerLocation;
+    if (basePath[0] === '/') {
+      basePath = basePath.substr(1);
+    }
+
     if (local) {
-      const safePath = this._resolver.asset.httpServerLocation
-        .substr(1)
+      const safePath = basePath
         .replace(/\.\.\//g, '_');
       // If this asset was created with the newer saveAssetPlugin, then we should shorten the path
       // This conditional is added to allow back compat of older bundles which might have been created without the saveAssetPlugin
@@ -102,10 +106,6 @@ class AssetResolverLateScaleResolution {
       return safePath;
     }
 
-    let basePath = this._resolver.asset.httpServerLocation;
-    if (basePath[0] === '/') {
-      basePath = basePath.substr(1);
-    }
     return basePath;
   }
 

--- a/packages/@office-iss/react-native-win32/src/Libraries/Image/resolveAssetSource.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Image/resolveAssetSource.win32.js
@@ -96,8 +96,7 @@ class AssetResolverLateScaleResolution {
     }
 
     if (local) {
-      const safePath = basePath
-        .replace(/\.\.\//g, '_');
+      const safePath = basePath.replace(/\.\.\//g, '_');
       // If this asset was created with the newer saveAssetPlugin, then we should shorten the path
       // This conditional is added to allow back compat of older bundles which might have been created without the saveAssetPlugin
       if (this._resolver.asset.__useShortPath) {


### PR DESCRIPTION
The asset path handling is trimming an extra character off the path of assets assuming that its a '/'.  In metro this is always true, but for other bundlers it may not be.  This aligns the logic with the other code paths.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12119)