### PR TITLE
[0.73] Update fmt to 10.1.0

### DIFF
--- a/change/react-native-windows-57b4d8bd-9fd4-4950-94fb-fc27f7f8ef15.json
+++ b/change/react-native-windows-57b4d8bd-9fd4-4950-94fb-fc27f7f8ef15.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update fmt to 10.1.0",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Directory.Build.props
+++ b/vnext/Directory.Build.props
@@ -19,8 +19,8 @@
     <FollyVersion>2023.03.06.00</FollyVersion>
     <FollyCommitHash>ce2b95715de229fcb51bd97410469a3ad4d2bfb2</FollyCommitHash>
     <!-- When bumping the fmt version, be sure to bump the git hash of that version's commit and build fmt.vcxproj (to update its cgmanifest.json) too. -->
-    <FmtVersion>8.0.0</FmtVersion>
-    <FmtCommitHash>9e8b86fd2d9806672cc73133d21780dd182bfd24</FmtCommitHash>
+    <FmtVersion>10.1.0</FmtVersion>
+    <FmtCommitHash>ca2e3685b160617d3d95fcd9e789c4e06ca88</FmtCommitHash>
     <!-- Commit hash for https://github.com/microsoft/node-api-jsi code. -->
     <NodeApiJsiCommitHash>53b897b03c1c7e57c3372acc6234447a44e150d6</NodeApiJsiCommitHash>
   </PropertyGroup>

--- a/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
+++ b/vnext/Microsoft.ReactNative.Managed.CodeGen/Microsoft.ReactNative.Managed.CodeGen.csproj
@@ -11,7 +11,8 @@
     <!-- We are a tool, so on all platforms force win-x64 -->
     <PlatformTarget>x64</PlatformTarget>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-
+    <SelfContained>true</SelfContained>
+    
     <Nullable>enable</Nullable>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>

--- a/vnext/fmt/cgmanifest.json
+++ b/vnext/fmt/cgmanifest.json
@@ -6,7 +6,7 @@
                 "Type": "git",
                 "Git": {
                   "RepositoryUrl": "https://github.com/fmtlib/fmt",
-                  "CommitHash": "9e8b86fd2d9806672cc73133d21780dd182bfd24"
+                  "CommitHash": "ca2e3685b160617d3d95fcd9e789c4e06ca88"
                 }
             },
             "DevelopmentDependency": false


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
MSVC is deprecating stdext::checked_array_iterator which fmt was using and caused build breaks when we updated to VS 17.8.

### What
Updating to fmt 10.1.0 since it removes all stdext::checked_array_iterator references. 

## Changelog
Should this change be included in the release notes: yes

Update fmt version from 8.0.0 to 10.1.0
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12413)