### PR TITLE
[Fabric] Add native PointerEntered+PointerExited events

### DIFF
--- a/change/react-native-windows-0d984d7b-b9bc-4673-859b-ba694d9ba669.json
+++ b/change/react-native-windows-0d984d7b-b9bc-4673-859b-ba694d9ba669.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add native PointerEntered+PointerExited events",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -69,6 +69,10 @@ struct IComponentView {
   virtual RECT getClientRect() const noexcept = 0;
   virtual void onFocusLost() noexcept = 0;
   virtual void onFocusGained() noexcept = 0;
+  virtual void onPointerEntered(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept = 0;
+  virtual void onPointerExited(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept = 0;
   virtual void onPointerPressed(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept = 0;
   virtual void onPointerReleased(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
@@ -119,6 +119,18 @@ void AbiCompositionViewComponentView::onKeyUp(
   Super::onKeyUp(source, args);
 }
 
+void AbiCompositionViewComponentView::onPointerEntered(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  Builder().OnPointerEntered(args);
+  Super::onPointerEntered(args);
+}
+
+void AbiCompositionViewComponentView::onPointerExited(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  Builder().OnPointerExited(args);
+  Super::onPointerExited(args);
+}
+
 void AbiCompositionViewComponentView::onPointerPressed(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   Builder().OnPointerPressed(args);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.h
@@ -47,6 +47,10 @@ struct AbiCompositionViewComponentView : CompositionBaseComponentView {
   void onKeyUp(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept override;
+  void onPointerEntered(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void onPointerExited(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerPressed(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerReleased(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -67,10 +67,16 @@ class CompositionEventHandler {
     Touch,
   };
   enum class TouchEventType { Start = 0, End, Move, Cancel, CaptureLost, PointerEntered, PointerExited, PointerMove };
-  void DispatchTouchEvent(TouchEventType eventType, PointerId pointerId);
+  void DispatchTouchEvent(
+      TouchEventType eventType,
+      PointerId pointerId,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+      winrt::Windows::System::VirtualKeyModifiers keyModifiers);
   void HandleIncomingPointerEvent(
       facebook::react::PointerEvent &pe,
       IComponentView *targetView,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+      winrt::Windows::System::VirtualKeyModifiers keyModifiers,
       std::function<void(std::vector<IComponentView *> &)> handler);
 
   struct ActiveTouch {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -158,6 +158,20 @@ void CompositionBaseComponentView::onKeyUp(
   }
 }
 
+void CompositionBaseComponentView::onPointerEntered(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  if (m_parent && !args.Handled()) {
+    m_parent->onPointerEntered(args);
+  }
+}
+
+void CompositionBaseComponentView::onPointerExited(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  if (m_parent && !args.Handled()) {
+    m_parent->onPointerExited(args);
+  }
+}
+
 void CompositionBaseComponentView::onPointerPressed(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_parent && !args.Handled()) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -35,6 +35,10 @@ struct CompositionBaseComponentView : public IComponentView,
   bool runOnChildren(bool forward, Mso::Functor<bool(IComponentView &)> &fn) noexcept override;
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
+  void onPointerEntered(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void onPointerExited(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerPressed(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerReleased(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -59,6 +59,14 @@ void ReactCompositionViewComponentBuilder::SetKeyUpHandler(KeyHandler impl) noex
   m_keyUp = impl;
 }
 
+void ReactCompositionViewComponentBuilder::SetPointerEnteredHandler(PointerHandler impl) noexcept {
+  m_pointerEntered = impl;
+}
+
+void ReactCompositionViewComponentBuilder::SetPointerExitedHandler(PointerHandler impl) noexcept {
+  m_pointerExited = impl;
+}
+
 void ReactCompositionViewComponentBuilder::SetPointerReleasedHandler(PointerHandler impl) noexcept {
   m_pointerReleased = impl;
 }
@@ -141,6 +149,20 @@ void ReactCompositionViewComponentBuilder::OnKeyUp(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   if (m_keyUp) {
     m_keyUp(source, args);
+  }
+}
+
+void ReactCompositionViewComponentBuilder::OnPointerEntered(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  if (m_pointerEntered) {
+    m_pointerEntered(args);
+  }
+}
+
+void ReactCompositionViewComponentBuilder::OnPointerExited(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  if (m_pointerExited) {
+    m_pointerExited(args);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -36,6 +36,8 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   void SetKeyDownHandler(KeyHandler impl) noexcept;
   void SetKeyUpHandler(KeyHandler impl) noexcept;
 
+  void SetPointerEnteredHandler(PointerHandler impl) noexcept;
+  void SetPointerExitedHandler(PointerHandler impl) noexcept;
   void SetPointerReleasedHandler(PointerHandler impl) noexcept;
   void SetPointerPressedHandler(PointerHandler impl) noexcept;
   void SetPointerMovedHandler(PointerHandler impl) noexcept;
@@ -61,6 +63,8 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   void OnKeyUp(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;
+  void OnPointerEntered(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
+  void OnPointerExited(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
   void OnPointerPressed(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
   void OnPointerReleased(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
@@ -80,6 +84,8 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   MessageHandler m_messageHandler;
   KeyHandler m_keyUp;
   KeyHandler m_keyDown;
+  PointerHandler m_pointerEntered;
+  PointerHandler m_pointerExited;
   PointerHandler m_pointerReleased;
   PointerHandler m_pointerPressed;
   PointerHandler m_pointerMoved;

--- a/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
@@ -98,6 +98,9 @@ namespace Microsoft.ReactNative.Composition
     void SetPointerReleasedHandler(PointerHandler impl);
     void SetPointerMovedHandler(PointerHandler impl);
     void SetPointerWheelChangedHandler(PointerHandler impl);
+    void SetPointerEnteredHandler(PointerHandler impl);
+    void SetPointerExitedHandler(PointerHandler impl);
+
   };
 
 


### PR DESCRIPTION
Adding PointerEntered and PointerExited events for fabric.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12222)