### PR TITLE
Fix Fabric E2E test

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -58,7 +58,7 @@ jobs:
                 buildEnvironment: ${{ config.buildEnvironment }}
 
             - powershell: |
-                Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
+                Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ matrix.BuildPlatform }}\BuildLogs"
               displayName: Set BuildLogDirectory
 
             - task: PowerShell@2
@@ -151,114 +151,106 @@ jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
       - ${{ each matrix in config.Matrix }}:
-        - job: E2ETestFabric${{ matrix.Name }}
-          displayName: E2E Test App Fabric ${{ matrix.Name }}
+        - ${{ if eq(matrix.UseHermes, true) }}:
+          - job: E2ETestFabric${{ matrix.Name }}
+            displayName: E2E Test App Fabric ${{ matrix.Name }}
 
-          variables: [template: ../variables/windows.yml]
-          pool: ${{ parameters.AgentPool.Medium }}
-          timeoutInMinutes: 60 # how long to run the job before automatically cancelling
-          cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
+            variables: [template: ../variables/windows.yml]
+            pool: ${{ parameters.AgentPool.Medium }}
+            timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+            cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
-          steps:
-            - template: ../templates/checkout-shallow.yml
+            steps:
+              - template: ../templates/checkout-shallow.yml
 
-            - template: ../templates/prepare-js-env.yml
+              - template: ../templates/prepare-js-env.yml
 
-            - template: ../templates/prepare-build-env.yml
-              parameters:
-                platform: ${{ matrix.BuildPlatform }}
-                configuration: Release
-                buildEnvironment: ${{ config.buildEnvironment }}
+              - template: ../templates/prepare-build-env.yml
+                parameters:
+                  platform: ${{ matrix.BuildPlatform }}
+                  configuration: Release
+                  buildEnvironment: ${{ config.buildEnvironment }}
 
-            - powershell: |
-                Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ parameters.BuildPlatform }}\BuildLogs"
-              displayName: Set BuildLogDirectory
+              - powershell: |
+                  Write-Host "##vso[task.setvariable variable=BuildLogDirectory]$(Build.BinariesDirectory)\${{ matrix.BuildPlatform }}\BuildLogs"
+                displayName: Set BuildLogDirectory
 
-            - template: ../templates/set-experimental-feature.yml
-              parameters:
-                package: packages/e2e-test-app-fabric
-                feature: UseHermes
-                value: ${{ matrix.UseHermes }}
+              - template: ../templates/run-windows-with-certificates.yml
+                parameters:
+                  buildEnvironment: ${{ parameters.BuildEnvironment }}
+                  certificateName: reactUWPTestAppEncodedKey
+                  buildConfiguration: Release
+                  buildPlatform: ${{ matrix.BuildPlatform }}
+                  buildLogDirectory: $(BuildLogDirectory)
+                  deployOption: '--no-deploy'
+                  workingDirectory: packages/e2e-test-app-fabric
+              
+              - script: |
+                  echo ##vso[task.setvariable variable=StartedFabricTests]true
+                displayName: Set StartedFabricTests
 
-            - task: PowerShell@2
-              displayName: Start tracing
-              inputs:
-                targetType: filePath # filePath | inline
-                filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Start-Tracing.ps1
-
-            - template: ../templates/run-windows-with-certificates.yml
-              parameters:
-                buildEnvironment: ${{ parameters.BuildEnvironment }}
-                certificateName: reactUWPTestAppEncodedKey
-                buildConfiguration: Release
-                buildPlatform: ${{ matrix.BuildPlatform }}
-                buildLogDirectory: $(BuildLogDirectory)
-                deployOption: '--no-deploy'
+              - script: |
+                  set E2ETestFabricBuildConfiguration=${{ matrix.BuildConfiguration }}
+                  set E2ETestFabricBuildPlatform=${{ matrix.BuildPlatform }}
+                  yarn e2etest
+                displayName: yarn e2etest
                 workingDirectory: packages/e2e-test-app-fabric
-            
-            - script: |
-                echo ##vso[task.setvariable variable=StartedFabricTests]true
-              displayName: Set StartedFabricTests
 
-            - script: yarn e2etest
-              displayName: yarn e2etest
-              workingDirectory: packages/e2e-test-app-fabric
+              - script: npx jest --clearCache
+                displayName: clear jest cache
+                workingDirectory: packages/e2e-test-app-fabric
+                condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
 
-            - script: npx jest --clearCache
-              displayName: clear jest cache
-              workingDirectory: packages/e2e-test-app-fabric
-              condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+              - script: yarn e2etest -u
+                displayName: Update snapshots
+                workingDirectory: packages/e2e-test-app-fabric
+                condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+                
+              - task: PowerShell@2
+                displayName: Stop tracing
+                inputs:
+                  targetType: filePath # filePath | inline
+                  filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Stop-Tracing.ps1
+                  arguments: -NoAnalysis -outputFolder $(Build.StagingDirectory)/Tracing
+                condition: true
 
-            - script: yarn e2etest -u
-              displayName: Update snapshots
-              workingDirectory: packages/e2e-test-app-fabric
-              condition: and(failed(), eq(variables.StartedFabricTests, 'true'))
+              - task: PublishBuildArtifacts@1
+                displayName: Upload traces
+                inputs:
+                  pathtoPublish: '$(Build.StagingDirectory)/Tracing'
+                  artifactName: 'Traces - $(Agent.JobName)-$(System.JobAttempt)'
+                condition: true
 
-            - task: PowerShell@2
-              displayName: Stop tracing
-              inputs:
-                targetType: filePath # filePath | inline
-                filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tracing\Stop-Tracing.ps1
-                arguments: -NoAnalysis -outputFolder $(Build.StagingDirectory)/Tracing
-              condition: true
+              - task: CopyFiles@2
+                displayName: Copy Fabric snapshots
+                inputs:
+                  sourceFolder: packages/e2e-test-app-fabric/test/__snapshots__
+                  targetFolder: $(Build.StagingDirectory)/snapshots-fabric
+                  contents: "**"
+                condition: failed()
 
-            - task: PublishBuildArtifacts@1
-              displayName: Upload traces
-              inputs:
-                pathtoPublish: '$(Build.StagingDirectory)/Tracing'
-                artifactName: 'Traces - $(Agent.JobName)-$(System.JobAttempt)'
-              condition: true
+              - task: CopyFiles@2
+                displayName: Copy RNTesterApp artifacts
+                inputs:
+                  sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric
+                  targetFolder: $(Build.StagingDirectory)/RNTesterApp-Fabric
+                  contents: AppPackages\**
+                condition: failed()
 
-            - task: CopyFiles@2
-              displayName: Copy Fabric snapshots
-              inputs:
-                sourceFolder: packages/e2e-test-app-fabric/test/__snapshots__
-                targetFolder: $(Build.StagingDirectory)/snapshots-fabric
-                contents: "**"
-              condition: failed()
+              - task: PublishPipelineArtifact@1
+                displayName: "Publish Artifact: RNTesterApp Fabric"
+                inputs:
+                  artifactName: RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
+                  targetPath: $(Build.StagingDirectory)/RNTesterApp-Fabric
+                condition: failed()
 
-            - task: CopyFiles@2
-              displayName: Copy RNTesterApp artifacts
-              inputs:
-                sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric
-                targetFolder: $(Build.StagingDirectory)/RNTesterApp-Fabric
-                contents: AppPackages\**
-              condition: failed()
+              - task: PublishPipelineArtifact@1
+                displayName: "Publish Artifact: Fabric Snapshots"
+                inputs:
+                  artifactName: Snapshots - RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
+                  targetPath: $(Build.StagingDirectory)/snapshots-fabric
+                condition: failed()
 
-            - task: PublishPipelineArtifact@1
-              displayName: "Publish Artifact: RNTesterApp Fabric"
-              inputs:
-                artifactName: RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
-                targetPath: $(Build.StagingDirectory)/RNTesterApp-Fabric
-              condition: failed()
-
-            - task: PublishPipelineArtifact@1
-              displayName: "Publish Artifact: Fabric Snapshots"
-              inputs:
-                artifactName: Snapshots - RNTesterApp-Fabric-${{ matrix.Name }}-$(System.JobAttempt)
-                targetPath: $(Build.StagingDirectory)/snapshots-fabric
-              condition: failed()
-
-            - template: ../templates/upload-build-logs.yml
-              parameters:
-                buildLogDirectory: '$(BuildLogDirectory)'
+              - template: ../templates/upload-build-logs.yml
+                parameters:
+                  buildLogDirectory: '$(BuildLogDirectory)'

--- a/packages/e2e-test-app-fabric/jest.config.js
+++ b/packages/e2e-test-app-fabric/jest.config.js
@@ -60,7 +60,12 @@ module.exports = {
   setupFilesAfterEnv: ['react-native-windows/jest/setup', './jest.setup.js'],
 
   testEnvironmentOptions: {
-    app: `windows\\x64\\Release\\RNTesterApp-Fabric.exe`,
+    app: `windows\\${
+      (process.env.E2ETestFabricBuildPlatform === 'x86'
+        ? ''
+        : (process.env.E2ETestFabricBuildPlatform ?? 'x64') + '\\') +
+      (process.env.E2ETestFabricBuildConfiguration ?? 'Release')
+    }\\RNTesterApp-Fabric.exe`,
     appWorkingDir: 'windows\\RNTesterApp-Fabric',
     enableAutomationChannel: true,
     /* -- Enable for more detailed logging


### PR DESCRIPTION
## Description

This PR fixes the E2E Test App Fabric jobs in CI:
* Stop testing Fabric with Chakra (it's unsupported)
* Enable testing the x86 build in CI

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

The Fabric E2E tests were passing in PR but failing in CI.

Resolves #12251

### What

Add a filter to the pipeline job matrix to stop testing Fabric with Chakra (it's unsupported)

Modify the jest config to allow for a environment variable to specify builds other than x64/Release
## Screenshots
N/A

## Testing
Verified the new config works.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12253)