### PR TITLE
[Fabric] ScrollViewComponentView should report ContentOffset to its shadownode state

### DIFF
--- a/change/react-native-windows-cd43f7b4-f22b-4a94-a3fc-784d8abcd991.json
+++ b/change/react-native-windows-cd43f7b4-f22b-4a94-a3fc-784d8abcd991.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] ScrollViewComponentView should report ContentOffset to its shadownode state",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -177,10 +177,22 @@ void ScrollViewComponentView::updateProps(
 void ScrollViewComponentView::updateState(
     facebook::react::State::Shared const &state,
     facebook::react::State::Shared const &oldState) noexcept {
-  const auto &newState = *std::static_pointer_cast<facebook::react::ScrollViewShadowNode::ConcreteState const>(state);
-
-  m_contentSize = newState.getData().getContentSize();
+  m_state = std::static_pointer_cast<facebook::react::ScrollViewShadowNode::ConcreteState const>(state);
+  m_contentSize = m_state->getData().getContentSize();
   updateContentVisualSize();
+}
+
+void ScrollViewComponentView::updateStateWithContentOffset() noexcept {
+  if (!m_state) {
+    return;
+  }
+
+  m_state->updateState([contentOffset = m_scrollVisual.ScrollPosition()](
+                           const facebook::react::ScrollViewShadowNode::ConcreteState::Data &data) {
+    auto newData = data;
+    newData.contentOffset = {contentOffset.x, contentOffset.y};
+    return std::make_shared<facebook::react::ScrollViewShadowNode::ConcreteState::Data const>(newData);
+  });
 }
 
 void ScrollViewComponentView::updateLayoutMetrics(
@@ -524,6 +536,7 @@ void ScrollViewComponentView::ensureVisual() noexcept {
         [this](
             winrt::IInspectable const & /*sender*/,
             winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs const &args) {
+          updateStateWithContentOffset();
           auto eventEmitter = GetEventEmitter();
           if (eventEmitter) {
             facebook::react::ScrollViewMetrics scrollMetrics;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -11,6 +11,7 @@
 #pragma warning(push)
 #pragma warning(disable : 4305)
 #include <react/renderer/components/scrollview/ScrollViewProps.h>
+#include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
 #pragma warning(pop)
 #include <winrt/Windows.UI.Composition.interactions.h>
 
@@ -106,6 +107,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool scrollLeft(float delta, bool aniamte) noexcept;
   bool scrollRight(float delta, bool animate) noexcept;
   void updateBackgroundColor(const facebook::react::SharedColor &color) noexcept;
+  void updateStateWithContentOffset() noexcept;
 
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
@@ -120,6 +122,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   bool m_isHorizontal = false;
   bool m_changeViewAfterLoaded = false;
   bool m_dismissKeyboardOnDrag = false;
+  std::shared_ptr<facebook::react::ScrollViewShadowNode::ConcreteState const> m_state;
 
  private:
   bool shouldBeControl() const noexcept;


### PR DESCRIPTION
## Description
ScrollView should be reporting its current contentOffset to its ShadowNode so that various scroll properties and methods can work correctly on the JS side.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12588)