### PR TITLE
Use HTTP form data as JSArray

### DIFF
--- a/change/react-native-windows-16ae9eea-0f37-40b2-91da-33069ca74dd5.json
+++ b/change/react-native-windows-16ae9eea-0f37-40b2-91da-33069ca74dd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use form data as JSArray",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTHttpResource.cpp
+++ b/vnext/Shared/Networking/WinRTHttpResource.cpp
@@ -202,29 +202,27 @@ IAsyncOperation<HttpRequestMessage> WinRTHttpResource::CreateRequest(
       content = HttpStreamContent{std::move(stream)};
     } else if (data.find("formData") != data.cend()) {
       winrt::Windows::Web::Http::HttpMultipartFormDataContent multiPartContent;
-      auto &formData = data["formData"].AsObject();
+      auto &formData = data["formData"].AsArray();
 
       // #6046 -  Overwriting WinRT's HttpMultipartFormDataContent implicit Content-Type clears the generated boundary
       contentType = nullptr;
 
       for (auto &formDataPart : formData) {
         IHttpContent formContent{nullptr};
-        auto &itr = formDataPart.second["string"];
-        if (!formDataPart.second["string"].IsNull()) {
-          formContent = HttpStringContent{to_hstring(formDataPart.second["string"].AsString())};
-        } else if (!formDataPart.second["uri"].IsNull()) {
-          auto filePath = to_hstring(formDataPart.second["uri"].AsString());
+        auto &formDataPartObj = formDataPart.AsObject();
+        if (!formDataPartObj["string"].IsNull()) {
+          formContent = HttpStringContent{to_hstring(formDataPartObj["string"].AsString())};
+        } else if (!formDataPartObj["uri"].IsNull()) {
+          auto filePath = to_hstring(formDataPartObj["uri"].AsString());
           auto file = co_await StorageFile::GetFileFromPathAsync(filePath);
           auto stream = co_await file.OpenReadAsync();
           formContent = HttpStreamContent{stream};
         }
-
         if (formContent) {
-          AttachMultipartHeaders(formContent, formDataPart.second["headers"].AsObject());
-          multiPartContent.Add(formContent, to_hstring(formDataPart.second["fieldName"].AsString()));
+          AttachMultipartHeaders(formContent, formDataPartObj["headers"].AsObject());
+          multiPartContent.Add(formContent, to_hstring(formDataPartObj["fieldName"].AsString()));
         }
       } // foreach form data part
-
       content = multiPartContent;
     }
   }


### PR DESCRIPTION
## Description
Use HTTP form data as array.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
After adopting the HTTP module spec from react-native\Libraries\Network\NativeNetworkingIOS.js, form data is now provided as a JSArray of JSObjects.

Resolves #12392

### What
Cast and handle request form data as `JSArray`.

## Testing
See https://github.com/jurocha-ms/Repro/tree/main/ReactNative/formupload

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12506)