### PR TITLE
Update RNW Dependency Script Node.js and Windows SDK versions

### DIFF
--- a/change/react-native-windows-04c9d96c-59d9-47d2-8bb5-cff09ff7b8a4.json
+++ b/change/react-native-windows-04c9d96c-59d9-47d2-8bb5-cff09ff7b8a4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update RNW Dependency Script Node.js and Windows SDK versions",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -72,6 +72,11 @@ if (!($tagsToInclude.Contains('buildLab'))) {
     $vsComponents += 'Microsoft.VisualStudio.ComponentGroup.UWP.VC';
 }
 
+# Windows11SDK is only needed for the more experimental composition projects using newer WinAppSDK versions
+if ($tagsToInclude.Contains('rnwDev')) {
+    $vsComponents += 'Microsoft.VisualStudio.Component.Windows11SDK.22000';
+}
+
 $vsWorkloads = @('Microsoft.VisualStudio.Workload.ManagedDesktop',
     'Microsoft.VisualStudio.Workload.NativeDesktop',
     'Microsoft.VisualStudio.Workload.Universal');
@@ -435,7 +440,7 @@ $requirements = @(
         Name = 'Node.js (LTS, >= 18.0)';
         Tags = @('appDev');
         Valid = { CheckNode; }
-        Install = { WinGetInstall OpenJS.NodeJS.LTS };
+        Install = { WinGetInstall OpenJS.NodeJS.LTS "18.16.1" };
         HasVerboseOutput = $true;
     },
     @{
@@ -528,12 +533,18 @@ function EnsureWinGetForInstall {
 
 function WinGetInstall {
     param(
-        [string]$wingetPackage
+        [string]$wingetPackage,
+        [string]$packageVersion = "",
     )
 
     EnsureWinGetForInstall;
-    Write-Verbose "Executing `winget install `"$wingetPackage`"";
-    & winget install "$wingetPackage" --accept-source-agreements --accept-package-agreements
+    if ($packageVersion -ne "") {
+        Write-Verbose "Executing `winget install `"$wingetPackage`" --version `"$packageVersion`"";
+        & winget install "$wingetPackage" --version "$packageVersion" --accept-source-agreements --accept-package-agreements
+    } else {
+        Write-Verbose "Executing `winget install `"$wingetPackage`"";
+        & winget install "$wingetPackage" --accept-source-agreements --accept-package-agreements
+    }
  }
  
 function IsElevated {

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -534,7 +534,7 @@ function EnsureWinGetForInstall {
 function WinGetInstall {
     param(
         [string]$wingetPackage,
-        [string]$packageVersion = "",
+        [string]$packageVersion = ""
     )
 
     EnsureWinGetForInstall;


### PR DESCRIPTION
## Description

This PR updates the `rnw-dependencies.ps1` script as follows:

- For the `rnwDev` setup, ensures the Windows 11 22000 SDK is installed, as required for some of the new Fabric/Composition apps
- Since the Node LTS package on winget is already on Node 20, and we currently still use Node 18, change the installer to install the exact version we also use in CI, just to reduce new developers getting untested setups

Closes #12443

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
To help ensure devs had the a working setup.

### What
Added the correct SDK component and changed the WinGetInstall method to allow a specific version number.

## Screenshots
N/A

## Testing
Verified install works

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12621)