### PR TITLE
[0.70] Enable the `/PROFILE` linker flag for all C++ release binaries

### DIFF
--- a/change/react-native-windows-31a36a4a-d57a-4bc4-a0f4-e84d0ec76158.json
+++ b/change/react-native-windows-31a36a4a-d57a-4bc4-a0f4-e84d0ec76158.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.70] Enable `/PROFILE` linker flag for vulcan compatibility",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/Release.props
+++ b/vnext/PropertySheets/Release.props
@@ -21,6 +21,7 @@
 
     <Link>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <Profile>true</Profile>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
This PR backports #12313 to 0.70.

## Description

This PR enables the `/PROFILE` linker flag so binaries are [vulcan ready](https://eng.ms/docs/products/apiscan/howto/preparinginput/binaries/creating_vulcan_ready_files), and will therefore pass internal compliance requirements.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To pass APIScan.

### What
Added `<Link><Profile>true</Profile><Link>` to `Release.props`.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: yes

Enabled the `/PROFILE` linker flag for all C++ release binaries
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12495)