### PR TITLE
[0.72] Fix peer dependencies for react-native

### DIFF
--- a/change/@office-iss-react-native-win32-c40abe5d-af56-493a-ae49-34214d035a10.json
+++ b/change/@office-iss-react-native-win32-c40abe5d-af56-493a-ae49-34214d035a10.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Fix peer dependencies for react-native",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-e9beb7b0-e993-4305-9ea8-d1a5292b9149.json
+++ b/change/react-native-windows-e9beb7b0-e993-4305-9ea8-d1a5292b9149.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Fix peer dependencies for react-native",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/package.json
+++ b/packages/@office-iss/react-native-win32-tester/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@office-iss/react-native-win32": "0.72.8",
     "react": "18.0.0",
-    "react-native": "^0.72.0"
+    "react-native": "^0.72.6"
   },
   "devDependencies": {
     "@office-iss/react-native-win32": "0.72.8",

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -89,7 +89,7 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.72.3"
+    "react-native": "^0.72.6"
   },
   "beachball": {
     "defaultNpmTag": "latest",

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@react-native-picker/picker": "2.4.10",
     "react": "18.0.0",
-    "react-native": "^0.72.0",
+    "react-native": "^0.72.6",
     "react-native-windows": "0.72.15",
     "react-native-xaml": "^0.0.50"
   },

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -87,7 +87,7 @@
   },
   "peerDependencies": {
     "react": "18.2.0",
-    "react-native": "^0.72.3"
+    "react-native": "^0.72.6"
   },
   "beachball": {
     "defaultNpmTag": "latest",


### PR DESCRIPTION
## Description

This PR fixes the peer-dependency versions for RN to require 0.72.6 (which was missed in the last integrate).

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Make sure folks don't have a bad combination of versions.

### What
Updated package.json files.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12282)