### PR TITLE
Convert publish.yml to extend 1ES PT

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -87,301 +87,368 @@ variables:
 trigger: none
 pr: none
 
-jobs:
-  - job: RnwNpmPublish
-    displayName: React-Native-Windows Npm Build Rev Publish
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
     pool: ${{ parameters.AgentPool.Medium }}
-    timeoutInMinutes: 120
-    cancelTimeoutInMinutes: 5
-    steps:
-      - powershell: |
-          Write-Host "Stopping because commit message contains ***NO_CI***."
-          $uri = "https://dev.azure.com/microsoft/ReactNative/_apis/build/builds/$(Build.BuildId)?api-version=5.1"
-          $json = @{status="Cancelling"} | ConvertTo-Json -Compress
-          $build = Invoke-RestMethod -Uri $uri -Method Patch -Headers @{Authorization = "Bearer $(System.AccessToken)"} -ContentType "application/json" -Body $json
-          Write-Host $build
-          Write-Host "Waiting 60 seconds for build cancellation..."
-          Start-Sleep -Seconds 60
-        displayName: Stop pipeline if latest commit message contains ***NO_CI***
-        condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
+    customBuildTags:
+    - ES365AIMigrationTooling
+    sdl:
+      credscan:
+          suppressionsFile: $(Build.SourcesDirectory)\.ado\config\CredScanSuppressions.json
+      spotBugs:
+          enabled: false # We don't have any java, but random packages in node_modules do
+    stages:
+    - stage: RNWPublish
+      jobs:
+        - job: RnwNpmPublish
+          displayName: React-Native-Windows Npm Build Rev Publish
+          pool: ${{ parameters.AgentPool.Medium }}
+          timeoutInMinutes: 120
+          cancelTimeoutInMinutes: 5
+          steps:
+          - powershell: |
+              Write-Host "Stopping because commit message contains ***NO_CI***."
+              $uri = "https://dev.azure.com/microsoft/ReactNative/_apis/build/builds/$(Build.BuildId)?api-version=5.1"
+              $json = @{status="Cancelling"} | ConvertTo-Json -Compress
+              $build = Invoke-RestMethod -Uri $uri -Method Patch -Headers @{Authorization = "Bearer $(System.AccessToken)"} -ContentType "application/json" -Body $json
+              Write-Host $build
+              Write-Host "Waiting 60 seconds for build cancellation..."
+              Start-Sleep -Seconds 60
+            displayName: Stop pipeline if latest commit message contains ***NO_CI***
+            condition: and(${{ parameters.stopOnNoCI }}, contains(variables['Build.SourceVersionMessage'], '***NO_CI***'))
 
-      - template: templates/checkout-full.yml
-        parameters:
-          persistCredentials: false # We're going to use rnbot's git creds to publish
+          - template: .ado/templates/checkout-full.yml@self
+            parameters:
+              persistCredentials: false # We're going to use rnbot's git creds to publish
 
-      - powershell: gci env:/BUILD_*
-        displayName: Show build information  
+          - powershell: gci env:/BUILD_*
+            displayName: Show build information  
 
-      - template: templates/prepare-js-env.yml
+          - template: .ado/templates/prepare-js-env.yml@self
 
-      - template: templates/run-compliance-prebuild.yml
+          - template: .ado/templates/run-compliance-prebuild.yml@self
 
-      - template: templates/configure-git.yml
+          - template: .ado/templates/configure-git.yml@self
 
-      - script: |
-          echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish
-        displayName: Enable No-Publish
-        condition: ${{ parameters.skipNpmPublish }}
+          - script: |
+              echo ##vso[task.setvariable variable=SkipNpmPublishArgs]--no-publish
+            displayName: Enable No-Publish
+            condition: ${{ parameters.skipNpmPublish }}
 
-      - script: |
-          echo ##vso[task.setvariable variable=SkipGitPushPublishArgs]--no-push
-        displayName: Enable No-Publish
-        condition: ${{ parameters.skipGitPush }}
+          - script: |
+              echo ##vso[task.setvariable variable=SkipGitPushPublishArgs]--no-push
+            displayName: Enable No-Publish
+            condition: ${{ parameters.skipGitPush }}
 
-      - script: if not exist %USERPROFILE%\AppData\Roaming\npm (mkdir %USERPROFILE%\AppData\Roaming\npm)
-        displayName: Fix missing npm config
+          - script: if not exist %USERPROFILE%\AppData\Roaming\npm (mkdir %USERPROFILE%\AppData\Roaming\npm)
+            displayName: Fix missing npm config
 
-      - task: PowerShell@2
-        displayName: Beachball Check
-        inputs:
-          targetType: 'inline'
-          pwsh: true
-          script: |
-            npx beachball check --verbose 2>&1 | Tee-Object -Variable beachballOutput
-            $beachballOutput | Where-Object { $_ -match "ERROR: *"} | ForEach { Write-Host "##vso[task.logissue type=error]$_" }
+          - pwsh: |
+              npx beachball check --verbose 2>&1 | Tee-Object -Variable beachballOutput
+              $beachballOutput | Where-Object { $_ -match "ERROR: *"} | ForEach { Write-Host "##vso[task.logissue type=error]$_" }
+            displayName: Beachball Check
 
-      - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
-        displayName: Beachball Publish
+          - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
+            displayName: Beachball Publish
 
-      # Beachball reverts to local state after publish, but we want the updates it added
-      - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
-        displayName: git pull
+          # Beachball reverts to local state after publish, but we want the updates it added
+          - script: git pull origin ${{ variables['Build.SourceBranchName'] }}
+            displayName: git pull
 
-      - script: npx @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
-        displayName: Create GitHub Releases (New Canary Version)
-        condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ eq(variables['Build.SourceBranchName'], 'main') }} )
+          - script: npx @rnw-scripts/create-github-releases --yes --authToken $(githubAuthToken)
+            displayName: Create GitHub Releases (New Canary Version)
+            condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ eq(variables['Build.SourceBranchName'], 'main') }} )
 
-      - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
-        displayName: Create GitHub Releases (New Stable Version)
-        condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )
+          - script: npx --yes @rnw-scripts/create-github-releases@latest --yes --authToken $(githubAuthToken)
+            displayName: Create GitHub Releases (New Stable Version)
+            condition: and(succeeded(), ${{ not(parameters.skipGitPush) }}, ${{ ne(variables['Build.SourceBranchName'], 'main') }} )
 
-      - template: templates/set-version-vars.yml
-        parameters:
-          buildEnvironment: Continuous
+          - template: .ado/templates/set-version-vars.yml@self
+            parameters:
+              buildEnvironment: Continuous
 
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 📒 Generate Manifest Npm
-        inputs:
-          BuildDropPath: $(System.DefaultWorkingDirectory)
-    
-      - task: PublishPipelineArtifact@1
-        displayName: 📒 Publish Manifest Npm
-        inputs:
-          artifactName: SBom-$(System.JobAttempt)
-          targetPath: $(System.DefaultWorkingDirectory)/_manifest
-    
-      - template: templates/publish-version-vars.yml
+          - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+            displayName: 📒 Generate Manifest Npm
+            inputs:
+              BuildDropPath: $(System.DefaultWorkingDirectory)
 
-  - ${{ each matrix in parameters.desktopBuildMatrix }}:
-    - job: RnwNativeBuildDesktop${{ matrix.Name }}
-      displayName: Build Desktop ${{ matrix.Name }}
-      dependsOn: RnwNpmPublish
-      pool: ${{ parameters.AgentPool.Large }}
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                displayName: "📒 Publish Manifest Npm"
+                artifactName: SBom-$(System.JobAttempt)
+                targetPath: $(System.DefaultWorkingDirectory)/_manifest
+                sbomEnabled: false # This output is in fact an SBOM itself
+              - output: pipelineArtifact
+                displayName: 'Publish version variables'
+                targetPath: $(Build.StagingDirectory)/versionEnvVars
+                artifactName: VersionEnvVars
 
-      steps:
-        - template: templates/prepare-js-env.yml
+        - ${{ each matrix in parameters.desktopBuildMatrix }}:
+          - job: RnwNativeBuildDesktop${{ matrix.Name }}
+            displayName: Build Desktop ${{ matrix.Name }}
+            dependsOn: RnwNpmPublish
+            pool: ${{ parameters.AgentPool.Large }}
 
-        - template: templates/prepare-build-env.yml
-          parameters:
-            platform: ${{ matrix.BuildPlatform }}
-            configuration: ${{ matrix.BuildConfiguration }}
-            buildEnvironment: Publish
+            steps:
+            - template: .ado/templates/prepare-js-env.yml@self
 
-        - template: templates/apply-published-version-vars.yml
+            - template: .ado/templates/prepare-build-env.yml@self
+              parameters:
+                platform: ${{ matrix.BuildPlatform }}
+                configuration: ${{ matrix.BuildConfiguration }}
+                buildEnvironment: Publish
 
-        - ${{ if eq(matrix.UseFabric, true) }}:
-          - template: templates/enable-fabric-experimental-feature.yml
+            - template: .ado/templates/apply-published-version-vars.yml@self
 
-        - template: templates/msbuild-sln.yml
-          parameters:
-            solutionDir: vnext
-            solutionName: ReactWindows-Desktop.sln
-            buildPlatform: ${{ matrix.BuildPlatform }}
-            buildConfiguration: ${{ matrix.BuildConfiguration }}
+            - ${{ if eq(matrix.UseFabric, true) }}:
+              - template: .ado/templates/enable-fabric-experimental-feature.yml@self
 
-        - template: templates/publish-build-artifacts.yml
-          parameters:
-            ${{ if eq(matrix.UseFabric, true) }}:
-              artifactName: DesktopFabric
-            ${{ if eq(matrix.UseFabric, false) }}:
+            - template: .ado/templates/msbuild-sln.yml@self
+              parameters:
+                solutionDir: vnext
+                solutionName: ReactWindows-Desktop.sln
+                buildPlatform: ${{ matrix.BuildPlatform }}
+                buildConfiguration: ${{ matrix.BuildConfiguration }}
+                oneESMode: true ## Files are only copied to staging, not published
+
+            - template: .ado/templates/publish-build-artifacts.yml@self
+              parameters:
+                oneESMode: true ## Files are only copied to staging, not published
+                ${{ if eq(matrix.UseFabric, true) }}:
+                  artifactName: DesktopFabric
+                ${{ if eq(matrix.UseFabric, false) }}:
+                  artifactName: Desktop
+                buildPlatform: ${{ matrix.BuildPlatform }}
+                buildConfiguration: ${{ matrix.BuildConfiguration }}
+                contents: |
+                  React.Windows.Desktop\**
+                  React.Windows.Desktop.DLL\**
+                  React.Windows.Desktop.Test.DLL\**
+
+            - template: .ado/templates/component-governance.yml@self
+
+            templateContext:
+              sdl:
+                binskim:
+                  analyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\React.Windows.Desktop.DLL\react-native-win32.dll'
+              outputs:
+              - output: pipelineArtifact
+                displayName: 'Upload build logs'
+                condition: succeededOrFailed()
+                targetPath: $(BuildLogDirectory)
+                artifactName: Build logs - $(Agent.JobName)-$(System.JobAttempt)
+              - output: pipelineArtifact
+                displayName: 'Upload crash dumps'
+                condition: and(succeededOrFailed(), eq(variables.HasCrashDumps, 'True'))
+                targetPath: '$(CrashDumpRootPath)'
+                artifactName: Crash dumps - $(Agent.JobName)-$(System.JobAttempt)
+              - output: pipelineArtifact
+                ${{ if eq(matrix.UseFabric, true) }}:
+                  displayName: 'Publish Artifact: DesktopFabric.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}'
+                  artifactName: DesktopFabric.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}
+                  targetPath: $(Build.StagingDirectory)/NuGet/DesktopFabric/${{matrix.buildPlatform}}/${{matrix.buildConfiguration}}
+                ${{ if eq(matrix.UseFabric, false) }}:
+                  displayName: 'Publish Artifact: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}'
+                  artifactName: Desktop.${{matrix.buildPlatform}}.${{matrix.buildConfiguration}}
+                  targetPath: $(Build.StagingDirectory)/NuGet/Desktop/${{matrix.buildPlatform}}/${{matrix.buildConfiguration}}
+
+        - job: RnwNativeBuildUniversal
+          displayName: Build Universal
+          dependsOn: RnwNpmPublish
+          strategy:
+            matrix:
+              X64Release:
+                BuildConfiguration: Release
+                BuildPlatform: x64
+              X86Release:
+                BuildConfiguration: Release
+                BuildPlatform: x86
+              Arm64Release:
+                BuildConfiguration: Release
+                BuildPlatform: ARM64
+              X64Debug:
+                BuildConfiguration: Debug
+                BuildPlatform: x64
+              X86Debug:
+                BuildConfiguration: Debug
+                BuildPlatform: x86
+              Arm64Debug:
+                BuildConfiguration: Debug
+                BuildPlatform: ARM64          
+          pool: ${{ parameters.AgentPool.Large }}
+
+          steps:
+          - template: .ado/templates/prepare-js-env.yml@self
+
+          - template: .ado/templates/prepare-build-env.yml@self
+            parameters:
+              platform: $(BuildPlatform)
+              configuration: $(BuildConfiguration)
+              buildEnvironment: Publish
+
+          - template: .ado/templates/apply-published-version-vars.yml@self
+
+          - template: .ado/templates/msbuild-sln.yml@self
+            parameters:
+              solutionDir: vnext
+              solutionName: Microsoft.ReactNative.sln
+              buildPlatform: $(BuildPlatform)
+              buildConfiguration: $(BuildConfiguration)
+              oneESMode: true ## Files are only copied to staging, not published
+
+          - task: PowerShell@2
+            displayName: Make AnyCPU Reference Assemblies
+            inputs:
+              filePath: vnext/Scripts/Tfs/Make-AnyCPU-RefAssemblies.ps1
+              arguments: -TargetRoot $(Build.SourcesDirectory)\vnext\target -BuildRoot $(Build.SourcesDirectory)\vnext\target
+
+          - template: .ado/templates/publish-build-artifacts.yml@self
+            parameters:
+              oneESMode: true ## Files are only copied to staging, not published
+              artifactName: ReactWindows
+              buildPlatform: $(BuildPlatform)
+              buildConfiguration: $(BuildConfiguration)
+              contents: |
+                Microsoft.ReactNative\**
+                Microsoft.ReactNative.Managed\**
+                Microsoft.ReactNative.Managed.CodeGen\**
+
+          - template: .ado/templates/component-governance.yml@self
+
+          # Make symbols available through http://symweb.
+          - task: PublishSymbols@2
+            displayName: Publish symbols
+            inputs:
+              SearchPattern: vnext/target/**/*.pdb
+              SymbolServerType: TeamServices
+          
+          templateContext:
+            sdl:
+              binskim:
+                analyzeTargetGlob: '$(Build.SourcesDirectory)\vnext\target\$(BuildPlatform)\$(BuildConfiguration)\Microsoft.ReactNative\Microsoft.ReactNative.dll'
+            outputs:
+            - output: pipelineArtifact
+              displayName: 'Upload build logs'
+              condition: succeededOrFailed()
+              targetPath: $(BuildLogDirectory)
+              artifactName: Build logs - $(Agent.JobName)-$(System.JobAttempt)
+            - output: pipelineArtifact
+              displayName: 'Upload crash dumps'
+              condition: and(succeededOrFailed(), eq(variables.HasCrashDumps, 'True'))
+              targetPath: '$(CrashDumpRootPath)'
+              artifactName: Crash dumps - $(Agent.JobName)-$(System.JobAttempt)
+            - output: pipelineArtifact
+              displayName: 'Publish Artifact: ReactWindows.$(BuildPlatform).$(BuildConfiguration)'
+              artifactName: ReactWindows.$(BuildPlatform).$(BuildConfiguration)
+              targetPath: $(Build.StagingDirectory)/NuGet/ReactWindows/$(BuildPlatform)/$(BuildConfiguration)
+
+        - job: RNWNuget
+          dependsOn:
+            - RnwNpmPublish
+            - ${{ each matrix in parameters.desktopBuildMatrix }}:
+              - RnwNativeBuildDesktop${{ matrix.Name }}
+            - RnwNativeBuildUniversal
+          displayName: Sign Binaries and Publish NuGet
+          pool: ${{ parameters.AgentPool.Medium }}
+
+          steps:
+          - template: .ado/templates/checkout-shallow.yml@self
+
+          - template: .ado/templates/prepare-js-env.yml@self
+
+          - template: .ado/templates/apply-published-version-vars.yml@self
+
+          # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
+          - task: NuGetToolInstaller@1
+            inputs:
+              versionSpec: ">=5.8.0"
+
+          - template: .ado/templates/prep-and-pack-nuget.yml@self
+            parameters:
+              artifactName: ReactWindows
+              publishCommitId: $(publishCommitId)
+              npmVersion: $(npmVersion)
+              nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
+              packMicrosoftReactNative: true
+              packMicrosoftReactNativeCxx: true
+              packMicrosoftReactNativeManaged: true
+              packMicrosoftReactNativeManagedCodeGen: true
+              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+                signMicrosoft: true
+              slices:
+                - platform: x64
+                  configuration: Release
+                - platform: x86
+                  configuration: Release
+                - platform: ARM64
+                  configuration: Release  
+                - platform: x64
+                  configuration: Debug
+                - platform: x86
+                  configuration: Debug
+                - platform: ARM64
+                  configuration: Debug
+
+          - template: .ado/templates/prep-and-pack-nuget.yml@self
+            parameters:
               artifactName: Desktop
-            buildPlatform: ${{ matrix.BuildPlatform }}
-            buildConfiguration: ${{ matrix.BuildConfiguration }}
-            contents: |
-              React.Windows.Desktop\**
-              React.Windows.Desktop.DLL\**
-              React.Windows.Desktop.Test.DLL\**
+              publishCommitId: $(publishCommitId)
+              npmVersion: $(npmVersion)
+              nugetroot: $(System.DefaultWorkingDirectory)\Desktop
+              packDesktop: true
+              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+                signMicrosoft: true
+              slices:
+                - platform: x64
+                  configuration: Release
+                - platform: x86
+                  configuration: Release
+                - platform: ARM64
+                  configuration: Release
+                - platform: x64
+                  configuration: Debug
+                - platform: x86
+                  configuration: Debug
+                - platform: ARM64
+                  configuration: Debug
 
-        - template: templates/component-governance.yml
+          - template: .ado/templates/prep-and-pack-nuget.yml@self
+            parameters:
+              artifactName: DesktopFabric
+              publishCommitId: $(publishCommitId)
+              npmVersion: $(npmVersion)-Fabric
+              nugetroot: $(System.DefaultWorkingDirectory)\Desktop
+              packDesktop: true
+              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+                signMicrosoft: true
+              slices:
+                - platform: x64
+                  configuration: Release
+                - platform: x86
+                  configuration: Release
+                # - platform: ARM64
+                #   configuration: Release
+                - platform: x64
+                  configuration: Debug
+                - platform: x86
+                  configuration: Debug
+                # - platform: ARM64
+                #   configuration: Debug
 
-  - job: RnwNativeBuildUniversal
-    displayName: Build Universal
-    dependsOn: RnwNpmPublish
-    strategy:
-      matrix:
-        X64Release:
-          BuildConfiguration: Release
-          BuildPlatform: x64
-        X86Release:
-          BuildConfiguration: Release
-          BuildPlatform: x86
-        Arm64Release:
-          BuildConfiguration: Release
-          BuildPlatform: ARM64
-        X64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x64
-        X86Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: x86
-        Arm64Debug:
-          BuildConfiguration: Debug
-          BuildPlatform: ARM64          
-    pool: ${{ parameters.AgentPool.Large }}
-
-    steps:
-      - template: templates/prepare-js-env.yml
-
-      - template: templates/prepare-build-env.yml
-        parameters:
-          platform: $(BuildPlatform)
-          configuration: $(BuildConfiguration)
-          buildEnvironment: Publish
-
-      - template: templates/apply-published-version-vars.yml
-
-      - template: templates/msbuild-sln.yml
-        parameters:
-          solutionDir: vnext
-          solutionName: Microsoft.ReactNative.sln
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
-
-      - task: PowerShell@2
-        displayName: Make AnyCPU Reference Assemblies
-        inputs:
-          filePath: vnext/Scripts/Tfs/Make-AnyCPU-RefAssemblies.ps1
-          arguments: -TargetRoot $(Build.SourcesDirectory)\vnext\target -BuildRoot $(Build.SourcesDirectory)\vnext\target
-
-      - template: templates/publish-build-artifacts.yml
-        parameters:
-          artifactName: ReactWindows
-          buildPlatform: $(BuildPlatform)
-          buildConfiguration: $(BuildConfiguration)
-          contents: |
-            Microsoft.ReactNative\**
-            Microsoft.ReactNative.Managed\**
-            Microsoft.ReactNative.Managed.CodeGen\**
-
-      - template: templates/component-governance.yml
-
-      # Make symbols available through http://symweb.
-      - task: PublishSymbols@2
-        displayName: Publish symbols
-        inputs:
-          SearchPattern: vnext/target/**/*.pdb
-          SymbolServerType: TeamServices
-
-  - job: RNWNuget
-    dependsOn:
-      - RnwNpmPublish
-      - ${{ each matrix in parameters.desktopBuildMatrix }}:
-        - RnwNativeBuildDesktop${{ matrix.Name }}
-      - RnwNativeBuildUniversal
-    displayName: Sign Binaries and Publish NuGet
-    pool: ${{ parameters.AgentPool.Medium }}
-
-    steps:
-      - template: templates/checkout-shallow.yml
-
-      - template: templates/prepare-js-env.yml
-
-      - template: templates/apply-published-version-vars.yml
-
-      # The commit tag in the nuspec requires that we use at least nuget 5.8 (because things break with nuget versions before and Vs 16.8 or later)
-      - task: NuGetToolInstaller@1
-        inputs:
-          versionSpec: ">=5.8.0"
-
-      - template: templates/prep-and-pack-nuget.yml
-        parameters:
-          artifactName: ReactWindows
-          publishCommitId: $(publishCommitId)
-          npmVersion: $(npmVersion)
-          nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
-          packMicrosoftReactNative: true
-          packMicrosoftReactNativeCxx: true
-          packMicrosoftReactNativeManaged: true
-          packMicrosoftReactNativeManagedCodeGen: true
-          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-            signMicrosoft: true
-          slices:
-            - platform: x64
-              configuration: Release
-            - platform: x86
-              configuration: Release
-            - platform: ARM64
-              configuration: Release  
-            - platform: x64
-              configuration: Debug
-            - platform: x86
-              configuration: Debug
-            - platform: ARM64
-              configuration: Debug
-
-      - template: templates/prep-and-pack-nuget.yml
-        parameters:
-          artifactName: Desktop
-          publishCommitId: $(publishCommitId)
-          npmVersion: $(npmVersion)
-          nugetroot: $(System.DefaultWorkingDirectory)\Desktop
-          packDesktop: true
-          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-            signMicrosoft: true
-          slices:
-            - platform: x64
-              configuration: Release
-            - platform: x86
-              configuration: Release
-            - platform: ARM64
-              configuration: Release
-            - platform: x64
-              configuration: Debug
-            - platform: x86
-              configuration: Debug
-            - platform: ARM64
-              configuration: Debug
-
-      - template: templates/prep-and-pack-nuget.yml
-        parameters:
-          artifactName: DesktopFabric
-          publishCommitId: $(publishCommitId)
-          npmVersion: $(npmVersion)-Fabric
-          nugetroot: $(System.DefaultWorkingDirectory)\Desktop
-          packDesktop: true
-          ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
-            signMicrosoft: true
-          slices:
-            - platform: x64
-              configuration: Release
-            - platform: x86
-              configuration: Release
-            # - platform: ARM64
-            #   configuration: Release
-            - platform: x64
-              configuration: Debug
-            - platform: x86
-              configuration: Debug
-            # - platform: ARM64
-            #   configuration: Debug
-
-      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-        displayName: 📒 Generate Manifest Nuget
-        inputs:
-          BuildDropPath: $(System.DefaultWorkingDirectory)
-
-      - task: PublishPipelineArtifact@1
-        displayName: "Publish final nuget artifacts"
-        inputs:
-          targetPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
-          artifactName: "ReactWindows-final-nuget"
+          templateContext:
+            sdl:
+              binskim:
+                analyzeTargetGlob: '$(System.DefaultWorkingDirectory)\ReactWindows\**\Microsoft.ReactNative\Microsoft.ReactNative.dll;$(System.DefaultWorkingDirectory)\Desktop\**\React.Windows.Desktop.DLL\react-native-win32.dll'
+            outputs:
+            - output: pipelineArtifact
+              displayName: 'Publish final nuget artifacts'
+              targetPath: $(System.DefaultWorkingDirectory)\NugetRootFinal
+              artifactName: "ReactWindows-final-nuget"

--- a/.ado/templates/msbuild-sln.yml
+++ b/.ado/templates/msbuild-sln.yml
@@ -14,6 +14,7 @@ parameters:
   buildConfiguration: Debug
   msbuildArguments: ''
   warnAsError: true
+  oneESMode: false
 
 steps:
   - powershell: |
@@ -69,3 +70,4 @@ steps:
   - template: upload-build-logs.yml
     parameters:
       buildLogDirectory: $(BuildLogDirectory)
+      oneESMode: ${{ parameters.oneESMode }}

--- a/.ado/templates/publish-build-artifacts.yml
+++ b/.ado/templates/publish-build-artifacts.yml
@@ -9,6 +9,9 @@ parameters:
   - name: buildConfiguration
     type: string
     default: Debug
+  - name: oneESMode
+    type: boolean
+    default: false
 
 steps:
   - task: CopyFiles@2
@@ -18,15 +21,16 @@ steps:
       targetFolder: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
       contents: ${{parameters.contents}}
 
-  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-    displayName: "📒 Generate Manifest: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
-    inputs:
-      BuildDropPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
+  - ${{ if not(parameters.oneESMode) }}:
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: "📒 Generate Manifest: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
+      inputs:
+        BuildDropPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
 
-  - task: PublishPipelineArtifact@1
-    displayName: "Publish Artifact: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
-    # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt
-    continueOnError: true
-    inputs:
-      artifactName: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}
-      targetPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}
+    - task: PublishPipelineArtifact@1
+      displayName: "Publish Artifact: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}"
+      # Do nothing if the artifact was already published. E.g. after rerunning a past successful job attempt
+      continueOnError: true
+      inputs:
+        artifactName: ${{parameters.artifactName}}.${{parameters.buildPlatform}}.${{parameters.buildConfiguration}}
+        targetPath: $(Build.StagingDirectory)/NuGet/${{ parameters.artifactName }}/${{ parameters.buildPlatform }}/${{ parameters.buildConfiguration }}

--- a/.ado/templates/upload-build-logs.yml
+++ b/.ado/templates/upload-build-logs.yml
@@ -3,14 +3,16 @@ parameters:
   buildLogDirectory: $(Build.BinariesDirectory)\$(BuildPlatform)\$(BuildConfiguration)\BuildLogs
   uploadBuildLogs: true
   uploadCrashDumps: true
+  oneESMode: false
 
 steps:
-  - task: PublishBuildArtifacts@1
-    displayName: Upload build logs
-    condition:  and(succeededOrFailed(), ${{ parameters.uploadBuildLogs }})
-    inputs:
-      pathtoPublish: '${{ parameters.buildLogDirectory }}'
-      artifactName: 'Build logs - ${{ parameters.artifactName }}'
+  - ${{ if not(parameters.oneESMode) }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Upload build logs
+      condition:  and(succeededOrFailed(), ${{ parameters.uploadBuildLogs }},  not(parameters.oneESMode))
+      inputs:
+        pathtoPublish: '${{ parameters.buildLogDirectory }}'
+        artifactName: 'Build logs - ${{ parameters.artifactName }}'
 
   - task: PowerShell@2
     displayName: Cleanup ProcDump
@@ -43,9 +45,10 @@ steps:
         $HasCrashDumps = (Get-ChildItem -Path $(CrashDumpRootPath) -File -Recurse | Measure-Object).Count -gt 0;
         Write-Host "##vso[task.setvariable variable=HasCrashDumps]$HasCrashDumps";
 
-  - task: PublishBuildArtifacts@1
-    displayName: Upload crash dumps
-    condition: and(succeededOrFailed(), ${{ parameters.uploadCrashDumps }}, eq(variables.HasCrashDumps, 'True'))
-    inputs:
-      pathtoPublish: '$(CrashDumpRootPath)'
-      artifactName: 'Crash dumps - ${{ parameters.artifactName }}'
+  - ${{ if not(parameters.oneESMode) }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Upload crash dumps
+      condition: and(succeededOrFailed(), ${{ parameters.uploadCrashDumps }}, eq(variables.HasCrashDumps, 'True'),  not(parameters.oneESMode))
+      inputs:
+        pathtoPublish: '$(CrashDumpRootPath)'
+        artifactName: 'Crash dumps - ${{ parameters.artifactName }}'


### PR DESCRIPTION
## Description

This PR migrates our publish.yml on top of the required 1ES Pipeline Template, including some minor refactors to some template files to prevent them from conflicting with how the 1ES templates work.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Compliance push.

### What
Refactors the pipeline to be passed to the template, and added parameters to our templates that publish build artifacts to allow the publish to op-out, and let the 1ES template do that publish.

## Screenshots

![image](https://github.com/microsoft/react-native-windows/assets/10852185/a5986d42-388f-429c-b8d5-7cc0c1135785)

## Testing
Verified that the pipeline runs successfully.

## Changelog
Should this change be included in the release notes: yes

Converted publish.yml ADO pipeline to extend the v1/1ES.Official.PipelineTemplate.yml template
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12302)