### PR TITLE
Expose DisableXamlGuard property to allow mixing of WinUI 2/3

### DIFF
--- a/change/react-native-windows-8d563e33-0333-4262-8dab-f291bbfb06c4.json
+++ b/change/react-native-windows-8d563e33-0333-4262-8dab-f291bbfb06c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Expose DisableXamlGuard property to allow mixing of WinUI 2/3",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/WinUI.props
+++ b/vnext/PropertySheets/WinUI.props
@@ -10,6 +10,11 @@
     <WinUI2xVersion Condition="'$(WinUI2xVersion)'==''">2.8.0</WinUI2xVersion>
   </PropertyGroup>
 
+  <PropertyGroup Label="XamlGuard">
+    <!-- Setting DisableXamlGuard to true will disable the code which prevents mixing WinUI2 and WinUI3 in the same process. -->
+    <DisableXamlGuard Condition="'$(DisableXamlGuard)'==''">false</DisableXamlGuard>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(UseWinUI3)'=='true'">
     <WinUIPackageName>Microsoft.WindowsAppSDK</WinUIPackageName>
     <WinUIPackageVersion>$(WinUI3Version)</WinUIPackageVersion>
@@ -36,6 +41,13 @@
     <Midl>
       <PreprocessorDefinitions>USE_WINUI3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </Midl>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(DisableXamlGuard)'=='true'">
+    <!-- Enlighten C++ code to not block WinUI2 and WinUI3 from loading in the same process. -->
+    <ClCompile>
+      <PreprocessorDefinitions>DISABLE_XAML_GUARD;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
   </ItemDefinitionGroup>
 
   <Target Name="PrintWinUIConfig" BeforeTargets="Midl;Build;ResolveSDKReferences">


### PR DESCRIPTION
## Description

You can't mix WinUI 2 and WinUI 3 in the same process, so just to be safe, RNW implements a guard (see PR #5290) which will cause an explicit crash if you try, in case an end developer does so unintentionally.

This PR adds an msbuild prop `DisableXamlGuard` which, when set to true, will remove this guard in the RNW code.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Some customers want to experiment with mixing WinUI 2 and WinUI 3 in the same process, so exposing this property unblocks their experiments.

Related: #10131

### What
Added a new `DisableXamlGuard` prop to `WinUI.props` and, if it's set to true, define the `DISABLE_XAML_GUARD` constant which will ifndef out the guard in the code.

## Screenshots
N/A.

## Testing
Verified I could still build and run an app with the guard missing.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12215)