### PR TITLE
C++ 20: Replace Usage of `std::allocator::construct()`

### DIFF
--- a/change/react-native-windows-a9c0f898-04a7-44ef-9a6d-cab3625ade84.json
+++ b/change/react-native-windows-a9c0f898-04a7-44ef-9a6d-cab3625ade84.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "C++ 20: Replace Usage of std::allocator::construct()",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/debugAssertApi/debugAssertApi.cpp
+++ b/vnext/Mso/src/debugAssertApi/debugAssertApi.cpp
@@ -31,7 +31,7 @@ struct Data {
     // to call malloc.
     std::allocator<Data> alloc;
     auto p = alloc.allocate(1);
-    alloc.construct(p);
+    new (p) Data();
     return p;
   }
 };


### PR DESCRIPTION
This API was deprecated in C++ 17, and removed from C++ 20. Replace it with placement new.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12330)