### PR TITLE
[Fabric] Add support for loading image files from local files

### DIFF
--- a/change/react-native-windows-8295ceba-97f3-4570-afc5-ffa8b10c51d1.json
+++ b/change/react-native-windows-8295ceba-97f3-4570-afc5-ffa8b10c51d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add support for loading images from local files",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -434,8 +434,8 @@ void CompositionEventHandler::onKeyDown(
 
   bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) ==
       winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
-  bool fCtrl =
-      GetKeyState(winrt::Windows::System::VirtualKey::Control) == winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
+  bool fCtrl = source.GetKeyState(winrt::Windows::System::VirtualKey::Control) ==
+      winrt::Windows::UI::Core::CoreVirtualKeyStates::Down;
 
   if (fShift && fCtrl && args.Key() == static_cast<winrt::Windows::System::VirtualKey>(VkKeyScanA('d')) &&
       Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle())) {

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -23,13 +23,62 @@ winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImag
   try {
     co_await winrt::resume_background();
 
-    auto httpMethod{
-        source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{winrt::to_hstring(source.method)}};
-
     winrt::Uri uri = UriTryCreate(winrt::to_hstring(source.uri));
     if (!uri) {
       co_return nullptr;
     }
+
+    if (uri.SchemeName() == L"file") {
+      auto path = winrt::to_string(uri.Path());
+      std::replace(path.begin(), path.end(), '/', '\\');
+      auto getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(winrt::to_hstring(path));
+      co_await lessthrow_await_adapter<
+          winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::StorageFile>>{getFileSync};
+
+      if (FAILED(getFileSync.ErrorCode())) {
+        co_return nullptr;
+      }
+
+      winrt::Windows::Storage::StorageFile file{getFileSync.GetResults()};
+
+      auto openReadAsync = file.OpenReadAsync();
+      co_await lessthrow_await_adapter<winrt::Windows::Foundation::IAsyncOperation<
+          winrt::Windows::Storage::Streams::IRandomAccessStreamWithContentType>>{openReadAsync};
+
+      if (FAILED(openReadAsync.ErrorCode())) {
+        co_return nullptr;
+      }
+
+      winrt::Windows::Storage::Streams::IRandomAccessStreamWithContentType stream{openReadAsync.GetResults()};
+      return stream;
+    }
+
+    if (uri.SchemeName() == L"ms-appx") {
+      auto getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
+      co_await lessthrow_await_adapter<
+          winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::StorageFile>>{getFileSync};
+
+      if (FAILED(getFileSync.ErrorCode())) {
+        co_return nullptr;
+      }
+
+      winrt::Windows::Storage::StorageFile file{getFileSync.GetResults()};
+
+      auto openReadAsync = file.OpenReadAsync();
+      co_await lessthrow_await_adapter<winrt::Windows::Foundation::IAsyncOperation<
+          winrt::Windows::Storage::Streams::IRandomAccessStreamWithContentType>>{openReadAsync};
+
+      if (FAILED(openReadAsync.ErrorCode())) {
+        co_return nullptr;
+      }
+
+      winrt::Windows::Storage::Streams::IRandomAccessStreamWithContentType stream{openReadAsync.GetResults()};
+      return stream;
+    }
+
+    auto httpMethod{
+        source.method.empty() ? winrt::HttpMethod::Get() : winrt::HttpMethod{winrt::to_hstring(source.method)}};
+
     winrt::HttpRequestMessage request{httpMethod, uri};
 
     if (!source.headers.empty()) {


### PR DESCRIPTION
## Description
Previous logic was only handling fetching images from web locations (or the bundler)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12264)