### PR TITLE
Rename IReactPackageProvider for Playground-win32

### DIFF
--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj
@@ -119,8 +119,8 @@
     </ClInclude>
     <ClInclude Include="GridItemViewManager.h" />
     <ClInclude Include="GridViewManager.h" />
-    <ClInclude Include="ReactPackageProvider.h">
-      <DependentUpon>ReactPackageProvider.idl</DependentUpon>
+    <ClInclude Include="PlaygroundReactPackageProvider.h">
+      <DependentUpon>PlaygroundReactPackageProvider.idl</DependentUpon>
     </ClInclude>
     <ClInclude Include="pch.h" />
   </ItemGroup>
@@ -133,14 +133,14 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="ReactPackageProvider.cpp">
-      <DependentUpon>ReactPackageProvider.idl</DependentUpon>
+    <ClCompile Include="PlaygroundReactPackageProvider.cpp">
+      <DependentUpon>PlaygroundReactPackageProvider.idl</DependentUpon>
     </ClCompile>
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Midl Include="GridItemView.idl" />
-    <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="PlaygroundReactPackageProvider.idl" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundNativeModules.vcxproj.filters
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Midl Include="ReactPackageProvider.idl" />
+    <Midl Include="PlaygroundReactPackageProvider.idl" />
     <Midl Include="GridItemView.idl" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
-    <ClCompile Include="ReactPackageProvider.cpp" />
+    <ClCompile Include="PlaygroundReactPackageProvider.cpp" />
     <ClCompile Include="GridItemViewManager.cpp" />
     <ClCompile Include="GridViewManager.cpp" />
     <ClCompile Include="GridItemView.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
-    <ClInclude Include="ReactPackageProvider.h" />
+    <ClInclude Include="PlaygroundReactPackageProvider.h" />
     <ClInclude Include="GridItemViewManager.h" />
     <ClInclude Include="GridViewManager.h" />
     <ClInclude Include="GridItemView.h" />

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.cpp
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
-#include "ReactPackageProvider.h"
-#if __has_include("ReactPackageProvider.g.cpp")
-#include "ReactPackageProvider.g.cpp"
+#include "PlaygroundReactPackageProvider.h"
+#if __has_include("PlaygroundReactPackageProvider.g.cpp")
+#include "PlaygroundReactPackageProvider.g.cpp"
 #endif
 #include "GridItemViewManager.h"
 #include "GridViewManager.h"
@@ -10,7 +10,7 @@ using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::PlaygroundNativeModules::implementation {
 
-void ReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
+void PlaygroundReactPackageProvider::CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept {
   packageBuilder.AddViewManager(L"GridViewManager", []() { return winrt::make<GridViewManager>(); });
   packageBuilder.AddViewManager(L"GridItemViewManager", []() { return winrt::make<GridItemViewManager>(); });
 }

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.h
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.h
@@ -1,11 +1,11 @@
 #pragma once
-#include "ReactPackageProvider.g.h"
+#include "PlaygroundReactPackageProvider.g.h"
 
 using namespace winrt::Microsoft::ReactNative;
 
 namespace winrt::PlaygroundNativeModules::implementation {
-struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider> {
-  ReactPackageProvider() = default;
+struct PlaygroundReactPackageProvider : PlaygroundReactPackageProviderT<PlaygroundReactPackageProvider> {
+  PlaygroundReactPackageProvider() = default;
 
   void CreatePackage(IReactPackageBuilder const &packageBuilder) noexcept;
 };
@@ -13,6 +13,8 @@ struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider> {
 
 namespace winrt::PlaygroundNativeModules::factory_implementation {
 
-struct ReactPackageProvider : ReactPackageProviderT<ReactPackageProvider, implementation::ReactPackageProvider> {};
+struct PlaygroundReactPackageProvider
+    : PlaygroundReactPackageProviderT<PlaygroundReactPackageProvider, implementation::PlaygroundReactPackageProvider> {
+};
 
 } // namespace winrt::PlaygroundNativeModules::factory_implementation

--- a/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.idl
+++ b/packages/playground/windows/PlaygroundNativeModules/PlaygroundReactPackageProvider.idl
@@ -1,0 +1,9 @@
+namespace PlaygroundNativeModules
+{
+    [webhosthidden]
+    [default_interface]
+    runtimeclass PlaygroundReactPackageProvider : Microsoft.ReactNative.IReactPackageProvider
+    {
+        PlaygroundReactPackageProvider();
+    };
+} // namespace PlaygroundNativeModules

--- a/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.idl
+++ b/packages/playground/windows/PlaygroundNativeModules/ReactPackageProvider.idl
@@ -1,9 +1,0 @@
-namespace PlaygroundNativeModules
-{
-    [webhosthidden]
-    [default_interface]
-    runtimeclass ReactPackageProvider : Microsoft.ReactNative.IReactPackageProvider
-    {
-        ReactPackageProvider();
-    };
-} // namespace PlaygroundNativeModules

--- a/packages/playground/windows/playground-win32/Playground-Win32.cpp
+++ b/packages/playground/windows/playground-win32/Playground-Win32.cpp
@@ -15,6 +15,7 @@
 #include <winrt/Microsoft.Toolkit.Win32.UI.XamlHost.h>
 #include <winrt/Microsoft.UI.Xaml.Controls.h>
 #include <winrt/Microsoft.UI.Xaml.XamlTypeInfo.h>
+#include <winrt/PlaygroundNativeModules.h>
 
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
@@ -112,6 +113,7 @@ struct WindowData {
 
           auto host = Host();
           RegisterAutolinkedNativeModulePackages(host.PackageProviders()); // Includes any autolinked modules
+          host.PackageProviders().Append(winrt::PlaygroundNativeModules::PlaygroundReactPackageProvider());
 
           host.InstanceSettings().JavaScriptBundleFile(m_bundleFile);
 

--- a/packages/playground/windows/playground-win32/Playground-win32.vcxproj
+++ b/packages/playground/windows/playground-win32/Playground-win32.vcxproj
@@ -167,6 +167,11 @@
     <Import Project="$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets" Condition="Exists('$(ReactNativeWindowsDir)\PropertySheets\External\Microsoft.ReactNative.Uwp.CppApp.targets')" />
   </ImportGroup>
   <ItemGroup>
+    <ProjectReference Include="$(ProjectDir)..\PlaygroundNativeModules\PlaygroundNativeModules.vcxproj">
+      <Project>{fbc281f9-e7fa-4d3f-9a15-f7507a803007}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="boost" Version="1.76.0.0" />
     <PackageReference Include="Microsoft.Toolkit.Win32.UI.XamlApplication" Version="6.1.3" />
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.2-rc" />


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We build react-native-windows Playground-win32 with buck, which errors when two headers have the exact same name without being nested in namespace sub-folder.

### What
This ensures the header name (ReactPackageProvider.g.h) does not conflict with header names from @react-native-picker/picker.

## Testing
Playground-win32 still compiles, and the nativeLayout example works again.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12534)