### PR TITLE
 Move winrt/Windows.Storage.h include out of USE_V8 conditional

### DIFF
--- a/change/react-native-windows-eb48950f-48ba-4e28-b8a9-93a2ce7e2282.json
+++ b/change/react-native-windows-eb48950f-48ba-4e28-b8a9-93a2ce7e2282.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move winrt/Windows.Storage.h include out of USE_V8 conditional",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -74,8 +74,9 @@
 #include "BaseScriptStoreImpl.h"
 #include "HermesRuntimeHolder.h"
 
-#if defined(USE_V8)
 #include <winrt/Windows.Storage.h>
+
+#if defined(USE_V8)
 #include "JSI/V8RuntimeHolder.h"
 #endif // USE_V8
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### What
We now use the winrt/Windows.Storage.h header in the initialization of Hermes (not just V8), so this header needs to be imported unconditionally.

## Changelog
Should this change be included in the release notes: _yes_

Fixes compilation of Microsoft.ReactNative without USE_V8 compile constant