### PR TITLE
Conditionally register WebSocket Cxx module

### DIFF
--- a/change/react-native-windows-a292054c-e016-4f31-bb25-3808d092176b.json
+++ b/change/react-native-windows-a292054c-e016-4f31-bb25-3808d092176b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Conditionally register WebSocket Cxx module",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -556,6 +556,9 @@ void ReactInstanceWin::Initialize() noexcept {
             auto omitNetCxxPropName = ReactPropertyBagHelper::GetName(nullptr, L"OmitNetworkingCxxModules");
             auto omitNetCxxPropValue = m_options.Properties.Get(omitNetCxxPropName);
             devSettings->omitNetworkingCxxModules = winrt::unbox_value_or(omitNetCxxPropValue, false);
+            auto useWebSocketTurboModulePropName = ReactPropertyBagHelper::GetName(nullptr, L"UseWebSocketTurboModule");
+            auto useWebSocketTurboModulePropValue = m_options.Properties.Get(useWebSocketTurboModulePropName);
+            devSettings->useWebSocketTurboModule = winrt::unbox_value_or(useWebSocketTurboModulePropValue, false);
             auto bundleRootPath = devSettings->bundleRootPath;
             auto instanceWrapper = facebook::react::CreateReactInstance(
                 std::shared_ptr<facebook::react::Instance>(strongThis->m_instance.Load()),

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -102,6 +102,9 @@ struct DevSettings {
 
   // Transitory. Used to indicate whether or not to load networking types in the default Cxx module registry.
   bool omitNetworkingCxxModules{false};
+
+  // OC:8368383 - Memory leak under investigation.
+  bool useWebSocketTurboModule{false};
 };
 
 } // namespace react

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -538,14 +538,18 @@ std::vector<std::unique_ptr<NativeModule>> InstanceImpl::GetDefaultNativeModules
   // If this code is enabled, we will have unused module instances.
   // Also, MSRN has a different property bag mechanism incompatible with this method's transitionalProps variable.
 #if (defined(_MSC_VER) && !defined(WINRT))
-  // Applications using the Windows ABI feature should loade the networking TurboModule variants instead.
-  if (!m_devSettings->omitNetworkingCxxModules) {
+
+  // OC:8368383 - Memory leak under investigation.
+  if (!m_devSettings->useWebSocketTurboModule) {
     modules.push_back(std::make_unique<CxxNativeModule>(
         m_innerInstance,
         Microsoft::React::GetWebSocketModuleName(),
         [transitionalProps]() { return Microsoft::React::CreateWebSocketModule(transitionalProps); },
         nativeQueue));
+  }
 
+  // Applications using the Windows ABI feature should loade the networking TurboModule variants instead.
+  if (!m_devSettings->omitNetworkingCxxModules) {
     // Use in case the host app provides its a non-Blob-compatilbe HTTP module.
     if (!Microsoft::React::GetRuntimeOptionBool("Blob.DisableModule")) {
       modules.push_back(std::make_unique<CxxNativeModule>(


### PR DESCRIPTION
- Conditionally register WebSocket Cxx module
- Change files

## Description

Allow using the Cxx WebSocket module instead of its TurboModule variant.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Using the WebSocket TurboModule could lead to a memory leak on application shutdown.
This issue is currently under investigation.

### What
- Define enum entry `facebook::react::DevSettings::useWebSocketTurboModule`.
- Conditionally register WebSocket Cxx module based on React context's `UseWebSocketTurboModule` property.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12218)