### PR TITLE
[Fabric] Add `react-native initWindows --template cpp-app` to CI

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -96,6 +96,20 @@ parameters:
             platform: x64
             projectType: app
             lowResource: true
+          - Name: FabricX64Release
+            language: cpp
+            configuration: Release
+            platform: x64
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Debug
+            language: cpp
+            configuration: Debug
+            platform: x86
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64ReleaseCpp
@@ -269,6 +283,34 @@ parameters:
             platform: x64
             projectType: app
             lowResource: true
+          - Name: FabricX64Debug
+            language: cpp
+            configuration: Debug
+            platform: x64
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
+          - Name: FabricX64Release
+            language: cpp
+            configuration: Release
+            platform: x64
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Debug
+            language: cpp
+            configuration: Debug
+            platform: x86
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Release
+            language: cpp
+            configuration: Release
+            platform: x86
+            projectType: app
+            initPath: InitWindows
+            additionalRunArguments: --no-autolink
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
@@ -315,6 +357,7 @@ jobs:
                   configuration: ${{ matrix.configuration }}
                   platform: ${{ matrix.platform }}
                   projectType: ${{ matrix.projectType }}
+                  initPath: ${{ coalesce(matrix.initPath, 'ReactNativeWindowsInit') }}
                   additionalInitArguments: ${{ matrix.additionalInitArguments }}
                   additionalRunArguments: ${{ matrix.additionalRunArguments }}
                   runWack: ${{ coalesce(matrix.runWack, false) }}

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -30,6 +30,12 @@ parameters:
   - name: runWack
     type: boolean
     default: false
+  - name: initPath
+    type: string
+    default: ReactNativeWindowsInit
+    values:
+      - ReactNativeWindowsInit
+      - InitWindows
   - name: additionalInitArguments
     type: string
     default: ''
@@ -96,29 +102,48 @@ steps:
   - script: yarn config set registry http://localhost:4873
     displayName: Modify yarn config to point to local verdaccio server
 
-  - ${{ if eq(parameters.useNuget, true) }}:
-    - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
-      displayName: Apply windows template (with nuget)
-      workingDirectory: $(Agent.BuildDirectory)\testcli
-      env:
-        npm_config_registry: http://localhost:4873
+  - ${{ if eq(parameters.initPath, 'ReactNativeWindowsInit') }}:
 
-  - ${{ if eq(parameters.useNuget, false) }}:
-    - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
-      displayName: Apply windows template (without nuget)
-      workingDirectory: $(Agent.BuildDirectory)\testcli
-      env:
-        npm_config_registry: http://localhost:4873
+    - ${{ if eq(parameters.useNuget, true) }}:
+      - script: |
+          npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
+        displayName: Apply windows template (with nuget)
+        workingDirectory: $(Agent.BuildDirectory)\testcli
+        env:
+          npm_config_registry: http://localhost:4873
 
-  - ${{ if eq(parameters.projectType, 'app') }}:
-    - powershell: |
-        [xml] $manifest = Get-Content .\Package.appxmanifest
-        $manifest.Package.Identity.Name = 'ReactNative.InitTest'
-        $manifest.Save("$pwd\Package.appxmanifest")
-      displayName: Set AppX package name to "ReactNative.InitTest"
-      workingDirectory: $(Agent.BuildDirectory)\testcli\windows\testcli
+    - ${{ if eq(parameters.useNuget, false) }}:
+      - script: |
+          npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
+        displayName: Apply windows template (without nuget)
+        workingDirectory: $(Agent.BuildDirectory)\testcli
+        env:
+          npm_config_registry: http://localhost:4873
+
+    - ${{ if eq(parameters.projectType, 'app') }}:
+      - powershell: |
+          [xml] $manifest = Get-Content .\Package.appxmanifest
+          $manifest.Package.Identity.Name = 'ReactNative.InitTest'
+          $manifest.Save("$pwd\Package.appxmanifest")
+        displayName: Set AppX package name to "ReactNative.InitTest"
+        workingDirectory: $(Agent.BuildDirectory)\testcli\windows\testcli
+  
+  - ${{ if eq(parameters.initPath, 'InitWindows') }}:
+    - ${{ if and(eq(parameters.projectType, 'app'), eq(parameters.language, 'cpp')) }}:
+      - script: |
+          call yarn add react-native-windows@$(npmVersion)
+          call yarn react-native init-windows --template cpp-app --overwrite --logging ${{ parameters.additionalInitArguments }}
+        displayName: Call react-native init-windows
+        workingDirectory: $(Agent.BuildDirectory)\testcli
+        env:
+          npm_config_registry: http://localhost:4873
+      
+      - powershell: |
+          [xml] $manifest = Get-Content .\Package.appxmanifest
+          $manifest.Package.Identity.Name = 'ReactNative.InitTest'
+          $manifest.Save("$pwd\Package.appxmanifest")
+        displayName: Set AppX package name to "ReactNative.InitTest"
+        workingDirectory: $(Agent.BuildDirectory)\testcli\windows\testcli.Package
 
   # Reclaim memory used by Verdaccio to reduce the chance of build OOM issues
   - script: tskill node

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -34,7 +34,7 @@ parameters:
 steps:
   - ${{ if eq(parameters.buildConfiguration, 'Debug') }}:
     - script: >
-        yarn windows
+        yarn react-native run-windows
         --arch ${{ parameters.buildPlatform }}
         --no-launch
         --logging
@@ -46,7 +46,7 @@ steps:
 
   - ${{ if and(eq(parameters.buildConfiguration, 'Release'), eq(parameters.buildEnvironment, 'PullRequest')) }}:
     - script: >
-        yarn windows
+        yarn react-native run-windows
         --arch ${{ parameters.buildPlatform }}
         --release
         --no-launch
@@ -63,7 +63,7 @@ steps:
         certificateName: ${{ parameters.certificateName }}
 
     - script: >
-        yarn windows
+        yarn react-native run-windows
         --arch ${{ parameters.buildPlatform }}
         --release
         --no-launch

--- a/change/@react-native-windows-cli-e83c269b-fa39-4421-be79-1ea0195ca4ec.json
+++ b/change/@react-native-windows-cli-e83c269b-fa39-4421-be79-1ea0195ca4ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use glob to look through folders recursively",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-7cd4367c-e7a0-4840-aa19-893c27796f6f.json
+++ b/change/react-native-windows-7cd4367c-e7a0-4840-aa19-893c27796f6f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use glob to look through folders recursively",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
## Description

Adds the usage of our new `init-windows` command, with the new fabric-based `cpp-app` template, to our CI, so we don't break it as we make changes.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
We're still making (breaking) changes to the Composition surface area, so we want to make sure that changes made to the in-repo fabric apps also get reflected in the new app template.

### What
Modifies our existing CLI test workflows to optionally use the new command instead. Also makes some changes to how the init code reads files recursively, which wasn't working in CI.

## Screenshots
N/A

## Testing
Verified the workflows ran.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12183)