### PR TITLE
Promote 0.72 to legacy

### DIFF
--- a/change/@office-iss-react-native-win32-9be91a2d-db10-4f5b-8cf6-70f220bef704.json
+++ b/change/@office-iss-react-native-win32-9be91a2d-db10-4f5b-8cf6-70f220bef704.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-28734a9c-b9e7-45cf-8242-21d33915b1df.json
+++ b/change/@react-native-windows-cli-28734a9c-b9e7-45cf-8242-21d33915b1df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/cli",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-60eef339-adb2-43fb-bb92-29282bc0242e.json
+++ b/change/@react-native-windows-codegen-60eef339-adb2-43fb-bb92-29282bc0242e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/codegen",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-9dd0547c-f5f7-4c8d-b53e-f621edd7f803.json
+++ b/change/@react-native-windows-find-repo-root-9dd0547c-f5f7-4c8d-b53e-f621edd7f803.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-d5ce7d96-66f4-4255-9f74-3a407bda080c.json
+++ b/change/@react-native-windows-fs-d5ce7d96-66f4-4255-9f74-3a407bda080c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/fs",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-cd0de561-e384-463e-bd6e-d1a2411001cc.json
+++ b/change/@react-native-windows-package-utils-cd0de561-e384-463e-bd6e-d1a2411001cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-a95d5dfc-01f7-4b11-ae12-bffd0612a734.json
+++ b/change/@react-native-windows-telemetry-a95d5dfc-01f7-4b11-ae12-bffd0612a734.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-18cd368f-513e-4451-8689-6cecf8043bea.json
+++ b/change/react-native-windows-18cd368f-513e-4451-8689-6cecf8043bea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Promote 0.72 to legacy",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -92,7 +92,7 @@
     "react-native": "^0.72.6"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -74,7 +74,7 @@
     "powershell"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -57,7 +57,7 @@
     "src"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -32,7 +32,7 @@
     "typescript": "^4.9.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -36,7 +36,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -34,7 +34,7 @@
     "typescript": "^4.9.5"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -50,7 +50,7 @@
     "lib-commonjs"
   ],
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -90,7 +90,7 @@
     "react-native": "^0.72.6"
   },
   "beachball": {
-    "defaultNpmTag": "latest",
+    "defaultNpmTag": "v0.72-stable",
     "disallowedChangeTypes": [
       "major",
       "minor",


### PR DESCRIPTION
## Description
Promote 0.72 to legacy so we can promote 0.73 to latest
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12503)