### PR TITLE
C++ 20: Switch AutomationChannel and IntegrationTest to /std:C++20

### DIFF
--- a/change/@react-native-windows-automation-channel-b40845ff-ac08-4250-bba7-6f0d4378f435.json
+++ b/change/@react-native-windows-automation-channel-b40845ff-ac08-4250-bba7-6f0d4378f435.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "C++ 20",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-d93b5adf-a8b2-4ceb-89f1-aeedd9546d76.json
+++ b/change/react-native-windows-d93b5adf-a8b2-4ceb-89f1-aeedd9546d76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Build using C++ 20",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/AutomationChannel.vcxproj
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/AutomationChannel.vcxproj
@@ -82,6 +82,7 @@
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <PreprocessorDefinitions>_WINRT_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CppWinrtLessExceptions.h
+++ b/packages/@react-native-windows/automation-channel/windows/AutomationChannel/CppWinrtLessExceptions.h
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+#pragma once
 
 #include <winrt/base.h>
+#include <coroutine>
 
 // Copied from "vnext\Shared\Utils\CppWinrtLessExceptions.h" until we have a good way to share between packages
 
@@ -15,7 +17,7 @@ struct lessthrow_await_adapter {
     return async.Status() == winrt::Windows::Foundation::AsyncStatus::Completed;
   }
 
-  void await_suspend(std::experimental::coroutine_handle<> handle) const {
+  void await_suspend(std::coroutine_handle<> handle) const {
     auto context = winrt::capture<winrt::impl::IContextCallback>(WINRT_IMPL_CoGetObjectContext);
 
     async.Completed([handle, context = std::move(context)](auto const &, winrt::Windows::Foundation::AsyncStatus) {
@@ -23,7 +25,7 @@ struct lessthrow_await_adapter {
       args.data = handle.address();
 
       auto callback = [](winrt::impl::com_callback_args *args) noexcept -> int32_t {
-        std::experimental::coroutine_handle<>::from_address(args->data)();
+        std::coroutine_handle<>::from_address(args->data)();
         return S_OK;
       };
 

--- a/packages/integration-test-app/windows/integrationtest/TestHostHarness.h
+++ b/packages/integration-test-app/windows/integrationtest/TestHostHarness.h
@@ -8,6 +8,7 @@
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Networking.Sockets.h>
+#include <coroutine>
 #include <functional>
 
 #include "TestCommand.h"
@@ -17,12 +18,12 @@ namespace IntegrationTest {
 
 //! Wrapper to allow co_await on a value that may be set in the future.
 template <typename T>
-struct Awaitable final : public std::experimental::suspend_always {
+struct Awaitable final : public std::suspend_always {
   bool await_ready() noexcept {
     return false;
   }
 
-  void await_suspend(std::experimental::coroutine_handle<> handle) noexcept {
+  void await_suspend(std::coroutine_handle<> handle) noexcept {
     m_valueSetEvent.add([handle{std::move(handle)}]() noexcept { handle(); });
   }
 

--- a/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
+++ b/packages/integration-test-app/windows/integrationtest/integrationtest.vcxproj
@@ -81,6 +81,7 @@
       <WarningLevel>Level4</WarningLevel>
       <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
These projects make use of ts-specific `std::experimental` coroutine APIs. Bump to C++ 20, and C++ 20 standard coroutines. These both have WinRT binary boundaries, so this should have no interaction with other projects (and should have no impact to MSRN interop.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12325)