### PR TITLE
Fix license header in file overrides

### DIFF
--- a/change/@office-iss-react-native-win32-4978107b-1f1d-4c70-bc36-d4179876bcbf.json
+++ b/change/@office-iss-react-native-win32-4978107b-1f1d-4c70-bc36-d4179876bcbf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix license header in file overrides",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-6f011f27-f8c7-4f17-9014-8460dcce9596.json
+++ b/change/react-native-windows-6f011f27-f8c7-4f17-9014-8460dcce9596.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix license header in file overrides",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/@office-iss/react-native-win32-tester/NativeComponentExample/js/MyNativeView.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/@office-iss/react-native-win32-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Color/ColorGradientWin32Example.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Color/ColorGradientWin32Example.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Pressable/PressableExample.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples-win32/Pressable/PressableExample.win32.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32-tester/src/js/examples/PlatformColor/PlatformColorExample.win32.js
+++ b/packages/@office-iss/react-native-win32-tester/src/js/examples/PlatformColor/PlatformColorExample.win32.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypes.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypes.win32.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/StyleSheet/PlatformColorValueTypesWin32.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@react-native-windows/tester/NativeComponentExample/js/MyNativeView.js
+++ b/packages/@react-native-windows/tester/NativeComponentExample/js/MyNativeView.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/@react-native-windows/tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/@react-native-windows/tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/IntegrationTests/WebSocketBinaryTest.js
+++ b/vnext/src/IntegrationTests/WebSocketBinaryTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/IntegrationTests/WebSocketBlobTest.js
+++ b/vnext/src/IntegrationTests/WebSocketBlobTest.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/IntegrationTests/websocket_integration_test_server_binary.js
+++ b/vnext/src/IntegrationTests/websocket_integration_test_server_binary.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/IntegrationTests/websocket_integration_test_server_blob.js
+++ b/vnext/src/IntegrationTests/websocket_integration_test_server_blob.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/Libraries/Alert/NativeDialogManagerWindows.js
+++ b/vnext/src/Libraries/Alert/NativeDialogManagerWindows.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
+++ b/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
  * @flow
  * @format
  */

--- a/vnext/src/Libraries/StyleSheet/PlatformColorValueTypes.windows.js
+++ b/vnext/src/Libraries/StyleSheet/PlatformColorValueTypes.windows.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
### Why
 
The upstream license headers switched from:
```
Copyright (c) Facebook, Inc. and its affiliates.
```
To:
```
Copyright (c) Meta Platforms, Inc. and affiliates.
```

### What

This updates all the file overrides with the correct license header.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12596)