### PR TITLE
[0.72] Fix Playground Debug Test Pipeline

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -171,7 +171,7 @@ jobs:
               # of debug feature tests. In the future, these tests should be performed against a host app
               # better suited for automated tests (probably the E2E test app).
               - powershell: |
-                  $appRecipeToolPath = Join-Path (Get-CimInstance MSFT_VSInstance | Sort-Object -Property 'Version' -Descending)[0].InstallLocation "Common7\IDE\DeployAppRecipe.exe"
+                  $appRecipeToolPath = Join-Path (& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath) "Common7\IDE\DeployAppRecipe.exe"
                   if (!(Test-Path $appRecipeToolPath)) { throw "can't find '$appRecipeToolPath'" }
                   $platDirs = @{ "x64" = "x64\"; "x86" = ""} # map from ADO BuildPlatform arg to VS build output dir part 
                   $appRecipePath = "$(Build.SourcesDirectory)\packages\playground\windows\$($platDirs['${{ matrix.BuildPlatform }}'])${{ matrix.BuildConfiguration }}\playground\playground.build.appxrecipe"


### PR DESCRIPTION
## Description

It looks the the method used for detecting VS used in this job no longer works consistently (maybe a Windows or VS update)? Replacing with the more reliable `vswhere.exe`

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

To improve the debug test job reliability.

### What
Replace `Get-CimInstance MSFT_VSInstance` with `vswhere.exe`.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12226)