### PR TITLE
[Fabric] Fix Textinput's caret on focus lost

### DIFF
--- a/change/react-native-windows-bc016154-a9c1-4dcd-8367-781644093aaa.json
+++ b/change/react-native-windows-bc016154-a9c1-4dcd-8367-781644093aaa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix fabric textinput's caret on focus lost",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -846,6 +846,7 @@ struct CompCaretVisual : winrt::implements<CompCaretVisual, winrt::Microsoft::Re
       m_compVisual.StartAnimation(L"opacity", m_opacityAnimation);
     } else {
       m_compVisual.StopAnimation(L"opacity");
+      m_compVisual.Opacity(0.0f);
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -583,6 +583,7 @@ void WindowsTextInputComponentView::unmountChildComponentView(
 void WindowsTextInputComponentView::onFocusLost() noexcept {
   Super::onFocusLost();
   sendMessage(WM_KILLFOCUS, 0, 0);
+  m_caretVisual.IsVisible(false);
 }
 
 void WindowsTextInputComponentView::onFocusGained() noexcept {


### PR DESCRIPTION
## Description
Makes TextInput's caret lose visibility when focus is lost.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #12125

### What
Set visibility to false when focus is lost

## Screenshots

https://github.com/microsoft/react-native-windows/assets/42554868/e8734a4c-f131-4977-b0f7-261bed706a7d

## Testing
tested locally

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12157)