### PR TITLE
[Fabric] Fix offset for automation provider when running in islands

### DIFF
--- a/change/react-native-windows-62e7496f-cd8d-49bb-8775-c127c760d022.json
+++ b/change/react-native-windows-62e7496f-cd8d-49bb-8775-c127c760d022.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix offset for automation provider when running in islands",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/nativeFabricComponent.tsx
+++ b/packages/playground/Samples/nativeFabricComponent.tsx
@@ -5,6 +5,7 @@
  */
 import React from 'react';
 import {AppRegistry, View} from 'react-native';
+import type {ViewProps} from 'react-native';
 
 import {
   setRuntimeConfigProvider,
@@ -22,7 +23,7 @@ setRuntimeConfigProvider((name: string) => {
   };
 });
 
-interface NativeProps {
+interface NativeProps extends ViewProps {
   label: string;
 }
 
@@ -36,7 +37,7 @@ const MyCustomComponent = get<NativeProps>('MyCustomComponent', () => {
       label: true,
     },
   };
-});
+}) as React.ComponentType<NativeProps>;
 
 const Bootstrap = () => {
   return (
@@ -46,8 +47,9 @@ const Bootstrap = () => {
         margin: 10,
         borderWidth: 2,
         gap: 5,
+        height: 500,
       }}>
-      <MyCustomComponent label="test" style={{width: 500, height: 500}} />
+      <MyCustomComponent label="test" style={{flex: 1}} />
     </View>
   );
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/AbiCompositionViewComponentView.cpp
@@ -108,50 +108,50 @@ int64_t AbiCompositionViewComponentView::sendMessage(uint32_t msg, uint64_t wPar
 void AbiCompositionViewComponentView::onKeyDown(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
-  Builder().OnKeyDown(source, args);
+  Builder().OnKeyDown(m_handle, source, args);
   Super::onKeyDown(source, args);
 }
 
 void AbiCompositionViewComponentView::onKeyUp(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
-  Builder().OnKeyUp(source, args);
+  Builder().OnKeyUp(m_handle, source, args);
   Super::onKeyUp(source, args);
 }
 
 void AbiCompositionViewComponentView::onPointerEntered(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerEntered(args);
+  Builder().OnPointerEntered(m_handle, args);
   Super::onPointerEntered(args);
 }
 
 void AbiCompositionViewComponentView::onPointerExited(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerExited(args);
+  Builder().OnPointerExited(m_handle, args);
   Super::onPointerExited(args);
 }
 
 void AbiCompositionViewComponentView::onPointerPressed(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerPressed(args);
+  Builder().OnPointerPressed(m_handle, args);
   Super::onPointerPressed(args);
 }
 
 void AbiCompositionViewComponentView::onPointerReleased(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerReleased(args);
+  Builder().OnPointerReleased(m_handle, args);
   Super::onPointerReleased(args);
 }
 
 void AbiCompositionViewComponentView::onPointerMoved(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerMoved(args);
+  Builder().OnPointerMoved(m_handle, args);
   Super::onPointerMoved(args);
 }
 
 void AbiCompositionViewComponentView::onPointerWheelChanged(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  Builder().OnPointerWheelChanged(args);
+  Builder().OnPointerWheelChanged(m_handle, args);
   Super::onPointerWheelChanged(args);
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -75,6 +75,7 @@ struct CompositionTypeTraits<WindowsTypeTag> {
   using ICompositionDrawingSurfaceInterop = ABI::Windows::UI::Composition::ICompositionDrawingSurfaceInterop;
   using ICompositorInterop = ABI::Windows::UI::Composition::ICompositorInterop;
 
+  using IInnerCompositionCompositor = IWindowsCompositionCompositor;
   using IInnerCompositionDropShadow = IWindowsCompositionDropShadow;
   using IInnerCompositionVisual = IWindowsCompositionVisual;
   using IInnerCompositionBrush = IWindowsCompositionBrush;
@@ -131,6 +132,7 @@ struct CompositionTypeTraits<MicrosoftTypeTag> {
   using ICompositionDrawingSurfaceInterop = winrt::Microsoft::UI::Composition::ICompositionDrawingSurfaceInterop;
   using ICompositorInterop = winrt::Microsoft::UI::Composition::ICompositorInterop;
 
+  using IInnerCompositionCompositor = IMicrosoftCompositionCompositor;
   using IInnerCompositionDropShadow = IMicrosoftCompositionDropShadow;
   using IInnerCompositionVisual = IMicrosoftCompositionVisual;
   using IInnerCompositionBrush = IMicrosoftCompositionBrush;
@@ -1231,6 +1233,7 @@ template <typename TTypeRedirects>
 struct CompContext : winrt::implements<
                          CompContext<TTypeRedirects>,
                          winrt::Microsoft::ReactNative::Composition::ICompositionContext,
+                         typename TTypeRedirects::IInnerCompositionCompositor,
                          ICompositionContextInterop> {
   CompContext(typename TTypeRedirects::Compositor const &compositor) : m_compositor(compositor) {}
 
@@ -1326,7 +1329,7 @@ struct CompContext : winrt::implements<
 
   typename TTypeRedirects::CompositionGraphicsDevice CompositionGraphicsDevice() noexcept;
 
-  typename TTypeRedirects::Compositor InnerCompositor() noexcept {
+  typename TTypeRedirects::Compositor InnerCompositor() const noexcept {
     return m_compositor;
   }
 
@@ -1492,34 +1495,34 @@ IVisual WindowsCompositionContextHelper::CreateVisual(winrt::Windows::UI::Compos
 
 winrt::Windows::UI::Composition::Compositor WindowsCompositionContextHelper::InnerCompositor(
     ICompositionContext context) noexcept {
-  winrt::com_ptr<::Microsoft::ReactNative::Composition::WindowsCompContext> s;
-  context.as(s);
+  winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionCompositor> s;
+  context.try_as(s);
   return s ? s->InnerCompositor() : nullptr;
 }
 
 winrt::Windows::UI::Composition::Visual WindowsCompositionContextHelper::InnerVisual(IVisual visual) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionVisual> s;
-  visual.as(s);
+  visual.try_as(s);
   return s ? s->InnerVisual() : nullptr;
 }
 
 winrt::Windows::UI::Composition::DropShadow WindowsCompositionContextHelper::InnerDropShadow(
     IDropShadow shadow) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionDropShadow> s;
-  shadow.as(s);
+  shadow.try_as(s);
   return s ? s->InnerShadow() : nullptr;
 }
 
 winrt::Windows::UI::Composition::CompositionBrush WindowsCompositionContextHelper::InnerBrush(IBrush brush) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionBrush> s;
-  brush.as(s);
+  brush.try_as(s);
   return s ? s->InnerBrush() : nullptr;
 }
 
 winrt::Windows::UI::Composition::ICompositionSurface WindowsCompositionContextHelper::InnerSurface(
     IDrawingSurfaceBrush surface) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionDrawingSurfaceInner> s;
-  surface.as(s);
+  surface.try_as(s);
   return s ? s->Inner() : nullptr;
 }
 
@@ -1538,35 +1541,35 @@ IVisual MicrosoftCompositionContextHelper::CreateVisual(
 
 winrt::Microsoft::UI::Composition::Compositor MicrosoftCompositionContextHelper::InnerCompositor(
     ICompositionContext context) noexcept {
-  winrt::com_ptr<::Microsoft::ReactNative::Composition::MicrosoftCompContext> s;
-  context.as(s);
+  winrt::com_ptr<::Microsoft::ReactNative::Composition::IMicrosoftCompositionCompositor> s;
+  context.try_as(s);
   return s ? s->InnerCompositor() : nullptr;
 }
 
 winrt::Microsoft::UI::Composition::Visual MicrosoftCompositionContextHelper::InnerVisual(IVisual visual) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IMicrosoftCompositionVisual> s;
-  visual.as(s);
+  visual.try_as(s);
   return s ? s->InnerVisual() : nullptr;
 }
 
 winrt::Microsoft::UI::Composition::DropShadow MicrosoftCompositionContextHelper::InnerDropShadow(
     IDropShadow shadow) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IMicrosoftCompositionDropShadow> s;
-  shadow.as(s);
+  shadow.try_as(s);
   return s ? s->InnerShadow() : nullptr;
 }
 
 winrt::Microsoft::UI::Composition::CompositionBrush MicrosoftCompositionContextHelper::InnerBrush(
     IBrush brush) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IMicrosoftCompositionBrush> s;
-  brush.as(s);
+  brush.try_as(s);
   return s ? s->InnerBrush() : nullptr;
 }
 
 winrt::Microsoft::UI::Composition::ICompositionSurface MicrosoftCompositionContextHelper::InnerSurface(
     IDrawingSurfaceBrush surface) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IMicrosoftCompositionDrawingSurfaceInner> s;
-  surface.as(s);
+  surface.try_as(s);
   return s ? s->Inner() : nullptr;
 }
 #endif

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -133,6 +133,15 @@ class CompositionEventHandler {
   std::map<PointerId, std::vector<ReactTaggedView>> m_currentlyHoveredViewsPerPointer;
   winrt::Microsoft::ReactNative::CompositionRootView m_compRootView{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
+
+#ifdef USE_WINUI3
+  winrt::event_token m_pointerPressedToken;
+  winrt::event_token m_pointerReleasedToken;
+  winrt::event_token m_pointerMovedToken;
+  winrt::event_token m_pointerWheelChangedToken;
+  winrt::event_token m_keyDownToken;
+  winrt::event_token m_keyUpToken;
+#endif
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -11,6 +11,12 @@ namespace Microsoft::ReactNative {
 
 namespace Composition {
 
+// Windows composition specific interface to extract the inner compositor object
+MSO_STRUCT_GUID(IWindowsCompositionCompositor, "4FA84446-B662-440F-AE53-43A223D2068E")
+struct IWindowsCompositionCompositor : public IUnknown {
+  virtual winrt::Windows::UI::Composition::Compositor InnerCompositor() const noexcept = 0;
+};
+
 // Windows composition specific interface to extract the inner composition object
 MSO_STRUCT_GUID(IWindowsCompositionVisual, "2F7F7E82-0BEA-4Cf8-9531-E81338754187")
 struct IWindowsCompositionVisual : public IUnknown {
@@ -36,6 +42,12 @@ struct IWindowsCompositionDrawingSurfaceInner : public IUnknown {
 };
 
 #ifdef USE_WINUI3
+// Windows composition specific interface to extract the inner compositor object
+MSO_STRUCT_GUID(IMicrosoftCompositionCompositor, "B7B3E027-6A87-4946-B397-247AAB8634C6")
+struct IMicrosoftCompositionCompositor : public IUnknown {
+  virtual winrt::Microsoft::UI::Composition::Compositor InnerCompositor() const noexcept = 0;
+};
+
 // Microsoft composition specific interface to extract the inner composition object
 MSO_STRUCT_GUID(IMicrosoftCompositionVisual, "FF8731D8-8AFA-4F6F-9E76-7F538F3C1157")
 struct IMicrosoftCompositionVisual : public IUnknown {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootAutomationProvider.cpp
@@ -81,6 +81,21 @@ HRESULT __stdcall CompositionRootAutomationProvider::get_BoundingRectangle(UiaRe
   if (pRetVal == nullptr)
     return E_POINTER;
 
+#ifdef USE_WINUI3
+  if (m_island) {
+    auto cc = m_island.CoordinateConverter();
+    auto origin = cc.ConvertLocalToScreen(winrt::Windows::Foundation::Point{0, 0});
+    pRetVal->left = origin.X;
+    pRetVal->top = origin.Y;
+
+    auto size = m_island.ActualSize();
+    pRetVal->width = size.x;
+    pRetVal->height = size.y;
+
+    return S_OK;
+  }
+#endif
+
   // TODO: Need host site offsets
   // Assume we're hosted in some other visual-based hosting site
   if (m_hwnd == nullptr || !IsWindow(m_hwnd)) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -137,60 +137,68 @@ int64_t ReactCompositionViewComponentBuilder::SendMessage(
 }
 
 void ReactCompositionViewComponentBuilder::OnKeyDown(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   if (m_keyDown) {
-    m_keyDown(source, args);
+    m_keyDown(handle, source, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnKeyUp(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
   if (m_keyUp) {
-    m_keyUp(source, args);
+    m_keyUp(handle, source, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerEntered(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerEntered) {
-    m_pointerEntered(args);
+    m_pointerEntered(handle, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerExited(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerExited) {
-    m_pointerExited(args);
+    m_pointerExited(handle, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerPressed(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerPressed) {
-    m_pointerPressed(args);
+    m_pointerPressed(handle, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerReleased(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerReleased) {
-    m_pointerReleased(args);
+    m_pointerReleased(handle, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerMoved(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerMoved) {
-    m_pointerMoved(args);
+    m_pointerMoved(handle, args);
   }
 }
 
 void ReactCompositionViewComponentBuilder::OnPointerWheelChanged(
+    winrt::Windows::Foundation::IInspectable handle,
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   if (m_pointerWheelChanged) {
-    m_pointerWheelChanged(args);
+    m_pointerWheelChanged(handle, args);
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -58,18 +58,30 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   int64_t
   SendMessage(winrt::Windows::Foundation::IInspectable handle, uint32_t Msg, uint64_t WParam, int64_t LParam) noexcept;
   void OnKeyDown(
+      winrt::Windows::Foundation::IInspectable handle,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;
   void OnKeyUp(
+      winrt::Windows::Foundation::IInspectable handle,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;
-  void OnPointerEntered(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
-  void OnPointerExited(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
-  void OnPointerPressed(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
-  void OnPointerReleased(
+  void OnPointerEntered(
+      winrt::Windows::Foundation::IInspectable handle,
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
-  void OnPointerMoved(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
+  void OnPointerExited(
+      winrt::Windows::Foundation::IInspectable handle,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
+  void OnPointerPressed(
+      winrt::Windows::Foundation::IInspectable handle,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
+  void OnPointerReleased(
+      winrt::Windows::Foundation::IInspectable handle,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
+  void OnPointerMoved(
+      winrt::Windows::Foundation::IInspectable handle,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
   void OnPointerWheelChanged(
+      winrt::Windows::Foundation::IInspectable handle,
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
 
  private:

--- a/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
@@ -47,10 +47,10 @@ namespace Microsoft.ReactNative.Composition
   delegate Int64 MessageHandler(Object handle, UInt32 Msg, UInt64 WParam, Int64 LParam);
 
   [experimental]
-  delegate void KeyHandler(Microsoft.ReactNative.Composition.Input.KeyboardSource source, Microsoft.ReactNative.Composition.Input.KeyRoutedEventArgs args);
+  delegate void KeyHandler(Object handle, Microsoft.ReactNative.Composition.Input.KeyboardSource source, Microsoft.ReactNative.Composition.Input.KeyRoutedEventArgs args);
 
   [experimental]
-  delegate void PointerHandler(Microsoft.ReactNative.Composition.Input.PointerRoutedEventArgs args);
+  delegate void PointerHandler(Object handle, Microsoft.ReactNative.Composition.Input.PointerRoutedEventArgs args);
 
   [webhosthidden]
   [experimental]


### PR DESCRIPTION
## Description
- The AutomationProvider was not providing an appropriate bounding rect when hosted in an island, causing the coordinates provided to UIA to be incorrect.
- Fixed issue where pointer/key events for custom components were unusable.
- Fixed issue where Microsoft/WindowsCompositionContext would return an invalid pointer for InnerCompositor.
- Fixed issue where CompositionEventHandler would not unregister from island events when destroyed.
- Minor cleanup of playground code from feedback on previous PR.
- Extended playground custom component to use pointer events

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12236)