### PR TITLE
[0.73] Lock to applicationinsights@2.7.3 to prevent using newer broken versions

### DIFF
--- a/change/@react-native-windows-telemetry-9788bf42-5c81-406e-ba8e-883e7a515d93.json
+++ b/change/@react-native-windows-telemetry-9788bf42-5c81-406e-ba8e-883e7a515d93.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.73] Lock to applicationinsights@2.7.3 to prevent using newer broken versions",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@react-native-windows/fs": "0.73.0",
     "@xmldom/xmldom": "^0.7.7",
-    "applicationinsights": "^2.3.1",
+    "applicationinsights": "2.7.3",
     "ci-info": "^3.2.0",
     "envinfo": "^7.8.1",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,7 +3989,7 @@ appdirsjs@^1.2.4:
   resolved "https://registry.yarnpkg.com/appdirsjs/-/appdirsjs-1.2.6.tgz#fccf9ee543315492867cacfcfd4a2b32257d30ac"
   integrity sha512-D8wJNkqMCeQs3kLasatELsddox/Xqkhp+J07iXGyL54fVN7oc+nmNfYzGuCs1IEP6uBw+TfpuO3JKwc+lECy4w==
 
-applicationinsights@^2.3.1:
+applicationinsights@2.7.3:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.7.3.tgz#8781454d29c0b14c9773f2e892b4cf5e7468ffa5"
   integrity sha512-JY8+kTEkjbA+kAVNWDtpfW2lqsrDALfDXuxOs74KLPu2y13fy/9WB52V4LfYVTVcW1/jYOXjTxNS2gPZIDh1iw==


### PR DESCRIPTION
## Description

When updating dependencies in main, (see #12575), we found that applicationinsights@2.9.2 breaks our CLI commands.

We aren't actually collecting telemetry so there's no problem with locking the version of this package in this branch for now.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To unblock calls to CLI commands by new projects.

### What
Lock to the current version used by this branch.

## Screenshots
N/A

## Testing
Ran yarn build locally, which calls `codegen-windows` internally.

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12586)