### PR TITLE
Implement BlobCollector

### DIFF
--- a/change/react-native-windows-5d9952b2-0b6d-4246-a1ec-994f54168545.json
+++ b/change/react-native-windows-5d9952b2-0b6d-4246-a1ec-994f54168545.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Implement BlobCollector",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Modules/BlobCollector.cpp
+++ b/vnext/Shared/Modules/BlobCollector.cpp
@@ -10,14 +10,10 @@ namespace Microsoft::React {
 using Networking::IBlobResource;
 
 BlobCollector::BlobCollector(string blobId, std::shared_ptr<IBlobResource> resource) noexcept
-  : m_blobId { blobId }, m_weakResource { std::weak_ptr<IBlobResource>(resource) }
-{
-}
+    : m_blobId{blobId}, m_weakResource{std::weak_ptr<IBlobResource>(resource)} {}
 
-BlobCollector::~BlobCollector() noexcept
-{
-  if (auto rc = m_weakResource.lock())
-  {
+BlobCollector::~BlobCollector() noexcept {
+  if (auto rc = m_weakResource.lock()) {
     rc->Release(std::move(m_blobId));
   }
 }

--- a/vnext/Shared/Modules/BlobCollector.cpp
+++ b/vnext/Shared/Modules/BlobCollector.cpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "BlobCollector.h"
+
+using std::string;
+
+namespace Microsoft::React {
+
+using Networking::IBlobResource;
+
+BlobCollector::BlobCollector(string blobId, std::shared_ptr<IBlobResource> resource) noexcept
+  : m_blobId { blobId }, m_weakResource { std::weak_ptr<IBlobResource>(resource) }
+{
+}
+
+BlobCollector::~BlobCollector() noexcept
+{
+  if (auto rc = m_weakResource.lock())
+  {
+    rc->Release(std::move(m_blobId));
+  }
+}
+
+} // namespace Microsoft::React

--- a/vnext/Shared/Modules/BlobCollector.h
+++ b/vnext/Shared/Modules/BlobCollector.h
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Networking/IBlobResource.h>
+
+// JSI
+#include <jsi/jsi.h>
+
+namespace Microsoft::React {
+
+class JSI_EXPORT BlobCollector : public facebook::jsi::HostObject
+{
+  std::string m_blobId;
+  std::weak_ptr<Networking::IBlobResource> m_weakResource;
+
+public:
+  BlobCollector(std::string blobId, std::shared_ptr<Networking::IBlobResource> resource) noexcept;
+
+  ~BlobCollector() noexcept;
+};
+
+}// namespace Microsoft::React

--- a/vnext/Shared/Modules/BlobCollector.h
+++ b/vnext/Shared/Modules/BlobCollector.h
@@ -10,15 +10,14 @@
 
 namespace Microsoft::React {
 
-class JSI_EXPORT BlobCollector : public facebook::jsi::HostObject
-{
+class JSI_EXPORT BlobCollector : public facebook::jsi::HostObject {
   std::string m_blobId;
   std::weak_ptr<Networking::IBlobResource> m_weakResource;
 
-public:
+ public:
   BlobCollector(std::string blobId, std::shared_ptr<Networking::IBlobResource> resource) noexcept;
 
   ~BlobCollector() noexcept;
 };
 
-}// namespace Microsoft::React
+} // namespace Microsoft::React

--- a/vnext/Shared/Modules/BlobModule.cpp
+++ b/vnext/Shared/Modules/BlobModule.cpp
@@ -4,10 +4,13 @@
 #include "BlobModule.h"
 
 #include <CreateModules.h>
+#include <JSI/JsiApiContext.h>
 #include <Modules/CxxModuleUtilities.h>
+#include "BlobCollector.h"
 
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>
+
 
 using namespace facebook::xplat;
 
@@ -38,6 +41,27 @@ void BlobTurboModule::Initialize(msrn::ReactContext const &reactContext) noexcep
   m_resource->Callbacks().OnError = [&reactContext](string &&errorText) {
     Modules::SendEvent(reactContext, L"blobFailed", {errorText});
   };
+
+  namespace jsi = facebook::jsi;
+  msrn::ExecuteJsi(reactContext, [resource = m_resource](jsi::Runtime& runtime)
+  {
+    runtime.global().setProperty(
+      runtime,
+      "__blobCollectorProvider",
+      jsi::Function::createFromHostFunction(
+        runtime,
+        jsi::PropNameID::forAscii(runtime, "__blobCollectorProvider"),
+        1,
+        [resource](jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count)
+        {
+          auto blobId = args[0].asString(rt).utf8(rt);
+          auto collector = std::make_shared<BlobCollector>(blobId, resource);
+
+          return jsi::Object::createFromHostObject(rt, collector);
+        }
+      )
+    );
+  });
 }
 
 ReactNativeSpecs::BlobModuleSpec_Constants BlobTurboModule::GetConstants() noexcept {

--- a/vnext/Shared/Modules/BlobModule.cpp
+++ b/vnext/Shared/Modules/BlobModule.cpp
@@ -11,7 +11,6 @@
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>
 
-
 using namespace facebook::xplat;
 
 using folly::dynamic;
@@ -43,24 +42,20 @@ void BlobTurboModule::Initialize(msrn::ReactContext const &reactContext) noexcep
   };
 
   namespace jsi = facebook::jsi;
-  msrn::ExecuteJsi(reactContext, [resource = m_resource](jsi::Runtime& runtime)
-  {
+  msrn::ExecuteJsi(reactContext, [resource = m_resource](jsi::Runtime &runtime) {
     runtime.global().setProperty(
-      runtime,
-      "__blobCollectorProvider",
-      jsi::Function::createFromHostFunction(
         runtime,
-        jsi::PropNameID::forAscii(runtime, "__blobCollectorProvider"),
-        1,
-        [resource](jsi::Runtime& rt, const jsi::Value& thisVal, const jsi::Value* args, size_t count)
-        {
-          auto blobId = args[0].asString(rt).utf8(rt);
-          auto collector = std::make_shared<BlobCollector>(blobId, resource);
+        "__blobCollectorProvider",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "__blobCollectorProvider"),
+            1,
+            [resource](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) {
+              auto blobId = args[0].asString(rt).utf8(rt);
+              auto collector = std::make_shared<BlobCollector>(blobId, resource);
 
-          return jsi::Object::createFromHostObject(rt, collector);
-        }
-      )
-    );
+              return jsi::Object::createFromHostObject(rt, collector);
+            }));
   });
 }
 

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -193,6 +193,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)LayoutAnimation.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Logging.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)MemoryMappedBuffer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\CxxModuleUtilities.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\ExceptionsManagerModule.cpp" />
@@ -327,6 +328,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\V8RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ScriptStore.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\CxxModuleUtilities.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\FileReaderModule.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -275,6 +275,9 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewProps.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewEventEmitter.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.cpp">
+      <Filter>Source Files\Modules</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -750,6 +753,9 @@
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformTouch.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewEventEmitter.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.h">
+      <Filter>Header Files\Modules</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp">


### PR DESCRIPTION
## Description
Allows disposing of unused Blob data when JS garbage collection takes place.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Continuous instantiation of `Blob` JavaScript objects can lead to memory leaks because the disposal of those objects does not trigger the deallocation of the blob data on the native side (see `IBlobPersistor`).

- See https://github.com/facebook/react-native/pull/24745
- See https://github.com/jurocha-ms/Repro/tree/blobmemleak/ReactNative/fetchwinleak

For further context:
- https://github.com/facebook/react-native/pull/24405
- https://github.com/facebook/react-native/pull/24767
- https://github.com/facebook/react-native/issues/39441
- https://github.com/facebook/react-native/issues/23801
- https://github.com/facebook/react-native/issues/24654

### What
- Define `Microsoft::React::BlobCollector`.
  - Gets attached to the JavaScript `Blob` instance lifetime and cleans up its corresponding blob data on destruction.
- Register factory method `__blobCollectorProvider` through JSI.

**Important**: This fix only applies to the TurboModule variant.
We need to figure out a way to set this up for the Blob CxxModule, which requires accessing its `facebook::jsi::Runtime` instance reference.

## Testing
Use proof of concept https://github.com/jurocha-ms/Repro/tree/blobmemleak/ReactNative/fetchwinleak (see README).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12269)