### PR TITLE
[Fabric] Add Textinput's cursorColor

### DIFF
--- a/change/react-native-windows-59c4c93d-b696-4ed2-ad29-ce2c7aa0c3ca.json
+++ b/change/react-native-windows-59c4c93d-b696-4ed2-ad29-ce2c7aa0c3ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add fabric textinput's cursorColor",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -107,6 +107,7 @@ namespace Microsoft.ReactNative.Composition
     void Size(Windows.Foundation.Numerics.Vector2 size);
     void Position(Windows.Foundation.Numerics.Vector2 position);
     Boolean IsVisible { get; set; };
+    void updateColor(Windows.UI.Color color);
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -96,7 +96,7 @@ namespace Microsoft.ReactNative.Composition
   [experimental]
   interface IActivityVisual requires IVisual
   {
-    void updateColor(Windows.UI.Color color);
+    void Color(Windows.UI.Color color);
   }
 
   [webhosthidden]
@@ -107,7 +107,7 @@ namespace Microsoft.ReactNative.Composition
     void Size(Windows.Foundation.Numerics.Vector2 size);
     void Position(Windows.Foundation.Numerics.Vector2 position);
     Boolean IsVisible { get; set; };
-    void updateColor(Windows.UI.Color color);
+    void Color(Windows.UI.Color color);
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -54,7 +54,7 @@ void ActivityIndicatorComponentView::updateProps(
 
   // update color if needed
   if (newViewProps->color && (!oldProps || newViewProps->color != oldViewProps->color)) {
-    m_ActivityIndicatorVisual.updateColor(newViewProps->color.AsWindowsColor());
+    m_ActivityIndicatorVisual.Color(newViewProps->color.AsWindowsColor());
   }
 
   if (newViewProps->animating != oldViewProps->animating) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -629,7 +629,7 @@ struct CompActivityVisual : winrt::implements<
     }
   }
 
-  void updateColor(winrt::Windows::UI::Color color) noexcept {
+  void Color(winrt::Windows::UI::Color color) noexcept {
     // Change the color of each SpriteVisual
     for (auto &spriteVisual : m_spriteVisuals) {
       auto colorBrush = m_visual.Compositor().CreateColorBrush(color);
@@ -829,7 +829,7 @@ struct CompCaretVisual : winrt::implements<CompCaretVisual, winrt::Microsoft::Re
     return m_visual;
   }
 
-  void updateColor(winrt::Windows::UI::Color color) noexcept {
+  void Color(winrt::Windows::UI::Color color) noexcept {
     m_compVisual.Brush(m_compositor.CreateColorBrush(color));
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -829,6 +829,10 @@ struct CompCaretVisual : winrt::implements<CompCaretVisual, winrt::Microsoft::Re
     return m_visual;
   }
 
+  void updateColor(winrt::Windows::UI::Color color) noexcept {
+    m_compVisual.Brush(m_compositor.CreateColorBrush(color));
+  }
+
   void Size(winrt::Windows::Foundation::Numerics::float2 size) noexcept {
     m_compVisual.Size(size);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -651,6 +651,10 @@ void WindowsTextInputComponentView::updateProps(
     m_needsRedraw = true;
   }
 
+  if (oldTextInputProps.cursorColor != newTextInputProps.cursorColor) {
+    m_caretVisual.updateColor(newTextInputProps.cursorColor.AsWindowsColor());
+  }
+
   /*
   if (oldTextInputProps.textAttributes.foregroundColor != newTextInputProps.textAttributes.foregroundColor) {
     if (newTextInputProps.textAttributes.foregroundColor)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -652,7 +652,7 @@ void WindowsTextInputComponentView::updateProps(
   }
 
   if (oldTextInputProps.cursorColor != newTextInputProps.cursorColor) {
-    m_caretVisual.updateColor(newTextInputProps.cursorColor.AsWindowsColor());
+    m_caretVisual.Color(newTextInputProps.cursorColor.AsWindowsColor());
   }
 
   /*


### PR DESCRIPTION
## Description
Adds support for cursorColor

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
component parity

### What
added Color to CompCaretVisual (this should also help when implementing selectionColor)

## Screenshots
https://github.com/microsoft/react-native-windows/assets/42554868/ff2bbbbe-b1e4-4e62-9d00-6a654f1a9bbb

## Testing
tested locally

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12158)