### PR TITLE
Increase publish build timeout to handle CodeQL overhead

### DIFF
--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -196,7 +196,7 @@ extends:
             displayName: Build Desktop ${{ matrix.Name }}
             dependsOn: RnwNpmPublish
             pool: ${{ parameters.AgentPool.Large }}
-
+            timeoutInMinutes: 360 # CodeQL requires 3x usual build timeout
             steps:
             - template: .ado/templates/prepare-js-env.yml@self
 
@@ -284,6 +284,7 @@ extends:
                 BuildConfiguration: Debug
                 BuildPlatform: ARM64          
           pool: ${{ parameters.AgentPool.Large }}
+          timeoutInMinutes: 360 # CodeQL requires 3x usual build timeout
 
           steps:
           - template: .ado/templates/prepare-js-env.yml@self


### PR DESCRIPTION
## Description

CodeQL triples build times when it runs and therefore recommends you triple your timeout. Moving to the 1ES PT where we're forced to run CodeQL (and control how often it decides to do so), we need to increase our job timeouts.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
First time running a real main publish with the 1ES template got canceled due to a timeout.


### What
Added timeouts.

## Screenshots
N/A

## Testing
We did this for the (no longer needed?) compliance pipeline.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12310)