### PR TITLE
Fixed incorrect accessibilityRole value breaking Accessibility Insights in RNTester View example page

### DIFF
--- a/packages/@react-native-windows/tester/src/js/examples/View/ViewExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/View/ViewExample.windows.js
@@ -400,7 +400,7 @@ class AccessibilityExample extends React.Component<
       <View
         accessibilityLabel="A View with accessibility values"
         accessibilityHint="Accessibility Hint"
-        accessibilityRole="View"
+        accessibilityRole="none"
         accessibilityValue={0}
         accessibilityActions={[
           {name: 'cut', label: 'cut'},

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -79190,7 +79190,7 @@ exports[`snapshotAllPages View 23`] = `
   }
   accessibilityHint="Accessibility Hint"
   accessibilityLabel="A View with accessibility values"
-  accessibilityRole="View"
+  accessibilityRole="none"
   accessibilityValue={0}
   accessible={true}
   focusable={true}

--- a/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app/test/__snapshots__/ViewComponentTest.test.ts.snap
@@ -252,7 +252,7 @@ exports[`ViewTests Views can have a custom nativeID 1`] = `
 
 exports[`ViewTests Views can have accessibility customization 1`] = `
 {
-  "AccessibilityRole": "Unknown",
+  "AccessibilityRole": "None",
   "AutomationId": "accessibility",
   "Background": null,
   "BorderBrush": null,


### PR DESCRIPTION
## Description
Removed accessibilityRole prop from View example which was causing an exception

### Type of Change
_Erase all that don't apply._
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Why
Allow Accessibility Insights to work on the View example page.

### What
Removed invalid accessibilityRole prop on the View example page. Previously `accessibilityRole` was set to 'View' which is not a valid role type, and was causing an error in the Fabric code when trying to evaluate the control type.


## Testing
Ran Accessibility Insights for Windows on the View example page.

## Changelog
No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12192)