### PR TITLE
Adds `eqeqeq` to eslint configuration and a few other lint fixes

### DIFF
--- a/change/@office-iss-react-native-win32-c8f05d48-2e06-40a5-a678-84a890bf527f.json
+++ b/change/@office-iss-react-native-win32-c8f05d48-2e06-40a5-a678-84a890bf527f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds `eqeqeq` to eslint configuration and a few other lint fixes",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-eslint-config-07a27c62-5b09-4435-ba2f-b47a2811a718.json
+++ b/change/@rnw-scripts-eslint-config-07a27c62-5b09-4435-ba2f-b47a2811a718.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds `eqeqeq` to eslint configuration and a few other lint fixes",
+  "packageName": "@rnw-scripts/eslint-config",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a4303d58-1520-4375-b661-e3df9c0dfd9f.json
+++ b/change/react-native-windows-a4303d58-1520-4375-b661-e3df9c0dfd9f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds `eqeqeq` to eslint configuration and a few other lint fixes",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/TextInput/TextInput.win32.js
@@ -1490,8 +1490,8 @@ function InternalTextInput(props: Props): React.Node {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyDownEvents) {
         if (
-          event.nativeEvent.code == el.code &&
-          el.handledEventPhase == eventPhase.Bubbling
+          event.nativeEvent.code === el.code &&
+          el.handledEventPhase === eventPhase.Bubbling
         ) {
           event.stopPropagation();
         }
@@ -1504,7 +1504,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyUpEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyUpEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 3) {
           event.stopPropagation();
         }
       }
@@ -1516,7 +1516,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyDownEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyDownEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 1) {
           event.stopPropagation();
         }
       }
@@ -1528,7 +1528,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyUpEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyUpEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 1) {
           event.stopPropagation();
         }
       }

--- a/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Components/View/View.win32.js
@@ -138,7 +138,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyDownEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 3
+          ) {
             event.stopPropagation();
           }
         }
@@ -150,7 +153,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyUpEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 3
+          ) {
             event.stopPropagation();
           }
         }
@@ -162,7 +168,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyDownEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 1
+          ) {
             event.stopPropagation();
           }
         }
@@ -174,7 +183,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyUpEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 1
+          ) {
             event.stopPropagation();
           }
         }

--- a/packages/@rnw-scripts/eslint-config/eslintrc.js
+++ b/packages/@rnw-scripts/eslint-config/eslintrc.js
@@ -75,6 +75,7 @@ module.exports = {
         ],
         'block-scoped-var': 'error',
         'complexity': 'warn',
+        'eqeqeq': [ 'error', 'allow-null' ],
         'guard-for-in': 'error',
         'no-constructor-return': 'error',
         'no-useless-concat': 'error',

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -36,7 +36,6 @@ import useAndroidRippleForView, {
 import * as React from 'react';
 import {useImperativeHandle, useMemo, useRef, useState} from 'react';
 import type {HandledKeyboardEvent} from '../../Components/View/ViewPropTypes';
-import TextInputState from '../TextInput/TextInputState';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 

--- a/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src/Libraries/Components/TextInput/TextInput.windows.js
@@ -1522,8 +1522,8 @@ function InternalTextInput(props: Props): React.Node {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyDownEvents) {
         if (
-          event.nativeEvent.code == el.code &&
-          el.handledEventPhase == eventPhase.Bubbling
+          event.nativeEvent.code === el.code &&
+          el.handledEventPhase === eventPhase.Bubbling
         ) {
           event.stopPropagation();
         }
@@ -1536,7 +1536,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyUpEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyUpEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 3) {
           event.stopPropagation();
         }
       }
@@ -1548,7 +1548,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyDownEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyDownEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 1) {
           event.stopPropagation();
         }
       }
@@ -1560,7 +1560,7 @@ function InternalTextInput(props: Props): React.Node {
     if (props.keyUpEvents && event.isPropagationStopped() !== true) {
       // $FlowFixMe - keyDownEvents was already checked to not be undefined
       for (const el of props.keyUpEvents) {
-        if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+        if (event.nativeEvent.code === el.code && el.handledEventPhase === 1) {
           event.stopPropagation();
         }
       }

--- a/vnext/src/Libraries/Components/View/View.windows.js
+++ b/vnext/src/Libraries/Components/View/View.windows.js
@@ -126,7 +126,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyDownEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 3
+          ) {
             event.stopPropagation();
           }
         }
@@ -138,7 +141,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyUpEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 3) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 3
+          ) {
             event.stopPropagation();
           }
         }
@@ -150,7 +156,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyDownEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyDownEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 1
+          ) {
             event.stopPropagation();
           }
         }
@@ -162,7 +171,10 @@ const View: React.AbstractComponent<
       if (otherProps.keyUpEvents && event.isPropagationStopped() !== true) {
         // $FlowFixMe - keyDownEvents was already checked to not be undefined
         for (const el of otherProps.keyUpEvents) {
-          if (event.nativeEvent.code == el.code && el.handledEventPhase == 1) {
+          if (
+            event.nativeEvent.code === el.code &&
+            el.handledEventPhase === 1
+          ) {
             event.stopPropagation();
           }
         }
@@ -191,7 +203,7 @@ const View: React.AbstractComponent<
         }
         return child;
       });
-      if (updatedChildren.length == 1) {
+      if (updatedChildren.length === 1) {
         return updatedChildren[0];
       } else {
         return updatedChildren;

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -629,7 +629,7 @@ export default class Pressability {
           (event.nativeEvent.code === 'Space' ||
             event.nativeEvent.code === 'Enter' ||
             event.nativeEvent.code === 'GamepadA') &&
-          event.defaultPrevented != true &&
+          event.defaultPrevented !== true &&
           this._isKeyDown
         ) {
           const {onPressOut, onPress} = this._config;
@@ -649,7 +649,7 @@ export default class Pressability {
           (event.nativeEvent.code === 'Space' ||
             event.nativeEvent.code === 'Enter' ||
             event.nativeEvent.code === 'GamepadA') &&
-          event.defaultPrevented != true
+          event.defaultPrevented !== true
         ) {
           const {onPressIn} = this._config;
           this._isKeyDown = true;


### PR DESCRIPTION



## Description

### What
It's generally good practice to use `===` when comparing values in JavaScript (other than null checks), so this change adds that to the eslint config.

This change also cleans up a miscellaneous unused variable in Pressable.windows.js.

## Testing
Wait for GitHub lint checks.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12267)