### PR TITLE
Fix @rnw-scripts/create-github-releases

### DIFF
--- a/change/@rnw-scripts-create-github-releases-4e22ce8d-fcb7-4bbc-93a0-3ac00645ae61.json
+++ b/change/@rnw-scripts-create-github-releases-4e22ce8d-fcb7-4bbc-93a0-3ac00645ae61.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix @rnw-scripts/create-github-releases",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
+++ b/packages/@rnw-scripts/create-github-releases/src/createGithubReleases.ts
@@ -161,7 +161,8 @@ function needsRelease(
 ) {
   if (
     !ELIGIBLE_PACKAGES.includes(release.packageName) ||
-    release.version.prerelease[0] === 'canary'
+    (release.version.prerelease.length > 0 &&
+      release.version.prerelease[0] !== 'preview') // preview is the only pre-release tag we want GH releases
   ) {
     return false;
   }


### PR DESCRIPTION
## Description

This PR fixes an issue with the create-github-releases script that we need to get 0.73 to publish correctly.

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Unblock 0.73 publish

### What
Don't publish GH releases if the semver prerelease tag is anything but the word preview.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12290)