### PR TITLE
[0.73] Add Beachball Check to publish.yml

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -131,6 +131,11 @@ jobs:
       - script: if not exist %USERPROFILE%\AppData\Roaming\npm (mkdir %USERPROFILE%\AppData\Roaming\npm)
         displayName: Fix missing npm config
 
+      - powershell: |
+          npx beachball check --verbose 2>&1 | Tee-Object -Variable beachballOutput
+          $beachballOutput | Where-Object { $_ -match "ERROR: *"} | ForEach { Write-Host "##vso[task.logissue type=error]$_" }
+        displayName: Beachball Check
+
       - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
         displayName: Beachball Publish
 

--- a/change/@react-native-windows-automation-0463e716-dca8-42f8-af1d-e1aff0fac0e9.json
+++ b/change/@react-native-windows-automation-0463e716-dca8-42f8-af1d-e1aff0fac0e9.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Add support for appWorkingDir option",
-  "packageName": "@react-native-windows/automation",
-  "email": "30809111+acoates-ms@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
This PR backports #12293 to 0.73.

## Description

This PR adds `npx beachball check` to the Publish pipeline to prevent attempting to publish with invalid changefiles present.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

We accidentally published `react-native-windows@0.73.0` instead of `react-native-windows@0.73.0-preview.3` because a bad change file was present and beachball will still try to do what you asked for even if it's not expected.

### What
Added a `npx beachball check` to the publish pipeline and explicitly fail if a bad change-file is detected.

## Screenshots
N/A

## Testing
Verified that this would have detected the bad change file and prevented the bad publish.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12294)