### PR TITLE
ReactContext should have a weak ref on the PropertyBag

### DIFF
--- a/change/react-native-windows-676c6305-2f32-4911-ae83-3b168ddb3759.json
+++ b/change/react-native-windows-676c6305-2f32-4911-ae83-3b168ddb3759.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ReactContext should have a weak ref on the PropertyBag",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
@@ -121,6 +121,42 @@ bool ReactSettingsSnapshot::UseDeveloperSupport() const noexcept {
   return false;
 }
 
+struct WeakRefPropertyBag : winrt::implements<WeakRefPropertyBag, winrt::Microsoft::ReactNative::IReactPropertyBag> {
+  WeakRefPropertyBag(winrt::Microsoft::ReactNative::IReactPropertyBag propertyBag) : m_wkPropBag(propertyBag) {}
+
+  IInspectable Get(winrt::Microsoft::ReactNative::IReactPropertyName const &name) noexcept {
+    if (auto propBag = m_wkPropBag.get()) {
+      return propBag.Get(name);
+    }
+    return nullptr;
+  }
+
+  IInspectable GetOrCreate(
+      winrt::Microsoft::ReactNative::IReactPropertyName const &name,
+      winrt::Microsoft::ReactNative::ReactCreatePropertyValue const &createValue) noexcept {
+    if (auto propBag = m_wkPropBag.get()) {
+      return propBag.GetOrCreate(name, createValue);
+    }
+    return nullptr;
+  }
+
+  IInspectable Set(winrt::Microsoft::ReactNative::IReactPropertyName const &name, IInspectable const &value) noexcept {
+    if (auto propBag = m_wkPropBag.get()) {
+      return propBag.Set(name, value);
+    }
+    return nullptr;
+  }
+
+  void CopyFrom(winrt::Microsoft::ReactNative::IReactPropertyBag const &value) noexcept {
+    if (auto propBag = m_wkPropBag.get()) {
+      return propBag.CopyFrom(value);
+    }
+  }
+
+ private:
+  winrt::weak_ref<winrt::Microsoft::ReactNative::IReactPropertyBag> m_wkPropBag;
+};
+
 //=============================================================================================
 // ReactContext implementation
 //=============================================================================================
@@ -131,7 +167,7 @@ ReactContext::ReactContext(
     winrt::Microsoft::ReactNative::IReactNotificationService const &notifications) noexcept
     : m_reactInstance{std::move(reactInstance)},
       m_settings{Mso::Make<ReactSettingsSnapshot>(Mso::Copy(m_reactInstance))},
-      m_properties{properties},
+      m_properties{winrt::make<WeakRefPropertyBag>(properties)},
       m_notifications{notifications} {}
 
 void ReactContext::Destroy() noexcept {


### PR DESCRIPTION
## Description
`ReactContext` is supposed to be a weak reference to the inner react instance.  But it is currently also holding a reference onto the `ReactPropertyBag`, which means that `ReactContext` is keeping alive a lot more than it should be.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12340)