### PR TITLE
[Fabric] Custom native components should have access to the ReactContext

### DIFF
--- a/change/react-native-windows-1a194256-b950-463f-acfa-3fc056fb0276.json
+++ b/change/react-native-windows-1a194256-b950-463f-acfa-3fc056fb0276.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Custom native components should have access to the ReactContext",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -42,7 +42,9 @@ struct CustomProps : winrt::implements<CustomProps, winrt::Microsoft::ReactNativ
 };
 
 struct CustomComponent : winrt::implements<CustomComponent, winrt::IInspectable> {
-  CustomComponent(winrt::Microsoft::ReactNative::Composition::ICompositionContext compContext)
+  CustomComponent(
+      winrt::Microsoft::ReactNative::IReactContext reactContext,
+      winrt::Microsoft::ReactNative::Composition::ICompositionContext compContext)
       : m_compContext(compContext) {}
 
   void UpdateProps(winrt::Microsoft::ReactNative::IComponentProps props) noexcept {

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -112,8 +112,9 @@ struct CustomComponent : winrt::implements<CustomComponent, winrt::IInspectable>
           auto compBuilder =
               builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
           compBuilder.SetCreateView(
-              [](winrt::Microsoft::ReactNative::Composition::ICompositionContext context) noexcept {
-                return winrt::make<CustomComponent>(context);
+              [](winrt::Microsoft::ReactNative::IReactContext reactContext,
+                 winrt::Microsoft::ReactNative::Composition::ICompositionContext context) noexcept {
+                return winrt::make<CustomComponent>(reactContext, context);
               });
           compBuilder.SetPropsUpdater([](winrt::Windows::Foundation::IInspectable handle,
                                          winrt::Microsoft::ReactNative::IComponentProps props) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
@@ -13,23 +13,25 @@
 namespace Microsoft::ReactNative {
 
 AbiCompositionViewComponentView::AbiCompositionViewComponentView(
+    const winrt::Microsoft::ReactNative::IReactContext &reactContext,
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder)
     : Super(compContext, tag), m_builder(builder) {
   static auto const defaultProps = std::make_shared<AbiViewProps const>();
   m_props = defaultProps;
-  m_handle = Builder().CreateView(compContext);
+  m_handle = Builder().CreateView(reactContext, compContext);
   m_visual = Builder().CreateVisual(m_handle);
   OuterVisual().InsertAt(m_visual, 0);
 }
 
 std::shared_ptr<AbiCompositionViewComponentView> AbiCompositionViewComponentView::Create(
+    const winrt::Microsoft::ReactNative::IReactContext &reactContext,
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder) noexcept {
   return std::shared_ptr<AbiCompositionViewComponentView>(
-      new AbiCompositionViewComponentView(compContext, tag, builder));
+      new AbiCompositionViewComponentView(reactContext, compContext, tag, builder));
 }
 
 winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder &

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.h
@@ -19,6 +19,7 @@ struct AbiCompositionViewComponentView : CompositionBaseComponentView {
   using Super = CompositionBaseComponentView;
 
   [[nodiscard]] static std::shared_ptr<AbiCompositionViewComponentView> Create(
+      const winrt::Microsoft::ReactNative::IReactContext &reactContext,
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder) noexcept;
@@ -49,6 +50,7 @@ struct AbiCompositionViewComponentView : CompositionBaseComponentView {
 
  private:
   AbiCompositionViewComponentView(
+      const winrt::Microsoft::ReactNative::IReactContext &reactContext,
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -73,7 +73,10 @@ ComponentViewDescriptor const &ComponentViewRegistry::dequeueComponentViewWithCo
     auto descriptor =
         WindowsComponentDescriptorRegistry::FromProperties(m_context.Properties())->GetDescriptor(componentHandle);
     view = AbiCompositionViewComponentView::Create(
-        compContext, tag, descriptor.as<winrt::Microsoft::ReactNative::IReactViewComponentBuilder>());
+        m_context.Handle(),
+        compContext,
+        tag,
+        descriptor.as<winrt::Microsoft::ReactNative::IReactViewComponentBuilder>());
   }
 
   auto it = m_registry.insert({tag, ComponentViewDescriptor{view}});

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -52,8 +52,9 @@ void ReactCompositionViewComponentBuilder::SetMessageHandler(MessageHandler impl
 }
 
 winrt::Windows::Foundation::IInspectable ReactCompositionViewComponentBuilder::CreateView(
+    IReactContext reactContext,
     ICompositionContext context) noexcept {
-  return m_createView(context);
+  return m_createView(reactContext, context);
 }
 
 bool ReactCompositionViewComponentBuilder::HandelCommand(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -36,7 +36,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
  public:
   IComponentProps CreateProps(ViewProps props) noexcept;
 
-  winrt::Windows::Foundation::IInspectable CreateView(ICompositionContext context) noexcept;
+  winrt::Windows::Foundation::IInspectable CreateView(IReactContext reactContext, ICompositionContext context) noexcept;
   bool HandelCommand(
       winrt::Windows::Foundation::IInspectable handle,
       winrt::hstring commandName,

--- a/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
@@ -4,6 +4,7 @@
 #include "DocString.h"
 import "CompositionSwitcher.idl";
 import "IJSValueReader.idl";
+import "IReactContext.idl";
 import "ViewProps.idl";
 
 namespace Microsoft.ReactNative.Composition
@@ -17,7 +18,7 @@ namespace Microsoft.ReactNative.Composition
 
   [experimental]
   DOC_STRING("Provides a factory method to create an instance of a ViewComponent. See @IReactCompositionViewComponentBuilder.SetCreateView")
-  delegate Object CompositionComponentFactory(ICompositionContext context);
+  delegate Object CompositionComponentFactory(Microsoft.ReactNative.IReactContext reactContext, ICompositionContext context);
 
   // TODO should make an event args, with a handled bit instead of return value
   [experimental]


### PR DESCRIPTION
## Description
ViewManagers have access to the ReactContext, which enabled a bunch of functionality and data passing scenarios.
Fabric view components should also have access to the ReactContext.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12128)