### PR TITLE
[Fabric] Add scrollbar show/hide logic

### DIFF
--- a/change/react-native-windows-b7c46047-47e0-4c3e-a5bc-0c331d63c024.json
+++ b/change/react-native-windows-b7c46047-47e0-4c3e-a5bc-0c331d63c024.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix minor high dpi issue with scrollbar",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -20,6 +20,14 @@ namespace Microsoft.ReactNative.Composition
     Visible,
     Hidden
   };
+  
+  enum AnimationClass
+  {
+    None = 0,
+    ScrollBar,
+    ScrollBarThumbHorizontal,
+    ScrollBarThumbVertical,
+  };
 
   [webhosthidden]
   [uuid("172def51-9e1a-4e3c-841a-e5a470065acc")] // uuid needed for empty interfaces
@@ -64,6 +72,7 @@ namespace Microsoft.ReactNative.Composition
     void RelativeSizeWithOffset(Windows.Foundation.Numerics.Vector2 size, Windows.Foundation.Numerics.Vector2 relativeSizeAdjustment);
     BackfaceVisibility BackfaceVisibility{ get; set; };
     String Comment { get; set; };
+    void AnimationClass(AnimationClass value);
   }
 
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
@@ -445,7 +445,7 @@ winrt::Windows::Foundation::Point PointerPoint::Position() noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     auto pos = m_sysPointerPoint.Position();
-    return {pos.X - m_offset.X, pos.Y - (m_offset.Y / m_scaleFactor)};
+    return {pos.X - (m_offset.X / m_scaleFactor), pos.Y - (m_offset.Y / m_scaleFactor)};
   }
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -260,18 +260,10 @@ void CompositionBaseComponentView::onCharacterReceived(
 }
 
 void CompositionBaseComponentView::onPointerEntered(
-    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  if (m_parent && !args.Handled()) {
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onPointerEntered(args);
-  }
-}
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs & /*args*/) noexcept {}
 
 void CompositionBaseComponentView::onPointerExited(
-    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
-  if (m_parent && !args.Handled()) {
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onPointerExited(args);
-  }
-}
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs & /*args*/) noexcept {}
 
 void CompositionBaseComponentView::onPointerPressed(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -397,10 +397,8 @@ struct ScrollBarComponent {
 
     winrt::com_ptr<IDWriteTextLayout> spTextLayout;
     winrt::check_hresult(::Microsoft::ReactNative::DWriteFactory()->CreateTextLayout(
-        m_vertical
-            ? ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDDB" : L"\uEDDC")
-            : ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDD9"
-                                                          : L"\uEDDA"),
+        m_vertical ? ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDDB" : L"\uEDDC")
+                   : ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDD9" : L"\uEDDA"),
         1, // The length of the string.
         spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
         (m_arrowSize / m_scaleFactor), // The width of the layout box.

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -53,6 +53,14 @@ struct ScrollBarComponent {
     m_rootVisual.InsertAt(m_arrowVisualLast, 2);
     m_rootVisual.InsertAt(m_thumbVisual, 3);
 
+    m_trackVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
+    m_arrowVisualFirst.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
+    m_arrowVisualLast.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
+    m_thumbVisual.AnimationClass(
+        vertical ? winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical
+                 : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
+
+    updateShy(true);
     onScaleChanged();
     OnThemeChanged();
   }
@@ -126,6 +134,7 @@ struct ScrollBarComponent {
   void onScaleChanged() noexcept {
     m_arrowSize = 12 * m_scaleFactor; // From Xaml resource: ScrollBarSize
     m_thumbWidth = 6 * m_scaleFactor; // From Xaml resource: ScrollBarThumbStrokeThickness
+    m_thumbShyWidth = 2 * m_scaleFactor;
     m_arrowMargin = 4 * m_scaleFactor; // From Xaml resource: ScrollBar(Vertical|Horizontal)(Increase|Decrease)Margin
     m_trackEdgeMargin = 1 * m_scaleFactor; // From Xaml resource: ScrollViewerScrollBarMargin
     m_trackMargin =
@@ -255,17 +264,21 @@ struct ScrollBarComponent {
     m_thumbPos = (scrollRange > 0 ? ::MulDiv(scrollOffset, maxThumbLength - thumbCorrection, scrollRange) : 0);
 
     auto thumbOffset = (m_arrowSize - m_thumbWidth) / 2.0f;
+    auto shyOffset = m_shy ? (m_thumbWidth - m_thumbShyWidth) : 0.0f;
+    auto thumbScale = m_shy ? (m_thumbShyWidth / m_thumbWidth) : 1.0f;
 
     if (m_vertical) {
       m_thumbVisual.Size({m_thumbWidth, static_cast<float>(m_thumbSize)});
       m_thumbVisual.Offset(
-          {-m_arrowSize + thumbOffset, m_arrowSize + m_arrowMargin + static_cast<float>(m_thumbPos), 0.0f},
+          {-m_arrowSize + thumbOffset + shyOffset, m_arrowSize + m_arrowMargin + static_cast<float>(m_thumbPos), 0.0f},
           {1.0f, 0.0f, 0.0f});
+      m_thumbVisual.Scale({thumbScale, 1.0f, 1.0f});
     } else {
       m_thumbVisual.Size({static_cast<float>(m_thumbSize), m_thumbWidth});
       m_thumbVisual.Offset(
-          {m_arrowSize + m_arrowMargin + static_cast<float>(m_thumbPos), -m_arrowSize + thumbOffset, 0.0f},
+          {m_arrowSize + m_arrowMargin + static_cast<float>(m_thumbPos), -m_arrowSize + thumbOffset + shyOffset, 0.0f},
           {0.0f, 1.0f, 0.0f});
+      m_thumbVisual.Scale({1.0f, thumbScale, 1.0f});
     }
   }
 
@@ -276,7 +289,7 @@ struct ScrollBarComponent {
   void OnPointerReleased(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
     if (!m_visible)
       return;
-    auto pt = args.GetCurrentPoint(-1);
+    auto pt = args.GetCurrentPoint(m_outer.Tag());
     if (m_nTrackInputOffset != -1 &&
         pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse &&
         pt.Properties().PointerUpdateKind() ==
@@ -284,6 +297,9 @@ struct ScrollBarComponent {
       handleMoveThumb(args);
       m_nTrackInputOffset = -1;
       // Stop tracking
+
+      auto reg = HitTest(pt.Position());
+      updateShy(reg == ScrollbarHitRegion::Unknown);
     }
   }
 
@@ -349,12 +365,36 @@ struct ScrollBarComponent {
     if (pt.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
       auto pos = pt.Position();
       auto reg = HitTest(pos);
+      updateShy(reg == ScrollbarHitRegion::Unknown && m_nTrackInputOffset == -1);
       setHighlightedRegion(reg);
 
       if (m_nTrackInputOffset != -1) {
         handleMoveThumb(args);
       }
     }
+  }
+
+  void OnPointerExited(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
+    if (!m_visible)
+      return;
+
+    // TODO once we start capturing pointer, we would't need to stop tracking here
+    m_nTrackInputOffset = -1;
+
+    updateShy(m_nTrackInputOffset == -1);
+  }
+
+  void updateShy(bool shy) {
+    if (shy == m_shy)
+      return;
+
+    m_shy = shy;
+
+    m_trackVisual.Opacity(m_shy ? 0.0f : 1.0f);
+    m_arrowVisualFirst.Opacity(m_shy ? 0.0f : 1.0f);
+    m_arrowVisualLast.Opacity(m_shy ? 0.0f : 1.0f);
+
+    updateThumb();
   }
 
   void setHighlightedRegion(ScrollbarHitRegion region) noexcept {
@@ -488,23 +528,20 @@ struct ScrollBarComponent {
     }
   }
 
-  void OnPointerExited(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
-    if (!m_visible)
-      return;
-  }
-
  private:
   winrt::Microsoft::ReactNative::Composition::ScrollViewComponentView m_outer;
   winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compContext;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
   const bool m_vertical;
   bool m_visible{false};
+  bool m_shy{false};
   int m_thumbSize{0};
   float m_arrowSize{0};
   float m_arrowMargin{0}; // margin on outside end of arrow buttons
   float m_trackEdgeMargin{0}; // margin between track and edge of component
   float m_trackMargin{0}; // margin of track background to ends of scrollbar
   float m_thumbWidth{0};
+  float m_thumbShyWidth{0};
   int m_minThumbSize{0};
   float m_scaleFactor{1};
   int m_thumbPos{0};
@@ -838,6 +875,13 @@ void ScrollViewComponentView::onPointerMoved(
   m_verticalScrollbarComponent->OnPointerMoved(args);
   m_horizontalScrollbarComponent->OnPointerMoved(args);
   Super::onPointerMoved(args);
+}
+
+void ScrollViewComponentView::onPointerExited(
+    const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
+  m_verticalScrollbarComponent->OnPointerExited(args);
+  m_horizontalScrollbarComponent->OnPointerExited(args);
+  Super::onPointerExited(args);
 }
 
 void ScrollViewComponentView::onKeyDown(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -113,13 +113,13 @@ struct ScrollBarComponent {
     if (m_vertical) {
       m_rootVisual.RelativeSizeWithOffset({m_arrowSize, 0.0f}, {0.0f, 1.0f});
       m_rootVisual.Offset({-(m_arrowSize + m_trackEdgeMargin), 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f});
-      m_arrowVisualFirst.Offset({-m_arrowSize, m_arrowMargin, 0.0f}, {1.0f, 0.0f, 0.0f});
-      m_arrowVisualLast.Offset({-m_arrowSize, -(m_arrowSize + m_arrowMargin), 0.0f}, {1.0f, 1.0f, 0.0f});
+      m_arrowVisualFirst.Offset({0.0f, m_arrowMargin, 0.0f});
+      m_arrowVisualLast.Offset({0.0f, -(m_arrowSize + m_arrowMargin), 0.0f}, {0.0f, 1.0f, 0.0f});
     } else {
       m_rootVisual.RelativeSizeWithOffset({0.0f, m_arrowSize}, {1.0f, 0.0f});
       m_rootVisual.Offset({0.0f, -(m_arrowSize + m_trackEdgeMargin), 0.0f}, {0.0f, 1.0f, 0.0f});
-      m_arrowVisualFirst.Offset({m_arrowMargin, -m_arrowSize, 0.0f}, {0.0f, 1.0f, 0.0f});
-      m_arrowVisualLast.Offset({-(m_arrowSize + m_arrowMargin), -m_arrowSize, 0.0f}, {1.0f, 1.0f, 0.0f});
+      m_arrowVisualFirst.Offset({m_arrowMargin, 0.0f, 0.0f});
+      m_arrowVisualLast.Offset({-(m_arrowSize + m_arrowMargin), 0.0f, 0.0f}, {1.0f, 0.0f, 0.0f});
     }
   }
 
@@ -400,11 +400,11 @@ struct ScrollBarComponent {
         m_vertical
             ? ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDDB" : L"\uEDDC")
             : ((region == ScrollbarHitRegion::ArrowFirst) ? L"\uEDD9"
-                                                          : L"\uEDDA"), // The string to be laid out and formatted.
+                                                          : L"\uEDDA"),
         1, // The length of the string.
         spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
-        m_arrowSize, // The width of the layout box.
-        m_arrowSize, // The height of the layout box.
+        (m_arrowSize / m_scaleFactor), // The width of the layout box.
+        (m_arrowSize / m_scaleFactor), // The height of the layout box.
         spTextLayout.put() // The IDWriteTextLayout interface pointer.
         ));
 
@@ -418,9 +418,6 @@ struct ScrollBarComponent {
         float oldDpiX, oldDpiY;
         d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
         d2dDeviceContext->SetDpi(dpi, dpi);
-
-        float offsetX = static_cast<float>(offset.x / m_scaleFactor);
-        float offsetY = static_cast<float>(offset.y / m_scaleFactor);
 
         // Create a solid color brush for the text. A more sophisticated application might want
         // to cache and reuse a brush across all text elements instead, taking care to recreate
@@ -440,7 +437,6 @@ struct ScrollBarComponent {
         }
         winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(color, brush.put()));
 
-        // if (!m_vertical)
         {
           DWRITE_TEXT_METRICS dtm{};
           winrt::check_hresult(spTextLayout->GetMetrics(&dtm));

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -92,6 +92,8 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerWheelChanged(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void onPointerExited(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
 
   void StartBringIntoView(winrt::Microsoft::ReactNative::implementation::BringIntoViewOptions &&args) noexcept override;
   virtual std::string DefaultControlType() const noexcept;


### PR DESCRIPTION
## Description
ScrollBars will now shrink down to touch indicators when not in use
Fix minor misalignment of scrollbar arrow buttons in high dpi.
Modified PointerEntered/PointerExited events to not bubble by default, aligning better with WinUI, and being easier to use.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12625)