### PR TITLE
Untrack HTTP responses when processed by IResponseHandler

### DIFF
--- a/change/react-native-windows-766f6cc5-f66b-4147-9bd6-bcf8c9897469.json
+++ b/change/react-native-windows-766f6cc5-f66b-4147-9bd6-bcf8c9897469.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Untrack HTTP responses when processed by IResponseHandler",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -545,7 +545,7 @@ WinRTHttpResource::PerformSendRequest(HttpMethod &&method, Uri &&rtUri, IInspect
           if (self->m_onComplete) {
             self->m_onComplete(reqArgs->RequestId);
           }
-          co_return;
+          co_return self->UntrackResponse(reqArgs->RequestId);
         }
       }
 

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -283,6 +283,7 @@
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeSchedulerBinding.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\Task.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\utils\CoreFeatures.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\graphics\PlatformColorUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
Prevent memory leaks by untracking responses managed by a custom response handler.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
HTTP responses are not releasing their allocated resources when processed by a response handler (i.e. `BlobModuleResponseHandler`).

### What
Explicitly untrack the response's resources when processed by a response handler.
