### PR TITLE
[0.72] Add checksum to ScriptStore cache

### DIFF
--- a/change/react-native-windows-c60ee71f-e2dd-4ae4-8f83-46c2acfa1183.json
+++ b/change/react-native-windows-c60ee71f-e2dd-4ae4-8f83-46c2acfa1183.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add checksum to ScriptStore cache",
+  "packageName": "react-native-windows",
+  "email": "tudor.mihai@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Desktop.UnitTests/ScriptStoreTests.cpp
+++ b/vnext/Desktop.UnitTests/ScriptStoreTests.cpp
@@ -65,7 +65,8 @@ TEST_CLASS (ScriptStoreIntegrationTest) {
     // Without memory mapping: about 6.11 MB (fileSize + app overhead)
     // With memory mapping: about 2.14 MB (view overhead + app overhead)
     // Expected working set size should be lower than the actual file size, provided it is larger than the app overhead
-    Assert::IsTrue(endWorkingSet - startWorkingSet < fileSize);
+    // plus 10% to account for memory used by hashing
+    Assert::IsTrue(endWorkingSet - startWorkingSet < fileSize * 1.1);
   }
 };
 } // namespace Microsoft::JSI::Test

--- a/vnext/Shared/Hasher.cpp
+++ b/vnext/Shared/Hasher.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+#include "Hasher.h"
+
+#ifndef NT_SUCCESS
+#define NT_SUCCESS(Status) ((NTSTATUS)(Status) >= 0)
+#endif // NT_SUCCESS
+
+#define CheckNTSuccess(s)      \
+  do {                         \
+    NTSTATUS status = (s);     \
+    if (!NT_SUCCESS(status)) { \
+      throw status;            \
+    }                          \
+  } while (false)
+
+namespace Microsoft::ReactNative {
+
+std::optional<std::vector<std::uint8_t>> GetSHA256Hash(const void *pb, size_t cb) {
+  try {
+    SHA256Hasher hasher;
+    hasher.HashData(pb, cb);
+    return hasher.GetHashValue();
+  } catch (...) {
+    return std::nullopt;
+  }
+}
+
+SHA256Hasher::SHA256Hasher() {
+  CheckNTSuccess(BCryptOpenAlgorithmProvider(&m_hAlg, BCRYPT_SHA256_ALGORITHM, NULL, 0));
+
+  DWORD cbObject;
+  DWORD cbData;
+  CheckNTSuccess(BCryptGetProperty(m_hAlg, BCRYPT_OBJECT_LENGTH, (PBYTE)&cbObject, sizeof(DWORD), &cbData, 0));
+
+  m_hashObject.resize(cbObject);
+  CheckNTSuccess(
+      BCryptCreateHash(m_hAlg, &m_hHash, m_hashObject.data(), static_cast<ULONG>(m_hashObject.size()), NULL, 0, 0));
+}
+
+SHA256Hasher::~SHA256Hasher() {
+  BCryptDestroyHash(m_hHash);
+  BCryptCloseAlgorithmProvider(m_hAlg, 0);
+}
+
+void SHA256Hasher::HashData(const void *pb, size_t cb) {
+  if (cb > LONG_MAX) {
+    // Input too large
+    throw E_INVALIDARG;
+  }
+
+  CheckNTSuccess(BCryptHashData(m_hHash, (PBYTE)pb, (DWORD)cb, 0));
+}
+
+std::vector<std::uint8_t> SHA256Hasher::GetHashValue() {
+  DWORD hashLength;
+  DWORD cbData;
+  CheckNTSuccess(BCryptGetProperty(m_hAlg, BCRYPT_HASH_LENGTH, (PBYTE)&hashLength, sizeof(DWORD), &cbData, 0));
+
+  std::vector<uint8_t> hashValue(hashLength, 0);
+  CheckNTSuccess(BCryptFinishHash(m_hHash, &hashValue[0], static_cast<ULONG>(hashValue.size()), 0));
+
+  return hashValue;
+}
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Hasher.h
+++ b/vnext/Shared/Hasher.h
@@ -1,0 +1,24 @@
+#include <bcrypt.h>
+#include <optional>
+#include <vector>
+
+namespace Microsoft::ReactNative {
+std::optional<std::vector<std::uint8_t>> GetSHA256Hash(const void *pb, size_t cb);
+
+class SHA256Hasher {
+ public:
+  SHA256Hasher();
+  ~SHA256Hasher();
+
+  SHA256Hasher(const SHA256Hasher &) = delete;
+  SHA256Hasher &operator=(const SHA256Hasher &) = delete;
+
+  std::vector<std::uint8_t> GetHashValue();
+  void HashData(const void *pb, size_t cb);
+
+ private:
+  BCRYPT_ALG_HANDLE m_hAlg;
+  BCRYPT_HASH_HANDLE m_hHash;
+  std::vector<std::uint8_t> m_hashObject;
+};
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -153,6 +153,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)DevSupportManager.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Executors\WebSocketJSExecutor.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Executors\WebSocketJSExecutorFactory.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Hasher.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)HermesRuntimeHolder.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)HermesSamplingProfiler.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)InspectorPackagerConnection.cpp" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -264,6 +264,7 @@
       <Filter>Hermes</Filter>
     </ClCompile>
     <ClCompile Include="$(NodeApiJsiDir)src\ApiLoaders\HermesApi.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Hasher.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JSI\V8RuntimeHolder.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SafeLoadLibrary.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)V8JSIRuntimeHolder.cpp" />


### PR DESCRIPTION
This backport the change from https://github.com/microsoft/react-native-windows/pull/11780 that already exists in main, 0.71 and 0.73.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
We're seeing some crashes that may be caused by corrupt script caches.

### What
Add a checksum to avoid loading a corrupt cache.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12615)