### PR TITLE
Remove generated signature from file

### DIFF
--- a/change/react-native-windows-740eb7f7-da15-4ae8-9c1e-9cff8011ca94.json
+++ b/change/react-native-windows-740eb7f7-da15-4ae8-9c1e-9cff8011ca94.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove generated signature from file",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/components/view/HostPlatformViewEventEmitter.cpp
@@ -55,5 +55,3 @@ void HostPlatformViewEventEmitter::onMouseLeave(PointerEvent const &pointerEvent
 }
 
 } // namespace facebook::react
-
-// @generated SignedSource<<a6f36c63efa0edf80beb29b0187deb77>>


### PR DESCRIPTION

## Description

### Why
When copying code from our fork of react-native-windows, this generated code signature leaked by mistake. This change removes it.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12304)