### PR TITLE
Normalizes headers for clang builds

### DIFF
--- a/change/react-native-windows-309d1be9-0f85-43eb-9c74-12f0cc98b258.json
+++ b/change/react-native-windows-309d1be9-0f85-43eb-9c74-12f0cc98b258.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Normalizes headers for clang builds",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
+++ b/vnext/Microsoft.ReactNative.Cxx/Microsoft.ReactNative.Cxx.vcxitems
@@ -8,6 +8,8 @@
     <ReactNativeDir Condition="'$(ReactNativeDir)' == '' AND Exists('$(MSBuildThisFileDirectory)..\..\..\node_modules\react-native\package.json')">$(MSBuildThisFileDirectory)..\..\..\node_modules\react-native</ReactNativeDir>
     <JSI_SourcePath Condition="'$(JSI_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\jsi</JSI_SourcePath>
     <JSI_SourcePath Condition="'$(JSI_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)jsi\jsi.h')">$(MSBuildThisFileDirectory)</JSI_SourcePath>
+    <JSIExecutor_SourcePath Condition="'$(JSIExecutor_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\jsiexecutor</JSIExecutor_SourcePath>
+    <JSIExecutor_SourcePath Condition="'$(JSIExecutor_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)jsireact\JSIExecutor.h')">$(MSBuildThisFileDirectory)</JSIExecutor_SourcePath>
     <CallInvoker_SourcePath Condition="'$(CallInvoker_SourcePath)' == '' AND '$(ReactNativeDir)' != ''">$(ReactNativeDir)\ReactCommon\callinvoker</CallInvoker_SourcePath>
     <CallInvoker_SourcePath Condition="'$(CallInvoker_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\CallInvoker.h')">$(MSBuildThisFileDirectory)</CallInvoker_SourcePath>
     <CallInvoker_SourcePath Condition="'$(CallInvoker_SourcePath)' == '' AND Exists('$(MSBuildThisFileDirectory)ReactCommon\SchedulerPriority.h')">$(MSBuildThisFileDirectory)</CallInvoker_SourcePath>
@@ -29,6 +31,7 @@
       <AdditionalIncludeDirectories>
         $(MSBuildThisFileDirectory);
         $(JSI_SourcePath);
+        $(JSIExecutor_SourcePath);
         $(CallInvoker_SourcePath);
         $(TurboModule_SourcePath);
         $(Bridging_SourcePath);

--- a/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/ImageViewManagerModule.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "codegen/NativeImageLoaderIOSSpec.g.h"
-#include <NativeImageLoaderIOSSpec.g.h>
 #include <NativeModules.h>
 #include <winrt/Windows.ApplicationModel.h>
 #include <winrt/Windows.Foundation.h>

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -11,6 +11,7 @@
 #include <Views/ViewManager.h>
 #include <XamlUtils.h>
 #include <cxxreact/SystraceSection.h>
+#include <glog/logging.h>
 #include "ShadowNodeBase.h"
 #include "Unicode.h"
 #include "XamlUIService.h"

--- a/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/MsoReactContext.cpp
@@ -3,7 +3,7 @@
 
 #include "MsoReactContext.h"
 #include <winrt/Microsoft.ReactNative.h>
-#include "Microsoft.ReactNative/IReactNotificationService.h"
+#include "IReactNotificationService.h"
 #include "MsoUtils.h"
 #include "ReactInstanceWin.h"
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -16,7 +16,7 @@
 #endif
 #include "ReactErrorProvider.h"
 
-#include "Microsoft.ReactNative/IReactNotificationService.h"
+#include "IReactNotificationService.h"
 #include "NativeModules.h"
 #include "NativeModulesProvider.h"
 #include "Unicode.h"

--- a/vnext/Shared/Modules/BlobModule.h
+++ b/vnext/Shared/Modules/BlobModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <NativeBlobModuleSpec.g.h>
+#include <codegen/NativeBlobModuleSpec.g.h>
 
 #include <Networking/IBlobResource.h>
 

--- a/vnext/Shared/Modules/FileReaderModule.h
+++ b/vnext/Shared/Modules/FileReaderModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <NativeFileReaderModuleSpec.g.h>
+#include <codegen/NativeFileReaderModuleSpec.g.h>
 
 #include <IFileReaderResource.h>
 #include <NativeModules.h>

--- a/vnext/Shared/Modules/HttpModule.h
+++ b/vnext/Shared/Modules/HttpModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <NativeNetworkingIOSSpec.g.h>
+#include <codegen/NativeNetworkingIOSSpec.g.h>
 #include <NativeModules.h>
 #include <Networking/IHttpResource.h>
 

--- a/vnext/Shared/Modules/WebSocketTurboModule.h
+++ b/vnext/Shared/Modules/WebSocketTurboModule.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <NativeWebSocketModuleSpec.g.h>
+#include <codegen/NativeWebSocketModuleSpec.g.h>
 #include <Modules/IWebSocketModuleProxy.h>
 #include <NativeModules.h>
 #include <Networking/IWebSocketResource.h>

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -13,7 +13,7 @@
 #include <folly/Bits.h>
 #include <folly/json.h>
 #include <jsi/jsi.h>
-#include <jsiexecutor/jsireact/JSIExecutor.h>
+#include <jsireact/JSIExecutor.h>
 #include <filesystem>
 #include "OInstance.h"
 #include "Unicode.h"


### PR DESCRIPTION
## Description

### Why
Normalizes a few react-native-windows #includes to simplify our clang builds. Specifically:

1. All includes of `vnext/codegen` module headers use `codegen/` header namespace.
2. `IReactNotificationService.h` should not use the `Microsoft.ReactNative` header namespace
3. `glog/logging.h` is needed to compile PaperUIManagerModule.h (the `CHECK` callsites)
4. Switch `jsiexecutor/jsireact/JSIExecutor.h` to `jsireact/JSIExecutor.h` to match upstream mobile RN header namespacing expectations.

## Testing
Built Playground locally, CI checks should cover most configurations

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12573)