### PR TITLE
[0.72] Update fmt to 10.1.0

### DIFF
--- a/change/react-native-windows-f6ce9779-80b8-4939-b78b-f28dfa7b0e8c.json
+++ b/change/react-native-windows-f6ce9779-80b8-4939-b78b-f28dfa7b0e8c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "update fmt to 10.1.0",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -19,8 +19,8 @@
     <FollyVersion>2022.11.28.00</FollyVersion>
     <FollyCommitHash>6ed36117cdc4831f3a3951e013ae76b405e88e15</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
-    <FmtVersion>8.0.0</FmtVersion>
-    <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>
+    <FmtVersion>10.1.0</FmtVersion>
+    <FmtCommitHash>ca2e3685b160617d3d95fcd9e789c4e06ca88</FmtCommitHash>
     <!-- Commit hash for https://github.com/microsoft/node-api-jsi code. -->
     <NodeApiJsiCommitHash>53b897b03c1c7e57c3372acc6234447a44e150d6</NodeApiJsiCommitHash>
   </PropertyGroup>

--- a/vnext/fmt/cgmanifest.json
+++ b/vnext/fmt/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/fmtlib/fmt",
-                  "CommitHash": "9e8b86fd2d9806672cc73133d21780dd182bfd24"
+                  "CommitHash": "ca2e3685b160617d3d95fcd9e789c4e06ca88"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
MSVC is deprecating stdext::checked_array_iterator which fmt was using and caused build breaks when we updated to VS 17.8.

### What
Updating to fmt 10.1.0 since it removes all stdext::checked_array_iterator references. 

## Changelog
Should this change be included in the release notes: yes

Update fmt version from 8.0.0 to 10.1.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12412)