### PR TITLE
Fabric: Enable react-test-renderer tests in the new cpp-app template

### DIFF
--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -112,6 +112,12 @@ steps:
     parameters:
       buildLogDirectory: '$(Build.BinariesDirectory)\${{ parameters.platform }}\${{ parameters.configuration }}\BuildLogs'
 
+  # Only run the following on apps
+  - ${{ if endsWith(parameters.template, '-app') }}:
+    - script: call yarn test:windows
+      displayName: Run jest tests with react-test-renderer
+      workingDirectory: $(Agent.BuildDirectory)\testcli
+
   # Only test bundling in debug since we already bundle as part of release builds
   - ${{ if and(endsWith(parameters.template, '-app'), eq(parameters.configuration, 'Debug')) }}:
     - script: npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle

--- a/change/react-native-windows-20088f72-5201-4d7b-96c9-2b522fed786b.json
+++ b/change/react-native-windows-20088f72-5201-4d7b-96c9-2b522fed786b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fabric: Enable react-test-renderer tests in the new cpp-app template",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/jest.config.windows.js
+++ b/vnext/templates/cpp-app/jest.config.windows.js
@@ -1,0 +1,3 @@
+const config = {};
+
+module.exports = require('@rnx-kit/jest-preset')('windows', config);

--- a/vnext/templates/cpp-app/template.config.js
+++ b/vnext/templates/cpp-app/template.config.js
@@ -107,10 +107,19 @@ async function getFileMappings(config = {}, options = {}) {
 }
 
 async function postInstall(config = {}, options = {}) {
-  // Update package.json with new scripts
+  // Update package.json with new scripts and dependencies
   await templateUtils.updateProjectPackageJson(config, options, {
-    scripts: {windows: 'react-native run-windows'},
+    scripts: {
+      windows: 'react-native run-windows',
+      'test:windows': 'jest --config jest.config.windows.js',
+    },
+    devDependencies: {
+      '@rnx-kit/jest-preset': '^0.1.16',
+    },
   });
+
+  // Install recently added dependencies
+  await templateUtils.runNpmInstall(config, options);
 
   console.log(chalk.white.bold('To run your new windows app:'));
   console.log(chalk.white('   npx react-native run-windows'));

--- a/vnext/templates/templateUtils.js
+++ b/vnext/templates/templateUtils.js
@@ -6,7 +6,25 @@
  * @format
  */
 
+const existsSync = require('fs').existsSync;
+const path = require('path');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
 const pkgUtils = require('@react-native-windows/package-utils');
+
+async function runNpmInstall(config = {}, options = {}) {
+  const projectPath = config?.root ?? process.cwd();
+
+  if (options?.logging) {
+    console.log('Installing dependencies...');
+  }
+  const isYarn = existsSync(path.join(projectPath, 'yarn.lock'));
+  await exec(
+    isYarn ? 'yarn' : 'npm i',
+    options?.logging ? {stdio: 'inherit'} : {},
+  );
+}
 
 async function updateProjectPackageJson(config = {}, options = {}, props = {}) {
   const projectPath = config?.root ?? process.cwd();
@@ -26,4 +44,4 @@ async function updateProjectPackageJson(config = {}, options = {}, props = {}) {
   await projectPackage.mergeProps(props);
 }
 
-module.exports = {updateProjectPackageJson};
+module.exports = {runNpmInstall, updateProjectPackageJson};


### PR DESCRIPTION
## Description

The upstream RN app template includes a jest test suite (run with `yarn test`) with a default test to render your app JS using the `react-test-renderer`. However, this only tests the iOS version of your app (it forces platform === 'ios') and therefore won't catch if there are issues in your `windows` platform files.

Using `@rnx-kit/jest-preset`, you can run jest tests against any platform via a custom jest config.

This PR adds `@rnx-kit/jest-preset` as a dependency to the new `cpp-app` template, as well as a `jest.config.windows.js` to use it. Furthermore it adds a script so users can run these tests for windows via `yarn test:windows`.

Finally this PR adds running `yarn test:windows` to the PR checks for testing the new app CLI.

Closes #11939

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To expand test coverage options for app developers.

Closes #11939

### What
See above.

## Screenshots

![image](https://github.com/microsoft/react-native-windows/assets/10852185/742c5e52-4135-4b34-9642-8bdc99c7f132)

## Testing

Ran the tests in the provided RN template.

## Changelog
Should this change be included in the release notes: yes

The new Fabric app template supports `yarn test:windows` to run jest app rendering tests with react-test-renderer
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12376)