### PR TITLE
[DRAFT] Fix RuntimeScheduler setup for concurrent mode

### DIFF
--- a/change/react-native-windows-8b686cb5-40c7-4c75-a48c-885541f2714c.json
+++ b/change/react-native-windows-8b686cb5-40c7-4c75-a48c-885541f2714c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[DRAFT] Fix RuntimeScheduler setup for concurrent mode",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/Samples/simple.tsx
+++ b/packages/playground/Samples/simple.tsx
@@ -1,21 +1,124 @@
-/**
- * Copyright (c) Microsoft Corporation.
- * Licensed under the MIT License.
- * @format
- */
-import React from 'react';
-import {AppRegistry, View} from 'react-native';
+import React, { memo, useState, useTransition } from 'react';
+import { AppRegistry, Button, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
-export default class Bootstrap extends React.Component {
-  render() {
-    return (
-      <View
-        accessible={true}
-        style={{borderRadius: 30, width: 60, height: 60, margin: 10}}>
-        <View style={{backgroundColor: 'magenta', width: 60, height: 60}} />
-      </View>
-    );
-  }
+const styles = StyleSheet.create({
+  tab: {
+    alignItems: 'center',
+  },
+  post: {
+    padding: 5,
+    borderTopWidth: 1,
+    backgroundColor: 'light-gray',
+    alignItems: 'center',
+  },
+  activeTab: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    alignSelf: 'center',
+  },
+  pendingTab: {
+    color: 'gray',
+  },
+
+});
+
+function ContactTab() {
+  return (
+    <View style={styles.tab}>
+      <Text>
+        You can find me online here:
+      </Text>
+      <Text>* admin@mysite.com</Text>
+      <Text>* +123456789</Text>
+    </View>
+  );
 }
 
-AppRegistry.registerComponent('Bootstrap', () => Bootstrap);
+function AboutTab() {
+  return (
+    <View style={styles.tab}>
+      <Text>Welcome to my profile!</Text>
+    </View>
+  );
+}
+
+const PostsTab = memo(function PostsTab() {
+  // Log once. The actual slowdown is inside SlowPost.
+  console.log('[ARTIFICIALLY SLOW] Rendering 500 <SlowPost />');
+
+  let items = [];
+  for (let i = 0; i < 500; i++) {
+    items.push(<SlowPost key={i} index={i} />);
+  }
+  return (
+    <ScrollView>
+      {items}
+    </ScrollView>
+  );
+});
+
+function SlowPost({ index }) {
+  let startTime = performance.now();
+  while (performance.now() - startTime < 1) {
+    // Do nothing for 1 ms per item to emulate extremely slow code
+  }
+
+  return (
+    <TouchableOpacity>
+      <View style={styles.post}>
+        <Text>
+          Post #{index + 1}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+function TabButton({ title, isActive, onClick }) {
+  const [isPending, startTransition] = useTransition();
+  if (isActive || isPending) {
+    const tabStyle = [styles.activeTab, isPending ? styles.pendingTab : null];
+    return <Text style={tabStyle}>{title}</Text>
+  }
+  return (
+    <Button
+      onPress={() => startTransition(onClick)}
+      title={title} />
+  )
+}
+
+
+export default function App() {
+  const [isPending, startTransition] = useTransition();
+  const [tab, setTab] = useState('about');
+
+  function selectTab(nextTab) {
+    startTransition(() => {
+      setTab(nextTab);
+    });
+  }
+
+  return (
+    <>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
+        <TabButton
+          isActive={tab === 'about'}
+          onClick={() => selectTab('about')}
+          title="About" />
+        <TabButton
+          isActive={tab === 'posts'}
+          onClick={() => selectTab('posts')}
+          title="Posts (slow)" />
+        <TabButton
+          isActive={tab === 'contact'}
+          onClick={() => selectTab('contact')}
+          title="Contact" />
+      </View>
+      {tab === 'about' && <AboutTab />}
+      {tab === 'posts' && <PostsTab />}
+      {tab === 'contact' && <ContactTab />}
+    </>
+  );
+}
+
+AppRegistry.registerComponent('Bootstrap', () => App);

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -153,6 +153,8 @@ struct WindowData {
               std::wstring(L"file:").append(workingDir).append(L"\\Bundle\\").c_str());
           host.InstanceSettings().UseDeveloperSupport(true);
 
+          winrt::Microsoft::ReactNative::QuirkSettings::SetUseRuntimeScheduler(host.InstanceSettings(), true);
+
           host.PackageProviders().Append(CreateStubDeviceInfoPackageProvider());
           host.PackageProviders().Append(winrt::make<CompReactPackageProvider>());
           winrt::Microsoft::ReactNative::ReactCoreInjection::SetTopLevelWindowId(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -288,8 +288,13 @@ void CompositionRootView::ShowInstanceLoaded() noexcept {
 
     auto rootTag = ::Microsoft::ReactNative::getNextRootViewTag();
     SetTag(rootTag);
-    uiManager->startSurface(
-        *this, rootTag, JSComponentName(), DynamicWriter::ToDynamic(Mso::Copy(m_reactViewOptions.InitialProps())));
+    // TODO: You should probably make concurrentRoot optional, although it's enabled by default in OSS.
+    auto initProps = DynamicWriter::ToDynamic(Mso::Copy(m_reactViewOptions.InitialProps()));
+    if (initProps.isNull()) {
+      initProps = folly::dynamic::object();
+    }
+    initProps["concurrentRoot"] = true;
+    uiManager->startSurface(*this, rootTag, JSComponentName(), initProps);
 
     m_isJSViewAttached = true;
   }

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -76,6 +76,9 @@ void FabricUIManager::installFabricUIManager() noexcept {
           return std::make_unique<SynchronousEventBeat>(ownerBox, context, runtimeExecutor, runtimeScheduler);
         };
     toolbox.synchronousEventBeatFactory = synchronousBeatFactory;
+    runtimeExecutor = [runtimeScheduler](std::function<void(facebook::jsi::Runtime & runtime)> &&callback) {
+      runtimeScheduler->scheduleWork(std::move(callback));
+    };
   } else {
     facebook::react::EventBeat::Factory synchronousBeatFactory =
         [runtimeExecutor, context = m_context](facebook::react::EventBeat::SharedOwnerBox const &ownerBox) {

--- a/vnext/Shared/InstanceManager.h
+++ b/vnext/Shared/InstanceManager.h
@@ -28,9 +28,11 @@ class MessageQueueThread;
 class ModuleRegistry;
 class IUIManager;
 class TurboModuleRegistry;
+class RuntimeScheduler;
 
 struct InstanceWrapper {
   virtual const std::shared_ptr<Instance> &GetInstance() const noexcept = 0;
+  virtual const std::shared_ptr<RuntimeScheduler> &GetRuntimeScheduler() const noexcept = 0;
 
   virtual void DispatchEvent(int64_t viewTag, std::string eventName, folly::dynamic &&eventData) = 0;
   virtual void invokeCallback(const int64_t callbackId, folly::dynamic &&params) = 0;

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -55,6 +55,9 @@
 #endif
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/TurboModuleBinding.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #include "BaseScriptStoreImpl.h"
 #include "ChakraRuntimeHolder.h"
 
@@ -88,26 +91,6 @@ class OJSIExecutorFactory : public JSExecutorFactory {
     }
     bindNativeLogger(*runtimeHolder_->getRuntime(), logger);
 
-    auto turboModuleManager = std::make_shared<TurboModuleManager>(turboModuleRegistry_, jsCallInvoker_);
-
-    // TODO: The binding here should also add the proxys that convert cxxmodules into turbomodules
-    // [@vmoroz] Note, that we must not use the RN TurboCxxModule.h code because it uses global
-    // LongLivedObjectCollection instance that prevents us from using multiple RN instance in the same process.
-    auto binding = [turboModuleManager](const std::string &name) -> std::shared_ptr<TurboModule> {
-      return turboModuleManager->getModule(name);
-    };
-
-    TurboModuleBinding::install(
-        *runtimeHolder_->getRuntime(),
-        std::function(binding),
-        TurboModuleBindingMode::HostObject,
-        longLivedObjectCollection_);
-
-    // init TurboModule
-    for (const auto &moduleName : turboModuleManager->getEagerInitModuleNames()) {
-      turboModuleManager->getModule(moduleName);
-    }
-
     return std::make_unique<JSIExecutor>(
         runtimeHolder_->getRuntime(),
         std::move(delegate),
@@ -122,22 +105,11 @@ class OJSIExecutorFactory : public JSExecutorFactory {
   OJSIExecutorFactory(
       std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> runtimeHolder,
       NativeLoggingHook loggingHook,
-      std::shared_ptr<TurboModuleRegistry> turboModuleRegistry,
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection,
-      bool isProfilingEnabled,
-      std::shared_ptr<CallInvoker> jsCallInvoker) noexcept
-      : runtimeHolder_{std::move(runtimeHolder)},
-        loggingHook_{std::move(loggingHook)},
-        turboModuleRegistry_{std::move(turboModuleRegistry)},
-        longLivedObjectCollection_{std::move(longLivedObjectCollection)},
-        jsCallInvoker_{std::move(jsCallInvoker)},
-        isProfilingEnabled_{isProfilingEnabled} {}
+      bool isProfilingEnabled) noexcept
+      : runtimeHolder_{std::move(runtimeHolder)}, loggingHook_{std::move(loggingHook)} {}
 
  private:
   std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> runtimeHolder_;
-  std::shared_ptr<TurboModuleRegistry> turboModuleRegistry_;
-  std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
-  std::shared_ptr<CallInvoker> jsCallInvoker_;
   NativeLoggingHook loggingHook_;
   bool isProfilingEnabled_;
 };
@@ -297,12 +269,7 @@ InstanceImpl::InstanceImpl(
     if (m_devSettings->jsiRuntimeHolder) {
       assert(m_devSettings->jsiEngineOverride == JSIEngineOverride::Default);
       jsef = std::make_shared<OJSIExecutorFactory>(
-          m_devSettings->jsiRuntimeHolder,
-          m_devSettings->loggingCallback,
-          m_turboModuleRegistry,
-          m_longLivedObjectCollection,
-          !m_devSettings->useFastRefresh,
-          m_innerInstance->getJSCallInvoker());
+          m_devSettings->jsiRuntimeHolder, m_devSettings->loggingCallback, !m_devSettings->useFastRefresh);
     } else {
       assert(m_devSettings->jsiEngineOverride != JSIEngineOverride::Default);
       switch (m_devSettings->jsiEngineOverride) {
@@ -347,16 +314,49 @@ InstanceImpl::InstanceImpl(
           break;
       }
       jsef = std::make_shared<OJSIExecutorFactory>(
-          m_devSettings->jsiRuntimeHolder,
-          m_devSettings->loggingCallback,
-          m_turboModuleRegistry,
-          m_longLivedObjectCollection,
-          !m_devSettings->useFastRefresh,
-          m_innerInstance->getJSCallInvoker());
+          m_devSettings->jsiRuntimeHolder, m_devSettings->loggingCallback, !m_devSettings->useFastRefresh);
     }
   }
 
   m_innerInstance->initializeBridge(std::move(callback), jsef, m_jsThread, m_moduleRegistry);
+
+  // For RuntimeScheduler to work properly, we need to install TurboModuleManager with RuntimeSchedulerCallbackInvoker.
+  // To be able to do that, we need to be able to call m_innerInstance->getRuntimeExecutor(), which we can only do after
+  // m_innerInstance->initializeBridge(...) is called.
+  const auto runtimeExecutor = m_innerInstance->getRuntimeExecutor();
+  m_runtimeScheduler = std::make_shared<RuntimeScheduler>(runtimeExecutor);
+  if (!m_devSettings->useWebDebugger) {
+    // Using runOnQueueSync because initializeBridge calls createJSExecutor with runOnQueueSync,
+    // so this is an attempt to keep the same semantics for exiting this method with TurboModuleManager
+    // initialized.
+    m_jsThread->runOnQueueSync([runtimeHolder = m_devSettings->jsiRuntimeHolder,
+                                runtimeScheduler = m_runtimeScheduler,
+                                turboModuleRegistry = m_turboModuleRegistry,
+                                longLivedObjectCollection = m_longLivedObjectCollection]() {
+      // TODO: This may need to be conditional on the QuirkSetting for enabling RuntimeScheduler
+      RuntimeSchedulerBinding::createAndInstallIfNeeded(*runtimeHolder->getRuntime(), runtimeScheduler);
+      const auto callInvoker = std::make_shared<RuntimeSchedulerCallInvoker>(runtimeScheduler);
+      auto turboModuleManager = std::make_shared<TurboModuleManager>(turboModuleRegistry, callInvoker);
+
+      // TODO: The binding here should also add the proxys that convert cxxmodules into turbomodules
+      // [@vmoroz] Note, that we must not use the RN TurboCxxModule.h code because it uses global
+      // LongLivedObjectCollection instance that prevents us from using multiple RN instance in the same process.
+      auto binding = [turboModuleManager](const std::string &name) -> std::shared_ptr<TurboModule> {
+        return turboModuleManager->getModule(name);
+      };
+
+      TurboModuleBinding::install(
+          *runtimeHolder->getRuntime(),
+          std::function(binding),
+          TurboModuleBindingMode::HostObject,
+          longLivedObjectCollection);
+
+      // init TurboModule
+      for (const auto &moduleName : turboModuleManager->getEagerInitModuleNames()) {
+        turboModuleManager->getModule(moduleName);
+      }
+    });
+  }
 
   // All JSI runtimes do support host objects and hence the native modules
   // proxy.

--- a/vnext/Shared/OInstance.h
+++ b/vnext/Shared/OInstance.h
@@ -12,6 +12,7 @@
 // React Native
 #include <ReactCommon/LongLivedObject.h>
 #include <cxxreact/Instance.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 
 // Standard Library
 #include <memory>
@@ -61,6 +62,10 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
     return m_innerInstance;
   }
 
+  virtual const std::shared_ptr<RuntimeScheduler> &GetRuntimeScheduler() const noexcept override {
+    return m_runtimeScheduler;
+  }
+
   void DispatchEvent(int64_t viewTag, std::string eventName, folly::dynamic &&eventData) override;
   void invokeCallback(const int64_t callbackId, folly::dynamic &&params) override;
 
@@ -88,6 +93,7 @@ class InstanceImpl final : public InstanceWrapper, private ::std::enable_shared_
 
  private:
   std::shared_ptr<Instance> m_innerInstance;
+  std::shared_ptr<RuntimeScheduler> m_runtimeScheduler;
 
   std::string m_jsBundleBasePath;
   std::shared_ptr<facebook::react::ModuleRegistry> m_moduleRegistry;

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -426,6 +426,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Views\DevMenu.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeScheduler.cpp" DisableSpecificWarnings="4715;%(DisableSpecificWarnings)" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeSchedulerBinding.cpp" />
+    <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeSchedulerCallInvoker.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\Task.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\utils\CoreFeatures.cpp" />
   </ItemGroup>


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In #12314, we added basic setup for RuntimeScheduler, but it missed a few important details to make concurrentRoot work properly in Fabric. For example, the RuntimeExecutor for AsynchronousEventBeat needs to route through the RuntimeScheduler, and the CallInvoker for the TurboModule binding needs to use the RuntimeSchedulerCallInvoker.

There's a few other details, and this is by no means a ready solution. It has not been tested with Paper or really anything other than WinComp Fabric. The simple.tsx example has a demo of `useTransition`, which relies on proper wiring of RuntimeScheduler to behave correctly.

## Testing

https://github.com/microsoft/react-native-windows/assets/1106239/e3dad5b1-d5c7-4443-a841-9b16785217b0


## Changelog
Should this change be included in the release notes: _yes_

Fixes RuntimeScheduler initialization for concurrent mode in Fabric
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12341)