### PR TITLE
Fabric: Add windows script to new cpp-app template

### DIFF
--- a/change/react-native-windows-aeaa392d-12c1-43af-8980-02dfd8e6d4f3.json
+++ b/change/react-native-windows-aeaa392d-12c1-43af-8980-02dfd8e6d4f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: Add `windows` script to new cpp-app template",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -15,6 +15,8 @@ const util = require('util');
 
 const glob = util.promisify(require('glob'));
 
+const templateUtils = require('../templateUtils');
+
 async function preInstall(config = {}, options = {}) {}
 
 async function getFileMappings(config = {}, options = {}) {
@@ -104,7 +106,12 @@ async function getFileMappings(config = {}, options = {}) {
   return fileMappings;
 }
 
-function postInstall(config = {}, options = {}) {
+async function postInstall(config = {}, options = {}) {
+  // Update package.json with new scripts
+  await templateUtils.updateProjectPackageJson(config, options, {
+    scripts: {windows: 'react-native run-windows'},
+  });
+
   console.log(chalk.white.bold('To run your new windows app:'));
   console.log(chalk.white('   npx react-native run-windows'));
 }

--- a/vnext/templates/templateUtils.js
+++ b/vnext/templates/templateUtils.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License.
+ *
+ * @ts check
+ * @format
+ */
+
+const pkgUtils = require('@react-native-windows/package-utils');
+
+async function updateProjectPackageJson(config = {}, options = {}, props = {}) {
+  const projectPath = config?.root ?? process.cwd();
+  const projectPackage = await pkgUtils.WritableNpmPackage.fromPath(
+    projectPath,
+  );
+
+  if (!projectPackage) {
+    throw new Error(
+      `The directory '${projectPath}' is not the root of an npm package`,
+    );
+  }
+
+  if (options?.logging) {
+    console.log('Modifying project package.json...');
+  }
+  await projectPackage.mergeProps(props);
+}
+
+module.exports = {updateProjectPackageJson};


### PR DESCRIPTION
## Description

Adds the functionality for apps created with the new cpp-app template to run `yarn windows`, as an alias for `react-native run-windows`, similar to the old template.

To do this, I've created a new `templateUtils` module for shared template config code, with a new `updateProjectPackageJson()` method to make it easy for templates to inject items into a project's package.json file (in this case, a new `scripts` entry).

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Adds a useful feature of the old templates to the new template

### What
See above.

## Screenshots
N/A

## Testing
Verified creating a new project works.

## Changelog
Should this change be included in the release notes: yes

The new Fabric app template now supports `yarn windows` as an alias to `react-native run-windows`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12374)