### PR TITLE
Switch ImageUtils.cpp to use co_return

### DIFF
--- a/change/react-native-windows-eef41231-d0eb-44a9-ac0d-d3905027d8bb.json
+++ b/change/react-native-windows-eef41231-d0eb-44a9-ac0d-d3905027d8bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Switch ImageUtils.cpp to use co_return",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -60,7 +60,7 @@ winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImag
       }
 
       winrt::Windows::Storage::Streams::IRandomAccessStreamWithContentType stream{openReadAsync.GetResults()};
-      return stream;
+      co_return stream;
     }
 
     auto httpMethod{


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In this async method in ImageUtils, we should be using co_return. It appears MSVC is a bit more forgiving than clang on this front.

### What
Changes return to co_return in async method.

## Testing
GitHub CI should tell us if this is okay.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12572)