### PR TITLE
Root view panel

### DIFF
--- a/change/react-native-windows-c36475ab-b28b-4ff9-b59e-b01c43278e83.json
+++ b/change/react-native-windows-c36475ab-b28b-4ff9-b59e-b01c43278e83.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Create RootViewPanel",
+  "packageName": "react-native-windows",
+  "email": "lyahdav@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -194,6 +194,10 @@
       <SubType>Code</SubType>
     </ClInclude>
     <ClInclude Include="ReactHost\JSCallInvokerScheduler.h" />
+    <ClInclude Include="RootViewPanel.h">
+      <DependentUpon>RootViewPanel.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Utils\ShadowNodeTypeUtils.h" />
     <ClInclude Include="Utils\BatchingEventEmitter.h" />
     <ClInclude Include="DevMenuControl.h">
@@ -428,6 +432,10 @@
       <SubType>Code</SubType>
     </ClCompile>
     <ClCompile Include="CoreApp.cpp" />
+    <ClCompile Include="RootViewPanel.cpp">
+      <DependentUpon>RootViewPanel.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="Utils\BatchingEventEmitter.cpp" />
     <ClCompile Include="CxxReactUWP\JSBigString.cpp" />
     <ClCompile Include="DevMenuControl.cpp">
@@ -584,6 +592,9 @@
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="ReactRootView.idl">
+      <SubType>Designer</SubType>
+    </Midl>
+    <Midl Include="RootViewPanel.idl">
       <SubType>Designer</SubType>
     </Midl>
     <Midl Include="XamlHelper.idl" />

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj.filters
@@ -713,6 +713,7 @@
     <Midl Include="DocString.idl" />
     <Midl Include="DesktopWindowMessage.idl" />
     <Midl Include="ReactPointerEventArgs.idl" />
+    <Midl Include="RootViewPanel.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="microsoft.reactnative.def" />

--- a/vnext/Microsoft.ReactNative/RootViewPanel.cpp
+++ b/vnext/Microsoft.ReactNative/RootViewPanel.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "RootViewPanel.h"
+
+#include <IReactContext.h>
+#include <Modules/NativeUIManager.h>
+#include <Modules/PaperUIManagerModule.h>
+#include <QuirkSettings.h>
+#include <ReactHost/MsoUtils.h>
+#include <UI.Xaml.Input.h>
+#include <UI.Xaml.Media.Media3D.h>
+#include <Utils/Helpers.h>
+#include <dispatchQueue/dispatchQueue.h>
+#include <winrt/Windows.UI.Core.h>
+#include "ReactNativeHost.h"
+#include "ReactViewInstance.h"
+#include "TouchEventHandler.h"
+#include "Views/ShadowNodeBase.h"
+#include "XamlUtils.h"
+
+// Needed for latest versions of C++/WinRT
+#if __has_include("RootViewPanel.g.cpp")
+#include "RootViewPanel.g.cpp"
+#endif
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+RootViewPanel::RootViewPanel(winrt::Microsoft::ReactNative::IReactContext reactContext) noexcept {
+  winrt::Microsoft::ReactNative::ReactContext reactContextImpl = reactContext;
+  auto contextSelf =
+      winrt::get_self<winrt::Microsoft::ReactNative::implementation::ReactContext>(reactContextImpl.Handle());
+
+  m_touchEventHandler = std::make_shared<::Microsoft::ReactNative::TouchEventHandler>(contextSelf->GetInner());
+  m_touchEventHandler->AddTouchHandlers(*this);
+  m_previewKeyboardEventHandlerOnRoot =
+      std::make_shared<::Microsoft::ReactNative::PreviewKeyboardEventHandlerOnRoot>(contextSelf->GetInner());
+  m_previewKeyboardEventHandlerOnRoot->hook(*this);
+}
+
+RootViewPanel::~RootViewPanel() noexcept {
+  if (m_touchEventHandler) {
+    m_touchEventHandler->RemoveTouchHandlers();
+  }
+
+  if (m_previewKeyboardEventHandlerOnRoot) {
+    m_previewKeyboardEventHandlerOnRoot->unhook();
+  }
+
+  // Clear members with a dependency on the reactInstance
+  m_touchEventHandler.reset();
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/RootViewPanel.h
+++ b/vnext/Microsoft.ReactNative/RootViewPanel.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "RootViewPanel.g.h"
+
+#include "Views/KeyboardEventHandler.h"
+#include "Views/ViewPanel.h"
+
+namespace Microsoft::ReactNative {
+class TouchEventHandler;
+class PreviewKeyboardEventHandlerOnRoot;
+} // namespace Microsoft::ReactNative
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct RootViewPanel : RootViewPanelT<RootViewPanel, ViewPanel> {
+  RootViewPanel(winrt::Microsoft::ReactNative::IReactContext reactContext) noexcept;
+  ~RootViewPanel() noexcept;
+
+ private:
+  std::shared_ptr<::Microsoft::ReactNative::TouchEventHandler> m_touchEventHandler;
+  std::shared_ptr<::Microsoft::ReactNative::PreviewKeyboardEventHandlerOnRoot> m_previewKeyboardEventHandlerOnRoot;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+struct RootViewPanel : RootViewPanelT<RootViewPanel, implementation::RootViewPanel> {};
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/RootViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/RootViewPanel.idl
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "ViewPanel.idl";
+import "IReactContext.idl";
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+  [default_interface]
+  [webhosthidden]
+  DOC_STRING("A XAML component that manages keyboard/touch inputs.")
+  runtimeclass RootViewPanel : ViewPanel
+  {
+    DOC_STRING("Creates a new instance of @RootViewPanel")
+    RootViewPanel(IReactContext reactContext);
+  }
+} // namespace Microsoft. ReactNative

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/ViewPanel.idl
@@ -8,7 +8,7 @@ namespace Microsoft.ReactNative
 {
   [default_interface]
   [webhosthidden]
-  runtimeclass ViewPanel : XAML_NAMESPACE.Controls.Grid
+  unsealed runtimeclass ViewPanel : XAML_NAMESPACE.Controls.Grid
   {
     // Constructors
     ViewPanel();


### PR DESCRIPTION
## Description
RootViewPanel is useful for product view manager which need to manage keyboard/touch inputs.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Before this change it's not possible to make a view manager in product code for XAML controls such as Popup/Flyout. This is why it's not possible to make something like FlyoutViewManager in product code as it requires TouchEventHandler/PreviewKeyboardEventHandlerOnRoot which are not exposed in the RNW ABI.

### What
Created RootViewPanel class which is exposed via RNW ABI for use in product view managers.

## Testing
At Meta we've used this class to create a product view manager which uses XAML Popup. In the view manager's AddView method you can add child views onto a RootViewPanel.

## Changelog
Should this change be included in the release notes: no