### PR TITLE
Stub impl of DebuggingOverlay to remove errors when running react-devtools

### DIFF
--- a/change/react-native-windows-b1e4afda-403b-4f56-b137-a5aa845f06fc.json
+++ b/change/react-native-windows-b1e4afda-403b-4f56-b137-a5aa845f06fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Stub impl of DebuggingOverlay to remove errors when running react-devtools",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CoreUIManagers.cpp
+++ b/vnext/Microsoft.ReactNative/Base/CoreUIManagers.cpp
@@ -10,6 +10,7 @@
 // Standard View Managers
 #include <GlyphViewManager.h>
 #include <Views/ActivityIndicatorViewManager.h>
+#include <Views/DebuggingOverlayViewManager.h>
 #include <Views/FlyoutViewManager.h>
 #include <Views/Image/ImageViewManager.h>
 #include <Views/PopupViewManager.h>
@@ -32,6 +33,7 @@ void AddStandardViewManagers(
     std::vector<std::unique_ptr<Microsoft::ReactNative::IViewManager>> &viewManagers,
     const Mso::React::IReactContext &context) noexcept {
   viewManagers.push_back(std::make_unique<ActivityIndicatorViewManager>(context));
+  viewManagers.push_back(std::make_unique<DebuggingOverlayViewManager>(context));
   viewManagers.push_back(std::make_unique<FlyoutViewManager>(context));
   viewManagers.push_back(std::make_unique<ImageViewManager>(context));
   viewManagers.push_back(std::make_unique<UnimplementedViewManager>(context, L"RCTModalHostView"));

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -33,6 +33,12 @@ namespace Microsoft.ReactNative.Composition
   [default_interface]
   unsealed runtimeclass RootComponentView : ViewComponentView {
   };
+  
+  [experimental]
+  [webhosthidden]
+  [default_interface]
+  unsealed runtimeclass DebuggingOverlayComponentView : ViewComponentView {
+  };
 
   [experimental]
   [webhosthidden]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -14,6 +14,7 @@
 #include <Fabric/Composition/ActivityIndicatorComponentView.h>
 #include <Fabric/Composition/CompositionHelpers.h>
 #include <Fabric/Composition/CompositionViewComponentView.h>
+#include <Fabric/Composition/DebuggingOverlayComponentView.h>
 #include <Fabric/Composition/ImageComponentView.h>
 #include <Fabric/Composition/Modal/WindowsModalHostViewComponentView.h>
 #include <Fabric/Composition/Modal/WindowsModalHostViewShadowNode.h>
@@ -82,6 +83,9 @@ ComponentViewDescriptor const &ComponentViewRegistry::dequeueComponentViewWithCo
         compContext, tag, m_context);
   } else if (componentHandle == facebook::react::UnimplementedNativeViewShadowNode::Handle()) {
     view = winrt::Microsoft::ReactNative::Composition::implementation::UnimplementedNativeViewComponentView::Create(
+        compContext, tag, m_context);
+  } else if (componentHandle == facebook::react::DebuggingOverlayShadowNode::Handle()) {
+    view = winrt::Microsoft::ReactNative::Composition::implementation::DebuggingOverlayComponentView::Create(
         compContext, tag, m_context);
   } else {
     auto descriptor =

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -33,7 +33,7 @@ winrt::Microsoft::ReactNative::ComponentView DebuggingOverlayComponentView::Crea
 
 void DebuggingOverlayComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
   if (commandName == "draw") {
-    // The current spec has a Draw command -- but this will be replaced with some different commands in 
+    // The current spec has a Draw command -- but this will be replaced with some different commands in
     // https://github.com/facebook/react-native/pull/42119
     // There is little point in attempting to implement these commands until then.
     return;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -1,0 +1,45 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DebuggingOverlayComponentView.h"
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+DebuggingOverlayComponentView::DebuggingOverlayComponentView(
+    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    facebook::react::Tag tag,
+    winrt::Microsoft::ReactNative::ReactContext const &reactContext)
+    : base_type(compContext, tag, reactContext) {}
+
+void DebuggingOverlayComponentView::mountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+}
+
+void DebuggingOverlayComponentView::unmountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+}
+
+winrt::Microsoft::ReactNative::ComponentView DebuggingOverlayComponentView::Create(
+    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    facebook::react::Tag tag,
+    winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
+  return winrt::make<DebuggingOverlayComponentView>(compContext, tag, reactContext);
+}
+
+void DebuggingOverlayComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
+  if (commandName == "draw") {
+    // The current spec has a Draw command -- but this will be replaced with some different commands in 
+    // https://github.com/facebook/react-native/pull/42119
+    // There is little point in attempting to implement these commands until then.
+    return;
+  }
+
+  base_type::handleCommand(commandName, arg);
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
@@ -10,8 +10,8 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-struct DebuggingOverlayComponentView : DebuggingOverlayComponentViewT<DebuggingOverlayComponentView, CompositionViewComponentView> {
-
+struct DebuggingOverlayComponentView
+    : DebuggingOverlayComponentViewT<DebuggingOverlayComponentView, CompositionViewComponentView> {
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
@@ -1,0 +1,35 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "CompositionViewComponentView.h"
+
+#include "Composition.DebuggingOverlayComponentView.g.h"
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+struct DebuggingOverlayComponentView : DebuggingOverlayComponentViewT<DebuggingOverlayComponentView, CompositionViewComponentView> {
+
+  [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
+      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      facebook::react::Tag tag,
+      winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
+
+  void mountChildComponentView(
+      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+      uint32_t index) noexcept override;
+  void unmountChildComponentView(
+      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+      uint32_t index) noexcept override;
+
+  DebuggingOverlayComponentView(
+      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      facebook::react::Tag tag,
+      winrt::Microsoft::ReactNative::ReactContext const &reactContext);
+
+  void handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept override;
+};
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsComponentDescriptorRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsComponentDescriptorRegistry.cpp
@@ -35,6 +35,8 @@ WindowsComponentDescriptorRegistry::WindowsComponentDescriptorRegistry()
   m_componentDescriptorRegistry->add(facebook::react::concreteComponentDescriptorProvider<
                                      facebook::react::ActivityIndicatorViewComponentDescriptor>());
   m_componentDescriptorRegistry->add(
+      facebook::react::concreteComponentDescriptorProvider<facebook::react::DebuggingOverlayComponentDescriptor>());
+  m_componentDescriptorRegistry->add(
       facebook::react::concreteComponentDescriptorProvider<facebook::react::ImageComponentDescriptor>());
   m_componentDescriptorRegistry->add(
       facebook::react::concreteComponentDescriptorProvider<facebook::react::WindowsModalHostViewComponentDescriptor>());

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -493,6 +493,7 @@
     <ClCompile Include="Views\ActivityIndicatorViewManager.cpp" />
     <ClCompile Include="Views\ConfigureBundlerDlg.cpp" />
     <ClCompile Include="Views\ControlViewManager.cpp" />
+    <ClCompile Include="Views\DebuggingOverlayViewManager.cpp" />
     <ClCompile Include="Views\DynamicAutomationPeer.cpp" />
     <ClCompile Include="Views\DynamicAutomationProperties.cpp" />
     <ClCompile Include="Views\DynamicValueProvider.cpp" />

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
@@ -39,17 +39,16 @@ XamlView DebuggingOverlayViewManager::CreateViewCore(
 }
 
 void DebuggingOverlayViewManager::DispatchCommand(
-      const XamlView &viewToUpdate,
-      const std::string &commandId,
-      winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) {
-if (commandId == DebuggingOverlayCommands::Draw) {
-  // The current spec has a Draw command -- but this will be replaced with some different commands in 
-  // https://github.com/facebook/react-native/pull/42119
-  // There is little point in attempting to implement these commands until then.
-  return;
-}
+    const XamlView &viewToUpdate,
+    const std::string &commandId,
+    winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) {
+  if (commandId == DebuggingOverlayCommands::Draw) {
+    // The current spec has a Draw command -- but this will be replaced with some different commands in
+    // https://github.com/facebook/react-native/pull/42119
+    // There is little point in attempting to implement these commands until then.
+    return;
+  }
   Super::DispatchCommand(viewToUpdate, commandId, std::move(commandArgs));
 }
-
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include <UI.Xaml.Controls.h>
+
+#include <Views/DebuggingOverlayViewManager.h>
+
+#include <JSValueWriter.h>
+
+namespace Microsoft::ReactNative {
+
+namespace DebuggingOverlayCommands {
+constexpr const char *Draw = "draw";
+}; // namespace DebuggingOverlayCommands
+
+DebuggingOverlayViewManager::DebuggingOverlayViewManager(const Mso::React::IReactContext &context) : Super(context) {}
+
+const wchar_t *DebuggingOverlayViewManager::GetName() const {
+  return L"DebuggingOverlay";
+}
+
+void DebuggingOverlayViewManager::GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
+  Super::GetNativeProps(writer);
+}
+
+void DebuggingOverlayViewManager::GetCommands(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const {
+  // Upstream JS will dispatch the string directly instead of ever actually calling this, but providing a real
+  // implementation is simple enough in case anything changes.
+  writer.WritePropertyName(winrt::to_hstring(DebuggingOverlayCommands::Draw));
+  writer.WriteString(winrt::to_hstring(DebuggingOverlayCommands::Draw));
+}
+
+XamlView DebuggingOverlayViewManager::CreateViewCore(
+    int64_t /*tag*/,
+    const winrt::Microsoft::ReactNative::JSValueObject &) {
+  return xaml::Controls::Canvas();
+}
+
+void DebuggingOverlayViewManager::DispatchCommand(
+      const XamlView &viewToUpdate,
+      const std::string &commandId,
+      winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) {
+if (commandId == DebuggingOverlayCommands::Draw) {
+  // The current spec has a Draw command -- but this will be replaced with some different commands in 
+  // https://github.com/facebook/react-native/pull/42119
+  // There is little point in attempting to implement these commands until then.
+  return;
+}
+  Super::DispatchCommand(viewToUpdate, commandId, std::move(commandArgs));
+}
+
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.h
@@ -19,8 +19,8 @@ class REACTWINDOWS_EXPORT DebuggingOverlayViewManager : public FrameworkElementV
   void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   void GetCommands(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
   XamlView DebuggingOverlayViewManager::CreateViewCore(
-    int64_t /*tag*/,
-    const winrt::Microsoft::ReactNative::JSValueObject &) override;
+      int64_t /*tag*/,
+      const winrt::Microsoft::ReactNative::JSValueObject &) override;
   void DispatchCommand(
       const XamlView &viewToUpdate,
       const std::string &commandId,

--- a/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.h
+++ b/vnext/Microsoft.ReactNative/Views/DebuggingOverlayViewManager.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "FrameworkElementViewManager.h"
+
+namespace Microsoft::ReactNative {
+
+struct ShadowNodeBase;
+
+class REACTWINDOWS_EXPORT DebuggingOverlayViewManager : public FrameworkElementViewManager {
+  using Super = FrameworkElementViewManager;
+
+ public:
+  DebuggingOverlayViewManager(const Mso::React::IReactContext &context);
+
+  const wchar_t *GetName() const override;
+  void GetNativeProps(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
+  void GetCommands(const winrt::Microsoft::ReactNative::IJSValueWriter &writer) const override;
+  XamlView DebuggingOverlayViewManager::CreateViewCore(
+    int64_t /*tag*/,
+    const winrt::Microsoft::ReactNative::JSValueObject &) override;
+  void DispatchCommand(
+      const XamlView &viewToUpdate,
+      const std::string &commandId,
+      winrt::Microsoft::ReactNative::JSValueArray &&commandArgs) override;
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -90,6 +90,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\DebuggingOverlayComponentView.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\ImageComponentView.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>


### PR DESCRIPTION
Currently if you run react-devtools you'll get errors due to missing implementation of DebuggingOverlay.

The actual implementation of DebuggingOverlay is rapidly changing, so I'm going to leave it as a stub until it has settled a little upstream.  This change at least makes react-devtools work without erroring now.