### PR TITLE
[0.73] Make Hermes the default JS engine

### DIFF
--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -51,32 +51,32 @@ parameters:
             platform: x86
             projectType: lib
             additionalRunArguments: --no-autolink --no-deploy
-          - Name: X86DebugCppHermes
+          - Name: X86DebugCppChakra
             language: cpp
             configuration: Debug
             platform: x86
             projectType: app
-            additionalInitArguments: --useHermes
-          - Name: X64ReleaseCsHermes
+            useChakra: true
+          - Name: X64ReleaseCsChakra
             language: cs
             configuration: Release
             platform: x64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             runWack: true
-          - Name: Arm64ReleaseCsHermes
+          - Name: Arm64ReleaseCsChakra
             language: cs
             configuration: Release
             platform: ARM64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             additionalRunArguments: --no-deploy
-          - Name: X64ReleaseCppHermes
+          - Name: X64ReleaseCppChakra
             language: cpp
             configuration: Release
             platform: x64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             runWack: true
           - Name: X86DebugCppNuget
             language: cpp
@@ -224,32 +224,32 @@ parameters:
             platform: x86
             projectType: lib
             additionalRunArguments: --no-autolink --no-deploy
-          - Name: X86DebugCppHermes
+          - Name: X86DebugCppChakra
             language: cpp
             configuration: Debug
             platform: x86
             projectType: app
-            additionalInitArguments: --useHermes
-          - Name: X64ReleaseCsHermes
+            useChakra: true
+          - Name: X64ReleaseCsChakra
             language: cs
             configuration: Release
             platform: x64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             runWack: true
-          - Name: Arm64ReleaseCsHermes
+          - Name: Arm64ReleaseCsChakra
             language: cs
             configuration: Release
             platform: ARM64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             additionalRunArguments: --no-deploy
-          - Name: X64ReleaseCppHermes
+          - Name: X64ReleaseCppChakra
             language: cpp
             configuration: Release
             platform: x64
             projectType: app
-            additionalInitArguments: --useHermes
+            useChakra: true
             runWack: true
           - Name: X86DebugCppNuget
             language: cpp
@@ -410,4 +410,5 @@ jobs:
                   additionalRunArguments: ${{ matrix.additionalRunArguments }}
                   runWack: ${{ coalesce(matrix.runWack, false) }}
                   buildEnvironment: ${{ parameters.buildEnvironment }}
+                  useChakra: ${{ coalesce(matrix.useChakra, false) }} 
                   useNuGet: ${{ coalesce(matrix.useNuGet, false) }}

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -15,30 +15,30 @@ parameters:
         Matrix:
           - Name: X64Chakra
             BuildPlatform: x64
-            UseHermes: false
+            UseChakra: true
           - Name: X64Hermes
             BuildPlatform: x64
-            UseHermes: true
+            UseChakra: false
           - Name: X86Chakra
             BuildPlatform: x86
-            UseHermes: false
+            UseChakra: true
           - Name: X86Hermes
             BuildPlatform: x86
-            UseHermes: true
+            UseChakra: false
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X64Chakra
             BuildPlatform: x64
-            UseHermes: false
+            UseChakra: true
           - Name: X64Hermes
             BuildPlatform: x64
-            UseHermes: true
+            UseChakra: false
           - Name: X86Chakra
             BuildPlatform: x86
-            UseHermes: false
+            UseChakra: true
           - Name: X86Hermes
             BuildPlatform: x86
-            UseHermes: true
+            UseChakra: false
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -77,7 +77,7 @@ jobs:
               parameters:
                 package: packages/e2e-test-app
                 feature: UseHermes
-                value: ${{ matrix.UseHermes }}
+                value: ${{ not(coalesce(matrix.UseChakra, false)) }}
 
             - template: ../templates/run-windows-with-certificates.yml
               parameters:
@@ -157,7 +157,7 @@ jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
       - ${{ each matrix in config.Matrix }}:
-        - ${{ if eq(matrix.UseHermes, true) }}:
+        - ${{ if eq(matrix.UseChakra, false) }}:
           - job: E2ETestFabric${{ matrix.Name }}
             displayName: E2E Test App Fabric ${{ matrix.Name }}
 

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -16,54 +16,64 @@ parameters:
             BuildPlatform: ARM64
             BuildConfiguration: Debug
             DeployOptions: --no-deploy # We don't have Arm agents
-            UseHermes: false
           - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
             DeployOptions:
-            UseHermes: false
-          - Name: X64ReleaseHermes
-            BuildPlatform: x64
-            BuildConfiguration: Release
-            DeployOptions:
-            UseHermes: true
           - Name: X86WebDebug
             BuildPlatform: x86
             BuildConfiguration: Debug
             DeployOptions:
-            UseHermes: false
-          - Name: X86ReleaseHermes
+          - Name: X64Release
+            BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions:
+          - Name: X86Release
             BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions:
-            UseHermes: true
+          - Name: X64ReleaseChakra
+            BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions:
+            UseChakra: true
+          - Name: X86ReleaseChakra
+            BuildPlatform: x86
+            BuildConfiguration: Release
+            DeployOptions:
+            UseChakra: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: Arm64Debug
             BuildPlatform: ARM64
             BuildConfiguration: Debug
             DeployOptions: --no-deploy # We don't have Arm agents
-            UseHermes: false
           - Name: X64WebDebug
             BuildPlatform: x64
             BuildConfiguration: Debug
             DeployOptions:
-            UseHermes: false
-          - Name: X64ReleaseHermes
-            BuildPlatform: x64
-            BuildConfiguration: Release
-            DeployOptions:
-            UseHermes: true
           - Name: X86WebDebug
             BuildPlatform: x86
             BuildConfiguration: Debug
             DeployOptions:
-            UseHermes: false
-          - Name: X86ReleaseHermes
+          - Name: X64Release
+            BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions:
+          - Name: X86Release
             BuildPlatform: x86
             BuildConfiguration: Release
             DeployOptions:
-            UseHermes: true
+          - Name: X64ReleaseChakra
+            BuildPlatform: x64
+            BuildConfiguration: Release
+            DeployOptions:
+            UseChakra: true
+          - Name: X86ReleaseChakra
+            BuildPlatform: x86
+            BuildConfiguration: Release
+            DeployOptions:
+            UseChakra: true
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -101,7 +111,7 @@ jobs:
               parameters:
                 package: packages/integration-test-app
                 feature: UseHermes
-                value: ${{ matrix.UseHermes }}
+                value: ${{ not(coalesce(matrix.UseChakra, false))}}
 
             - ${{ if eq(matrix.BuildConfiguration, 'Debug') }}:
               # The build is more likely to crash after we've started other bits that

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -24,6 +24,9 @@ parameters:
   - name: additionalRunArguments
     type: string
     default: ''
+  - name: useChakra
+    type: boolean
+    default: false
   - name: useNuGet
     type: boolean
     default: false
@@ -102,6 +105,12 @@ steps:
       workingDirectory: $(Agent.BuildDirectory)\testcli
       env:
         npm_config_registry: http://localhost:4873
+  
+  - template:  set-experimental-feature.yml
+    parameters:
+      package: ..\testcli
+      feature: UseHermes
+      value: ${{ not(parameters.UseChakra) }}
 
   - ${{ if eq(parameters.projectType, 'app') }}:
     - powershell: |

--- a/change/@react-native-windows-cli-b478dee5-f5a0-4257-96b1-c3cd1ce241f0.json
+++ b/change/@react-native-windows-cli-b478dee5-f5a0-4257-96b1-c3cd1ce241f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.73] Make Hermes the default JS engine",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-199ec877-3e4a-4205-bdf0-60a698957050.json
+++ b/change/react-native-windows-199ec877-3e4a-4205-bdf0-60a698957050.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[0.73] Make Hermes the default JS engine",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
+++ b/packages/@react-native-windows/cli/src/commands/config/configUtils.ts
@@ -300,6 +300,28 @@ export function tryFindPropertyValue(
   return null;
 }
 
+/**
+ * Search for the given property in the project contents and return its value.
+ * @param projectContents The XML project contents.
+ * @param propertyName The property to look for.
+ * @return The value of the tag if it exists.
+ */
+export function tryFindPropertyValueAsBoolean(
+  projectContents: Node,
+  propertyName: string,
+): boolean | null {
+  const rawValue = tryFindPropertyValue(projectContents, propertyName);
+
+  switch (rawValue) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return null;
+  }
+}
+
 export function findPropertyValue(
   projectContents: Node,
   propertyName: string,

--- a/packages/@react-native-windows/cli/src/generator-windows/index.ts
+++ b/packages/@react-native-windows/cli/src/generator-windows/index.ts
@@ -16,6 +16,7 @@ import findUp from 'find-up';
 import {
   readProjectFile,
   findPropertyValue,
+  tryFindPropertyValueAsBoolean,
 } from '../commands/config/configUtils';
 
 import {
@@ -129,6 +130,27 @@ export async function copyProjectTemplateAndReplace(
   if (options.experimentalNuGetDependency) {
     console.log('Using experimental NuGet dependency.');
   }
+
+  const experimentalPropsPath = path.join(
+    destPath,
+    windowsDir,
+    'ExperimentalFeatures.props',
+  );
+
+  let existingUseHermes: boolean | null = null;
+  if (fs.existsSync(experimentalPropsPath)) {
+    existingUseHermes = tryFindPropertyValueAsBoolean(
+      readProjectFile(experimentalPropsPath),
+      'UseHermes',
+    );
+  }
+
+  if (existingUseHermes === false) {
+    console.warn(
+      'Hermes is now the default JS engine and will be enabled for this project. Support for Chakra will be deprecated in the future. To disable Hermes and keep using Chakra for now, see https://microsoft.github.io/react-native-windows/docs/hermes#disabling-hermes.',
+    );
+  }
+  options.useHermes = true;
 
   if (options.useWinUI3) {
     throw new CodedError(

--- a/packages/e2e-test-app/windows/ExperimentalFeatures.props
+++ b/packages/e2e-test-app/windows/ExperimentalFeatures.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
-    <UseHermes>false</UseHermes>
+    <UseHermes>true</UseHermes>
     <EnableSourceLink>true</EnableSourceLink>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>

--- a/packages/integration-test-app/windows/ExperimentalFeatures.props
+++ b/packages/integration-test-app/windows/ExperimentalFeatures.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
-    <UseHermes>false</UseHermes>
+    <UseHermes>true</UseHermes>
     <EnableSourceLink>true</EnableSourceLink>
     <ReactExperimentalFeaturesSet>true</ReactExperimentalFeaturesSet>
   </PropertyGroup>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiSimpleTurboModuleTests.js
@@ -6,6 +6,10 @@
  * @format
  */
 
+// Make sure that we import something from react-native so that we build a complete bundle
+// eslint-disable-next-line no-unused-vars
+import {View} from 'react-native';
+
 import {default as myTrivialTurboModule} from './NativeMyTrivialTurboModule';
 
 myTrivialTurboModule.startFromJS();

--- a/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.js
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/JsiTurboModuleTests.js
@@ -6,6 +6,10 @@
  * @format
  */
 
+// Make sure that we import something from react-native so that we build a complete bundle
+// eslint-disable-next-line no-unused-vars
+import {View} from 'react-native';
+
 import {default as mySimpleTurboModule} from './NativeMySimpleTurboModuleCxx';
 
 // The logging of the TurboModule functions is verified against the test action sequence.

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestBundle.targets
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestBundle.targets
@@ -1,12 +1,20 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<BundleOutputPath>$(OutputPath)</BundleOutputPath>
+		<BundleSourceMapDir>$(OutputPath)sourcemaps\react</BundleSourceMapDir>
+	</PropertyGroup>
 	<Import Project="$(ReactNativeWindowsDir)\PropertySheets\Bundle.props" />
 	<Target
 		Name="MakeTestBundles"
 		Condition="'$(DesignTimeBuild)' != 'true'"
 		BeforeTargets="PrepareForBuild"
 		Inputs="@(JsBundleEntry)"
-		Outputs="@(JsBundleEntry->'$(OutputPath)%(Filename).bundle')">
-		<MakeDir Directories="$(OutputPath)" Condition="!Exists('$(OutputPath)')" />
-		<Exec Command="$(BundleCliCommand) --platform windows --entry-file %(JsBundleEntry.FullPath) --bundle-output $(OutputPath)%(JsBundleEntry.Filename).bundle" ConsoleToMSBuild="true" />
+		Outputs="
+			@(JsBundleEntry->'$(BundleOutputPath)%(Filename).bundle');
+			@(JsBundleEntry->'$(BundleSourceMapDir)\%(Filename).bundle.packager.map')">
+		<MakeDir Directories="$(BundleOutputPath)" Condition="!Exists('$(BundleOutputPath)')" />
+		<MakeDir Directories="$(BundleSourceMapDir)" Condition="!Exists('$(BundleSourceMapDir)')" />
+		<Message Importance="High" Text="Running [$(BundleCliCommand) --platform windows --entry-file %(JsBundleEntry.FullPath) --bundle-output $(BundleOutputPath)%(JsBundleEntry.Filename).bundle --dev $(UseDevBundle) --reset-cache --sourcemap-output $(BundleSourceMapDir)\%(JsBundleEntry.Filename).bundle.packager.map $(BundlerExtraArgs)] to build bundle file." />
+		<Exec Command='$(BundleCliCommand) --platform windows --entry-file "%(JsBundleEntry.FullPath)" --bundle-output "$(BundleOutputPath)%(JsBundleEntry.Filename).bundle" --dev $(UseDevBundle) --reset-cache --sourcemap-output "$(BundleSourceMapDir)\%(JsBundleEntry.Filename).bundle.packager.map" $(BundlerExtraArgs)' ConsoleToMSBuild="true" WorkingDirectory="$(BundleCommandWorkingDir)" />
 	</Target>
 </Project>

--- a/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Common.props
+++ b/vnext/PropertySheets/External/Microsoft.ReactNative.Composition.Common.props
@@ -8,5 +8,13 @@
   Do not make any changes here unless it applies to ALL such projects.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="EnsureUseHermes" BeforeTargets="PrepareForBuild" Condition="'$(UseHermes)' == 'false'">
+    <Warning Text="Property 'UseHermes' was set to 'false'. Projects built against Microsoft.ReactNative.Composition require Hermes and it will be set to true." />
+  </Target>
+
+  <PropertyGroup>
+    <UseHermes>true</UseHermes>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildThisFileDirectory)Microsoft.ReactNative.Common.props" />
 </Project>

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <JsEnginePropsDefined>true</JsEnginePropsDefined>
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
-    <UseHermes Condition="'$(UseHermes)' == ''">false</UseHermes>
+    <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
     <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.15</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>

--- a/vnext/metro.config.js
+++ b/vnext/metro.config.js
@@ -19,4 +19,4 @@ if (
 }
 
 const {makeMetroConfig} = require('@rnw-scripts/metro-dev-config');
-module.exports = makeMetroConfig();
+module.exports = makeMetroConfig({projectRoot: __dirname});

--- a/vnext/templates/cpp-app/windows/ExperimentalFeatures.props
+++ b/vnext/templates/cpp-app/windows/ExperimentalFeatures.props
@@ -2,7 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
-    <UseHermes>true</UseHermes>
     <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
 

--- a/vnext/templates/old/generateWrapper.js
+++ b/vnext/templates/old/generateWrapper.js
@@ -20,7 +20,7 @@ function makeGenerateWindowsWrapper(
         })`
       : `React Native Windows Application (Old Arch, UWP, ${
           language === 'cs' ? 'C#' : 'C++'
-        }, Chakra)`;
+        }, Hermes)`;
   const description =
     projectType === 'lib'
       ? `A RNW module written in ${
@@ -28,7 +28,7 @@ function makeGenerateWindowsWrapper(
         }, targeting UWP and RN's old architecture.`
       : `A RNW app written in ${
           language === 'cs' ? 'C#' : 'C++'
-        }, targeting UWP and RN's old architecture, with the Chakra JS engine.`;
+        }, targeting UWP and RN's old architecture, with the Hermes JS engine.`;
 
   const postInstall = async (config = {}, options = {}) => {
     const experimentalFeatures = config?.project?.windows?.experimentalFeatures;
@@ -40,7 +40,7 @@ function makeGenerateWindowsWrapper(
       experimentalNuGetDependency:
         experimentalFeatures?.UseExperimentalNuget ?? false,
       useWinUI3: experimentalFeatures?.UseWinUI3 ?? false,
-      useHermes: experimentalFeatures?.UseHermes ?? false,
+      useHermes: experimentalFeatures?.UseHermes ?? true,
       useDevMode: false,
       verbose: !!options.logging,
       telemetry: !!options.telemetry,

--- a/vnext/templates/old/uwp-cpp-lib/template.config.js
+++ b/vnext/templates/old/uwp-cpp-lib/template.config.js
@@ -12,4 +12,4 @@
 
 const {makeGenerateWindowsWrapper} = require('../generateWrapper');
 
-module.exports = makeGenerateWindowsWrapper('cpp', 'lib', false);
+module.exports = makeGenerateWindowsWrapper('cpp', 'lib');


### PR DESCRIPTION
This PR backports #12321 to 0.73.

## Description

This PR makes Hermes the default JS engine for RNW going forward.

For now, this is still managed by setting the `<UseHermes>` MSBuild property. However, if the property is not explicitly set, the default value in `JSEngine.props` will now be `true` instead of `false`.

The property will remain exposed (and now set to `true`) in project's `ExperimentalFeatures.props` files. This will be done for new projects created with the `npx react-native-windows-init` command targeting versions with this change. (Use or omission of the `--useHermes` flag will no longer be recognized at project creation time). Hermes will also be the default for projects created with the new `npx react-native init-windows` CLI command.

Current users attempting to *upgrade* their existing projects with these tools will be given a warning if they were previously using the Chakra engine, and instructions to revert back to using Chakra if necessary. However, support for Chakra will be deprecated in the future, so best to migrate sooner rather than later.

In addition, this PR should also enable Hermes use when consuming the official (experimental) NuGet package binaries.

Finally, this PR updates our CI infrastructure to instead denote "Chakra" (rather than "Hermes") for builds and tests.

### Type of Change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
Hermes is the officially supported and maintained JS engine for React Native, and as time goes on, the cost of maintain Chakra (which hasn't been updated in years) only increases. The "new" architecture includes Hermes.

Resolves #11251 

### What
See above

## Screenshots
N/A

## Testing
Ran existing tests

## Changelog
Should this change be included in the release notes: yes

Hermes is now the default JS engine for all new projects and will eventually be the only supported JS engine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12371)