### PR TITLE
[Fabric] Add support for custom themes and support runtime theme change

### DIFF
--- a/change/react-native-windows-bd63c12c-5336-4f32-a5f0-2f1b5aed9420.json
+++ b/change/react-native-windows-bd63c12c-5336-4f32-a5f0-2f1b5aed9420.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add support for custom theme's, and support runtime theme change",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/HomeUIADump.test.ts.snap
@@ -4425,8 +4425,8 @@ exports[`Home UIA Tree Dump Components Tab 1`] = `
               },
               {
                 "Offset": [
-                  0,
-                  0,
+                  -0,
+                  -0,
                   0,
                 ],
                 "Opacity": 1,
@@ -4452,7 +4452,7 @@ exports[`Home UIA Tree Dump Components Tab 1`] = `
               {
                 "Offset": [
                   0,
-                  0,
+                  -0,
                   0,
                 ],
                 "Opacity": 1,

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -120,7 +120,7 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection (Impera
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -271,7 +271,7 @@ exports[`TextInput Tests Multi-line TextInputs can enable text selection 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -422,7 +422,7 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection (Imper
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -573,7 +573,7 @@ exports[`TextInput Tests Single-line TextInputs can enable text selection 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -724,7 +724,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Character
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -875,7 +875,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Sentences
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1026,7 +1026,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Turned Of
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1177,7 +1177,7 @@ exports[`TextInput Tests TextInputs can autocapitalize: Autocapitalize Words 1`]
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1328,7 +1328,7 @@ exports[`TextInput Tests TextInputs can autocomplete, address country 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1479,7 +1479,7 @@ exports[`TextInput Tests TextInputs can autocomplete, country 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1630,7 +1630,7 @@ exports[`TextInput Tests TextInputs can autocomplete, one-time-code 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1781,7 +1781,7 @@ exports[`TextInput Tests TextInputs can autocomplete, sms-otp 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1828,7 +1828,7 @@ exports[`TextInput Tests TextInputs can autogrow 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -1979,7 +1979,7 @@ exports[`TextInput Tests TextInputs can be editable 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2026,7 +2026,7 @@ exports[`TextInput Tests TextInputs can be multiline, bottomright alignment 1`] 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 255, 255)",
         },
         "Offset": [
           0,
@@ -2073,7 +2073,7 @@ exports[`TextInput Tests TextInputs can be multiline, center alignment 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2120,7 +2120,7 @@ exports[`TextInput Tests TextInputs can be multiline, topleft alignment 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2167,7 +2167,7 @@ exports[`TextInput Tests TextInputs can be set to not editable 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2318,7 +2318,7 @@ exports[`TextInput Tests TextInputs can be set to not editable 2 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2365,7 +2365,7 @@ exports[`TextInput Tests TextInputs can clear on submit 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2412,7 +2412,7 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2459,7 +2459,7 @@ exports[`TextInput Tests TextInputs can clear on submit with custom submit key e
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2506,7 +2506,7 @@ exports[`TextInput Tests TextInputs can customize its padding 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2553,7 +2553,7 @@ exports[`TextInput Tests TextInputs can enable spellcheck 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -2704,7 +2704,7 @@ exports[`TextInput Tests TextInputs can have a background color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3006,7 +3006,7 @@ exports[`TextInput Tests TextInputs can have a font family 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3157,7 +3157,7 @@ exports[`TextInput Tests TextInputs can have a font size 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3308,7 +3308,7 @@ exports[`TextInput Tests TextInputs can have a font style 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3459,7 +3459,7 @@ exports[`TextInput Tests TextInputs can have a font weight 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3610,7 +3610,7 @@ exports[`TextInput Tests TextInputs can have attributed text 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3657,7 +3657,7 @@ exports[`TextInput Tests TextInputs can have custom return key label, Compile 1`
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3704,7 +3704,7 @@ exports[`TextInput Tests TextInputs can have custom return key label, React Nati
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3751,7 +3751,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, done 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3798,7 +3798,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, go 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3845,7 +3845,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, next 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3892,7 +3892,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, none 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3939,7 +3939,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, previous 1`
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -3986,7 +3986,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, search 1`] 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4033,7 +4033,7 @@ exports[`TextInput Tests TextInputs can have custom return key type, send 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4080,7 +4080,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=-1
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4127,7 +4127,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=0 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4174,7 +4174,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=2 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4221,7 +4221,7 @@ exports[`TextInput Tests TextInputs can have customer letter spacing, spacing=9 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4456,7 +4456,7 @@ exports[`TextInput Tests TextInputs can have customized letter spacing 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4607,7 +4607,7 @@ exports[`TextInput Tests TextInputs can have customized line height 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4654,7 +4654,7 @@ exports[`TextInput Tests TextInputs can have inline images 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4701,7 +4701,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawable props not s
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4748,7 +4748,7 @@ exports[`TextInput Tests TextInputs can have inline images, drawableLeft and dra
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -4899,7 +4899,7 @@ exports[`TextInput Tests TextInputs can have text decoration lines 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5050,7 +5050,7 @@ exports[`TextInput Tests TextInputs can have text shadows 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5097,7 +5097,7 @@ exports[`TextInput Tests TextInputs can propagate events 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5144,7 +5144,7 @@ exports[`TextInput Tests TextInputs can register press events 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5295,7 +5295,7 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with C
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5446,7 +5446,7 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with N
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5597,7 +5597,7 @@ exports[`TextInput Tests TextInputs can rewrite characters: Replace Space with U
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5748,7 +5748,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to false 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5899,7 +5899,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5946,7 +5946,7 @@ exports[`TextInput Tests TextInputs can submit with custom key 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -5993,7 +5993,7 @@ exports[`TextInput Tests TextInputs have a custom background color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6040,7 +6040,7 @@ exports[`TextInput Tests TextInputs have a custom highlight color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6087,7 +6087,7 @@ exports[`TextInput Tests TextInputs have a custom placeholder text color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6134,7 +6134,7 @@ exports[`TextInput Tests TextInputs have a custom text color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 128, 0, 255)",
         },
         "Offset": [
           0,
@@ -6181,7 +6181,7 @@ exports[`TextInput Tests TextInputs have a custom underline color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6228,7 +6228,7 @@ exports[`TextInput Tests TextInputs have a default placeholder text color 1`] = 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6275,7 +6275,7 @@ exports[`TextInput Tests TextInputs have a default text color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6322,7 +6322,7 @@ exports[`TextInput Tests TextInputs have a default underline color 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6369,7 +6369,7 @@ exports[`TextInput Tests TextInputs support secure entry 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6416,7 +6416,7 @@ exports[`TextInput Tests TextInputs support secure entry, with placeholder text 
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(255, 0, 0, 255)",
         },
         "Offset": [
           0,
@@ -6463,7 +6463,7 @@ exports[`TextInput Tests TextInputs with set height and padding from theme 1`] =
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,
@@ -6614,7 +6614,7 @@ exports[`TextInput Tests Uncontrolled TextInput 1`] = `
       {
         "Brush": {
           "Brush Type": "ColorBrush",
-          "Color": "rgba(0, 0, 0, 255)",
+          "Color": "rgba(0, 0, 0, 228)",
         },
         "Offset": [
           0,

--- a/vnext/Microsoft.ReactNative/CompositionRootView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionRootView.idl
@@ -5,6 +5,7 @@ import "CompositionContext.idl";
 import "IJSValueWriter.idl";
 import "ReactCoreInjection.idl";
 import "ReactNativeHost.idl";
+import "Theme.idl";
 #include "NamespaceRedirect.h"
 #include "DocString.h"
 
@@ -79,6 +80,9 @@ namespace Microsoft.ReactNative
     Int64 SendMessage(UInt32 Msg, UInt64 WParam, Int64 LParam);
 
     Object GetUiaProvider();
+
+    DOC_STRING("Theme used for Platform colors within this RootView")
+    Microsoft.ReactNative.Composition.Theme Theme;
 
 #ifdef USE_WINUI3
     Microsoft.UI.Content.ContentIsland Island { get; };

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -69,8 +69,8 @@ struct IComponentView {
   virtual RootComponentView *rootComponentView() noexcept = 0;
   virtual void parent(IComponentView *parent) noexcept = 0;
   virtual IComponentView *parent() const noexcept = 0;
-  virtual void theme(const std::shared_ptr<Composition::Theme> &theme) noexcept = 0;
-  virtual std::shared_ptr<Composition::Theme> &theme() const noexcept = 0;
+  virtual void theme(winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme) noexcept = 0;
+  virtual winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme() const noexcept = 0;
   virtual void onThemeChanged() noexcept = 0;
   virtual const std::vector<IComponentView *> &children() const noexcept = 0;
   // Run fn on all children of this node until fn returns true

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -133,6 +133,7 @@ winrt::Microsoft::ReactNative::Composition::IVisual ActivityIndicatorComponentVi
 
 void ActivityIndicatorComponentView::onThemeChanged() noexcept {
   updateProgressColor(std::static_pointer_cast<const facebook::react::ActivityIndicatorViewProps>(m_props)->color);
+  Super::onThemeChanged();
 }
 
 bool ActivityIndicatorComponentView::focusable() const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -233,6 +233,11 @@ struct CompDrawingSurfaceBrush : public winrt::implements<
   }
 
   HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, POINT *offset) noexcept {
+#ifdef DEBUG
+    // Drawing to a zero sized surface is a waste of time
+    auto size = m_drawingSurfaceInterop.as<typename TTypeRedirects::CompositionDrawingSurface>().Size();
+    assert(size.Width != 0 && size.Height != 0);
+#endif
     return m_drawingSurfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), (void **)deviceContextOut, offset);
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -64,6 +64,9 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   float ScaleFactor() noexcept;
   void ScaleFactor(float value) noexcept;
 
+  winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
+  void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;
+
   winrt::Windows::Foundation::Size Measure(winrt::Windows::Foundation::Size const &availableSize) const;
   winrt::Windows::Foundation::Size Arrange(winrt::Windows::Foundation::Size finalSize) const;
 
@@ -114,6 +117,10 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   winrt::Microsoft::ReactNative::ReactViewOptions m_reactViewOptions;
   std::shared_ptr<::Microsoft::ReactNative::CompositionEventHandler> m_CompositionEventHandler;
   winrt::Microsoft::ReactNative::Composition::IVisual m_rootVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Theme m_theme{nullptr};
+  winrt::Microsoft::ReactNative::ReactNotificationSubscription m_themeChangedSubscription{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Theme::ThemeChanged_revoker m_themeChangedRevoker;
+
   void UpdateRootViewInternal() noexcept;
   void ClearLoadingUI() noexcept;
   void EnsureLoadingUI() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -53,6 +53,11 @@ float CompositionRootView::ScaleFactor() noexcept {
 
 void CompositionRootView::ScaleFactor(float) noexcept {}
 
+winrt::Microsoft::ReactNative::Composition::Theme CompositionRootView::Theme() noexcept {
+  return nullptr;
+}
+void CompositionRootView::Theme(const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {}
+
 winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -76,7 +76,8 @@ IComponentView *CompositionBaseComponentView::parent() const noexcept {
   return m_parent;
 }
 
-void CompositionBaseComponentView::theme(const std::shared_ptr<Composition::Theme> &value) noexcept {
+void CompositionBaseComponentView::theme(
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme *value) noexcept {
   if (m_theme != value) {
     for (auto it = m_children.begin(); it != m_children.end(); ++it) {
       (*it)->theme(value);
@@ -88,15 +89,21 @@ void CompositionBaseComponentView::theme(const std::shared_ptr<Composition::Them
 }
 
 void CompositionBaseComponentView::onThemeChanged() noexcept {
-  // TODO redraw borders / anything using theme
-}
-
-std::shared_ptr<Composition::Theme> &CompositionBaseComponentView::theme() const noexcept {
-  if (!m_theme) {
-    m_theme = Composition::Theme::FromContext(m_context);
+  if ((m_flags & CompositionComponentViewFeatures::NativeBorder) == CompositionComponentViewFeatures::NativeBorder) {
+    m_needsBorderUpdate = true;
+    finalizeBorderUpdates(m_layoutMetrics, *viewProps());
   }
 
-  return m_theme;
+  if ((m_flags & CompositionComponentViewFeatures::ShadowProps) == CompositionComponentViewFeatures::ShadowProps) {
+    applyShadowProps(*viewProps());
+  }
+}
+
+winrt::Microsoft::ReactNative::Composition::implementation::Theme *CompositionBaseComponentView::theme()
+    const noexcept {
+  return m_theme ? m_theme
+                 : winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(
+                       winrt::Microsoft::ReactNative::Composition::implementation::Theme::EmptyTheme());
 }
 
 bool CompositionBaseComponentView::runOnChildren(bool forward, Mso::Functor<bool(IComponentView &)> &fn) noexcept {
@@ -122,6 +129,9 @@ void CompositionBaseComponentView::updateProps(
 
   if ((m_flags & CompositionComponentViewFeatures::NativeBorder) == CompositionComponentViewFeatures::NativeBorder) {
     updateBorderProps(oldViewProps, newViewProps);
+  }
+  if ((m_flags & CompositionComponentViewFeatures::ShadowProps) == CompositionComponentViewFeatures::ShadowProps) {
+    updateShadowProps(oldViewProps, newViewProps);
   }
 }
 
@@ -580,7 +590,7 @@ struct AutoDrawHelper {
 
 template <typename TShape>
 void SetBorderLayerPropertiesCommon(
-    Composition::Theme &theme,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
     TShape &shape,
@@ -628,7 +638,7 @@ void SetBorderLayerPropertiesCommon(
     return;
 
   winrt::com_ptr<ID2D1SolidColorBrush> spBorderBrush;
-  pRT->CreateSolidColorBrush(theme.D2DColor(*borderColor), spBorderBrush.put());
+  pRT->CreateSolidColorBrush(theme->D2DColor(*borderColor), spBorderBrush.put());
   assert(spBorderBrush);
   if (spBorderBrush == nullptr)
     return;
@@ -670,7 +680,7 @@ void SetBorderLayerPropertiesCommon(
 
 template <typename TShape>
 void SetBorderLayerProperties(
-    Composition::Theme &theme,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
     TShape &shape,
@@ -704,7 +714,7 @@ void SetBorderLayerProperties(
       layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
       layer.Size({textureRect.right - textureRect.left, textureRect.bottom - textureRect.top});
 
-      layer.Brush(theme.Brush(*borderColor));
+      layer.Brush(theme->Brush(*borderColor));
 
       winrt::com_ptr<ID2D1Factory1> spD2dFactory;
       compContext.as<Composition::ICompositionContextInterop>()->D2DFactory(spD2dFactory.put());
@@ -736,7 +746,7 @@ const float Bottom = 1.0;
 
 template <typename TShape>
 void DrawAllBorderLayers(
-    Composition::Theme &theme,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
     winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     std::array<
         winrt::Microsoft::ReactNative::Composition::ISpriteVisual,
@@ -1042,7 +1052,7 @@ facebook::react::BorderMetrics resolveAndAlignBorderMetrics(
 }
 
 bool CompositionBaseComponentView::TryUpdateSpecialBorderLayers(
-    Composition::Theme &theme,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
     std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
     facebook::react::LayoutMetrics const &layoutMetrics,
     const facebook::react::ViewProps &viewProps) noexcept {
@@ -1147,14 +1157,14 @@ bool CompositionBaseComponentView::TryUpdateSpecialBorderLayers(
 void CompositionBaseComponentView::finalizeBorderUpdates(
     facebook::react::LayoutMetrics const &layoutMetrics,
     const facebook::react::ViewProps &viewProps) noexcept {
-  if (!m_needsBorderUpdate) {
+  if (!m_needsBorderUpdate || theme()->IsEmpty()) {
     return;
   }
 
   m_needsBorderUpdate = false;
   auto spBorderLayers = FindSpecialBorderLayers();
 
-  if (!TryUpdateSpecialBorderLayers(*theme(), spBorderLayers, layoutMetrics, viewProps)) {
+  if (!TryUpdateSpecialBorderLayers(theme(), spBorderLayers, layoutMetrics, viewProps)) {
     for (auto &spBorderLayer : spBorderLayers) {
       if (spBorderLayer) {
         spBorderLayer.as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>().Brush(nullptr);
@@ -1193,20 +1203,23 @@ void CompositionBaseComponentView::updateBorderProps(
 
 void CompositionBaseComponentView::updateShadowProps(
     const facebook::react::ViewProps &oldViewProps,
-    const facebook::react::ViewProps &newViewProps,
-    winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual) noexcept {
+    const facebook::react::ViewProps &newViewProps) noexcept {
   // Shadow Properties
   if (oldViewProps.shadowOffset != newViewProps.shadowOffset || oldViewProps.shadowColor != newViewProps.shadowColor ||
       oldViewProps.shadowOpacity != newViewProps.shadowOpacity ||
       oldViewProps.shadowRadius != newViewProps.shadowRadius) {
-    auto shadow = m_compContext.CreateDropShadow();
-    shadow.Offset({newViewProps.shadowOffset.width, newViewProps.shadowOffset.height, 0});
-    shadow.Opacity(newViewProps.shadowOpacity);
-    shadow.BlurRadius(newViewProps.shadowRadius);
-    if (newViewProps.shadowColor)
-      shadow.Color(theme()->Color(*newViewProps.shadowColor));
-    m_visual.Shadow(shadow);
+    applyShadowProps(newViewProps);
   }
+}
+
+void CompositionBaseComponentView::applyShadowProps(const facebook::react::ViewProps &viewProps) noexcept {
+  auto shadow = m_compContext.CreateDropShadow();
+  shadow.Offset({viewProps.shadowOffset.width, viewProps.shadowOffset.height, 0});
+  shadow.Opacity(viewProps.shadowOpacity);
+  shadow.BlurRadius(viewProps.shadowRadius);
+  if (viewProps.shadowColor)
+    shadow.Color(theme()->Color(*viewProps.shadowColor));
+  Visual().as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>().Shadow(shadow);
 }
 
 void CompositionBaseComponentView::updateTransformProps(
@@ -1507,11 +1520,20 @@ void CompositionViewComponentView::updateProps(
 
   // update BaseComponentView props
   updateAccessibilityProps(oldViewProps, newViewProps);
-  updateShadowProps(oldViewProps, newViewProps, m_visual);
   updateTransformProps(oldViewProps, newViewProps, m_visual);
   Super::updateProps(props, oldProps);
 
   m_props = std::static_pointer_cast<facebook::react::ViewProps const>(props);
+}
+
+void CompositionViewComponentView::onThemeChanged() noexcept {
+  if (m_props->backgroundColor) {
+    m_visual.Brush(theme()->Brush(*m_props->backgroundColor));
+  } else {
+    m_visual.Brush(nullptr);
+  }
+
+  Super::onThemeChanged();
 }
 
 facebook::react::Tag CompositionViewComponentView::hitTest(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -603,7 +603,7 @@ void SetBorderLayerPropertiesCommon(
     FLOAT strokeWidth,
     const facebook::react::SharedColor &borderColor,
     facebook::react::BorderStyle borderStyle) {
-  if ((textureRect.right - textureRect.left) <= 0 && (textureRect.bottom - textureRect.top) <= 0)
+  if ((textureRect.right - textureRect.left) <= 0 || (textureRect.bottom - textureRect.top) <= 0)
     return;
 
   auto surface = compContext.CreateDrawingSurfaceBrush(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -603,6 +603,8 @@ void SetBorderLayerPropertiesCommon(
     FLOAT strokeWidth,
     const facebook::react::SharedColor &borderColor,
     facebook::react::BorderStyle borderStyle) {
+  layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
+  layer.RelativeSizeWithOffset(size, relativeSizeAdjustment);
   if ((textureRect.right - textureRect.left) <= 0 || (textureRect.bottom - textureRect.top) <= 0)
     return;
 
@@ -613,8 +615,6 @@ void SetBorderLayerPropertiesCommon(
   surface.as(borderTexture);
 
   layer.Brush(surface);
-  layer.Offset({anchorOffset.x, anchorOffset.y, 0}, {anchorPoint.x, anchorPoint.y, 0});
-  layer.RelativeSizeWithOffset(size, relativeSizeAdjustment);
 
   AutoDrawHelper autoDraw(borderTexture);
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -18,6 +18,7 @@ struct CompContext;
 enum class CompositionComponentViewFeatures : std::uint_fast8_t {
   None = 0,
   NativeBorder = 1 << 0, // Standard border handling
+  ShadowProps = 1 << 1, // Apply shadow to visual
 
   Default = NativeBorder
 };
@@ -46,8 +47,8 @@ struct CompositionBaseComponentView : public IComponentView,
   IComponentView *parent() const noexcept override;
   facebook::react::Props::Shared props() noexcept override;
   virtual facebook::react::SharedViewProps viewProps() noexcept = 0;
-  void theme(const std::shared_ptr<Composition::Theme> &theme) noexcept override;
-  std::shared_ptr<Composition::Theme> &theme() const noexcept override;
+  void theme(winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme) noexcept override;
+  winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme() const noexcept override;
   void onThemeChanged() noexcept override;
   bool runOnChildren(bool forward, Mso::Functor<bool(IComponentView &)> &fn) noexcept override;
   void onFocusLost() noexcept override;
@@ -95,8 +96,8 @@ struct CompositionBaseComponentView : public IComponentView,
   void indexOffsetForBorder(uint32_t &index) const noexcept;
   void updateShadowProps(
       const facebook::react::ViewProps &oldViewProps,
-      const facebook::react::ViewProps &newViewProps,
-      winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual) noexcept;
+      const facebook::react::ViewProps &newViewProps) noexcept;
+  void applyShadowProps(const facebook::react::ViewProps &viewProps) noexcept;
   void updateTransformProps(
       const facebook::react::ViewProps &oldViewProps,
       const facebook::react::ViewProps &newViewProps,
@@ -149,7 +150,7 @@ struct CompositionBaseComponentView : public IComponentView,
       facebook::react::LayoutMetrics const &layoutMetrics,
       const facebook::react::ViewProps &viewProps) noexcept;
   bool TryUpdateSpecialBorderLayers(
-      Composition::Theme &theme,
+      winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
       std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
       facebook::react::LayoutMetrics const &layoutMetrics,
       const facebook::react::ViewProps &viewProps) noexcept;
@@ -158,7 +159,7 @@ struct CompositionBaseComponentView : public IComponentView,
   void UpdateCenterPropertySet() noexcept;
 
   CompositionComponentViewFeatures m_flags;
-  mutable std::shared_ptr<Composition::Theme> m_theme{nullptr};
+  mutable winrt::Microsoft::ReactNative::Composition::implementation::Theme *m_theme{nullptr};
   void showFocusVisual(bool show) noexcept;
   winrt::Microsoft::ReactNative::Composition::IFocusVisual m_focusVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::IVisual m_outerVisual{nullptr};
@@ -192,6 +193,7 @@ struct CompositionViewComponentView : public CompositionBaseComponentView {
   std::string DefaultControlType() const noexcept override;
 
   facebook::react::SharedViewProps viewProps() noexcept override;
+  void onThemeChanged() noexcept override;
 
   facebook::react::Tag hitTest(
       facebook::react::Point pt,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -110,7 +110,6 @@ void ImageComponentView::updateProps(
   ensureVisual();
 
   // update BaseComponentView props
-  updateShadowProps(oldImageProps, newImageProps, m_visual);
   updateTransformProps(oldImageProps, newImageProps, m_visual);
   Super::updateProps(props, oldProps);
 
@@ -191,10 +190,15 @@ void ImageComponentView::OnRenderingDeviceLost() noexcept {
   DrawImage();
 }
 
+bool ImageComponentView::themeEffectsImage() const noexcept {
+  return m_props->backgroundColor || isColorMeaningful(m_props->tintColor);
+}
+
 void ImageComponentView::onThemeChanged() noexcept {
-  if (m_props->backgroundColor || isColorMeaningful(m_props->tintColor)) {
+  if (themeEffectsImage()) {
     DrawImage();
   }
+  Super::onThemeChanged();
 }
 
 void ImageComponentView::ensureDrawingSurface() noexcept {
@@ -264,6 +268,14 @@ void ImageComponentView::DrawImage() noexcept {
   // to specify the entire surface, which nullptr is shorthand for (but, as it works out,
   // any time we make an update we touch the entire surface, so we always pass nullptr).
   POINT offset;
+
+  if (themeEffectsImage() && theme()->IsEmpty()) {
+    return;
+  }
+
+  if (!m_wicbmp) {
+    return;
+  }
 
   assert(m_context.UIDispatcher().HasThreadAccess());
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -82,6 +82,7 @@ struct ImageComponentView : CompositionBaseComponentView {
   void didReceiveFailureFromObserver() noexcept;
   void setStateAndResubscribeImageResponseObserver(
       facebook::react::ImageShadowNode::ConcreteState::Shared const &state) noexcept;
+  bool themeEffectsImage() const noexcept;
 
   std::shared_ptr<const facebook::react::ImageProps> m_props;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -61,7 +61,6 @@ void ParagraphComponentView::updateProps(
 
   // update BaseComponentView props
   updateAccessibilityProps(oldViewProps, newViewProps);
-  updateShadowProps(oldViewProps, newViewProps, m_visual);
   updateTransformProps(oldViewProps, newViewProps, m_visual);
   Super::updateProps(props, oldProps);
 
@@ -288,11 +287,12 @@ void ParagraphComponentView::updateVisualBrush() noexcept {
 
 void ParagraphComponentView::onThemeChanged() noexcept {
   DrawText();
+  Super::onThemeChanged();
 }
 
 // Renders the text into our composition surface
 void ParagraphComponentView::DrawText() noexcept {
-  if (!m_drawingSurface)
+  if (!m_drawingSurface || theme()->IsEmpty())
     return;
 
   if (m_layoutMetrics.frame.size.width == 0 || m_layoutMetrics.frame.size.height == 0) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -168,7 +168,6 @@ void ScrollViewComponentView::updateProps(
   }
 
   // update BaseComponentView props
-  updateShadowProps(oldViewProps, newViewProps, m_visual);
   updateTransformProps(oldViewProps, newViewProps, m_visual);
   Super::updateProps(props, oldProps);
 
@@ -263,6 +262,7 @@ void ScrollViewComponentView::OnPointerDown(const winrt::Windows::UI::Input::Poi
 
 void ScrollViewComponentView::onThemeChanged() noexcept {
   updateBackgroundColor(std::static_pointer_cast<const facebook::react::ScrollViewProps>(m_props)->backgroundColor);
+  Super::onThemeChanged();
 }
 
 void ScrollViewComponentView::onPointerWheelChanged(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -61,7 +61,6 @@ void SwitchComponentView::updateProps(
   }
 
   // update BaseComponentView props
-  updateShadowProps(oldViewProps, newViewProps, m_visual);
   updateTransformProps(oldViewProps, newViewProps, m_visual);
   Super::updateProps(props, oldProps);
   m_props = std::static_pointer_cast<facebook::react::ViewProps const>(props);
@@ -94,6 +93,10 @@ void SwitchComponentView::finalizeUpdates(RNComponentViewUpdateMask updateMask) 
 
 void SwitchComponentView::Draw() noexcept {
   POINT offset;
+
+  if (theme()->IsEmpty()) {
+    return;
+  }
 
   ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, &offset);
   if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
@@ -283,6 +286,7 @@ winrt::Microsoft::ReactNative::Composition::IVisual SwitchComponentView::Visual(
 
 void SwitchComponentView::onThemeChanged() noexcept {
   Draw();
+  Super::onThemeChanged();
 }
 
 void SwitchComponentView::onPointerPressed(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -903,7 +903,6 @@ void WindowsTextInputComponentView::updateProps(
     m_visual.Comment(winrt::to_hstring(newTextInputProps.testId));
   }
   // update BaseComponentView props
-  updateShadowProps(oldTextInputProps, newTextInputProps, m_visual);
   updateTransformProps(oldTextInputProps, newTextInputProps, m_visual);
   Super::updateProps(props, oldProps);
 
@@ -1319,7 +1318,7 @@ winrt::com_ptr<::IDWriteTextLayout> WindowsTextInputComponentView::CreatePlaceho
 
 void WindowsTextInputComponentView::DrawText() noexcept {
   m_needsRedraw = true;
-  if (m_cDrawBlock) {
+  if (m_cDrawBlock || theme()->IsEmpty()) {
     return;
   }
 
@@ -1457,6 +1456,7 @@ void WindowsTextInputComponentView::onThemeChanged() noexcept {
   auto props = std::static_pointer_cast<const facebook::react::WindowsTextInputProps>(m_props);
   updateCursorColor(props->cursorColor, props->textAttributes.foregroundColor);
   DrawText();
+  Super::onThemeChanged();
 }
 
 winrt::Microsoft::ReactNative::Composition::IVisual WindowsTextInputComponentView::Visual() const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
@@ -8,8 +8,7 @@
 
 #include "Composition.CustomResourceResult.g.h"
 #include <Fabric/Composition/CompositionUIService.h>
-#include <Modules/AppThemeModuleUwp.h>
-#include <Modules/AppearanceModule.h>
+#include <Utils/ThemeUtils.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 #include "ReactPropertyBag.h"
 #include "winrt/Microsoft.ReactNative.Composition.h"

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
@@ -5,24 +5,21 @@
 #pragma once
 
 #include "Theme.h"
-#include "winrt/Microsoft.ReactNative.Composition.h"
+
 #include "Composition.Theme.g.cpp"
+#include "winrt/Microsoft.ReactNative.Composition.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 Theme::Theme(
     const winrt::Microsoft::ReactNative::ReactContext &,
-    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept
-  {
-  }
+    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept {}
 
-
-void Theme::ClearCacheAndRaiseChangedEvent() noexcept {
-}
+void Theme::ClearCacheAndRaiseChangedEvent() noexcept {}
 
 Theme::Theme() noexcept {}
 
-bool Theme::TryGetPlatformColor(winrt::hstring , winrt::Windows::UI::Color &) noexcept {
+bool Theme::TryGetPlatformColor(winrt::hstring, winrt::Windows::UI::Color &) noexcept {
   return false;
 }
 
@@ -66,8 +63,7 @@ winrt::event_token Theme::ThemeChanged(
     winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable> const &) noexcept {
   return {};
 }
-void Theme::ThemeChanged(winrt::event_token const &) noexcept {
-}
+void Theme::ThemeChanged(winrt::event_token const &) noexcept {}
 
 winrt::Microsoft::ReactNative::Composition::Theme Theme::EmptyTheme() noexcept {
   return nullptr;
@@ -80,8 +76,7 @@ winrt::Microsoft::ReactNative::Composition::Theme Theme::EmptyTheme() noexcept {
 
 /*static*/ void Theme::SetDefaultTheme(
     const winrt::Microsoft::ReactNative::ReactInstanceSettings &,
-    const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {
-}
+    const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {}
 
 /*static*/ IReactPropertyName Theme::ThemeChangedEventName() noexcept {
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
@@ -1,0 +1,90 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Theme.h"
+#include "winrt/Microsoft.ReactNative.Composition.h"
+#include "Composition.Theme.g.cpp"
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+Theme::Theme(
+    const winrt::Microsoft::ReactNative::ReactContext &,
+    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept
+  {
+  }
+
+
+void Theme::ClearCacheAndRaiseChangedEvent() noexcept {
+}
+
+Theme::Theme() noexcept {}
+
+bool Theme::TryGetPlatformColor(winrt::hstring , winrt::Windows::UI::Color &) noexcept {
+  return false;
+}
+
+bool Theme::TryGetPlatformColor(const std::string &, winrt::Windows::UI::Color &) noexcept {
+  return false;
+}
+
+winrt::Windows::UI::Color Theme::Color(const facebook::react::Color &) noexcept {
+  return {};
+}
+
+winrt::Windows::UI::Color Theme::PlatformColor(const std::string &) noexcept {
+  return {};
+}
+
+winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(winrt::hstring) noexcept {
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(const std::string &) noexcept {
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::Composition::IBrush Theme::Brush(const facebook::react::Color &) noexcept {
+  return nullptr;
+}
+
+D2D1::ColorF Theme::D2DColor(const facebook::react::Color &) noexcept {
+  return D2D1::ColorF::Blue;
+}
+
+D2D1::ColorF Theme::D2DPlatformColor(const std::string &) noexcept {
+  return D2D1::ColorF::Blue;
+}
+
+bool Theme::IsEmpty() const noexcept {
+  return false;
+}
+
+winrt::event_token Theme::ThemeChanged(
+    winrt::Windows::Foundation::EventHandler<winrt::Windows::Foundation::IInspectable> const &) noexcept {
+  return {};
+}
+void Theme::ThemeChanged(winrt::event_token const &) noexcept {
+}
+
+winrt::Microsoft::ReactNative::Composition::Theme Theme::EmptyTheme() noexcept {
+  return nullptr;
+}
+
+/*static*/ winrt::Microsoft::ReactNative::Composition::Theme Theme::GetDefaultTheme(
+    const winrt::Microsoft::ReactNative::IReactContext &) noexcept {
+  return nullptr;
+}
+
+/*static*/ void Theme::SetDefaultTheme(
+    const winrt::Microsoft::ReactNative::ReactInstanceSettings &,
+    const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {
+}
+
+/*static*/ IReactPropertyName Theme::ThemeChangedEventName() noexcept {
+  return nullptr;
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -53,7 +53,12 @@ FabricUIManager::FabricUIManager() {
   facebook::react::CoreFeatures::enablePropIteratorSetter = true;
 }
 
-FabricUIManager::~FabricUIManager() {}
+FabricUIManager::~FabricUIManager() {
+  // Make sure that we destroy UI components on UI thread.
+  if (!m_context.UIDispatcher().HasThreadAccess()) {
+    m_context.UIDispatcher().Post([registry = std::move(m_registry)]() {});
+  }
+}
 
 void FabricUIManager::installFabricUIManager() noexcept {
   std::shared_ptr<const facebook::react::ReactNativeConfig> config =

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -8,6 +8,7 @@
 #include <Fabric/ComponentView.h>
 #include <Fabric/Composition/CompositionUIService.h>
 #include <Fabric/Composition/CompositionViewComponentView.h>
+#include <Fabric/Composition/RootComponentView.h>
 #include <Fabric/FabricUIManagerModule.h>
 #include <Fabric/ReactNativeConfigProperties.h>
 #include <Fabric/WindowsComponentDescriptorRegistry.h>
@@ -139,9 +140,12 @@ void FabricUIManager::startSurface(
     const folly::dynamic &initialProps) noexcept {
   m_surfaceRegistry.insert({surfaceId, {rootView.RootVisual(), rootView}});
 
-  m_context.UIDispatcher().Post([self = shared_from_this(), surfaceId]() {
+  m_context.UIDispatcher().Post([self = shared_from_this(), surfaceId, rootView]() {
     auto &rootComponentViewDescriptor = self->m_registry.dequeueComponentViewWithComponentHandle(
         facebook::react::RootShadowNode::Handle(), surfaceId, self->m_compContext);
+
+    static_cast<RootComponentView &>(*rootComponentViewDescriptor.view)
+        .theme(winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(rootView.Theme()));
 
     self->m_surfaceRegistry.at(surfaceId).rootVisual.InsertAt(
         static_cast<const CompositionBaseComponentView &>(*rootComponentViewDescriptor.view).OuterVisual(), 0);

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.cpp
@@ -9,11 +9,11 @@
 #include <IReactContext.h>
 #include <ReactPropertyBag.h>
 #include <Utils/Helpers.h>
+#include <Utils/ThemeUtils.h>
 #include <Utils/ValueUtils.h>
 #include <XamlUIService.h>
 #include <XamlUtils.h>
 #include <cxxreact/CxxModule.h>
-#include <winuser.h>
 #include <functional>
 #include <memory>
 #if _MSC_VER <= 1913
@@ -121,24 +121,6 @@ void AppTheme::Initialize(React::ReactContext const &reactContext) noexcept {
 ReactNativeSpecs::AppThemeSpec_AppThemeData AppTheme::GetConstants() noexcept {
   winrt::Microsoft::ReactNative::ReactPropertyBag pb{m_context.Properties()};
   return (*pb.Get(AppThemeHolderPropertyId()))->GetConstants();
-}
-
-bool IsInHighContrastWin32() noexcept {
-  BOOL fResult;
-  HIGHCONTRAST info;
-
-  fResult = SystemParametersInfo(
-      SPI_GETHIGHCONTRAST, // Get contrast information
-      0, // Not used
-      &info, // Holds contrast information
-      0); // Not used
-
-  // Double it.
-  if (fResult) {
-    return !!(info.dwFlags & HCF_HIGHCONTRASTON);
-  }
-
-  return false;
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
@@ -52,4 +52,6 @@ struct AppTheme : public std::enable_shared_from_this<AppTheme> {
   winrt::Microsoft::ReactNative::ReactContext m_context;
 };
 
+bool IsInHighContrastWin32() noexcept;
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppThemeModuleUwp.h
@@ -52,6 +52,4 @@ struct AppTheme : public std::enable_shared_from_this<AppTheme> {
   winrt::Microsoft::ReactNative::ReactContext m_context;
 };
 
-bool IsInHighContrastWin32() noexcept;
-
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.cpp
@@ -3,6 +3,7 @@
 
 #include "pch.h"
 #include "AppearanceModule.h"
+#include <Utils/ThemeUtils.h>
 #include <XamlUtils.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 
@@ -39,10 +40,6 @@ void Appearance::Initialize(winrt::Microsoft::ReactNative::ReactContext const &r
           });
         }
       });
-}
-
-bool IsColorLight(const winrt::Windows::UI::Color &clr) noexcept {
-  return (((5 * clr.G) + (2 * clr.R) + clr.B) > (8 * 128));
 }
 
 ApplicationTheme CurrentThemeFromUISettings(const winrt::Windows::UI::ViewManagement::UISettings &uiSettings) {

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -46,4 +46,6 @@ struct Appearance : std::enable_shared_from_this<Appearance> {
   UISettings::ColorValuesChanged_revoker m_revoker;
 };
 
+bool IsColorLight(const winrt::Windows::UI::Color &clr) noexcept;
+
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/AppearanceModule.h
@@ -46,6 +46,4 @@ struct Appearance : std::enable_shared_from_this<Appearance> {
   UISettings::ColorValuesChanged_revoker m_revoker;
 };
 
-bool IsColorLight(const winrt::Windows::UI::Color &clr) noexcept;
-
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Theme.idl
+++ b/vnext/Microsoft.ReactNative/Theme.idl
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DocString.h"
+import "CompositionSwitcher.idl";
+import "IReactContext.idl";
+import "IReactPropertyBag.idl";
+import "ReactInstanceSettings.idl";
+
+namespace Microsoft.ReactNative.Composition
+{
+  [experimental]
+  [webhosthidden]
+  enum ResourceType {
+    DOC_STRING("Resource type for a @Windows.UI.Color")
+    Color
+  };
+
+  [webhosthidden]
+  [experimental]
+  runtimeclass CustomResourceResult {
+    Object Resource;
+    DOC_STRING("The value of this resource should resolve to the value of another ResourceId")
+    String AlternateResourceId;
+  };
+
+  [webhosthidden]
+  [experimental]
+  DOC_STRING("Applications can implement this interface to provide custom values for native platform colors.")
+  interface ICustomResourceLoader {
+    DOC_STRING("Called when a theme is queried for a specific resource. "
+    "resourceId will be the name of the platform color. "
+    "Implementations should return an empty result if the resource is not being overridden.")
+    void GetResource(String resourceId, ResourceType resourceType, CustomResourceResult result);
+
+    DOC_STRING("Implementations should raise this event if the platform colors will return new values")
+    event Windows.Foundation.EventHandler<Object> ResourcesChanged;
+  };
+
+  [webhosthidden]
+  [experimental]
+  runtimeclass Theme {
+    Theme(Microsoft.ReactNative.IReactContext reactContext, ICustomResourceLoader resourceLoader);
+
+    Microsoft.ReactNative.Composition.IBrush PlatformBrush(String platformColor);
+    Boolean TryGetPlatformColor(String platformColor, out Windows.UI.Color color);
+    DOC_STRING("An empty theme is used when the final theme is not yet known.  It will generally return transparent colors.")
+    Boolean IsEmpty { get; };
+
+    event Windows.Foundation.EventHandler<Object> ThemeChanged;
+
+    static Theme GetDefaultTheme(Microsoft.ReactNative.IReactContext context);
+    static void SetDefaultTheme(Microsoft.ReactNative.ReactInstanceSettings settings, Theme theme);
+    static Microsoft.ReactNative.IReactPropertyName ThemeChangedEventName { get; };
+  };
+
+} // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ThemeUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ThemeUtils.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <Utils/ThemeUtils.h>
+
+#include <winuser.h>
+
+namespace Microsoft::ReactNative {
+
+bool IsColorLight(const winrt::Windows::UI::Color &clr) noexcept {
+  return (((5 * clr.G) + (2 * clr.R) + clr.B) > (8 * 128));
+}
+
+bool IsInHighContrastWin32() noexcept {
+  BOOL fResult;
+  HIGHCONTRAST info;
+
+  fResult = SystemParametersInfo(
+      SPI_GETHIGHCONTRAST, // Get contrast information
+      0, // Not used
+      &info, // Holds contrast information
+      0); // Not used
+
+  // Double it.
+  if (fResult) {
+    return !!(info.dwFlags & HCF_HIGHCONTRASTON);
+  }
+
+  return false;
+}
+
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ThemeUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ThemeUtils.cpp
@@ -30,5 +30,4 @@ bool IsInHighContrastWin32() noexcept {
   return false;
 }
 
-
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/ThemeUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/ThemeUtils.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <winrt/Windows.UI.h>
+
+namespace Microsoft::ReactNative {
+
+bool IsColorLight(const winrt::Windows::UI::Color &clr) noexcept;
+bool IsInHighContrastWin32() noexcept;
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -125,6 +125,7 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\Theme.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UiaHelpers.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
@@ -570,6 +571,7 @@
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactCompositionViewComponentBuilder.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
   </ItemGroup>
   <ItemGroup>

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -127,6 +127,11 @@
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\Theme_emptyimpl.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UiaHelpers.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -439,6 +439,7 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\TurboModulesProvider.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\Helpers.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ImageUtils.cpp" />
+    <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ThemeUtils.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Views\DevMenu.cpp" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeScheduler.cpp" DisableSpecificWarnings="4715;%(DisableSpecificWarnings)" />
     <ClCompile Include="$(ReactNativeDir)\ReactCommon\react\renderer\runtimescheduler\RuntimeSchedulerBinding.cpp" />


### PR DESCRIPTION
## Description
Adds a Theme runtimeclass and ability to provide custom colors.
Adds a Theme property to CompositionRootView to provide native colors for that root view.
Fixes Appearance module to provide theming information without Xaml.
Adds values to built-in theme for dark and high contrast themes.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12474)