### PR TITLE
Beachball Check should actually stop publish

### DIFF
--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -28,6 +28,12 @@ jobs:
 
       - script: npx lage build --scope @rnw-scripts/beachball-config --no-deps
         displayName: Build @rnw-scripts/beachball-config
+      
+      - pwsh: |
+          npx beachball check --verbose 2>&1 | Tee-Object -Variable beachballOutput
+          $beachballErrors = $beachballOutput | Where-Object { $_ -match "ERROR: *"}
+          $beachballErrors | ForEach { Write-Host "##vso[task.logissue type=warning]POSSIBLE $_" }
+        displayName: Warn for possible invalid change files
 
       - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
         - script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "##vso[task.logissue type=error]Run \"yarn change\" from root of repo to generate a change file."

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -13,6 +13,10 @@ parameters:
   displayName: Stop if latest commit is ***NO_CI***
   type: boolean
   default: true
+- name: performBeachballCheck
+  displayName: Perform Beachball Check (Disable when promoting)
+  type: boolean
+  default: true
 - name: AgentPool
   type: object
   default:
@@ -152,8 +156,11 @@ extends:
 
           - pwsh: |
               npx beachball check --verbose 2>&1 | Tee-Object -Variable beachballOutput
-              $beachballOutput | Where-Object { $_ -match "ERROR: *"} | ForEach { Write-Host "##vso[task.logissue type=error]$_" }
+              $beachballErrors = $beachballOutput | Where-Object { $_ -match "ERROR: *"}
+              $beachballErrors | ForEach { Write-Host "##vso[task.logissue type=error]$_" }
+              if ( $beachballErrors.Count -gt 0)  { throw "Beachball check found $($beachballErrors.Count) errors." }
             displayName: Beachball Check
+            condition: ${{ parameters.performBeachballCheck }}
 
           - script: npx beachball publish $(SkipNpmPublishArgs) $(SkipGitPushPublishArgs) --branch origin/$(Build.SourceBranchName) -n $(npmAuthToken) -yes --bump-deps --verbose --access public --message "applying package updates ***NO_CI***"
             displayName: Beachball Publish


### PR DESCRIPTION
## Description

This PR fixes the beachball check added in #12293 to actually stop the publish pipeline when errors are detected. Furthermore it adds a parameter to enable this check, default on, but which can be manually disabled when we're trying to promote a release branch (either from latest to legacy, preview to latest, etc).

This PR also adds a version of the check to the standard setup task that instead reports warnings when invalid change files are detected - hopefully this will improve our chances of catching these errors before getting to publish, without having to unduly block CI/PRs.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
In publishing 0.73 an (expected) error was detected as the `@office-iss\react-native-win32` package was being promoted. Any error should have caused the publish to bail early - but also highlighted that when we **want** to promote, we'll need a way to turn the check off.

### What
See above.

## Screenshots
N/A

## Testing
Verified by adding bad change files to this PR (now removed) to see that the check happens.

## Changelog
Should this change be included in the release notes: no

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12523)