### PR TITLE
Adds license header to WindowTextInputNativeComponent.js

### DIFF
--- a/change/react-native-windows-b07dd120-1e76-45d5-89a2-dcaebbbaa5b9.json
+++ b/change/react-native-windows-b07dd120-1e76-45d5-89a2-dcaebbbaa5b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds license header to WindowTextInputNativeComponent.js",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
+++ b/vnext/src/Libraries/Components/TextInput/WindowsTextInputNativeComponent.js
@@ -1,4 +1,9 @@
 /**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
  * @flow
  * @format
  */


### PR DESCRIPTION
## Description

### Why
Just following the pattern for other files in this folder to add a license header. Likely an oversight that it wasn't added in the first place.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12600)