### PR TITLE
Keep propertyBag alive for duration of InstanceDestroyed event

### DIFF
--- a/change/react-native-windows-3ff759df-eda0-48ed-8bc0-518bd22e9ae2.json
+++ b/change/react-native-windows-3ff759df-eda0-48ed-8bc0-518bd22e9ae2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Keep propertyBag alive for duration of InstanceDestroyed event",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -258,6 +258,12 @@ ReactInstanceWin::ReactInstanceWin(
   m_whenDestroyedResult =
       m_whenDestroyed.AsFuture().Then<Mso::Executors::Inline>([whenLoaded = m_whenLoaded,
                                                                onDestroyed = m_options.OnInstanceDestroyed,
+                                                               // If the ReactHost has been released, this
+                                                               // instance might be the only thing keeping
+                                                               // the propertyBag alive.
+                                                               // We want it to remain alive for the
+                                                               // InstanceDestroyed callbacks
+                                                               propBag = m_options.Properties,
                                                                reactContext = m_reactContext]() noexcept {
         whenLoaded.TryCancel(); // It only has an effect if whenLoaded was not set before
         Microsoft::ReactNative::HermesRuntimeHolder::storeTo(ReactPropertyBag(reactContext->Properties()), nullptr);


### PR DESCRIPTION
## Description
In some cases, it is possible for the `ReactPropertyBag` to have already been destroyed by the time the App gets the `InstanceDestroyed` event.  This can make cleanup code fail.

### What
Hold a ref to the PropertyBag while firing the InstanceDestroyed event.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12364)