### PR TITLE
Adds option for non-ABI TurboModule provider

### DIFF
--- a/change/react-native-windows-a51c7eb0-1683-4bda-b24f-f68d7a7c772a.json
+++ b/change/react-native-windows-a51c7eb0-1683-4bda-b24f-f68d7a7c772a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds option for non-ABI TurboModule provider",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/IJsiNonAbiHostObject.h
+++ b/vnext/Microsoft.ReactNative.Cxx/IJsiNonAbiHostObject.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "winrt/Microsoft.ReactNative.h"
 #include "jsi/jsi.h"
+#include "winrt/Microsoft.ReactNative.h"
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
@@ -15,11 +15,6 @@ struct JsiNonAbiHostObject : winrt::implements<JsiNonAbiHostObject, IJsiNonAbiHo
 
   std::shared_ptr<facebook::jsi::HostObject> HostObject() const noexcept {
     return m_hostObject;
-  }
-
- public: // IJsiNonAbiHostObject
-  bool HasValue() const noexcept {
-    return !!m_hostObject;
   }
 
  private:

--- a/vnext/Microsoft.ReactNative.Cxx/IJsiNonAbiHostObject.h
+++ b/vnext/Microsoft.ReactNative.Cxx/IJsiNonAbiHostObject.h
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "winrt/Microsoft.ReactNative.h"
+#include "jsi/jsi.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct JsiNonAbiHostObject : winrt::implements<JsiNonAbiHostObject, IJsiNonAbiHostObject> {
+ public: // IReactNonAbiHostObject
+  JsiNonAbiHostObject(std::shared_ptr<facebook::jsi::HostObject> const &hostObject) noexcept
+      : m_hostObject{hostObject} {}
+
+  std::shared_ptr<facebook::jsi::HostObject> HostObject() const noexcept {
+    return m_hostObject;
+  }
+
+ public: // IJsiNonAbiHostObject
+  bool HasValue() const noexcept {
+    return !!m_hostObject;
+  }
+
+ private:
+  std::shared_ptr<facebook::jsi::HostObject> m_hostObject;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -77,6 +77,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)NativeModules.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactDispatcher.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactNonAbiValue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)IJsiNonAbiHostObject.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactNotificationService.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactPropertyBag.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactContext.h" />

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems.filters
@@ -47,6 +47,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)NativeModules.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactDispatcher.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactNonAbiValue.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)IJsiNonAbiHostObject.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactNotificationService.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactPropertyBag.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)ReactContext.h" />

--- a/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
+++ b/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
@@ -10,9 +10,9 @@ namespace Microsoft.ReactNative
   [version(0)]
   [experimental]
   DOC_STRING(
-    "The `IJsiNonAbiHostObject` helps with passing non-ABI C++ TurboModules "
-    "via @ReactModuleProvider. Since React Native Windows already uses @IReactNonAbiValue "
-    "internally to represent attributed native modules, this wrapper is needed to have an "
-    "alternate interface to type check against.")
+    "The @IJsiNonAbiHostObject helps register C++ TurboModules to JSI runtime instances "
+    "that bypass ABI via @ReactModuleProvider. Since React Native Windows already uses "
+    "@IReactNonAbiValue internally to represent attributed native modules, this wrapper "
+    "is needed to have an alternate interface to type check against.")
   interface IJsiNonAbiHostObject {}
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
+++ b/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
@@ -6,13 +6,13 @@
 namespace Microsoft.ReactNative
 {
   [webhosthidden]
+  [uuid("62bb563d-865a-4131-b576-f91c90c7b6f7")] // uuid needed for empty interfaces
+  [version(0)]
+  [experimental]
   DOC_STRING(
     "The `IJsiNonAbiHostObject` helps with passing non-ABI C++ TurboModules "
     "via @ReactModuleProvider. Since React Native Windows already uses @IReactNonAbiValue "
     "internally to represent attributed native modules, this wrapper is needed to have an "
     "alternate interface to type check against.")
-  interface IJsiNonAbiHostObject {
-    DOC_STRING("Gets a value indicating whether the object has a value. This is just a dummy method to avoid issues with empty interfaces in C++/WinRT.")
-    Boolean HasValue { get; };
-  }
+  interface IJsiNonAbiHostObject {}
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
+++ b/vnext/Microsoft.ReactNative/IJsiNonAbiHostObject.idl
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DocString.h"
+
+namespace Microsoft.ReactNative
+{
+  [webhosthidden]
+  DOC_STRING(
+    "The `IJsiNonAbiHostObject` helps with passing non-ABI C++ TurboModules "
+    "via @ReactModuleProvider. Since React Native Windows already uses @IReactNonAbiValue "
+    "internally to represent attributed native modules, this wrapper is needed to have an "
+    "alternate interface to type check against.")
+  interface IJsiNonAbiHostObject {
+    DOC_STRING("Gets a value indicating whether the object has a value. This is just a dummy method to avoid issues with empty interfaces in C++/WinRT.")
+    Boolean HasValue { get; };
+  }
+} // namespace Microsoft.ReactNative

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -552,6 +552,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactCoreInjection.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactInstanceSettings.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactNativeHost.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IJsiNonAbiHostObject.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'">

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -789,6 +789,7 @@
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactCoreInjection.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactInstanceSettings.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ReactNativeHost.idl" />
+    <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IJsiNonAbiHostObject.idl" />
     <Midl Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\RedBoxHandler.idl" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
For react-native-windows apps that bypass the JsiAbiApi when initializing a JS runtime, it would be useful to use the same module provider infrastructure used for other modules in react-native-windows.

Today the only two options are:
1. Use attributed native modules
2. Use C++ TurboModules wrapped in JsiHostObjectWrappers

### What
This adds a third option:
3. Use C++ TurboModules wrapped in an IJsiNonAbiHostObject

The main reason for creating IJsiNonAbiHostObject and not repurposing IReactNonAbiValue is that there is already a baked in assumption in the TurboModule provider that assumes all IReactNonAbiValues are attributed native modules, so a new interface is needed.

## Testing
Integrated this change into our React Native Windows app, and we were able to use IJsiNonAbiTurboModule instances.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12383)