### PR TITLE
Updated jsinspector include path to match upstream

### DIFF
--- a/change/react-native-windows-dd260bf4-bb75-4fd2-bacc-08b5bef80b28.json
+++ b/change/react-native-windows-dd260bf4-bb75-4fd2-bacc-08b5bef80b28.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updated path to match upstream fork",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/ReactCommon/ReactCommon.vcxproj
+++ b/vnext/ReactCommon/ReactCommon.vcxproj
@@ -106,7 +106,7 @@
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\cxxreact\SystraceSection.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSIExecutor.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsiexecutor\jsireact\JSINativeModules.h" />
-    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsinspector\InspectorInterfaces.h" />
+    <ClInclude Include="$(ReactNativeDir)\ReactCommon\jsinspector-modern\InspectorInterfaces.h" />
     <ClInclude Include="$(ReactNativeDir)\ReactCommon\logger\react_native_log.h" />
     <ClInclude Include="$(YogaDir)\yoga\YGEnums.h" />
     <ClInclude Include="$(YogaDir)\yoga\YGMacros.h" />


### PR DESCRIPTION
## Description
When trying to run the init command to create a Fabric app version of Gallery, I was getting a build error regarding the path of the InspectorInterfaces.cpp file in ReactCommon upstream. There was a PR upstream which changed the name of the jsinspector directory here: https://github.com/facebook/react-native/pull/39288.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### What
Changed path in Include tag in ReactCommon.vcxproj file.

## Changelog
Should this change be included in the release notes: no