### PR TITLE
Fix native view config to include Fabric events

### DIFF
--- a/change/react-native-windows-07408f27-e6f7-4cda-8f8b-935be0bd6bfe.json
+++ b/change/react-native-windows-07408f27-e6f7-4cda-8f8b-935be0bd6bfe.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix native view config to include Fabric events",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.cpp
@@ -103,6 +103,44 @@ void ViewManagerBase::GetNativeProps(const winrt::Microsoft::ReactNative::IJSVal
   React::WriteProperty(writer, L"keyUpEvents", L"array");
   React::WriteProperty(writer, L"onMouseEnter", L"function");
   React::WriteProperty(writer, L"onMouseLeave", L"function");
+
+  // The events below define the properties that are not used by native directly,
+  // but required in the view config for new renderer to function.
+  // They can be deleted after Static View Configs are rolled out.
+
+  // PanResponder callbacks
+  React::WriteProperty(writer, L"onMoveShouldSetResponder", "function");
+  React::WriteProperty(writer, L"onMoveShouldSetResponderCapture", "function");
+  React::WriteProperty(writer, L"onStartShouldSetResponder", "function");
+  React::WriteProperty(writer, L"onStartShouldSetResponderCapture", "function");
+  React::WriteProperty(writer, L"onResponderGrant", "function");
+  React::WriteProperty(writer, L"onResponderReject", "function");
+  React::WriteProperty(writer, L"onResponderStart", "function");
+  React::WriteProperty(writer, L"onResponderEnd", "function");
+  React::WriteProperty(writer, L"onResponderRelease", "function");
+  React::WriteProperty(writer, L"onResponderMove", "function");
+  React::WriteProperty(writer, L"onResponderTerminate", "function");
+  React::WriteProperty(writer, L"onResponderTerminationRequest", "function");
+  React::WriteProperty(writer, "onShouldBlockNativeResponder", "function");
+
+  // Touch events
+  React::WriteProperty(writer, L"onTouchCancel", "function");
+  React::WriteProperty(writer, L"onTouchEnd", "function");
+  React::WriteProperty(writer, L"onTouchMove", "function");
+  React::WriteProperty(writer, L"onTouchStart", "function");
+
+  // W3C Pointer Events
+  React::WriteProperty(writer, L"onPointerDown", L"function");
+  React::WriteProperty(writer, L"onPointerMove", L"function");
+  React::WriteProperty(writer, L"onPointerUp", L"function");
+  React::WriteProperty(writer, L"onPointerCancel", L"function");
+  React::WriteProperty(writer, L"onPointerEnter", L"function");
+  React::WriteProperty(writer, L"onPointerLeave", L"function");
+  React::WriteProperty(writer, L"onPointerOver", L"function");
+  React::WriteProperty(writer, L"onPointerOut", L"function");
+  React::WriteProperty(writer, L"onGotPointerCapture", L"function");
+  React::WriteProperty(writer, L"onLostPointerCapture", L"function");
+  React::WriteProperty(writer, L"onClick", L"function");
 }
 
 void ViewManagerBase::GetConstants(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
On iOS, various JS-only events are registered on the native ViewManager for View solely for the purpose of allowing these events to flow to ViewProps and be used when considering view flattening: https://github.com/facebook/react-native/blob/b561d46b06a32e3872c4701ebeb325f8231e88dd/packages/react-native/React/Views/RCTViewManager.m#L523-L555

### What
This change adds these event props to ViewViewManager for the same purpose.

## Testing
Run `Playground-composition.sln`
Use the following example:
```
import React from 'react';
import {AppRegistry, View} from 'react-native';

function Example() {
  return (
    <View
      onTouchStart={() => alert('clicked')}
      style={{width: 100, height: 100}}>
      <View pointerEvents='none' style={{backgroundColor: 'blue', width: 50, height: 50}} />
    </View>
  );
}

AppRegistry.registerComponent('Bootstrap', () => Example);
```

Without this change, the `onTouchStart` event does not flow as expected.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12359)