### PR TITLE
[Fabric] Change Switch thumb to use composition animations

### DIFF
--- a/change/react-native-windows-646abbfc-a05b-44db-a498-bf96a28aa1c7.json
+++ b/change/react-native-windows-646abbfc-a05b-44db-a498-bf96a28aa1c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add fabric switch path animation",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -112,6 +112,17 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
+  interface ISwitchThumbVisual
+  {
+    IVisual InnerVisual { get; };
+    void Size(Windows.Foundation.Numerics.Vector2 size);
+    void Position(Windows.Foundation.Numerics.Vector2 position);
+    Boolean IsVisible { get; set; };
+    void Color(Windows.UI.Color color);
+  }
+
+  [webhosthidden]
+  [experimental]
   interface IFocusVisual
   {
     IVisual InnerVisual { get; };
@@ -127,6 +138,7 @@ namespace Microsoft.ReactNative.Composition
     IScrollVisual CreateScrollerVisual();
     IActivityVisual CreateActivityVisual();
     ICaretVisual CreateCaretVisual();
+    ISwitchThumbVisual CreateSwitchThumbVisual();
     IFocusVisual CreateFocusVisual();
     IDropShadow CreateDropShadow();
     IBrush CreateColorBrush(Windows.UI.Color color);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1039,17 +1039,17 @@ struct CompSwitchThumbVisual
         m_opacityAnimation(compositor.CreateScalarKeyFrameAnimation()) {
     m_visual = CreateVisual();
 
-    // Create circle
+    // Create Thumb
     auto ellipse = m_compositor.CreateEllipseGeometry();
-    ellipse.Radius({10.0f, 10.0f});
+    ellipse.Radius({8.25f, 8.25}); // controls the size
     auto spriteShape = m_compositor.CreateSpriteShape();
     spriteShape.Geometry(ellipse);
-    spriteShape.Offset(winrt::Windows::Foundation::Numerics::float2(0.0f, 0.0f));
+    spriteShape.Offset(winrt::Windows::Foundation::Numerics::float2(9.0f, 9.0f)); // controls the offset but gets cut off if outside of container 
     auto spriteVisualBrush = m_compositor.CreateColorBrush(winrt::Windows::UI::Colors::Green());
     spriteShape.FillBrush(spriteVisualBrush);
     auto circleShape = m_compositor.CreateShapeVisual();
     circleShape.Shapes().Append(spriteShape);
-    circleShape.Size({100.0f, 100.0f});
+    circleShape.Size({150.0f, 150.0f});
 
     m_compVisual.Children().InsertAtTop(circleShape);
 
@@ -1069,8 +1069,18 @@ struct CompSwitchThumbVisual
     m_compVisual.Size(size);
   }
 
-  void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept {
-    m_compVisual.Offset({position.x, position.y, 0.0f});
+  void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept { 
+    if (!isDrawn) {
+      isDrawn = true;
+      m_compVisual.Offset({position.x, position.y, 0.0f});
+    } else {
+      auto animation = m_compositor.CreateVector3KeyFrameAnimation();
+      animation.Duration(std::chrono::milliseconds(250));
+      animation.Direction(TTypeRedirects::AnimationDirection::Normal);
+      animation.InsertKeyFrame(1.0f, {position.x, position.y, 0.0f});
+
+      m_compVisual.StartAnimation(L"Offset", animation);
+    }
   }
 
   bool IsVisible() const noexcept {
@@ -1082,6 +1092,8 @@ struct CompSwitchThumbVisual
 
  private:
   bool m_isVisible{true};
+  bool isDrawn{false};
+  winrt::Windows::Foundation::Numerics::float2 position;
   typename TTypeRedirects::SpriteVisual m_compVisual;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
   typename TTypeRedirects::ScalarKeyFrameAnimation m_opacityAnimation;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -37,6 +37,7 @@ struct CompositionTypeTraits<WindowsTypeTag> {
   using CompositionBackfaceVisibility = winrt::Windows::UI::Composition::CompositionBackfaceVisibility;
   using CompositionBrush = winrt::Windows::UI::Composition::CompositionBrush;
   using CompositionDrawingSurface = winrt::Windows::UI::Composition::CompositionDrawingSurface;
+  using CompositionEllipseGeometry = winrt::Windows::UI::Composition::CompositionEllipseGeometry;
   using CompositionNineGridBrush = winrt::Windows::UI::Composition::CompositionNineGridBrush;
   using CompositionPath = winrt::Windows::UI::Composition::CompositionPath;
   using CompositionSpriteShape = winrt::Windows::UI::Composition::CompositionSpriteShape;
@@ -92,6 +93,7 @@ struct CompositionTypeTraits<MicrosoftTypeTag> {
   using CompositionBackfaceVisibility = winrt::Microsoft::UI::Composition::CompositionBackfaceVisibility;
   using CompositionBrush = winrt::Microsoft::UI::Composition::CompositionBrush;
   using CompositionDrawingSurface = winrt::Microsoft::UI::Composition::CompositionDrawingSurface;
+  using CompositionEllipseGeometry = winrt::Microsoft::UI::Composition::CompositionEllipseGeometry;
   using CompositionNineGridBrush = winrt::Microsoft::UI::Composition::CompositionNineGridBrush;
   using CompositionPath = winrt::Microsoft::UI::Composition::CompositionPath;
   using CompositionSpriteShape = winrt::Microsoft::UI::Composition::CompositionSpriteShape;
@@ -1031,11 +1033,11 @@ using MicrosoftCompCaretVisual = CompCaretVisual<MicrosoftTypeRedirects>;
 
 // Switch Thumb animations
 template <typename TTypeRedirects>
-struct CompSwitchThumbVisual
-    : winrt::implements<CompSwitchThumbVisual<TTypeRedirects>, winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual> {
+struct CompSwitchThumbVisual : winrt::implements<
+                                   CompSwitchThumbVisual<TTypeRedirects>,
+                                   winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual> {
   CompSwitchThumbVisual(typename TTypeRedirects::Compositor const &compositor)
-      : m_compositor(compositor),
-        m_compVisual(compositor.CreateSpriteVisual()) {
+      : m_compositor(compositor), m_compVisual(compositor.CreateSpriteVisual()) {
     m_visual = CreateVisual();
 
     // Create Thumb
@@ -1065,7 +1067,7 @@ struct CompSwitchThumbVisual
     m_compVisual.Size(size);
   }
 
-  void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept { 
+  void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept {
     if (!isDrawn) {
       // we don't want to animate if this is the first time the switch is drawn on screen
       isDrawn = true;
@@ -1084,8 +1086,7 @@ struct CompSwitchThumbVisual
     return m_isVisible;
   }
 
-  void IsVisible(bool value) noexcept {
-  }
+  void IsVisible(bool value) noexcept {}
 
  private:
   bool m_isVisible{true};
@@ -1093,8 +1094,10 @@ struct CompSwitchThumbVisual
   typename TTypeRedirects::SpriteVisual m_compVisual;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
   typename TTypeRedirects::Compositor m_compositor{nullptr};
-  winrt::Windows::UI::Composition::CompositionEllipseGeometry m_geometry{nullptr};
-  winrt::Windows::UI::Composition::CompositionSpriteShape m_spiritShape{nullptr};
+  typename TTypeRedirects::CompositionSpriteShape m_spiritShape{nullptr};
+  typename TTypeRedirects::CompositionEllipseGeometry m_geometry{nullptr};
+  // winrt::Windows::UI::Composition::CompositionEllipseGeometry m_geometry{nullptr};
+  // winrt::Windows::UI::Composition::CompositionSpriteShape m_spiritShape{nullptr};
 };
 
 winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<WindowsTypeRedirects>::CreateVisual()
@@ -1110,7 +1113,6 @@ winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<Micros
 }
 using MicrosoftCompSwitchThumbVisual = CompSwitchThumbVisual<MicrosoftTypeRedirects>;
 #endif
-
 
 // ending
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1029,6 +1029,82 @@ winrt::Microsoft::ReactNative::Composition::IVisual CompCaretVisual<MicrosoftTyp
 using MicrosoftCompCaretVisual = CompCaretVisual<MicrosoftTypeRedirects>;
 #endif
 
+// Switch Thumb animations
+template <typename TTypeRedirects>
+struct CompSwitchThumbVisual
+    : winrt::implements<CompSwitchThumbVisual<TTypeRedirects>, winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual> {
+  CompSwitchThumbVisual(typename TTypeRedirects::Compositor const &compositor)
+      : m_compositor(compositor),
+        m_compVisual(compositor.CreateSpriteVisual()),
+        m_opacityAnimation(compositor.CreateScalarKeyFrameAnimation()) {
+    m_visual = CreateVisual();
+
+    // Create circle
+    auto ellipse = m_compositor.CreateEllipseGeometry();
+    ellipse.Radius({10.0f, 10.0f});
+    auto spriteShape = m_compositor.CreateSpriteShape();
+    spriteShape.Geometry(ellipse);
+    spriteShape.Offset(winrt::Windows::Foundation::Numerics::float2(0.0f, 0.0f));
+    auto spriteVisualBrush = m_compositor.CreateColorBrush(winrt::Windows::UI::Colors::Green());
+    spriteShape.FillBrush(spriteVisualBrush);
+    auto circleShape = m_compositor.CreateShapeVisual();
+    circleShape.Shapes().Append(spriteShape);
+    circleShape.Size({100.0f, 100.0f});
+
+    m_compVisual.Children().InsertAtTop(circleShape);
+
+  }
+
+  winrt::Microsoft::ReactNative::Composition::IVisual CreateVisual() const noexcept;
+
+  winrt::Microsoft::ReactNative::Composition::IVisual InnerVisual() const noexcept {
+    return m_visual;
+  }
+
+  void Color(winrt::Windows::UI::Color color) noexcept {
+    m_compVisual.Brush(m_compositor.CreateColorBrush(color));
+  }
+
+  void Size(winrt::Windows::Foundation::Numerics::float2 size) noexcept {
+    m_compVisual.Size(size);
+  }
+
+  void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept {
+    m_compVisual.Offset({position.x, position.y, 0.0f});
+  }
+
+  bool IsVisible() const noexcept {
+    return m_isVisible;
+  }
+
+  void IsVisible(bool value) noexcept {
+  }
+
+ private:
+  bool m_isVisible{true};
+  typename TTypeRedirects::SpriteVisual m_compVisual;
+  winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
+  typename TTypeRedirects::ScalarKeyFrameAnimation m_opacityAnimation;
+  typename TTypeRedirects::Compositor m_compositor{nullptr};
+};
+
+winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<WindowsTypeRedirects>::CreateVisual()
+    const noexcept {
+  return winrt::make<Composition::WindowsCompSpriteVisual>(m_compVisual);
+}
+using WindowsCompSwitchThumbVisual = CompSwitchThumbVisual<WindowsTypeRedirects>;
+
+#ifdef USE_WINUI3
+winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<MicrosoftTypeRedirects>::CreateVisual()
+    const noexcept {
+  return winrt::make<Composition::MicrosoftCompSwitchThumbVisual>(m_compVisual);
+}
+using MicrosoftCompSwitchThumbVisual = CompSwitchThumbVisual<MicrosoftTypeRedirects>;
+#endif
+
+
+// ending
+
 template <typename TTypeRedirects>
 struct CompFocusVisual
     : winrt::implements<CompFocusVisual<TTypeRedirects>, winrt::Microsoft::ReactNative::Composition::IFocusVisual> {
@@ -1186,6 +1262,8 @@ struct CompContext : winrt::implements<
 
   winrt::Microsoft::ReactNative::Composition::ICaretVisual CreateCaretVisual() noexcept;
 
+  winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual CreateSwitchThumbVisual() noexcept;
+
   winrt::Microsoft::ReactNative::Composition::IFocusVisual CreateFocusVisual() noexcept;
 
   typename TTypeRedirects::CompositionGraphicsDevice CompositionGraphicsDevice() noexcept {
@@ -1256,6 +1334,11 @@ CompContext<WindowsTypeRedirects>::CreateCaretVisual() noexcept {
   return winrt::make<Composition::WindowsCompCaretVisual>(m_compositor);
 }
 
+winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual
+CompContext<WindowsTypeRedirects>::CreateSwitchThumbVisual() noexcept {
+  return winrt::make<Composition::WindowsCompSwitchThumbVisual>(m_compositor);
+}
+
 winrt::Microsoft::ReactNative::Composition::IFocusVisual
 CompContext<WindowsTypeRedirects>::CreateFocusVisual() noexcept {
   return winrt::make<Composition::WindowsCompFocusVisual>(m_compositor);
@@ -1305,6 +1388,11 @@ CompContext<MicrosoftTypeRedirects>::CreateDrawingSurfaceBrush(
 winrt::Microsoft::ReactNative::Composition::ICaretVisual
 CompContext<MicrosoftTypeRedirects>::CreateCaretVisual() noexcept {
   return winrt::make<Composition::MicrosoftCompCaretVisual>(m_compositor);
+}
+
+winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual
+CompContext<MicrosoftTypeRedirects>::CreateSwitchThumbVisual() noexcept {
+  return winrt::make<Composition::MicrosoftCompSwitchThumbVisual>(m_compositor);
 }
 
 winrt::Microsoft::ReactNative::Composition::IFocusVisual

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1107,7 +1107,7 @@ using WindowsCompSwitchThumbVisual = CompSwitchThumbVisual<WindowsTypeRedirects>
 #ifdef USE_WINUI3
 winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<MicrosoftTypeRedirects>::CreateVisual()
     const noexcept {
-  return winrt::make<Composition::MicrosoftCompSwitchThumbVisual>(m_compVisual);
+  return winrt::make<Composition::MicrosoftCompSpriteVisual>(m_compVisual);
 }
 using MicrosoftCompSwitchThumbVisual = CompSwitchThumbVisual<MicrosoftTypeRedirects>;
 #endif

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1096,8 +1096,6 @@ struct CompSwitchThumbVisual : winrt::implements<
   typename TTypeRedirects::Compositor m_compositor{nullptr};
   typename TTypeRedirects::CompositionSpriteShape m_spiritShape{nullptr};
   typename TTypeRedirects::CompositionEllipseGeometry m_geometry{nullptr};
-  // winrt::Windows::UI::Composition::CompositionEllipseGeometry m_geometry{nullptr};
-  // winrt::Windows::UI::Composition::CompositionSpriteShape m_spiritShape{nullptr};
 };
 
 winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<WindowsTypeRedirects>::CreateVisual()
@@ -1113,8 +1111,6 @@ winrt::Microsoft::ReactNative::Composition::IVisual CompSwitchThumbVisual<Micros
 }
 using MicrosoftCompSwitchThumbVisual = CompSwitchThumbVisual<MicrosoftTypeRedirects>;
 #endif
-
-// ending
 
 template <typename TTypeRedirects>
 struct CompFocusVisual

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -194,6 +194,12 @@ void SwitchComponentView::ensureVisual() noexcept {
     m_visual = m_compContext.CreateSpriteVisual();
     OuterVisual().InsertAt(m_visual, 0);
   }
+
+   if (!m_thumbVisual) {
+    m_thumbVisual = m_compContext.CreateSwitchThumbVisual();
+    m_visual.InsertAt(m_thumbVisual.InnerVisual(), 0);
+    m_thumbVisual.IsVisible(true);
+  }
 }
 
 void SwitchComponentView::ensureDrawingSurface() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -113,7 +113,7 @@ void SwitchComponentView::Draw() noexcept {
 
     // https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
     constexpr float thumbMargin = 3.0f;
-    constexpr float thumbRadius = 7.0f;
+    constexpr float thumbRadius = 7.0f ;
     constexpr float trackWidth = 40.0f;
     constexpr float trackHeight = 20.0f;
     constexpr float trackCornerRadius = 10.0f;
@@ -177,6 +177,16 @@ void SwitchComponentView::Draw() noexcept {
     D2D1_POINT_2F thumbCenter = D2D1 ::Point2F(thumbX, (trackRect.top + trackRect.bottom) / 2);
     D2D1_ELLIPSE thumb = D2D1::Ellipse(thumbCenter, thumbRadius, thumbRadius);
     d2dDeviceContext->FillEllipse(thumb, thumbBrush.get());
+
+    // NEW
+    float thumbXnew = (trackMarginX + (thumbMargin * m_layoutMetrics.pointScaleFactor) + 1.0f);
+    float thumbYnew = (trackMarginY + (thumbMargin * m_layoutMetrics.pointScaleFactor) + 1.0f);
+
+    if (switchProps->value) {
+      thumbXnew = thumbXnew + (trackWidth - thumbRadius - thumbRadius);
+    }
+
+    m_thumbVisual.Position({thumbXnew, thumbYnew});
 
     // Restore old dpi setting
     d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -198,7 +198,6 @@ void SwitchComponentView::ensureVisual() noexcept {
   if (!m_thumbVisual) {
     m_thumbVisual = m_compContext.CreateSwitchThumbVisual();
     m_visual.InsertAt(m_thumbVisual.InnerVisual(), 0);
-    m_thumbVisual.IsVisible(true);
   }
 }
 
@@ -216,14 +215,6 @@ void SwitchComponentView::ensureDrawingSurface() noexcept {
 
     m_visual.Brush(m_drawingSurface);
   }
-}
-
-void SwitchComponentView::onFocusLost() noexcept {
-  Super::onFocusLost();
-}
-
-void SwitchComponentView::onFocusGained() noexcept {
-  Super::onFocusGained();
 }
 
 facebook::react::Tag SwitchComponentView::hitTest(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -113,7 +113,7 @@ void SwitchComponentView::Draw() noexcept {
 
     // https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
     constexpr float thumbMargin = 3.0f;
-    constexpr float thumbRadius = 7.0f ;
+    constexpr float thumbRadius = 7.0f;
     constexpr float trackWidth = 40.0f;
     constexpr float trackHeight = 20.0f;
     constexpr float trackCornerRadius = 10.0f;
@@ -173,10 +173,10 @@ void SwitchComponentView::Draw() noexcept {
       thumbX = (trackMarginX + trackWidth - thumbRadius - thumbRadius - thumbMargin) * m_layoutMetrics.pointScaleFactor;
     }
 
-    m_thumbVisual.Size({thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
+    m_thumbVisual.Size(
+        {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
     m_thumbVisual.Position({thumbX, thumbY});
     m_thumbVisual.Color(thumbColor);
-
 
     // Restore old dpi setting
     d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);
@@ -195,7 +195,7 @@ void SwitchComponentView::ensureVisual() noexcept {
     OuterVisual().InsertAt(m_visual, 0);
   }
 
-   if (!m_thumbVisual) {
+  if (!m_thumbVisual) {
     m_thumbVisual = m_compContext.CreateSwitchThumbVisual();
     m_visual.InsertAt(m_thumbVisual.InnerVisual(), 0);
     m_thumbVisual.IsVisible(true);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -63,6 +63,7 @@ struct SwitchComponentView : CompositionBaseComponentView {
   winrt::Microsoft::ReactNative::ReactContext m_context;
   facebook::react::SharedViewProps m_props;
   winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_drawingSurface;
+  winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual m_thumbVisual;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -56,6 +56,8 @@ struct SwitchComponentView : CompositionBaseComponentView {
   void ensureVisual() noexcept;
   void Draw() noexcept;
   void ensureDrawingSurface() noexcept;
+  void onFocusLost() noexcept;
+  void onFocusGained() noexcept;
   bool toggle() noexcept;
 
   facebook::react::Size m_contentSize;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -56,8 +56,6 @@ struct SwitchComponentView : CompositionBaseComponentView {
   void ensureVisual() noexcept;
   void Draw() noexcept;
   void ensureDrawingSurface() noexcept;
-  void onFocusLost() noexcept;
-  void onFocusGained() noexcept;
   bool toggle() noexcept;
 
   facebook::react::Size m_contentSize;


### PR DESCRIPTION
## Description
Changes Switch's thumb to use composition animations and adds animation for path

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
First part of #12188, still need to animate thumb increasing in size on hover

### What
Add thumb visual to CompositionContextHelper

## Screenshots
Before (switch's are styled differently so color is different!)

https://github.com/microsoft/react-native-windows/assets/42554868/b41bd96c-98c2-4a99-b0f1-7f4cea0f600c

After

https://github.com/microsoft/react-native-windows/assets/42554868/fce699ae-929b-48f6-bf5a-d076260711eb

## Testing
tested locally on both devbox and laptop to check sizing!

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12207)