### PR TITLE
Implement IValueProvider

### DIFF
--- a/change/react-native-windows-008fe6b2-a10c-4b12-b46e-00415bf35fce.json
+++ b/change/react-native-windows-008fe6b2-a10c-4b12-b46e-00415bf35fce.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "value provider changes",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -360,9 +360,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::SetValue(LPCWSTR val) {
   auto baseView = std::static_pointer_cast<::Microsoft::ReactNative::CompositionBaseComponentView>(strongView);
   if (baseView == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
-  winrt::IInspectable uiaProvider = baseView->EnsureUiaProvider();
-  UpdateUiaProperty(uiaProvider, UIA_ValueValuePropertyId, *props->accessibilityValue.text, value);
-
+  baseView->updateAccessibilityValue(value);
   return S_OK;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -373,7 +373,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::SetValue(LPCWSTR val) {
   return S_OK;
 }
 
-HRESULT __stdcall CompositionDynamicAutomationProvider::get_Value(BSTR* pRetVal) {
+HRESULT __stdcall CompositionDynamicAutomationProvider::get_Value(BSTR *pRetVal) {
   if (pRetVal == nullptr)
     return E_POINTER;
   auto strongView = m_view.view();
@@ -387,7 +387,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::get_Value(BSTR* pRetVal)
   return S_OK;
 }
 
-HRESULT __stdcall CompositionDynamicAutomationProvider::get_IsReadOnly(BOOL* pRetVal) {
+HRESULT __stdcall CompositionDynamicAutomationProvider::get_IsReadOnly(BOOL *pRetVal) {
   return S_OK;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.cpp
@@ -333,13 +333,6 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::Invoke() {
   return S_OK;
 }
 
-std::string convertLPCWSTRToString(LPCWSTR val) {
-  int strLength = WideCharToMultiByte(CP_UTF8, 0, val, -1, nullptr, 0, nullptr, nullptr);
-  std::string str(strLength, 0);
-  WideCharToMultiByte(CP_UTF8, 0, val, -1, &str[0], strLength, nullptr, nullptr);
-  return str;
-}
-
 BSTR StringToBSTR(const std::string &str) {
   // Calculate the required BSTR size in bytes
   int len = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
@@ -363,7 +356,7 @@ HRESULT __stdcall CompositionDynamicAutomationProvider::SetValue(LPCWSTR val) {
     return UIA_E_ELEMENTNOTAVAILABLE;
 
   auto props = std::static_pointer_cast<const facebook::react::ViewProps>(strongView->props());
-  std::string value = convertLPCWSTRToString(val);
+  std::string value = winrt::to_string(val);
   auto baseView = std::static_pointer_cast<::Microsoft::ReactNative::CompositionBaseComponentView>(strongView);
   if (baseView == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
@@ -13,7 +13,8 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
                                                  IInspectable,
                                                  IRawElementProviderFragment,
                                                  IRawElementProviderSimple,
-                                                 IInvokeProvider> {
+                                                 IInvokeProvider,
+                                                 IValueProvider> {
  public:
   CompositionDynamicAutomationProvider(
       const std::shared_ptr<::Microsoft::ReactNative::CompositionBaseComponentView> &componentView) noexcept;
@@ -36,6 +37,10 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
   // inherited via IInvokeProvider
   virtual HRESULT __stdcall Invoke() override;
 
+  // inherited via IValueProvider
+  virtual HRESULT __stdcall SetValue(LPCWSTR val) override;
+  virtual HRESULT __stdcall get_Value(BSTR *pRetVal) override;
+  virtual HRESULT __stdcall get_IsReadOnly(BOOL *pRetVal) override;
  private:
   ::Microsoft::ReactNative::ReactTaggedView m_view;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionDynamicAutomationProvider.h
@@ -41,6 +41,7 @@ class CompositionDynamicAutomationProvider : public winrt::implements<
   virtual HRESULT __stdcall SetValue(LPCWSTR val) override;
   virtual HRESULT __stdcall get_Value(BSTR *pRetVal) override;
   virtual HRESULT __stdcall get_IsReadOnly(BOOL *pRetVal) override;
+
  private:
   ::Microsoft::ReactNative::ReactTaggedView m_view;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1305,6 +1305,17 @@ void CompositionBaseComponentView::EnsureTransformMatrixFacade() noexcept {
   }
 }
 
+void CompositionBaseComponentView::updateAccessibilityValue(std::string newValue) noexcept {
+  auto props = std::static_pointer_cast<const facebook::react::ViewProps>(this->props());
+  if (newValue != props->accessibilityValue.text) {
+    auto provider = EnsureUiaProvider();
+    if (provider != nullptr) {
+      winrt::Microsoft::ReactNative::implementation::UpdateUiaProperty(
+          provider, UIA_ValueValuePropertyId, *props->accessibilityValue.text, newValue);
+    }
+  }
+}
+
 facebook::react::SharedViewEventEmitter CompositionBaseComponentView::eventEmitter() noexcept {
   return m_eventEmitter;
 }
@@ -1385,6 +1396,12 @@ void CompositionViewComponentView::updateProps(
 
   if (oldViewProps.opacity != newViewProps.opacity) {
     m_visual.Opacity(newViewProps.opacity);
+  }
+
+  if (oldViewProps.accessibilityValue.text.has_value() &&
+      newViewProps.accessibilityValue.text.has_value() &&
+      oldViewProps.accessibilityValue.text != newViewProps.accessibilityValue.text) {
+    updateAccessibilityValue(*newViewProps.accessibilityValue.text);
   }
 
   // update BaseComponentView props

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1398,8 +1398,7 @@ void CompositionViewComponentView::updateProps(
     m_visual.Opacity(newViewProps.opacity);
   }
 
-  if (oldViewProps.accessibilityValue.text.has_value() &&
-      newViewProps.accessibilityValue.text.has_value() &&
+  if (oldViewProps.accessibilityValue.text.has_value() && newViewProps.accessibilityValue.text.has_value() &&
       oldViewProps.accessibilityValue.text != newViewProps.accessibilityValue.text) {
     updateAccessibilityValue(*newViewProps.accessibilityValue.text);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -35,6 +35,7 @@ struct CompositionBaseComponentView : public IComponentView,
   bool runOnChildren(bool forward, Mso::Functor<bool(IComponentView &)> &fn) noexcept override;
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
+  void updateAccessibilityValue(std::string newValue) noexcept;
   void onPointerEntered(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerExited(


### PR DESCRIPTION
### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Implements the IValueProvider and supporting methods which is used to provide access to controls that have an intrinsic value that does not span a range, and that can be represented as a string.

Based on the implementation of ValueProvider in Paper in #5080, the `get_IsReadOnly()` method does not need to be implemented due to no available corresponding React Native prop.

### What

Implemented SetValue and get_Value methods as part of the IValueProvider interface. 

## Screenshots
Before: 
![image](https://github.com/microsoft/react-native-windows/assets/30995198/6d0f48f7-5051-4236-9091-f9513fd8d51d)

After:
![image](https://github.com/microsoft/react-native-windows/assets/30995198/78893854-bc22-4e04-86a7-60c7dd98b10e)



## Testing
Tested locally on playground-composition.

## Changelog
Should this change be included in the release notes: yes

Implement UIA IValueProvider
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12238)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12263)