### PR TITLE
Have dependabot group some PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,25 @@ version: 2
 updates:
 - package-ecosystem: npm
   directory: "/"
+  groups:
+    babel:
+      patterns:
+        - '@babel*'
+      update-types:
+        - 'minor'
+        - 'patch'
+    jest:
+      patterns:
+        - '@jest*'
+      update-types:
+        - 'minor'
+        - 'patch'
+    rnx-kit:
+      patterns:
+        - '@rnx-kit*'
+      update-types:
+        - 'minor'
+        - 'patch'
   schedule:
     interval: daily
     time: "05:00"


### PR DESCRIPTION
Have dependabot group @babel, @jest and @rnx-kit PRs

Should reduce the number of PRs from dependabot, and it just makes sense to bump these all together.