### PR TITLE
Fix some incorrectly cased requires

### DIFF
--- a/change/@react-native-windows-codegen-8ccd3fe9-4d54-4b37-9276-ba4fbfa7ecd9.json
+++ b/change/@react-native-windows-codegen-8ccd3fe9-4d54-4b37-9276-ba4fbfa7ecd9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix some incorrectly cased requires",
+  "packageName": "@react-native-windows/codegen",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/codegen/src/index.ts
+++ b/packages/@react-native-windows/codegen/src/index.ts
@@ -259,7 +259,7 @@ export function generate(
   )).generate;
   const generatorPropsCPP = require(path.resolve(
     rncodegenPath,
-    'lib/generators/components/GeneratePropsCPP',
+    'lib/generators/components/GeneratePropsCpp',
   )).generate;
   const generatorShadowNodeH = require(path.resolve(
     rncodegenPath,
@@ -267,7 +267,7 @@ export function generate(
   )).generate;
   const generatorShadowNodeCPP = require(path.resolve(
     rncodegenPath,
-    'lib/generators/components/GenerateShadowNodeCPP',
+    'lib/generators/components/GenerateShadowNodeCpp',
   )).generate;
   const generatorComponentDescriptorH = require(path.resolve(
     rncodegenPath,


### PR DESCRIPTION
Saw these when trying to run a script which does `yarn build` in RNW fork on Linux server. May be more issues here (didn't test after making this fix). I know RNW yarn build is tested continuously on macOS (which is not case sensitive), so build should otherwise be relatively POSIX-y clean.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12169)