### PR TITLE
Update fmt version to 10.1.0

### DIFF
--- a/change/react-native-windows-f607455e-1870-4fd5-81f5-94717effb241.json
+++ b/change/react-native-windows-f607455e-1870-4fd5-81f5-94717effb241.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update fmt to 10.1.0",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -19,8 +19,8 @@
     <FollyVersion>2023.10.16.00</FollyVersion>
     <FollyCommitHash>3da4d3ccc4ea69bc10800754816e339d912736bd</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
-    <FmtVersion>8.0.0</FmtVersion>
-    <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>
+    <FmtVersion>10.1.0</FmtVersion>
+    <FmtCommitHash>ca2e3685b160617d3d95fcd9e789c4e06ca88</FmtCommitHash>
     <!-- Commit hash for https://github.com/microsoft/node-api-jsi code. -->
     <NodeApiJsiCommitHash>53b897b03c1c7e57c3372acc6234447a44e150d6</NodeApiJsiCommitHash>
   </PropertyGroup>

--- a/vnext/PropertySheets/Warnings.props
+++ b/vnext/PropertySheets/Warnings.props
@@ -22,9 +22,8 @@
           C4309 - truncation of constant value
           C4324 - structure was padded due to __declspec(align())
           C5205 - delete of an abstract class that has a non-virtual destructor results in undefined behavior
-          C4996 - use of stdext::checked_array_iterator which has been marked as deprecated
       -->
-    <ExtraWarningsToDisable>4068;4100;4101;4127;4189;4290;4309;4324;5205;4251;4996;$(DisableSpecificWarnings)</ExtraWarningsToDisable>
+    <ExtraWarningsToDisable>4068;4100;4101;4127;4189;4290;4309;4324;5205;4251;$(DisableSpecificWarnings)</ExtraWarningsToDisable>
   </PropertyGroup>
 
   <ItemDefinitionGroup>

--- a/vnext/fmt/cgmanifest.json
+++ b/vnext/fmt/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/fmtlib/fmt",
-                  "CommitHash": "9e8b86fd2d9806672cc73133d21780dd182bfd24"
+                  "CommitHash": "ca2e3685b160617d3d95fcd9e789c4e06ca88"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
MSVC is deprecating stdext::checked_array_iterator which fmt was using and caused build breaks when we updated to VS 17.8. 

Resolve #12407 

### What
Updating to fmt 10.1.0 since it removes all stdext::checked_array_iterator references. (fmtlib/fmt#3540)
Also removing current workaround of silencing the warning. 

## Testing
fmt.vcxproj now builds with VS 17.8

## Changelog
Should this change be included in the release notes: yes

Update fmt version from 8.0.0 to 10.1.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12411)