### PR TITLE
C++ 20: Move vnext to C++ 20 and C++ 20 coroutines 

### DIFF
--- a/change/react-native-windows-dce01c53-5395-463d-bbfd-9162cd9f309d.json
+++ b/change/react-native-windows-dce01c53-5395-463d-bbfd-9162cd9f309d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "C++ 20: Move vnext to C++ 20 and C++ 20 coroutines",
+  "packageName": "react-native-windows",
+  "email": "ngerlem@fb.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
+++ b/vnext/Desktop.UnitTests/React.Windows.Desktop.UnitTests.vcxproj
@@ -68,7 +68,6 @@
         $(VCInstallDir)UnitTest\include;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <AdditionalOptions>%(AdditionalOptions) /await</AdditionalOptions>
     </ClCompile>
     <Link>
       <!--

--- a/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.Cxx.UnitTests/Microsoft.ReactNative.Cxx.UnitTests.vcxproj
@@ -65,7 +65,7 @@
       <PreprocessorDefinitions>_CONSOLE;MSO_MOTIFCPP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/await %(AdditionalOptions) /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -64,7 +64,7 @@
       <PreprocessorDefinitions>_CONSOLE;MSO_MOTIFCPP;FOLLY_NO_CONFIG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/await %(AdditionalOptions) /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>Cdecl</CallingConvention>
       <!-- We need RuntimeTypeInfo for JSI tests -->

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -97,7 +97,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <WarningLevel>Level4</WarningLevel>
-      <AdditionalOptions>/await %(AdditionalOptions) /bigobj /ZH:SHA_256</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj /ZH:SHA_256</AdditionalOptions>
       <AdditionalIncludeDirectories>
         $(FmtDir)\include;
         $(ReactNativeWindowsDir)Microsoft.ReactNative;

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -62,7 +62,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_CONSOLE;MS_TARGET_WINDOWS;MSO_MOTIFCPP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
-      <AdditionalOptions>/await %(AdditionalOptions) /bigobj</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /bigobj</AdditionalOptions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>Cdecl</CallingConvention>
     </ClCompile>

--- a/vnext/PropertySheets/React.Cpp.props
+++ b/vnext/PropertySheets/React.Cpp.props
@@ -79,7 +79,7 @@
   </ImportGroup>
 
   <PropertyGroup>
-    <CppStandard Condition="'$(CppStandard)'==''">stdcpp17</CppStandard>
+    <CppStandard Condition="'$(CppStandard)'==''">stdcpp20</CppStandard>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/vnext/Shared/HermesSamplingProfiler.cpp
+++ b/vnext/Shared/HermesSamplingProfiler.cpp
@@ -5,7 +5,7 @@
 
 #include <hermes/hermes_api.h>
 #include <chrono>
-#include <future>
+#include <coroutine>
 
 #include "HermesRuntimeHolder.h"
 #include "HermesSamplingProfiler.h"
@@ -31,10 +31,8 @@ auto resume_in_dispatcher(const IReactDispatcher &dispatcher) noexcept {
 
     void await_resume() const noexcept {}
 
-    void await_suspend(std::experimental::coroutine_handle<> resume) noexcept {
-      callback_ = [context = resume.address()]() noexcept {
-        std::experimental::coroutine_handle<>::from_address(context)();
-      };
+    void await_suspend(std::coroutine_handle<> resume) noexcept {
+      callback_ = [context = resume.address()]() noexcept { std::coroutine_handle<>::from_address(context)(); };
       dispatcher_.Post(std::move(callback_));
     }
 

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -17,6 +17,7 @@
 #include <winrt/Windows.Security.Cryptography.h>
 
 // Standard Library
+#include <coroutine>
 #include <sstream>
 
 using Microsoft::Common::Utilities::CheckedReinterpretCast;
@@ -64,10 +65,8 @@ auto resume_in_queue(const Mso::DispatchQueue &queue) noexcept {
 
     void await_resume() const noexcept {}
 
-    void await_suspend(std::experimental::coroutine_handle<> resume) noexcept {
-      m_callback = [context = resume.address()]() noexcept {
-        std::experimental::coroutine_handle<>::from_address(context)();
-      };
+    void await_suspend(std::coroutine_handle<> resume) noexcept {
+      m_callback = [context = resume.address()]() noexcept { std::coroutine_handle<>::from_address(context)(); };
       m_queue.Post(std::move(m_callback));
     }
 

--- a/vnext/Shared/Utils/CppWinrtLessExceptions.h
+++ b/vnext/Shared/Utils/CppWinrtLessExceptions.h
@@ -22,6 +22,7 @@
 #define SHARED_UTILS_CPPWINRTLESSEXCEPTIONS_H_
 
 #include <winrt/base.h>
+#include <coroutine>
 
 // #define DEFAULT_CPPWINRT_EXCEPTIONS
 #ifndef DEFAULT_CPPWINRT_EXCEPTIONS
@@ -35,7 +36,7 @@ struct lessthrow_await_adapter {
     return async.Status() == winrt::Windows::Foundation::AsyncStatus::Completed;
   }
 
-  void await_suspend(std::experimental::coroutine_handle<> handle) const {
+  void await_suspend(std::coroutine_handle<> handle) const {
     auto context = winrt::capture<winrt::impl::IContextCallback>(WINRT_IMPL_CoGetObjectContext);
 
     async.Completed([handle, context = std::move(context)](auto const &, winrt::Windows::Foundation::AsyncStatus) {
@@ -43,7 +44,7 @@ struct lessthrow_await_adapter {
       args.data = handle.address();
 
       auto callback = [](winrt::impl::com_callback_args *args) noexcept -> int32_t {
-        std::experimental::coroutine_handle<>::from_address(args->data)();
+        std::coroutine_handle<>::from_address(args->data)();
         return S_OK;
       };
 


### PR DESCRIPTION
This moves projects in vnext to build with C++ 20 and C++ 20 coroutines. This should not impact the ABI of MSRN DLLs, but may need care for cases of Folly at legacy ABI boundary.

1. Set `<CppStandard>stdcpp20</CppStandard>` in `React.cpp.props`
2. Remove explicit usages of `/await` to opt into coroutines TS
3. Replace `std::experimental::coroutine_handle` with `std::coroutine_handle`

This depends on the earlier changes being merged, along with the rest of the `std::future` usages as a coroutine return type replaced (e.g. with winrt types). 