### PR TITLE
[0.72] Changed logic for setting collapsed property to true

### DIFF
--- a/change/react-native-windows-20feaf3b-ebde-4326-83d1-dc39007bfebf.json
+++ b/change/react-native-windows-20feaf3b-ebde-4326-83d1-dc39007bfebf.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "backport change",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -493,7 +493,7 @@ bool FrameworkElementViewManager::UpdateProperty(
             states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Expanded)] =
                 !innerValue.IsNull() && innerValue.AsBoolean();
             states[static_cast<int32_t>(winrt::Microsoft::ReactNative::AccessibilityStates::Collapsed)] =
-                innerValue.IsNull() || !innerValue.AsBoolean();
+                innerValue.IsNull() ? false : !innerValue.AsBoolean();
 
             const auto prevExpandedState = DynamicAutomationProperties::GetAccessibilityStateExpanded(element);
 


### PR DESCRIPTION
Backporting #11756 into 0.72. Potential fix for #12629. 

## Description
Changed logic in FrameworkElementViewManager for setting 'collapsed' accessibility state so that collapsed is not set to true by default when expanded is false.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves [#11734]

### What
Checks to see if the expanded property is null i.e not set by the component. If so, sets collapsed to false instead of defaulting to true when expanded is false. If property is not null, then performs check and sets collapsed property based on value.

Tested locally on RNTester Button page in playground. Seems to be performing as desired there - Narrator no longer making 'collapsed' announcement on buttons and UIA tree reflects this with the ExpandCollapsed property being of LeafNode instead of collapsed. Tested on Buttons and Touchable components in the APIs/Accessibility section in RNTester, and they performed as expected with respect to accessibilityState and the 'expanded' prop, and removed announcement of 'collapsed' on buttons.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoft/react-native-windows/pull/11756)
 ###### Microsoft Reviewers: codeflow:open?pullrequest=https://github.com/microsoft/react-native-windows/pull/11787&drop=dogfoodAlpha
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12630)