### PR TITLE
Fix build artifact uploads for Fabric E2E

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -190,7 +190,7 @@ jobs:
                   buildLogDirectory: $(BuildLogDirectory)
                   deployOption: '--no-deploy'
                   workingDirectory: packages/e2e-test-app-fabric
-              
+
               - script: |
                   echo ##vso[task.setvariable variable=StartedFabricTests]true
                 displayName: Set StartedFabricTests
@@ -238,9 +238,9 @@ jobs:
               - task: CopyFiles@2
                 displayName: Copy RNTesterApp artifacts
                 inputs:
-                  sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric
+                  sourceFolder: $(Build.SourcesDirectory)/packages/e2e-test-app-fabric/windows/${{ matrix.BuildPlatform }}/Release
                   targetFolder: $(Build.StagingDirectory)/RNTesterApp-Fabric
-                  contents: AppPackages\**
+                  contents: "**"
                 condition: failed()
 
               - task: PublishPipelineArtifact@1


### PR DESCRIPTION
A revision of the all-in-one C++ 20 PR caused a crash in Fabric E2E tests. I wanted to look at the crash dump, alongside the pdb and DLL used by the build. The previous copy of this logic, reused for Fabric, was dependent on the structure for a C# appx build. This updates the directory based on what I locally observed for the Fabric E2E test build.