### PR TITLE
Set UIA Name and HelpText properties on TextInput to match placeholder prop value

### DIFF
--- a/change/react-native-windows-bae3e528-c28a-4a7a-a119-2b91ceb4ec86.json
+++ b/change/react-native-windows-bae3e528-c28a-4a7a-a119-2b91ceb4ec86.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "uncommented changes",
+  "comment": "Set UIA Name and HelpText properties on TextInput to match placeholder prop value",
   "packageName": "react-native-windows",
   "email": "yajurgrover24@gmail.com",
   "dependentChangeType": "patch"

--- a/change/react-native-windows-bae3e528-c28a-4a7a-a119-2b91ceb4ec86.json
+++ b/change/react-native-windows-bae3e528-c28a-4a7a-a119-2b91ceb4ec86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "uncommented changes",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -285,8 +285,9 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
 
     case UIA_HelpTextPropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto helpText = props->accessibilityHint.empty() ? 
-        ::Microsoft::Common::Unicode::Utf8ToUtf16(baseView->DefaultHelpText()) : ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
+      auto helpText = props->accessibilityHint.empty()
+          ? ::Microsoft::Common::Unicode::Utf8ToUtf16(baseView->DefaultHelpText())
+          : ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
       pRetVal->bstrVal = SysAllocString(helpText.c_str());
       hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
       break;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -285,7 +285,8 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::GetPropertyValue(PROPERT
 
     case UIA_HelpTextPropertyId: {
       pRetVal->vt = VT_BSTR;
-      auto helpText = ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
+      auto helpText = props->accessibilityHint.empty() ? 
+        ::Microsoft::Common::Unicode::Utf8ToUtf16(baseView->DefaultHelpText()) : ::Microsoft::Common::Unicode::Utf8ToUtf16(props->accessibilityHint);
       pRetVal->bstrVal = SysAllocString(helpText.c_str());
       hr = pRetVal->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
       break;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1284,6 +1284,10 @@ std::string CompositionBaseComponentView::DefaultAccessibleName() const noexcept
   return "";
 }
 
+std::string CompositionBaseComponentView::DefaultHelpText() const noexcept {
+  return "";
+}
+
 CompositionViewComponentView::CompositionViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -82,6 +82,7 @@ struct CompositionBaseComponentView : public IComponentView,
 
   virtual std::string DefaultControlType() const noexcept;
   virtual std::string DefaultAccessibleName() const noexcept;
+  virtual std::string DefaultHelpText() const noexcept;
 
  protected:
   std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -660,9 +660,9 @@ std::string WindowsTextInputComponentView::DefaultControlType() const noexcept {
   return "textinput";
 }
 
-// std::string WindowsTextInputComponentView::DefaultAccessibleName() const noexcept {
-//   return m_props->placeholder;
-// }
+std::string WindowsTextInputComponentView::DefaultAccessibleName() const noexcept {
+  return m_props->placeholder;
+}
 
 void WindowsTextInputComponentView::updateProps(
     facebook::react::Props::Shared const &props,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -664,6 +664,10 @@ std::string WindowsTextInputComponentView::DefaultAccessibleName() const noexcep
   return m_props->placeholder;
 }
 
+std::string WindowsTextInputComponentView::DefaultHelpText() const noexcept {
+  return m_props->placeholder;
+}
+
 void WindowsTextInputComponentView::updateProps(
     facebook::react::Props::Shared const &props,
     facebook::react::Props::Shared const &oldProps) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -660,6 +660,10 @@ std::string WindowsTextInputComponentView::DefaultControlType() const noexcept {
   return "textinput";
 }
 
+// std::string WindowsTextInputComponentView::DefaultAccessibleName() const noexcept {
+//   return m_props->placeholder;
+// }
+
 void WindowsTextInputComponentView::updateProps(
     facebook::react::Props::Shared const &props,
     facebook::react::Props::Shared const &oldProps) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -53,7 +53,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   void onFocusGained() noexcept override;
   bool focusable() const noexcept override;
   std::string DefaultControlType() const noexcept override;
-//   std::string DefaultAccessibleName() const noexcept override;
+  std::string DefaultAccessibleName() const noexcept override;
   void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -53,6 +53,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   void onFocusGained() noexcept override;
   bool focusable() const noexcept override;
   std::string DefaultControlType() const noexcept override;
+//   std::string DefaultAccessibleName() const noexcept override;
   void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -54,6 +54,7 @@ struct WindowsTextInputComponentView : CompositionBaseComponentView {
   bool focusable() const noexcept override;
   std::string DefaultControlType() const noexcept override;
   std::string DefaultAccessibleName() const noexcept override;
+  std::string DefaultHelpText() const noexcept override;
   void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;


### PR DESCRIPTION
## Description
Set the UIA Name property on a TextInput component to match the value of the `placeholder` property on the TextInput.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Following the guidelines in the [Edit](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-supporteditcontroltype) control type documentation, which is the control type for TextInput, the Name property should be set by a static text label, or by the application developer (which is when `accessibilityLabel` is set). In the event that there is no accessibilityLabel property set, the name value defaults to the placeholder text. If there is no accessibilityLabel or placeholder property set, then the UIA Name property will be left unpopulated.

The documentation also says that when a placeholder prop is set, the HelpText UIA property should be set to the value of the placeholder. In the event that the accessibilityHint property is not set, the HelpText property will be set to the placeholder value. If there is no accessibilityLabel or placeholder property set, then the UIA HelpText property will be left unpopulated.

### What
Added code to set UIA Name and HelpText properties to placeholder value of TextInput

## Screenshots
Before: 
![image](https://github.com/microsoft/react-native-windows/assets/30995198/d0f3736f-fba7-4a63-bae9-9c5bc9fdec7d)
After:
![image](https://github.com/microsoft/react-native-windows/assets/30995198/8d4735f1-60ef-400f-a48a-d093baa828dc)


## Testing
Tested changes locally on the TextInput example page in RNTester on playground-composition.

## Changelog
Yes

Set UIA Name and HelpText properties on TextInput to match placeholder prop value
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12186)