### PR TITLE
Desktop fabric build should build against winappsdk

### DIFF
--- a/.ado/templates/enable-fabric-experimental-feature.yml
+++ b/.ado/templates/enable-fabric-experimental-feature.yml
@@ -5,7 +5,7 @@ steps:
       $nsm.AddNamespace('ns', $experimentalFeatures.DocumentElement.NamespaceURI)
 
       $xmlNode = $experimentalFeatures.CreateElement("PropertyGroup");
-      $xmlNode.InnerXml = "<UseFabric>true</UseFabric>"
+      $xmlNode.InnerXml = "<UseFabric>true</UseFabric><UseWinUI3>true</UseWinUI3>"
 
       $experimentalFeatures.DocumentElement.AppendChild($xmlNode);
 


### PR DESCRIPTION
Currently the react-native-win32 fabric dll is built without support for WinAppSDK composition. 

This change will only affect the win32 dll.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12498)