### PR TITLE
Integrate RN 0.72.6

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -171,7 +171,7 @@ jobs:
               # of debug feature tests. In the future, these tests should be performed against a host app
               # better suited for automated tests (probably the E2E test app).
               - powershell: |
-                  $appRecipeToolPath = Join-Path (Get-CimInstance MSFT_VSInstance | Sort-Object -Property 'Version' -Descending)[0].InstallLocation "Common7\IDE\DeployAppRecipe.exe"
+                  $appRecipeToolPath = Join-Path (& "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath) "Common7\IDE\DeployAppRecipe.exe"
                   if (!(Test-Path $appRecipeToolPath)) { throw "can't find '$appRecipeToolPath'" }
                   $platDirs = @{ "x64" = "x64\"; "x86" = ""} # map from ADO BuildPlatform arg to VS build output dir part 
                   $appRecipePath = "$(Build.SourcesDirectory)\packages\playground\windows\$($platDirs['${{ matrix.BuildPlatform }}'])${{ matrix.BuildConfiguration }}\playground\playground.build.appxrecipe"

--- a/change/@office-iss-react-native-win32-b7b34581-dc70-4c9f-ad39-0795f687aff8.json
+++ b/change/@office-iss-react-native-win32-b7b34581-dc70-4c9f-ad39-0795f687aff8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate RN 0.72.6",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-5b11cf36-5886-40ca-9aa8-5ae262e7fdf3.json
+++ b/change/react-native-windows-5b11cf36-5886-40ca-9aa8-5ae262e7fdf3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate RN 0.72.6",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/overrides.json
+++ b/packages/@office-iss/react-native-win32-tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win32/**"
   ],
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@office-iss/react-native-win32-tester/package.json
+++ b/packages/@office-iss/react-native-win32-tester/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.19.0",
     "just-scripts": "^1.3.3",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-platform-override": "^1.9.4",
     "typescript": "^4.9.5"
   },

--- a/packages/@office-iss/react-native-win32/overrides.json
+++ b/packages/@office-iss/react-native-win32/overrides.json
@@ -7,7 +7,7 @@
     "**/__snapshots__/**",
     "src/rntypes/**"
   ],
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "derived",

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -83,7 +83,7 @@
     "just-scripts": "^1.3.3",
     "prettier": "^2.4.1",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-platform-override": "^1.9.4",
     "typescript": "^4.9.5"
   },

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -31,7 +31,7 @@
     "just-scripts": "^1.3.2",
     "prettier": "^2.4.1",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12",
     "typescript": "^4.9.5"
   },

--- a/packages/@react-native-windows/tester/overrides.json
+++ b/packages/@react-native-windows/tester/overrides.json
@@ -5,7 +5,7 @@
   "excludePatterns": [
     "src/js/examples-win/**"
   ],
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^16.0.0",
     "eslint": "^8.19.0",
     "just-scripts": "^1.3.3",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-platform-override": "^1.9.4",
     "react-native-windows": "0.72.12",
     "typescript": "^4.9.5"

--- a/packages/@react-native/monorepo/overrides.json
+++ b/packages/@react-native/monorepo/overrides.json
@@ -1,5 +1,5 @@
 {
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "patch",

--- a/packages/@react-native/tester/overrides.json
+++ b/packages/@react-native/tester/overrides.json
@@ -1,5 +1,5 @@
 {
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "copy",

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -18,7 +18,7 @@
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12"
   },
   "devDependencies": {

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -19,7 +19,7 @@
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12",
     "react-native-xaml": "^0.0.74"
   },

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -16,7 +16,7 @@
     "@typescript-eslint/parser": "^5.21.0",
     "chai": "^4.2.0",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12"
   },
   "devDependencies": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,7 +15,7 @@
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12"
   },
   "devDependencies": {

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -15,7 +15,7 @@
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-windows": "0.72.12"
   },
   "devDependencies": {

--- a/vnext/overrides.json
+++ b/vnext/overrides.json
@@ -8,7 +8,7 @@
     "**/__snapshots__/**",
     "src/rntypes/**"
   ],
-  "baseVersion": "0.72.5",
+  "baseVersion": "0.72.6",
   "overrides": [
     {
       "type": "derived",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -80,7 +80,7 @@
     "metro-config": "0.76.4",
     "prettier": "^2.4.1",
     "react": "18.2.0",
-    "react-native": "0.72.5",
+    "react-native": "0.72.6",
     "react-native-platform-override": "^1.9.4",
     "react-refresh": "^0.4.0",
     "typescript": "^4.9.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10418,10 +10418,10 @@ react-native-xaml@^0.0.74:
     "@types/react-native" "*"
     typescript "^4.4.3"
 
-react-native@0.72.5:
-  version "0.72.5"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.72.5.tgz#2c343fa6f3ead362cf07376634a33a4078864357"
-  integrity sha512-oIewslu5DBwOmo7x5rdzZlZXCqDIna0R4dUwVpfmVteORYLr4yaZo5wQnMeR+H7x54GaMhmgeqp0ZpULtulJFg==
+react-native@0.72.6:
+  version "0.72.6"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.72.6.tgz#9f8d090694907e2f83af22e115cc0e4a3d5fa626"
+  integrity sha512-RafPY2gM7mcrFySS8TL8x+TIO3q7oAlHpzEmC7Im6pmXni6n1AuufGaVh0Narbr1daxstw7yW7T9BKW5dpVc2A==
   dependencies:
     "@jest/create-cache-key-function" "^29.2.1"
     "@react-native-community/cli" "11.3.7"


### PR DESCRIPTION
## Description

This PR updates RNW 0.72 to use RN 0.72.6.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Keep up with latest RN.

### What
Upgrade react-native dependency to 0.72.6

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12235)