### PR TITLE
[0.73] Refactor `init-windows` CI jobs

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -12,6 +12,11 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
+          - Name: FabricX64Debug
+            template: cpp-app
+            configuration: Debug
+            platform: x64
+            additionalRunArguments: --no-autolink
           - Name: FabricX64Release
             template: cpp-app
             configuration: Release
@@ -20,6 +25,11 @@ parameters:
           - Name: FabricX86Debug
             template: cpp-app
             configuration: Debug
+            platform: x86
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Release
+            template: cpp-app
+            configuration: Release
             platform: x86
             additionalRunArguments: --no-autolink
       - BuildEnvironment: Continuous

--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -1,0 +1,90 @@
+parameters:
+  - name: buildEnvironment
+    type: string
+    default: PullRequest
+    values:
+      - PullRequest
+      - Continuous
+  - name: AgentPool
+    type: object
+  - name: buildMatrix
+    type: object
+    default:
+      - BuildEnvironment: PullRequest
+        Matrix:
+          - Name: FabricX64Release
+            template: cpp-app
+            configuration: Release
+            platform: x64
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Debug
+            template: cpp-app
+            configuration: Debug
+            platform: x86
+            additionalRunArguments: --no-autolink
+      - BuildEnvironment: Continuous
+        Matrix:
+          - Name: FabricX64Debug
+            template: cpp-app
+            configuration: Debug
+            platform: x64
+            additionalRunArguments: --no-autolink
+          - Name: FabricX64Release
+            template: cpp-app
+            configuration: Release
+            platform: x64
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Debug
+            template: cpp-app
+            configuration: Debug
+            platform: x86
+            additionalRunArguments: --no-autolink
+          - Name: FabricX86Release
+            template: cpp-app
+            configuration: Release
+            platform: x86
+            additionalRunArguments: --no-autolink
+jobs:
+  - ${{ each config in parameters.buildMatrix }}:
+    - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
+      - ${{ each matrix in config.Matrix }}:
+          - job: CliInitWindows${{ matrix.Name }}
+            displayName: Verify CliInitWindows ${{ matrix.Name }}
+
+            variables: [template: ../variables/windows.yml]
+
+            ${{ if eq(matrix.lowResource, true) }}:
+              pool: ${{ parameters.AgentPool.Small }}
+            ${{ else }}:
+              pool: ${{ parameters.AgentPool.Medium }}
+            timeoutInMinutes: 60
+            cancelTimeoutInMinutes: 5
+
+            steps:
+              - template: ../templates/checkout-full.yml
+                parameters:
+                  persistCredentials: false # We don't need git creds in this job
+
+              - template: ../templates/prepare-js-env.yml
+
+              - template: ../templates/prepare-build-env.yml
+                parameters:
+                  platform: ${{ parameters.platform }}
+                  configuration: ${{ parameters.configuration }}
+                  buildEnvironment: ${{ parameters.buildEnvironment }}
+
+              - task: CmdLine@2
+                displayName: Create npm directory
+                name: createNpmDirectory
+                inputs:
+                  script: mkdir %APPDATA%\npm
+                  
+              - template: ../templates/react-native-init-windows.yml
+                parameters:
+                  template: ${{ matrix.template }}
+                  configuration: ${{ matrix.configuration }}
+                  platform: ${{ matrix.platform }}
+                  additionalInitArguments: ${{ matrix.additionalInitArguments }}
+                  additionalRunArguments: ${{ matrix.additionalRunArguments }}
+                  runWack: ${{ coalesce(matrix.runWack, false) }}
+                  buildEnvironment: ${{ parameters.buildEnvironment }}

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -186,34 +186,6 @@ parameters:
             platform: x64
             projectType: app
             lowResource: true
-          - Name: FabricX64Debug
-            language: cpp
-            configuration: Debug
-            platform: x64
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX64Release
-            language: cpp
-            configuration: Release
-            platform: x64
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX86Debug
-            language: cpp
-            configuration: Debug
-            platform: x86
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX86Release
-            language: cpp
-            configuration: Release
-            platform: x86
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64ReleaseCpp
@@ -387,34 +359,7 @@ parameters:
             platform: x64
             projectType: app
             lowResource: true
-          - Name: FabricX64Debug
-            language: cpp
-            configuration: Debug
-            platform: x64
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX64Release
-            language: cpp
-            configuration: Release
-            platform: x64
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX86Debug
-            language: cpp
-            configuration: Debug
-            platform: x86
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
-          - Name: FabricX86Release
-            language: cpp
-            configuration: Release
-            platform: x86
-            projectType: app
-            initPath: InitWindows
-            additionalRunArguments: --no-autolink
+
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
@@ -461,7 +406,6 @@ jobs:
                   configuration: ${{ matrix.configuration }}
                   platform: ${{ matrix.platform }}
                   projectType: ${{ matrix.projectType }}
-                  initPath: ${{ coalesce(matrix.initPath, 'ReactNativeWindowsInit') }}
                   additionalInitArguments: ${{ matrix.additionalInitArguments }}
                   additionalRunArguments: ${{ matrix.additionalRunArguments }}
                   runWack: ${{ coalesce(matrix.runWack, false) }}

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -85,3 +85,8 @@ stages:
           buildEnvironment: ${{ parameters.buildEnvironment }}
           AgentPool: ${{ parameters.AgentPool }}
           buildNuGetOnly: false
+      
+      - template: jobs/cli-init-windows.yml
+        parameters:
+          buildEnvironment: ${{ parameters.buildEnvironment }}
+          AgentPool: ${{ parameters.AgentPool }}

--- a/.ado/templates/react-native-debug-info.yml
+++ b/.ado/templates/react-native-debug-info.yml
@@ -1,0 +1,28 @@
+#
+parameters:
+  - name: workingDirectory
+    type: string
+  - name: doctor
+    type: boolean
+    default: true
+  - name: config
+    type: boolean
+    default: true
+
+steps:
+  # Useful info to have in the log, but also a necessary workaround to make sure the cli is cached by npx
+  - script: npx react-native info
+    displayName: React Native Info
+    workingDirectory: ${{ parameters.workingDirectory }}
+
+  - ${{ if eq(parameters.doctor, true) }}:
+    # Verify react-native doctor command works
+    - script: npx react-native doctor
+      displayName: React Native Doctor
+      workingDirectory: ${{ parameters.workingDirectory }}
+
+  - ${{ if eq(parameters.config, true) }}:
+    # Print the config for debugging react-native CLI commands
+    - script: npx react-native config
+      displayName: React Native Config
+      workingDirectory: ${{ parameters.workingDirectory }}

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -1,10 +1,7 @@
 #
 parameters:
-  - name: language
+  - name: template
     type: string
-    values:
-      - cpp
-      - cs
   - name: platform
     type: string
     values:
@@ -16,23 +13,15 @@ parameters:
     values:
       - Debug
       - Release
-  - name: projectType
-    type: string
-    values:
-      - app
-      - lib
   - name: additionalRunArguments
     type: string
     default: ''
-  - name: useNuGet
-    type: boolean
-    default: false
-  - name: runWack
-    type: boolean
-    default: false
   - name: additionalInitArguments
     type: string
     default: ''
+  - name: runWack
+    type: boolean
+    default: false
   - name: buildEnvironment
     type: string
     default: PullRequest
@@ -48,28 +37,13 @@ steps:
     parameters:
       buildEnvironment: ${{ parameters.buildEnvironment }}
 
-  - ${{ if eq(parameters.useNuGet, true) }}:
-    - template: prep-and-pack-nuget.yml
-      parameters:
-        artifactName: ReactWindows
-        npmVersion: $(npmVersion)
-        packMicrosoftReactNative: true
-        ${{ if eq(parameters.language, 'cpp') }}:
-          packMicrosoftReactNativeCxx: true
-        ${{ if eq(parameters.language, 'cs') }}:
-          packMicrosoftReactNativeManaged: true
-          packMicrosoftReactNativeManagedCodeGen: true
-        slices:
-          - platform: ${{ parameters.platform }}
-            configuration: Release
-
-  - ${{ if eq(parameters.projectType, 'app') }}:
+  - ${{ if endsWith(parameters.template, '-app') }}:
     - script: |
         npx --yes react-native@$(reactNativeDevDependency) init testcli --template react-native@$(reactNativeDevDependency)
       displayName: Init new app project
       workingDirectory: $(Agent.BuildDirectory)
 
-  - ${{ if eq(parameters.projectType, 'lib') }}:
+  - ${{ if endsWith(parameters.template, '-lib') }}:
     - script: |
         npx --yes create-react-native-module@0.20.2 --package-name "testcli" testcli
       displayName: Init new lib project
@@ -80,36 +54,35 @@ steps:
       displayName: Remove broken android folder # See issue https://github.com/microsoft/react-native-windows/issues/12209
       workingDirectory: $(Agent.BuildDirectory)\testcli
 
-    - script: |
-        call yarn install
-        call yarn upgrade react@$(reactDevDependency) --dev
-        call yarn upgrade react-native@$(reactNativeDevDependency) --dev
-      displayName: Update lib project react and react-native dev versions
-      workingDirectory: $(Agent.BuildDirectory)\testcli
+  - script: |
+      call yarn install
+      call yarn upgrade react@$(reactDevDependency) --dev
+      call yarn upgrade react-native@$(reactNativeDevDependency) --dev
+    displayName: Update project react and react-native dev versions
+    workingDirectory: $(Agent.BuildDirectory)\testcli
 
-  - ${{ if eq(parameters.useNuget, true) }}:
-    - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }} --experimentalNuGetDependency true --nuGetTestFeed $(System.DefaultWorkingDirectory)\NuGetTestFeed
-      displayName: Apply windows template (with nuget)
-      workingDirectory: $(Agent.BuildDirectory)\testcli
-      env:
-        npm_config_registry: http://localhost:4873
+  - script: |
+      call yarn add react-native-windows@$(npmVersion)
+    displayName: yarn add react-native-windows@$(npmVersion)
+    workingDirectory: $(Agent.BuildDirectory)\testcli
+    env:
+      npm_config_registry: http://localhost:4873
 
-  - ${{ if eq(parameters.useNuget, false) }}:
-    - script: |
-        npx --yes react-native-windows-init@latest --verbose --version $(npmVersion) --overwrite --language ${{ parameters.language }} --projectType ${{ parameters.projectType }} ${{ parameters.additionalInitArguments }}
-      displayName: Apply windows template (without nuget)
-      workingDirectory: $(Agent.BuildDirectory)\testcli
-      env:
-        npm_config_registry: http://localhost:4873
-
-  - ${{ if eq(parameters.projectType, 'app') }}:
+  - script: |
+      call yarn react-native init-windows --template ${{ parameters.template }} --overwrite --logging ${{ parameters.additionalInitArguments }}
+    displayName: Call react-native init-windows
+    workingDirectory: $(Agent.BuildDirectory)\testcli
+    env:
+      npm_config_registry: http://localhost:4873
+  
+  - ${{ if endsWith(parameters.template, '-app') }}:
     - powershell: |
-        [xml] $manifest = Get-Content .\Package.appxmanifest
+        $path = (Get-ChildItem -Filter "Package.appxmanifest" -File -Recurse).FullName;
+        [xml] $manifest = Get-Content $path
         $manifest.Package.Identity.Name = 'ReactNative.InitTest'
-        $manifest.Save("$pwd\Package.appxmanifest")
+        $manifest.Save("$path")
       displayName: Set AppX package name to "ReactNative.InitTest"
-      workingDirectory: $(Agent.BuildDirectory)\testcli\windows\testcli
+      workingDirectory: $(Agent.BuildDirectory)\testcli\windows
 
   # End npm test server
   - template: verdaccio-stop.yml
@@ -140,7 +113,7 @@ steps:
       buildLogDirectory: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
 
   # Only test bundling in debug since we already bundle as part of release builds
-  - ${{ if and(eq(parameters.projectType, 'app'), eq(parameters.configuration, 'Debug')) }}:
+  - ${{ if and(endsWith(parameters.template, '-app'), eq(parameters.configuration, 'Debug')) }}:
     - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle
       displayName: Create bundle testcli
       workingDirectory: $(Agent.BuildDirectory)\testcli

--- a/.ado/templates/verdaccio-start.yml
+++ b/.ado/templates/verdaccio-start.yml
@@ -1,0 +1,24 @@
+#
+parameters:
+  - name: beachballPublish
+    type: boolean
+    default: true
+
+steps:
+  - powershell: start-process verdaccio.cmd -ArgumentList @('--config', './.ado/verdaccio/config.yaml')
+    displayName: Launch test npm server (verdaccio)
+
+  - script: node .ado/scripts/waitForVerdaccio.js
+    displayName: Wait for verdaccio server to boot
+
+  - script: node .ado/scripts/npmAddUser.js user pass mail@nomail.com http://localhost:4873
+    displayName: Add npm user to verdaccio
+
+  - template: compute-beachball-branch-name.yml
+
+  - ${{ if eq(parameters.beachballPublish, true) }}:
+    - script: npx beachball publish --branch origin/$(BeachBallBranchName) --no-push --registry http://localhost:4873 --yes --verbose --access public --changehint "Run `yarn change` from root of repo to generate a change file."
+      displayName: Publish packages to verdaccio
+    
+  - script: yarn config set registry http://localhost:4873
+    displayName: Modify yarn config to point to local verdaccio server

--- a/.ado/templates/verdaccio-stop.yml
+++ b/.ado/templates/verdaccio-stop.yml
@@ -1,0 +1,21 @@
+#
+parameters:
+  - name: uploadLogs
+    type: boolean
+    default: true
+
+steps:
+  # Reclaim memory used by Verdaccio to reduce the chance of build OOM issues
+  - script: tskill node
+    displayName: Kill Verdaccio
+    condition: succeededOrFailed()
+
+  - ${{ if eq(parameters.uploadLogs, true) }}:
+    # We are experiencing random package restore failures.
+    # We want to uploading the vedaccio logs to aid in diagnosing if it is verdaccio or npmjs.org
+    - task: PublishPipelineArtifact@1
+      displayName: Upload Verdaccio.log (on failure)
+      inputs:
+        targetPath: 'verdaccio.log'
+        artifact: '$(Agent.JobName).Verdaccio.log-$(System.JobAttempt)'
+      condition: failed()


### PR DESCRIPTION
Backport PR #12213 into 0.73

## Description
PR #12183 show-horned a new variable and branching path in our existing `cli-init.yml` CI job to support the new `react-native init-windows` command.

However, this makes the pipeline hard to parse and maintain. This PR factors out the new new project path into a separate set of jobs, so we can leave the "old" pipeline as-is, run both for now, but have and easier time updating the new one (and eventually just delete the old one when it's no longer necessary).

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To make the new new project CI easier to maintain and drift from the old new project CI.

### What
Created a new `cli-init-windows.yml` job, which calls a new "template-focused" `react-native-init-windows.yml` template, and also factored out code common to both it and to `react-native-init.yml` (like starting/stopping verdaccio) into reusable templates.

## Screenshots
N/A

## Testing
Ran the new pipelines

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12261)