### PR TITLE
[Fabric] Add animation on Switch's thumb onHover

### DIFF
--- a/change/react-native-windows-c060b99f-d2ee-460d-9ba1-c681a5405039.json
+++ b/change/react-native-windows-c060b99f-d2ee-460d-9ba1-c681a5405039.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds fabric switch thumb animation",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -115,8 +115,9 @@ namespace Microsoft.ReactNative.Composition
   interface ISwitchThumbVisual
   {
     IVisual InnerVisual { get; };
-    void Size(Windows.Foundation.Numerics.Vector2 size);
-    void Position(Windows.Foundation.Numerics.Vector2 position);
+    Windows.Foundation.Numerics.Vector2 Size{ get; set; };
+    Windows.Foundation.Numerics.Vector2 Position{ get; set; };
+    void AnimatePosition(Windows.Foundation.Numerics.Vector2 position);
     Boolean IsVisible { get; set; };
     void Brush(IBrush brush);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1114,12 +1114,26 @@ struct CompSwitchThumbVisual : winrt::implements<
   }
 
   void Size(winrt::Windows::Foundation::Numerics::float2 size) noexcept {
-    m_geometry.Radius(size);
-    m_spiritShape.Offset(size);
-    m_compVisual.Size(size);
+    m_size = size;
+    m_geometry.Radius(m_size);
+    m_spiritShape.Offset(m_size);
+    m_compVisual.Size(m_size);
+  }
+
+  winrt::Windows::Foundation::Numerics::float2 Size() noexcept {
+    return m_size;
   }
 
   void Position(winrt::Windows::Foundation::Numerics::float2 position) noexcept {
+    m_pos = position;
+    m_compVisual.Offset({position.x, position.y, 0.0f});
+  }
+
+  winrt::Windows::Foundation::Numerics::float2 Position() noexcept {
+    return m_pos;
+  }
+
+  void AnimatePosition(winrt::Windows::Foundation::Numerics::float2 position) noexcept {
     if (!isDrawn) {
       // we don't want to animate if this is the first time the switch is drawn on screen
       isDrawn = true;
@@ -1132,6 +1146,7 @@ struct CompSwitchThumbVisual : winrt::implements<
 
       m_compVisual.StartAnimation(L"Offset", animation);
     }
+    m_pos = position;
   }
 
   bool IsVisible() const noexcept {
@@ -1145,6 +1160,8 @@ struct CompSwitchThumbVisual : winrt::implements<
   bool isDrawn{false};
   typename TTypeRedirects::SpriteVisual m_compVisual;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
+  winrt::Windows::Foundation::Numerics::float2 m_size;
+  winrt::Windows::Foundation::Numerics::float2 m_pos;
   typename TTypeRedirects::Compositor m_compositor{nullptr};
   typename TTypeRedirects::CompositionSpriteShape m_spiritShape{nullptr};
   typename TTypeRedirects::CompositionEllipseGeometry m_geometry{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1114,6 +1114,11 @@ struct CompSwitchThumbVisual : winrt::implements<
   }
 
   void Size(winrt::Windows::Foundation::Numerics::float2 size) noexcept {
+    assert(m_size.x == m_size.y);
+    // if the size has changed, update the position to the new center
+    if (m_size.x != 0.0f && m_size.x != size.x) {
+      Position({m_pos.x + (m_size.x - size.x), m_pos.y + (m_size.x - size.x)});
+    }
     m_size = size;
     m_geometry.Radius(m_size);
     m_spiritShape.Offset(m_size);
@@ -1160,7 +1165,7 @@ struct CompSwitchThumbVisual : winrt::implements<
   bool isDrawn{false};
   typename TTypeRedirects::SpriteVisual m_compVisual;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
-  winrt::Windows::Foundation::Numerics::float2 m_size;
+  winrt::Windows::Foundation::Numerics::float2 m_size{0.0f, 0.0f};
   winrt::Windows::Foundation::Numerics::float2 m_pos;
   typename TTypeRedirects::Compositor m_compositor{nullptr};
   typename TTypeRedirects::CompositionSpriteShape m_spiritShape{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -210,12 +210,7 @@ void SwitchComponentView::Draw() noexcept {
       m_thumbVisual.Size(
           {thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f,
            thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f});
-      m_thumbVisual.Position({m_thumbVisual.Position().x - 0.8f, m_thumbVisual.Position().y - 0.8f});
-    } else if (m_pointerExited && !switchProps->disabled) {
-      m_thumbVisual.Size(
-          {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
-      m_thumbVisual.Position({thumbX, thumbY});
-    } else { // we still want to draw the thumb even if it's disabled
+    } else {
       m_thumbVisual.Size(
           {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
       m_thumbVisual.AnimatePosition({thumbX, thumbY});
@@ -322,14 +317,12 @@ void SwitchComponentView::onPointerReleased(
 void SwitchComponentView::onPointerEntered(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = true;
-  m_pointerExited = false;
   Draw();
 }
 
 void SwitchComponentView::onPointerExited(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = false;
-  m_pointerExited = true;
   Draw();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -211,7 +211,7 @@ void SwitchComponentView::Draw() noexcept {
           {thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f,
            thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f});
       m_thumbVisual.Position({m_thumbVisual.Position().x - 0.8f, m_thumbVisual.Position().y - 0.8f});
-    } else if (m_pointerReleased && !switchProps->disabled) {
+    } else if (m_pointerExited && !switchProps->disabled) {
       m_thumbVisual.Size(
           {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
       m_thumbVisual.Position({thumbX, thumbY});
@@ -322,14 +322,14 @@ void SwitchComponentView::onPointerReleased(
 void SwitchComponentView::onPointerEntered(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = true;
-  m_pointerReleased = false;
+  m_pointerExited = false;
   Draw();
 }
 
 void SwitchComponentView::onPointerExited(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = false;
-  m_pointerReleased = true;
+  m_pointerExited = true;
   Draw();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -106,7 +106,7 @@ void SwitchComponentView::Draw() noexcept {
     float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
     float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);
 
-    // https://github.com/microsoft/microsoft-ui-xaml/blob/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+    // https://github.com/microsoft/microsoft-ui-xaml/blob/winui2/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
     constexpr float thumbMargin = 3.0f;
     constexpr float thumbRadius = 7.0f;
     constexpr float trackWidth = 40.0f;
@@ -203,9 +203,25 @@ void SwitchComponentView::Draw() noexcept {
       thumbX = (trackMarginX + trackWidth - thumbRadius - thumbRadius - thumbMargin) * m_layoutMetrics.pointScaleFactor;
     }
 
-    m_thumbVisual.Size(
-        {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
-    m_thumbVisual.Position({thumbX, thumbY});
+    // handles various mouse events
+    if (m_pressed && !switchProps->disabled) {
+      m_thumbVisual.AnimatePosition({thumbX - 0.8f, thumbY - 0.8f});
+    } else if (m_hovered && !switchProps->disabled) {
+      m_thumbVisual.Size(
+          {thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f,
+           thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f});
+      m_thumbVisual.Position({m_thumbVisual.Position().x - 0.8f, m_thumbVisual.Position().y - 0.8f});
+    } else if (m_pointerReleased && !switchProps->disabled) {
+      m_pointerReleased = false;
+      m_thumbVisual.Size(
+          {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
+      m_thumbVisual.Position({thumbX, thumbY});
+    } else { // we still want to draw the thumb even if it's disabled
+      m_thumbVisual.Size(
+          {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
+      m_thumbVisual.AnimatePosition({thumbX, thumbY});
+    }
+
     m_thumbVisual.Brush(thumbFill);
 
     // Restore old dpi setting
@@ -301,7 +317,6 @@ void SwitchComponentView::onPointerReleased(
   if (!args.GetCurrentPoint(-1).Properties().IsPrimary()) {
     return;
   }
-
   m_pressed = false;
 }
 
@@ -314,6 +329,7 @@ void SwitchComponentView::onPointerEntered(
 void SwitchComponentView::onPointerExited(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = false;
+  m_pointerReleased = true;
   Draw();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -212,7 +212,6 @@ void SwitchComponentView::Draw() noexcept {
            thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f});
       m_thumbVisual.Position({m_thumbVisual.Position().x - 0.8f, m_thumbVisual.Position().y - 0.8f});
     } else if (m_pointerReleased && !switchProps->disabled) {
-      m_pointerReleased = false;
       m_thumbVisual.Size(
           {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
       m_thumbVisual.Position({thumbX, thumbY});
@@ -323,6 +322,7 @@ void SwitchComponentView::onPointerReleased(
 void SwitchComponentView::onPointerEntered(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = true;
+  m_pointerReleased = false;
   Draw();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -67,7 +67,6 @@ struct SwitchComponentView : CompositionBaseComponentView {
 
   bool m_hovered{false};
   bool m_pressed{false};
-  bool m_pointerExited{false};
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   facebook::react::SharedViewProps m_props;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -67,7 +67,7 @@ struct SwitchComponentView : CompositionBaseComponentView {
 
   bool m_hovered{false};
   bool m_pressed{false};
-  bool m_pointerReleased{false};
+  bool m_pointerExited{false};
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   facebook::react::SharedViewProps m_props;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -67,6 +67,7 @@ struct SwitchComponentView : CompositionBaseComponentView {
 
   bool m_hovered{false};
   bool m_pressed{false};
+  bool m_pointerReleased{false};
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
   facebook::react::SharedViewProps m_props;


### PR DESCRIPTION
## Description
Changes the switch's thumb to increase in size onPointerHover

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Resolves #12188

## Screenshots

https://github.com/microsoft/react-native-windows/assets/42554868/e30490ac-de4c-41c3-be3b-bf3537ab59ae

Paper

https://github.com/microsoft/react-native-windows/assets/42554868/08cbd371-e1dc-47f3-ab41-47e2347b431b

Fabric

https://github.com/microsoft/react-native-windows/assets/42554868/cb95964b-ce84-4d6f-901f-167713c1fd5d

## Testing
tested locally

## Changelog
no

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12301)