### PR TITLE
[Fabric] Add caretHidden to TextInput

### DIFF
--- a/change/react-native-windows-d7fe4f1c-4277-4c6f-bf59-4b12118c130c.json
+++ b/change/react-native-windows-d7fe4f1c-4277-4c6f-bf59-4b12118c130c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add caretHidden to Fabric's TextInput",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -724,6 +724,20 @@ const examples: Array<RNTesterModuleExample> = [
       return <SpellCheckSample />;
     },
   },
+  {
+    title: 'CaretHidden set to True',
+    render: function (): React.Node {
+      return (
+        <View>
+          <Text>CaretHidden</Text>
+          <TextInput style={styles.singleLine}
+           caretHidden={true} 
+           placeholder='caretHidden={true}'
+           testID='textinput-carethidden' />
+        </View>
+      );
+    },
+  },
   // Windows]
 ];
 

--- a/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
+++ b/packages/@react-native-windows/tester/src/js/examples/TextInput/TextInputExample.windows.js
@@ -730,10 +730,12 @@ const examples: Array<RNTesterModuleExample> = [
       return (
         <View>
           <Text>CaretHidden</Text>
-          <TextInput style={styles.singleLine}
-           caretHidden={true} 
-           placeholder='caretHidden={true}'
-           testID='textinput-carethidden' />
+          <TextInput
+            style={styles.singleLine}
+            caretHidden={true}
+            placeholder="caretHidden={true}"
+            testID="textinput-carethidden"
+          />
         </View>
       );
     },

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -641,4 +641,10 @@ describe('TextInput Tests', () => {
     const dump = await dumpVisualTree('textinput-padding');
     expect(dump).toMatchSnapshot();
   });
+  test('TextInputs can have caretHidden', async () => {
+    const component = await app.findElementByTestID('textinput-carethidden');
+    await component.waitForDisplayed({timeout: 5000});
+    const dump = await dumpVisualTree('textinput-carethidden');
+    expect(dump).toMatchSnapshot();
+  });
 });

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -446,7 +446,7 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection (Imper
     "Opacity": 1,
     "Size": [
       916,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -1050,7 +1050,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Turned Of
     "Opacity": 1,
     "Size": [
       791,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -1201,7 +1201,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Words 1`]
     "Opacity": 1,
     "Size": [
       791,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -2728,7 +2728,7 @@ exports[`TextInput Tests TextInputs can have a background color 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -3030,7 +3030,7 @@ exports[`TextInput Tests TextInputs can have a font family 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -4923,7 +4923,7 @@ exports[`TextInput Tests TextInputs can have text decoration lines 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -3641,6 +3641,53 @@ exports[`TextInput Tests TextInputs can have attributed text 1`] = `
 }
 `;
 
+exports[`TextInput Tests TextInputs can have caretHidden 1`] = `
+{
+  "Automation Tree": {
+    "AutomationId": "textinput-carethidden",
+    "ControlType": 50004,
+    "HelpText": "caretHidden={true}",
+    "IsEnabled": true,
+    "IsKeyboardFocusable": true,
+    "LocalizedControlType": "edit",
+    "Name": "caretHidden={true}",
+  },
+  "Visual Tree": {
+    "Children": [
+      {
+        "Brush": {
+          "Brush Type": "ColorBrush",
+          "Color": "rgba(0, 0, 0, 255)",
+        },
+        "Offset": [
+          0,
+          0,
+          0,
+        ],
+        "Opacity": 0,
+        "Size": [
+          0,
+          0,
+        ],
+        "Visual Type": "SpriteVisual",
+      },
+    ],
+    "Comment": "textinput-carethidden",
+    "Offset": [
+      0,
+      0,
+      0,
+    ],
+    "Opacity": 1,
+    "Size": [
+      916,
+      23,
+    ],
+    "Visual Type": "SpriteVisual",
+  },
+}
+`;
+
 exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`] = `
 {
   "Automation Tree": {

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -446,7 +446,7 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection (Imper
     "Opacity": 1,
     "Size": [
       916,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -1050,7 +1050,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Turned Of
     "Opacity": 1,
     "Size": [
       791,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -1201,7 +1201,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Words 1`]
     "Opacity": 1,
     "Size": [
       791,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -2728,7 +2728,7 @@ exports[`TextInput Tests TextInputs can have a background color 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -3030,7 +3030,7 @@ exports[`TextInput Tests TextInputs can have a font family 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      28,
+      29,
     ],
     "Visual Type": "SpriteVisual",
   },
@@ -4923,7 +4923,7 @@ exports[`TextInput Tests TextInputs can have text decoration lines 1`] = `
     "Opacity": 1,
     "Size": [
       791,
-      29,
+      28,
     ],
     "Visual Type": "SpriteVisual",
   },

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -74800,23 +74800,21 @@ exports[`snapshotAllPages TextInput 36`] = `
 `;
 
 exports[`snapshotAllPages TextInput 37`] = `
-[
-  <View>
-      <Text>
-        CaretHidden
-      </Text>
-      <TextInput
-        caretHidden={true}
-        placeholder="caretHidden={true}"
-        style={
-          {
-            "fontSize": 16,
-          }
-        }
-        testID="textinput-carethidden"
-      />
-    </View>,
-]
+<View>
+  <Text>
+    CaretHidden
+  </Text>
+  <TextInput
+    caretHidden={true}
+    placeholder="caretHidden={true}"
+    style={
+      {
+        "fontSize": 16,
+      }
+    }
+    testID="textinput-carethidden"
+  />
+</View>
 `;
 
 exports[`snapshotAllPages TextInputs with key prop 1`] = `

--- a/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/snapshotPages.test.js.snap
@@ -74799,6 +74799,26 @@ exports[`snapshotAllPages TextInput 36`] = `
 ]
 `;
 
+exports[`snapshotAllPages TextInput 37`] = `
+[
+  <View>
+      <Text>
+        CaretHidden
+      </Text>
+      <TextInput
+        caretHidden={true}
+        placeholder="caretHidden={true}"
+        style={
+          {
+            "fontSize": 16,
+          }
+        }
+        testID="textinput-carethidden"
+      />
+    </View>,
+]
+`;
+
 exports[`snapshotAllPages TextInputs with key prop 1`] = `
 <View>
   <TextInput

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1043,7 +1043,6 @@ struct CompCaretVisual
     // TODO should make the caret use an invert brush by default
     m_compVisual.Brush(m_compositor.CreateColorBrush({255, 0, 0, 0} /* Black */));
     m_compVisual.Opacity(1.0f);
-    m_isVisible = true;
 
     // Blinking animation
     constexpr float ftCaretFadePct = 0.2385714285714f;
@@ -1095,7 +1094,7 @@ struct CompCaretVisual
   }
 
  private:
-  bool m_isVisible{false};
+  bool m_isVisible{true};
   typename TTypeRedirects::SpriteVisual m_compVisual;
   winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
   typename TTypeRedirects::ScalarKeyFrameAnimation m_opacityAnimation;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1043,6 +1043,7 @@ struct CompCaretVisual
     // TODO should make the caret use an invert brush by default
     m_compVisual.Brush(m_compositor.CreateColorBrush({255, 0, 0, 0} /* Black */));
     m_compVisual.Opacity(1.0f);
+    m_isVisible = true;
 
     // Blinking animation
     constexpr float ftCaretFadePct = 0.2385714285714f;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -161,7 +161,7 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
 
   //@cmember Show the caret
   BOOL TxShowCaret(BOOL fShow) override {
-    m_outer->m_props->caretHidden ? m_outer->ShowCaret(false) : m_outer->ShowCaret(fShow);
+    m_outer->ShowCaret(m_outer->m_props->caretHidden ? false : fShow);
     return true;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -161,7 +161,7 @@ struct CompTextHost : public winrt::implements<CompTextHost, ITextHost> {
 
   //@cmember Show the caret
   BOOL TxShowCaret(BOOL fShow) override {
-    m_outer->ShowCaret(fShow);
+    m_outer->m_props->caretHidden ? m_outer->ShowCaret(false) : m_outer->ShowCaret(fShow);
     return true;
   }
 


### PR DESCRIPTION
## Description
Adds caretHidden to Fabric's TextInput

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Component Parity with Paper

### What
Overrides RichEdit controlling the visibility of the caret visual if caretHidden is set to true.

## Screenshots
https://github.com/microsoft/react-native-windows/assets/42554868/085cfe07-1837-4f5e-8be2-3a64ba1811f1

## Testing
tested locally

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12430)