### PR TITLE
[Fabric] Remove DeviceInfo stub from template and test app

### DIFF
--- a/change/react-native-windows-1bf9ea6f-118d-4e08-98fb-6d8b9213ba67.json
+++ b/change/react-native-windows-1bf9ea6f-118d-4e08-98fb-6d8b9213ba67.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Remove DeviceInfo stub from template and test app",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -16,35 +16,7 @@
 #include <winrt/Windows.Foundation.h>
 #include "winrt/AutomationChannel.h"
 
-// Work around crash in DeviceInfo when running outside of XAML environment
-// TODO rework built-in DeviceInfo to allow it to be driven without use of HWNDs or XamlApps
-// Issue Tracking #11414
-#include "../../../../vnext/codegen/NativeDeviceInfoSpec.g.h"
-REACT_MODULE(DeviceInfo)
-struct DeviceInfo {
-  using ModuleSpec = Microsoft::ReactNativeSpecs::DeviceInfoSpec;
-
-  REACT_INIT(Initialize)
-  void Initialize(React::ReactContext const &reactContext) noexcept {
-    m_context = reactContext;
-  }
-
-  REACT_GET_CONSTANTS(GetConstants)
-  Microsoft::ReactNativeSpecs::DeviceInfoSpec_DeviceInfoConstants GetConstants() noexcept {
-    Microsoft::ReactNativeSpecs::DeviceInfoSpec_DeviceInfoConstants constants;
-    Microsoft::ReactNativeSpecs::DeviceInfoSpec_DisplayMetrics screenDisplayMetrics;
-    screenDisplayMetrics.fontScale = 1;
-    screenDisplayMetrics.height = 1024;
-    screenDisplayMetrics.width = 1024;
-    screenDisplayMetrics.scale = 1;
-    constants.Dimensions.screen = screenDisplayMetrics;
-    constants.Dimensions.window = screenDisplayMetrics;
-    return constants;
-  }
-
- private:
-  winrt::Microsoft::ReactNative::ReactContext m_context;
-};
+#include <NativeModules.h>
 
 struct RNTesterAppReactPackageProvider
     : winrt::implements<RNTesterAppReactPackageProvider, winrt::Microsoft::ReactNative::IReactPackageProvider> {

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -12,8 +12,6 @@
 
 #include <winrt/Windows.Foundation.Collections.h>
 
-#include "../../../../vnext/codegen/NativeDeviceInfoSpec.g.h"
-
 #include <DispatcherQueue.h>
 #include <UIAutomation.h>
 #include <windows.ui.composition.interop.h>

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
@@ -4,8 +4,6 @@
 #include "pch.h"
 #include "{{ name }}.h"
 
-#include "../../node_modules/react-native-windows/codegen/NativeDeviceInfoSpec.g.h"
-
 #include <DispatcherQueue.h>
 #include <UIAutomation.h>
 
@@ -16,35 +14,6 @@
 #include "ReactPropertyBag.h"
 
 constexpr size_t MAX_LOADSTRING = 100;
-
-// Work around crash in DeviceInfo when running outside of XAML environment
-// TODO rework built-in DeviceInfo to allow it to be driven without use of HWNDs or XamlApps
-// Issue Tracking #11414
-REACT_MODULE(DeviceInfo)
-struct DeviceInfo {
-  using ModuleSpec = Microsoft::ReactNativeSpecs::DeviceInfoSpec;
-
-  REACT_INIT(Initialize)
-  void Initialize(React::ReactContext const &reactContext) noexcept {
-    m_context = reactContext;
-  }
-
-  REACT_GET_CONSTANTS(GetConstants)
-  Microsoft::ReactNativeSpecs::DeviceInfoSpec_DeviceInfoConstants GetConstants() noexcept {
-    Microsoft::ReactNativeSpecs::DeviceInfoSpec_DeviceInfoConstants constants;
-    Microsoft::ReactNativeSpecs::DeviceInfoSpec_DisplayMetrics screenDisplayMetrics;
-    screenDisplayMetrics.fontScale = 1;
-    screenDisplayMetrics.height = 1024;
-    screenDisplayMetrics.width = 1024;
-    screenDisplayMetrics.scale = 1;
-    constants.Dimensions.screen = screenDisplayMetrics;
-    constants.Dimensions.window = screenDisplayMetrics;
-    return constants;
-  }
-
- private:
-  winrt::Microsoft::ReactNative::ReactContext m_context;
-};
 
 // Have to use TurboModules to override built in modules.. so the standard attributed package provider doesn't work.
 struct CompReactPackageProvider


### PR DESCRIPTION
## Description

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
DeviceInfo for Fabric was added by #12450 so we can remove the stubs used in the template and test app.

Resolves #12502 

## Changelog
Should this change be included in the release notes: no