### PR TITLE
Adds option to set Non-ABI Runtime instance

### DIFF
--- a/change/react-native-windows-7b79ad4a-100c-4545-9114-382ce48e59dd.json
+++ b/change/react-native-windows-7b79ad4a-100c-4545-9114-382ce48e59dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds option to set Non-ABI Runtime instance",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/DevSettings.h
+++ b/vnext/Shared/DevSettings.h
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #pragma once
+
+#include "JSI/JSExecutorFactoryDelegate.h"
 #include "Logging.h"
 
 #include <IRedBoxHandler.h>
@@ -85,6 +87,10 @@ struct DevSettings {
   /// thread, unless the specific runtime implementation explicitly guarantees
   /// reentrancy.
   std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> jsiRuntimeHolder;
+
+  /// A function that can be called with the current Instance to get
+  /// a JSExecutorFactory. This can be used to bypass the ABI JSI.
+  JSExecutorFactoryDelegate jsExecutorFactoryDelegate{nullptr};
 
   // Until the ABI story is addressed we'll use this instead of the above for
   // the purposes of selecting a JSI Runtime to use.

--- a/vnext/Shared/JSI/JSExecutorFactoryDelegate.h
+++ b/vnext/Shared/JSI/JSExecutorFactoryDelegate.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include <functional>
+#include <memory>
+
+namespace facebook::react {
+class CallInvoker;
+class JSExecutorFactory;
+using JSExecutorFactoryDelegate =
+    std::function<std::shared_ptr<JSExecutorFactory>(std::shared_ptr<CallInvoker> const &callInvoker)>;
+} // namespace facebook::react

--- a/vnext/Shared/JSI/JSExecutorFactorySettings.cpp
+++ b/vnext/Shared/JSI/JSExecutorFactorySettings.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "JSExecutorFactorySettings.h"
+
+namespace Microsoft::JSI::JSExecutorFactorySettings {
+
+winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<facebook::react::JSExecutorFactoryDelegate>>
+JSExecutorFactoryDelegateProperty() noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<facebook::react::JSExecutorFactoryDelegate>>
+      propId{L"ReactNative.JSI", L"JSExecutorFactory"};
+  return propId;
+}
+void SetJSExecutorFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    facebook::react::JSExecutorFactoryDelegate const &value) noexcept {
+  properties.Set(JSExecutorFactoryDelegateProperty(), value);
+}
+
+const facebook::react::JSExecutorFactoryDelegate GetJSExecutorFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept {
+  const auto jsExecutorFactoryDelegate = properties.Get(JSExecutorFactoryDelegateProperty());
+  if (!jsExecutorFactoryDelegate)
+    return nullptr;
+  return jsExecutorFactoryDelegate.Value();
+}
+
+} // namespace Microsoft::JSI::JSExecutorFactorySettings

--- a/vnext/Shared/JSI/JSExecutorFactorySettings.h
+++ b/vnext/Shared/JSI/JSExecutorFactorySettings.h
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "JSExecutorFactoryDelegate.h"
+#include "ReactPropertyBag.h"
+
+namespace facebook::react {
+class JSExecutorFactory;
+}
+
+namespace Microsoft::JSI::JSExecutorFactorySettings {
+
+void SetJSExecutorFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    facebook::react::JSExecutorFactoryDelegate const &value) noexcept;
+const facebook::react::JSExecutorFactoryDelegate GetJSExecutorFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
+} // namespace Microsoft::JSI::JSExecutorFactorySettings

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -417,6 +417,8 @@ InstanceImpl::InstanceImpl(
       assert(m_devSettings->jsiEngineOverride == JSIEngineOverride::Default);
       jsef = std::make_shared<OJSIExecutorFactory>(
           m_devSettings->jsiRuntimeHolder, m_devSettings->loggingCallback, !m_devSettings->useFastRefresh);
+    } else if (m_devSettings->jsExecutorFactoryDelegate != nullptr) {
+      jsef = m_devSettings->jsExecutorFactoryDelegate(m_innerInstance->getJSCallInvoker());
     } else {
       assert(m_devSettings->jsiEngineOverride != JSIEngineOverride::Default);
       switch (m_devSettings->jsiEngineOverride) {

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -224,6 +224,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JSI\V8RuntimeHolder.cpp">
       <ExcludedFromBuild Condition="'$(UseV8)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactorySettings.cpp"/>
     <ClCompile Include="$(MSBuildThisFileDirectory)LayoutAnimation.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Logging.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)MemoryMappedBuffer.cpp" />
@@ -370,6 +371,8 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\V8RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\RuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ScriptStore.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactoryDelegate.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactorySettings.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\BlobModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\CxxModuleUtilities.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -91,6 +91,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JSI\ChakraJsiRuntime_edgemode.cpp">
       <Filter>Source Files\JSI</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactorySettings.cpp">
+      <Filter>Source Files\JSI</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -577,6 +580,12 @@
       <Filter>Header Files\JSI</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\RuntimeHolder.h">
+      <Filter>Header Files\JSI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactoryDelegate.h">
+      <Filter>Header Files\JSI</Filter>
+    </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)JSI\JSExecutorFactorySettings.h">
       <Filter>Header Files\JSI</Filter>
     </ClInclude>
     <ClInclude Include="$(MSBuildThisFileDirectory)JSI\ScriptStore.h">


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Some apps may want to bypass the JsiAbiApi altogether (e.g., compiling a custom JS runtime that is not currently supported by react-native-windows).

### What
This change introduces the JSExecutorFactorySettings, which allows you to set a non-ABI JSExecutorFactory instance. It also prefers this option if available over the ABI JSI runtime.

## Testing
Validated in our app that we are able to inject a non-ABI JSExecutorFactory.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12382)