### PR TITLE
Ensure both property and value exist for Blob's HTTP proxy

### DIFF
--- a/change/react-native-windows-e6a650eb-7ab8-4cf5-b094-4b685648e01a.json
+++ b/change/react-native-windows-e6a650eb-7ab8-4cf5-b094-4b685648e01a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Check HTTP handler property and value exist",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
- Check HTTP handler property and value exist
- Change files

## Description
Ensure HTTP proxy (handler) is correctly registered by Blob resource after instance reload.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

When direct debugging is used instead of web debugging, module initialization happens out of order and HTTP blob responses get mishandled due to the lack of Blob module (and associated resources) setup.

This was partially addressed by #11439.

On React Instance reload, the property bag entries `Http.Proxy` and `Blob.Resource` still exist but their values are no longer valid (they were discarded next to the previous instance's module hierarchy).

Therefore, there is no HTTP proxy that can register the Blob resource nor a Blob resource that can register the HTTP proxy inside their corresponding modules, leading to the `Invalid response for blob` exception.

Resolves #12187

### What

This change ensures both the entry **and** value for `Http.Proxy` exist in the React Instance's property bag, else it tries the best-effort approach used for #11439.

## Testing
See sample repository `jurocha-ms/Repro` under path `ReactNative/blobInvReload` and follow on-screen instructions.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12417)