### PR TITLE
Minor cleanup of recent RuntimeScheduler integration

### DIFF
--- a/change/react-native-windows-9db342c6-2185-414b-9bcb-90e6b7f5dcb7.json
+++ b/change/react-native-windows-9db342c6-2185-414b-9bcb-90e6b7f5dcb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor cleanup of recent RuntimeScheduler integration",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -604,17 +604,12 @@ void ReactInstanceWin::Initialize() noexcept {
             // The InstanceCreated event can be used to augment the JS environment for all JS code.  So it needs to be
             // triggered before any platform JS code is run. Using m_jsMessageThread instead of jsDispatchQueue avoids
             // waiting for the JSCaller which can delay the event until after certain JS code has already run
-            m_jsMessageThread.Load()->runOnQueue([onCreated = m_options.OnInstanceCreated,
-                                                  reactContext = m_reactContext,
-                                                  jsiRuntimeHolder = std::move(jsiRuntimeHolder),
-                                                  instanceWrapper = m_instanceWrapper.Load(),
-                                                  instance = m_instance.Load(),
-                                                  turboModuleProvider = m_options.TurboModuleProvider,
-                                                  useWebDebugger = m_options.UseWebDebugger()]() noexcept {
-              if (onCreated) {
-                onCreated.Get()->Invoke(reactContext);
-              }
-            });
+            m_jsMessageThread.Load()->runOnQueue(
+                [onCreated = m_options.OnInstanceCreated, reactContext = m_reactContext]() noexcept {
+                  if (onCreated) {
+                    onCreated.Get()->Invoke(reactContext);
+                  }
+                });
 
             LoadJSBundles();
 

--- a/vnext/Microsoft.ReactNative/SchedulerSettings.cpp
+++ b/vnext/Microsoft.ReactNative/SchedulerSettings.cpp
@@ -4,7 +4,6 @@
 #include "pch.h"
 
 #include <cxxreact/MessageQueueThread.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include "ReactPropertyBag.h"
 #include "SchedulerSettings.h"
 

--- a/vnext/Microsoft.ReactNative/SynchronousEventBeat.cpp
+++ b/vnext/Microsoft.ReactNative/SynchronousEventBeat.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include "SynchronousEventBeat.h"
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/SynchronousEventBeat.h
+++ b/vnext/Microsoft.ReactNative/SynchronousEventBeat.h
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 #include <NativeModules.h>
 #include <react/renderer/core/EventBeat.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>


### PR DESCRIPTION
## Description

### Why
Clean code is nice.

### What
A copyright header here, a new line there, and a simplified lambda capture. This is a grab bag of things that were missed when integrating RuntimeScheduler.

## Testing
GitHub Actions has this covered.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12410)