### PR TITLE
Modules in react-native use relative imports

### DIFF
--- a/change/react-native-windows-ca1e0f76-9b50-47ba-b876-2d9f66d25406.json
+++ b/change/react-native-windows-ca1e0f76-9b50-47ba-b876-2d9f66d25406.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Modules in react-native use relative imports",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/NewAppScreen/components/DebugInstructions.windows.js
+++ b/vnext/src/Libraries/NewAppScreen/components/DebugInstructions.windows.js
@@ -8,9 +8,11 @@
  * @format
  */
 
-import React from 'react';
 import type {Node} from 'react';
-import {StyleSheet, Text} from 'react-native';
+
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
+import React from 'react';
 
 const styles = StyleSheet.create({
   highlight: {

--- a/vnext/src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js
+++ b/vnext/src/Libraries/NewAppScreen/components/ReloadInstructions.windows.js
@@ -9,7 +9,9 @@
  */
 
 import type {Node} from 'react';
-import {StyleSheet, Text} from 'react-native';
+
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
 import React from 'react';
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Description

### Why
Rather than using absolute imports, modules in react-native use relative imports.

### What
This matches the imports (with the exception of the irrelevant Platform import) from the overridden files in react-native.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12598)