### PR TITLE
Increase timeout to account for 1ES pipeline anti-malware scan sometimes taking a while

### DIFF
--- a/.ado/jobs/linting.yml
+++ b/.ado/jobs/linting.yml
@@ -12,7 +12,7 @@ parameters:
 jobs:
   - job: Linting
     displayName: Linting
-    timeoutInMinutes: 20
+    timeoutInMinutes: 40
     variables: [template: ../variables/windows.yml]
     pool: ${{ parameters.AgentPool.Medium }}
     steps:


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12309)