### PR TITLE
[Fabric] Add keyboard handlers to ScrollView

### DIFF
--- a/change/react-native-windows-58b41525-866f-4ad8-963c-cfa92497c7ac.json
+++ b/change/react-native-windows-58b41525-866f-4ad8-963c-cfa92497c7ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add keyboard handlers to ScrollView",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -88,7 +88,7 @@ namespace Microsoft.ReactNative.Composition
     event Windows.Foundation.EventHandler<IScrollPositionChangedArgs> ScrollPositionChanged;
     void ContentSize(Windows.Foundation.Numerics.Vector2 size);
     Windows.Foundation.Numerics.Vector3 ScrollPosition { get; };
-    void ScrollBy(Windows.Foundation.Numerics.Vector3 offset);
+    void ScrollBy(Windows.Foundation.Numerics.Vector3 offset, Boolean animate);
     void TryUpdatePosition(Windows.Foundation.Numerics.Vector3 position, Boolean animate);
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -75,6 +75,7 @@ struct IComponentView {
   virtual void onKeyUp(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept = 0;
+  virtual bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept = 0;
   virtual bool focusable() const noexcept = 0;
   virtual facebook::react::SharedViewEventEmitter eventEmitterAtPoint(facebook::react::Point pt) noexcept = 0;
   virtual facebook::react::SharedViewEventEmitter eventEmitter() noexcept = 0;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -728,9 +728,9 @@ struct CompScrollerVisual : winrt::implements<
   }
 
   // ChangeOffsets scrolling constants
-  static constexpr int s_offsetsChangeMsPerUnit{5};
-  static constexpr int s_offsetsChangeMinMs{50};
-  static constexpr int s_offsetsChangeMaxMs{1000};
+  static constexpr int64_t s_offsetsChangeMsPerUnit{5};
+  static constexpr int64_t s_offsetsChangeMinMs{50};
+  static constexpr int64_t s_offsetsChangeMaxMs{1000};
 
   typename TTypeRedirects::CompositionAnimation GetPositionAnimation(float x, float y) {
     const int64_t distance =
@@ -768,16 +768,7 @@ struct CompScrollerVisual : winrt::implements<
   void TryUpdatePosition(winrt::Windows::Foundation::Numerics::float3 const &position, bool animate) noexcept {
     auto maxPosition = m_interactionTracker.MaxPosition();
     if (animate) {
-      auto compositor = m_visual.Compositor();
-      auto cubicBezier = compositor.CreateCubicBezierEasingFunction({0.17f, 0.67f}, {1.0f, 1.0f});
-      auto kfa = compositor.CreateVector3KeyFrameAnimation();
-      kfa.Duration(std::chrono::seconds{1});
-      kfa.InsertKeyFrame(
-          1.0f,
-          {std::min(maxPosition.x, position.x),
-           std::min(maxPosition.y, position.y),
-           std::min(maxPosition.z, position.z)},
-          cubicBezier);
+      auto kfa = GetPositionAnimation(std::min(maxPosition.x, position.x), std::min(maxPosition.y, position.y));
       m_interactionTracker.TryUpdatePositionWithAnimation(kfa);
     } else {
       m_interactionTracker.TryUpdatePosition(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -739,8 +739,8 @@ struct CompScrollerVisual : winrt::implements<
     auto positionAnimation = compositor.CreateVector3KeyFrameAnimation();
 
     positionAnimation.InsertKeyFrame(1.0f, {x, y, 0.0f});
-    positionAnimation.Duration(winrt::TimeSpan::duration(
-        std::clamp(distance * s_offsetsChangeMsPerUnit, s_offsetsChangeMinMs, s_offsetsChangeMaxMs) * 10000));
+    positionAnimation.Duration(std::chrono::milliseconds(
+        std::clamp(distance * s_offsetsChangeMsPerUnit, s_offsetsChangeMinMs, s_offsetsChangeMaxMs)));
 
     return positionAnimation;
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -726,10 +726,18 @@ struct CompScrollerVisual : winrt::implements<
       auto cubicBezier = compositor.CreateCubicBezierEasingFunction({0.17f, 0.67f}, {1.0f, 1.0f});
       auto kfa = compositor.CreateVector3KeyFrameAnimation();
       kfa.Duration(std::chrono::seconds{1});
-      kfa.InsertKeyFrame(1.0f, {std::min(maxPosition.x, position.x), std::min(maxPosition.y, position.y), std::min(maxPosition.z, position.z)}, cubicBezier);
+      kfa.InsertKeyFrame(
+          1.0f,
+          {std::min(maxPosition.x, position.x),
+           std::min(maxPosition.y, position.y),
+           std::min(maxPosition.z, position.z)},
+          cubicBezier);
       m_interactionTracker.TryUpdatePositionWithAnimation(kfa);
     } else {
-      m_interactionTracker.TryUpdatePosition({std::min(maxPosition.x, position.x), std::min(maxPosition.y, position.y), std::min(maxPosition.z, position.z)});
+      m_interactionTracker.TryUpdatePosition(
+          {std::min(maxPosition.x, position.x),
+           std::min(maxPosition.y, position.y),
+           std::min(maxPosition.z, position.z)});
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -720,15 +720,16 @@ struct CompScrollerVisual : winrt::implements<
   };
 
   void TryUpdatePosition(winrt::Windows::Foundation::Numerics::float3 const &position, bool animate) noexcept {
+    auto maxPosition = m_interactionTracker.MaxPosition();
     if (animate) {
       auto compositor = m_visual.Compositor();
       auto cubicBezier = compositor.CreateCubicBezierEasingFunction({0.17f, 0.67f}, {1.0f, 1.0f});
       auto kfa = compositor.CreateVector3KeyFrameAnimation();
       kfa.Duration(std::chrono::seconds{1});
-      kfa.InsertKeyFrame(1.0f, position, cubicBezier);
+      kfa.InsertKeyFrame(1.0f, {std::min(maxPosition.x, position.x), std::min(maxPosition.y, position.y), std::min(maxPosition.z, position.z)}, cubicBezier);
       m_interactionTracker.TryUpdatePositionWithAnimation(kfa);
     } else {
-      m_interactionTracker.TryUpdatePosition(position);
+      m_interactionTracker.TryUpdatePosition({std::min(maxPosition.x, position.x), std::min(maxPosition.y, position.y), std::min(maxPosition.z, position.z)});
     }
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -34,6 +34,7 @@ struct CompositionTypeTraits<WindowsTypeTag> {
   using AnimationDelayBehavior = winrt::Windows::UI::Composition::AnimationDelayBehavior;
   using AnimationDirection = winrt::Windows::UI::Composition::AnimationDirection;
   using AnimationIterationBehavior = winrt::Windows::UI::Composition::AnimationIterationBehavior;
+  using CompositionAnimation = winrt::Windows::UI::Composition::CompositionAnimation;
   using CompositionBackfaceVisibility = winrt::Windows::UI::Composition::CompositionBackfaceVisibility;
   using CompositionBrush = winrt::Windows::UI::Composition::CompositionBrush;
   using CompositionDrawingSurface = winrt::Windows::UI::Composition::CompositionDrawingSurface;
@@ -89,6 +90,7 @@ struct CompositionTypeTraits<MicrosoftTypeTag> {
   using AnimationDelayBehavior = winrt::Microsoft::UI::Composition::AnimationDelayBehavior;
   using AnimationDirection = winrt::Microsoft::UI::Composition::AnimationDirection;
   using AnimationIterationBehavior = winrt::Microsoft::UI::Composition::AnimationIterationBehavior;
+  using CompositionAnimation = winrt::Microsoft::UI::Composition::CompositionAnimation;
   using CompositionBackfaceVisibility = winrt::Microsoft::UI::Composition::CompositionBackfaceVisibility;
   using CompositionBrush = winrt::Microsoft::UI::Composition::CompositionBrush;
   using CompositionDrawingSurface = winrt::Microsoft::UI::Composition::CompositionDrawingSurface;
@@ -536,13 +538,22 @@ struct CompScrollerVisual : winrt::implements<
 
     void CustomAnimationStateEntered(
         typename TTypeRedirects::InteractionTracker sender,
-        typename TTypeRedirects::InteractionTrackerCustomAnimationStateEnteredArgs args) noexcept {}
+        typename TTypeRedirects::InteractionTrackerCustomAnimationStateEnteredArgs args) noexcept {
+      m_outer->m_custom = true;
+      m_outer->m_inertia = false;
+    }
     void IdleStateEntered(
         typename TTypeRedirects::InteractionTracker sender,
-        typename TTypeRedirects::InteractionTrackerIdleStateEnteredArgs args) noexcept {}
+        typename TTypeRedirects::InteractionTrackerIdleStateEnteredArgs args) noexcept {
+      m_outer->m_custom = false;
+      m_outer->m_inertia = false;
+    }
     void InertiaStateEntered(
         typename TTypeRedirects::InteractionTracker sender,
-        typename TTypeRedirects::InteractionTrackerInertiaStateEnteredArgs args) noexcept {}
+        typename TTypeRedirects::InteractionTrackerInertiaStateEnteredArgs args) noexcept {
+      m_outer->m_custom = false;
+      m_outer->m_inertia = true;
+    }
     void InteractingStateEntered(
         typename TTypeRedirects::InteractionTracker sender,
         typename TTypeRedirects::InteractionTrackerInteractingStateEnteredArgs args) noexcept {}
@@ -552,6 +563,7 @@ struct CompScrollerVisual : winrt::implements<
     void ValuesChanged(
         typename TTypeRedirects::InteractionTracker sender,
         typename TTypeRedirects::InteractionTrackerValuesChangedArgs args) noexcept {
+      m_outer->m_currentPosition = args.Position();
       m_outer->FireScrollPositionChanged({args.Position().x, args.Position().y});
     }
 
@@ -715,8 +727,42 @@ struct CompScrollerVisual : winrt::implements<
     return m_interactionTracker.Position();
   }
 
-  void ScrollBy(winrt::Windows::Foundation::Numerics::float3 const &offset) noexcept {
-    m_interactionTracker.TryUpdatePositionBy(offset);
+  // ChangeOffsets scrolling constants
+  static constexpr int s_offsetsChangeMsPerUnit{5};
+  static constexpr int s_offsetsChangeMinMs{50};
+  static constexpr int s_offsetsChangeMaxMs{1000};
+
+  typename TTypeRedirects::CompositionAnimation GetPositionAnimation(float x, float y) {
+    const int64_t distance =
+        static_cast<int64_t>(std::sqrt(std::pow(x - m_currentPosition.x, 2.0f) + pow(y - m_currentPosition.y, 2.0f)));
+    auto compositor = m_visual.Compositor();
+    auto positionAnimation = compositor.CreateVector3KeyFrameAnimation();
+
+    positionAnimation.InsertKeyFrame(1.0f, {x, y, 0.0f});
+    positionAnimation.Duration(winrt::TimeSpan::duration(
+        std::clamp(distance * s_offsetsChangeMsPerUnit, s_offsetsChangeMinMs, s_offsetsChangeMaxMs) * 10000));
+
+    return positionAnimation;
+  }
+
+  void ScrollBy(winrt::Windows::Foundation::Numerics::float3 const &offset, bool animate) noexcept {
+    auto restingPosition = m_inertia ? m_interactionTracker.NaturalRestingPosition() : m_interactionTracker.Position();
+    if (m_custom) {
+      restingPosition = m_targetPosition;
+    }
+    if (animate) {
+      auto maxPosition = m_interactionTracker.MaxPosition();
+      m_custom = true;
+      m_targetPosition = {
+          std::clamp(restingPosition.x + offset.x, 0.0f, maxPosition.x),
+          std::clamp(restingPosition.y + offset.y, 0.0f, maxPosition.y),
+          std::clamp(restingPosition.z + offset.z, 0.0f, maxPosition.z)};
+
+      auto kfa = GetPositionAnimation(m_targetPosition.x, m_targetPosition.y);
+      m_interactionTracker.TryUpdatePositionWithAnimation(kfa);
+    } else {
+      m_interactionTracker.TryUpdatePositionBy(offset);
+    }
   };
 
   void TryUpdatePosition(winrt::Windows::Foundation::Numerics::float3 const &position, bool animate) noexcept {
@@ -753,6 +799,10 @@ struct CompScrollerVisual : winrt::implements<
          0});
   }
 
+  bool m_inertia{false};
+  bool m_custom{false};
+  winrt::Windows::Foundation::Numerics::float3 m_targetPosition;
+  winrt::Windows::Foundation::Numerics::float3 m_currentPosition;
   winrt::Windows::Foundation::Numerics::float2 m_contentSize{0};
   winrt::Windows::Foundation::Numerics::float2 m_visualSize{0};
   winrt::event<

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -156,7 +156,8 @@ void CompositionEventHandler::ScrollWheel(facebook::react::Point pt, uint32_t de
     facebook::react::Point ptLocal;
 
     facebook::react::Point ptScaled = {
-        static_cast<float>(pt.x / m_compRootView.ScaleFactor()), static_cast<float>(pt.y / m_compRootView.ScaleFactor())};
+        static_cast<float>(pt.x / m_compRootView.ScaleFactor()),
+        static_cast<float>(pt.y / m_compRootView.ScaleFactor())};
     auto tag = RootComponentView().hitTest(ptScaled, ptLocal);
 
     if (tag == -1) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -155,10 +155,17 @@ void CompositionEventHandler::ScrollWheel(facebook::react::Point pt, uint32_t de
           ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties())) {
     facebook::react::Point ptLocal;
 
-    RootComponentView().ScrollWheel(
-        {static_cast<float>(pt.x / m_compRootView.ScaleFactor()),
-         static_cast<float>(pt.y / m_compRootView.ScaleFactor())},
-        delta);
+    facebook::react::Point ptScaled = {
+        static_cast<float>(pt.x / m_compRootView.ScaleFactor()), static_cast<float>(pt.y / m_compRootView.ScaleFactor())};
+    auto tag = RootComponentView().hitTest(ptScaled, ptLocal);
+
+    if (tag == -1) {
+      return;
+    }
+
+    IComponentView *targetComponentView =
+        fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(tag).view.get();
+    static_cast<CompositionBaseComponentView *>(targetComponentView)->ScrollWheel(ptLocal, delta);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -176,6 +176,11 @@ const facebook::react::SharedViewEventEmitter &CompositionBaseComponentView::Get
 }
 
 bool CompositionBaseComponentView::ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept {
+  if (m_parent) {
+    pt.x += m_layoutMetrics.frame.origin.x * m_layoutMetrics.pointScaleFactor;
+    pt.y += m_layoutMetrics.frame.origin.y * m_layoutMetrics.pointScaleFactor;
+    return m_parent->ScrollWheel(pt, delta);
+  }
   return false;
 }
 
@@ -1375,19 +1380,6 @@ facebook::react::Tag CompositionViewComponentView::hitTest(
   }
 
   return -1;
-}
-
-bool CompositionViewComponentView::ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept {
-  facebook::react::Point ptLocal{pt.x - m_layoutMetrics.frame.origin.x, pt.y - m_layoutMetrics.frame.origin.y};
-
-  facebook::react::Tag tag;
-  if (std::any_of(m_children.rbegin(), m_children.rend(), [ptLocal, delta](auto child) {
-        return const_cast<CompositionBaseComponentView *>(static_cast<const CompositionBaseComponentView *>(child))
-            ->ScrollWheel(ptLocal, delta);
-      }))
-    return true;
-
-  return false;
 }
 
 void CompositionViewComponentView::onKeyDown(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -49,7 +49,7 @@ struct CompositionBaseComponentView : public IComponentView,
   facebook::react::Tag tag() const noexcept override;
   int64_t sendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept override;
 
-  virtual bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept;
+  bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept override;
   RECT getClientRect() const noexcept override;
 
   void indexOffsetForBorder(uint32_t &index) const noexcept;
@@ -147,7 +147,6 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
       facebook::react::Point pt,
       facebook::react::Point &localPt,
       bool ignorePointerEvents = false) const noexcept override;
-  bool ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept override;
 
   winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -157,20 +157,6 @@ void ScrollViewComponentView::updateProps(
     }
   }
 
-  /*
-  if (oldViewProps.borderColors != newViewProps.borderColors) {
-    if (newViewProps.borderColors.all) {
-      m_element.BorderBrush(SolidColorBrushFrom(*newViewProps.borderColors.all));
-    } else {
-      m_element.ClearValue(winrt::Microsoft::ReactNative::ViewPanel::BorderBrushProperty());
-    }
-  }
-
-  if (oldViewProps.borderStyles != newViewProps.borderStyles) {
-    m_needsBorderUpdate = true;
-  }
-  */
-
   // update BaseComponentView props
   updateShadowProps(oldViewProps, newViewProps, m_visual);
   updateTransformProps(oldViewProps, newViewProps, m_visual);
@@ -178,8 +164,6 @@ void ScrollViewComponentView::updateProps(
 
   m_props = std::static_pointer_cast<facebook::react::ViewProps const>(props);
 }
-
-void ScrollViewComponentView::updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept {}
 
 void ScrollViewComponentView::updateState(
     facebook::react::State::Shared const &state,
@@ -295,28 +279,28 @@ void ScrollViewComponentView::onKeyDown(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   switch (args.Key()) {
     case winrt::Windows::System::VirtualKey::End:
-      args.Handled(scrollToEnd(false));
+      args.Handled(scrollToEnd(true));
       break;
     case winrt::Windows::System::VirtualKey::Home:
-      args.Handled(scrollToStart(false));
+      args.Handled(scrollToStart(true));
       break;
     case winrt::Windows::System::VirtualKey::PageDown:
-      args.Handled(pageDown(false));
+      args.Handled(pageDown(true));
       break;
     case winrt::Windows::System::VirtualKey::PageUp:
-      args.Handled(pageUp(false));
+      args.Handled(pageUp(true));
       break;
     case winrt::Windows::System::VirtualKey::Up:
-      args.Handled(lineUp(false));
+      args.Handled(lineUp(true));
       break;
     case winrt::Windows::System::VirtualKey::Down:
-      args.Handled(lineDown(false));
+      args.Handled(lineDown(true));
       break;
     case winrt::Windows::System::VirtualKey::Left:
-      args.Handled(lineLeft(false));
+      args.Handled(lineLeft(true));
       break;
     case winrt::Windows::System::VirtualKey::Right:
-      args.Handled(lineRight(false));
+      args.Handled(lineRight(true));
       break;
   }
 }
@@ -339,28 +323,11 @@ bool ScrollViewComponentView::scrollToStart(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::pageUp(bool animate) noexcept {
-  if (m_scrollVisual.ScrollPosition().y <= 0.0f) {
-    return false;
-  }
-
-  float scrollToVertical =
-      m_scrollVisual.ScrollPosition().y - (m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
-  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
-  return true;
+  return scrollUp(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor, animate);
 }
 
 bool ScrollViewComponentView::pageDown(bool animate) noexcept {
-  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
-       m_scrollVisual.ScrollPosition().y) < 1.0f) {
-    return false;
-  }
-
-  float scrollToVertical =
-      m_scrollVisual.ScrollPosition().y + (m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
-  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
-  return true;
+  return scrollDown(m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor, animate);
 }
 
 bool ScrollViewComponentView::lineUp(bool animate) noexcept {
@@ -376,10 +343,7 @@ bool ScrollViewComponentView::lineLeft(bool animate) noexcept {
     return false;
   }
 
-  float scrollToVertical = m_scrollVisual.ScrollPosition().y;
-  float scrollToHorizontal =
-      m_scrollVisual.ScrollPosition().x - (c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor);
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  m_scrollVisual.ScrollBy({-c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor, 0, 0}, animate);
   return true;
 }
 
@@ -389,10 +353,7 @@ bool ScrollViewComponentView::lineRight(bool animate) noexcept {
     return false;
   }
 
-  float scrollToVertical = m_scrollVisual.ScrollPosition().y;
-  float scrollToHorizontal =
-      m_scrollVisual.ScrollPosition().x + (c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor);
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  m_scrollVisual.ScrollBy({c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor, 0, 0}, animate);
   return true;
 }
 
@@ -403,9 +364,7 @@ bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
     return false;
   }
 
-  float scrollToVertical = m_scrollVisual.ScrollPosition().y + delta;
-  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  m_scrollVisual.ScrollBy({0, delta, 0}, animate);
   return true;
 }
 
@@ -414,9 +373,7 @@ bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
     return false;
   }
 
-  float scrollToVertical = m_scrollVisual.ScrollPosition().y - delta;
-  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
-  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  m_scrollVisual.ScrollBy({0, -delta, 0}, animate);
   return true;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -21,6 +21,8 @@
 
 namespace Microsoft::ReactNative {
 
+constexpr float c_scrollerLineDelta = 16.0f;
+
 std::shared_ptr<ScrollViewComponentView> ScrollViewComponentView::Create(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag) noexcept {
@@ -272,37 +274,162 @@ void ScrollViewComponentView::OnPointerDown(const winrt::Windows::UI::Input::Poi
 */
 
 bool ScrollViewComponentView::ScrollWheel(facebook::react::Point pt, int32_t delta) noexcept {
-  facebook::react::Point ptViewport{pt.x - m_layoutMetrics.frame.origin.x, pt.y - m_layoutMetrics.frame.origin.y};
-
-  facebook::react::Point ptContent{
-      ptViewport.x + m_scrollVisual.ScrollPosition().x / m_layoutMetrics.pointScaleFactor,
-      ptViewport.y + m_scrollVisual.ScrollPosition().y / m_layoutMetrics.pointScaleFactor};
-
-  if (std::any_of(m_children.rbegin(), m_children.rend(), [ptContent, delta](auto child) {
-        return const_cast<CompositionBaseComponentView *>(static_cast<const CompositionBaseComponentView *>(child))
-            ->ScrollWheel(ptContent, delta);
-      }))
-    return true;
-
-  if (ptViewport.x >= 0 && ptViewport.x <= m_layoutMetrics.frame.size.width && ptViewport.y >= 0 &&
-      ptViewport.y <= m_layoutMetrics.frame.size.height) {
-    m_scrollVisual.ScrollBy({0, static_cast<float>(-delta), 0});
-    return true;
+  if (delta > 0) {
+    if (scrollUp(static_cast<float>(delta) * m_layoutMetrics.pointScaleFactor, true)) {
+      return true;
+    }
+  } else if (delta < 0) {
+    if (scrollDown(-static_cast<float>(delta) * m_layoutMetrics.pointScaleFactor, true)) {
+      return true;
+    };
   }
 
-  return false;
+  // Adjust pt for viewport before it goes to the parent
+  pt.x -= m_scrollVisual.ScrollPosition().x;
+  pt.y -= m_scrollVisual.ScrollPosition().y;
+  return Super::ScrollWheel(pt, delta);
 }
+
+void ScrollViewComponentView::onKeyDown(
+    const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
+    const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
+  switch (args.Key()) {
+    case winrt::Windows::System::VirtualKey::End:
+      args.Handled(scrollToEnd(false));
+      break;
+    case winrt::Windows::System::VirtualKey::Home:
+      args.Handled(scrollToStart(false));
+      break;
+    case winrt::Windows::System::VirtualKey::PageDown:
+      args.Handled(pageDown(false));
+      break;
+    case winrt::Windows::System::VirtualKey::PageUp:
+      args.Handled(pageUp(false));
+      break;
+    case winrt::Windows::System::VirtualKey::Up:
+      args.Handled(lineUp(false));
+      break;
+    case winrt::Windows::System::VirtualKey::Down:
+      args.Handled(lineDown(false));
+      break;
+    case winrt::Windows::System::VirtualKey::Left:
+      args.Handled(lineLeft(false));
+      break;
+    case winrt::Windows::System::VirtualKey::Right:
+      args.Handled(lineRight(false));
+      break;
+  }
+}
+
+bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
+  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y) < 1.0f)
+  {
+    return false;
+  }
+
+  auto x = (m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor;
+  auto y = (m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor;
+  m_scrollVisual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
+  return true;
+}
+
+bool ScrollViewComponentView::scrollToStart(bool animate) noexcept {
+  m_scrollVisual.TryUpdatePosition({0.0f, 0.0f, 0.0f}, animate);
+  return true;
+}
+
+bool ScrollViewComponentView::pageUp(bool animate) noexcept {
+  if (m_scrollVisual.ScrollPosition().y <= 0.0f) {
+    return false;
+  }
+
+  float scrollToVertical =
+      m_scrollVisual.ScrollPosition().y - (m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
+  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
+bool ScrollViewComponentView::pageDown(bool animate) noexcept {
+  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y) < 1.0f)
+  {
+    return false;
+  }
+
+  float scrollToVertical =
+      m_scrollVisual.ScrollPosition().y + (m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor);
+  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
+bool ScrollViewComponentView::lineUp(bool animate) noexcept {
+  return scrollUp(c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor, animate);
+}
+
+bool ScrollViewComponentView::lineDown(bool animate) noexcept {
+  return scrollDown(c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor, animate);
+}
+
+bool ScrollViewComponentView::lineLeft(bool animate) noexcept {
+  if (m_scrollVisual.ScrollPosition().x <= 0.0f) {
+    return false;
+  }
+
+  float scrollToVertical = m_scrollVisual.ScrollPosition().y;
+  float scrollToHorizontal =
+      m_scrollVisual.ScrollPosition().x - (c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor);
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
+bool ScrollViewComponentView::lineRight(bool animate) noexcept {
+  if ((((m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().x) < 1.0f) {
+    return false;
+  }
+
+  float scrollToVertical = m_scrollVisual.ScrollPosition().y;
+  float scrollToHorizontal =
+      m_scrollVisual.ScrollPosition().x + (c_scrollerLineDelta * m_layoutMetrics.pointScaleFactor);
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
+bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
+  if (((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y < 1.0f)
+  {
+    return false;
+  }
+
+  float scrollToVertical = m_scrollVisual.ScrollPosition().y + delta;
+  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
+bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
+  if (m_scrollVisual.ScrollPosition().y <= 0.0f) {
+    return false;
+  }
+
+  float scrollToVertical = m_scrollVisual.ScrollPosition().y - delta;
+  float scrollToHorizontal = m_scrollVisual.ScrollPosition().x;
+  m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
+  return true;
+}
+
 
 void ScrollViewComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
   if (commandName == "scrollTo") {
-    auto x = arg[0].asDouble();
-    auto y = arg[1].asDouble();
+    auto x = arg[0].asDouble() * m_layoutMetrics.pointScaleFactor;
+    auto y = arg[1].asDouble() * m_layoutMetrics.pointScaleFactor;
     auto animate = arg[2].asBool();
     m_scrollVisual.TryUpdatePosition({static_cast<float>(x), static_cast<float>(y), 0.0f}, animate);
   } else if (commandName == "flashScrollIndicators") {
     // No-op for now
   } else if (commandName == "scrollToEnd") {
-    // No-op for now
+    auto animate = arg[0].asBool();
+    scrollToEnd(animate);
   } else if (commandName == "zoomToRect") {
     // No-op for now
   } else {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -322,8 +322,8 @@ void ScrollViewComponentView::onKeyDown(
 }
 
 bool ScrollViewComponentView::scrollToEnd(bool animate) noexcept {
-  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y) < 1.0f)
-  {
+  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
+       m_scrollVisual.ScrollPosition().y) < 1.0f) {
     return false;
   }
 
@@ -351,8 +351,8 @@ bool ScrollViewComponentView::pageUp(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::pageDown(bool animate) noexcept {
-  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y) < 1.0f)
-  {
+  if ((((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
+       m_scrollVisual.ScrollPosition().y) < 1.0f) {
     return false;
   }
 
@@ -384,7 +384,8 @@ bool ScrollViewComponentView::lineLeft(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::lineRight(bool animate) noexcept {
-  if ((((m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().x) < 1.0f) {
+  if ((((m_contentSize.width - m_layoutMetrics.frame.size.width) * m_layoutMetrics.pointScaleFactor) -
+       m_scrollVisual.ScrollPosition().x) < 1.0f) {
     return false;
   }
 
@@ -396,8 +397,9 @@ bool ScrollViewComponentView::lineRight(bool animate) noexcept {
 }
 
 bool ScrollViewComponentView::scrollDown(float delta, bool animate) noexcept {
-  if (((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) - m_scrollVisual.ScrollPosition().y < 1.0f)
-  {
+  if (((m_contentSize.height - m_layoutMetrics.frame.size.height) * m_layoutMetrics.pointScaleFactor) -
+          m_scrollVisual.ScrollPosition().y <
+      1.0f) {
     return false;
   }
 
@@ -417,7 +419,6 @@ bool ScrollViewComponentView::scrollUp(float delta, bool animate) noexcept {
   m_scrollVisual.TryUpdatePosition({scrollToHorizontal, scrollToVertical, 0.0f}, false /*animate*/);
   return true;
 }
-
 
 void ScrollViewComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
   if (commandName == "scrollTo") {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -69,6 +69,9 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void finalizeUpdates(RNComponentViewUpdateMask updateMask) noexcept override;
   void prepareForRecycle() noexcept override;
   facebook::react::Props::Shared props() noexcept override;
+  void onKeyDown(
+      const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
+      const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept override;
 
   void handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept override;
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
@@ -88,6 +91,16 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
 
   void ensureVisual() noexcept;
   void updateContentVisualSize() noexcept;
+  bool scrollToEnd(bool animate) noexcept;
+  bool scrollToStart(bool animate) noexcept;
+  bool pageUp(bool animate) noexcept;
+  bool pageDown(bool animate) noexcept;
+  bool lineUp(bool animate) noexcept;
+  bool lineDown(bool animate) noexcept;
+  bool lineLeft(bool animate) noexcept;
+  bool lineRight(bool animate) noexcept;
+  bool scrollDown(float delta, bool animate) noexcept;
+  bool scrollUp(float delta, bool animate) noexcept;
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
@@ -100,7 +113,6 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool m_isScrollingFromInertia = false;
   bool m_isScrolling = false;
   bool m_isHorizontal = false;
-  bool m_isScrollingEnabled = true;
   bool m_changeViewAfterLoaded = false;
   bool m_dismissKeyboardOnDrag = false;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -60,7 +60,6 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void unmountChildComponentView(IComponentView &childComponentView, uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept
       override;
-  void updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept override;
   void updateState(facebook::react::State::Shared const &state, facebook::react::State::Shared const &oldState) noexcept
       override;
   void updateLayoutMetrics(


### PR DESCRIPTION
## Description
ScrollView does not respond to keyboard commands (page up, page down, home, end, or arrow keys).
Also fixes an issue where the scrollTo command would not scale the target location for scale factor, and ensures that scrollwheel handling chains through multiple scrollviews correctly.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Resolves #12076 and #12074

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12190)