### PR TITLE
[Fabric] Update switch visuals to newer fluent visuals

### DIFF
--- a/change/react-native-windows-f7d7e7a7-210b-4402-b595-5ef83e238f3f.json
+++ b/change/react-native-windows-f7d7e7a7-210b-4402-b595-5ef83e238f3f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Update switch visuals to newer fluent visuals",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -27,6 +27,7 @@ namespace Microsoft.ReactNative.Composition
     ScrollBar,
     ScrollBarThumbHorizontal,
     ScrollBarThumbVertical,
+    SwitchThumb,
   };
 
   [webhosthidden]
@@ -89,6 +90,8 @@ namespace Microsoft.ReactNative.Composition
   {
     void Brush(IBrush brush);
     void CornerRadius(Windows.Foundation.Numerics.Vector2 value);
+    void StrokeBrush(IBrush brush);
+    void StrokeThickness(Single value);
   }
 
   [webhosthidden]
@@ -130,18 +133,6 @@ namespace Microsoft.ReactNative.Composition
 
   [webhosthidden]
   [experimental]
-  interface ISwitchThumbVisual
-  {
-    IVisual InnerVisual { get; };
-    Windows.Foundation.Numerics.Vector2 Size{ get; set; };
-    Windows.Foundation.Numerics.Vector2 Position{ get; set; };
-    void AnimatePosition(Windows.Foundation.Numerics.Vector2 position);
-    Boolean IsVisible { get; set; };
-    void Brush(IBrush brush);
-  }
-
-  [webhosthidden]
-  [experimental]
   interface IFocusVisual
   {
     IVisual InnerVisual { get; };
@@ -158,7 +149,6 @@ namespace Microsoft.ReactNative.Composition
     IRoundedRectangleVisual CreateRoundedRectangleVisual();
     IActivityVisual CreateActivityVisual();
     ICaretVisual CreateCaretVisual();
-    ISwitchThumbVisual CreateSwitchThumbVisual();
     IFocusVisual CreateFocusVisual();
     IDropShadow CreateDropShadow();
     IBrush CreateColorBrush(Windows.UI.Color color);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -390,8 +390,8 @@ struct CompVisualImpl {
   void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
     auto containerChildren = InnerVisual().as<typename TTypeRedirects::ContainerVisual>().Children();
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
-    if (index == 0 || containerChildren.Count() == 0) {
-      containerChildren.InsertAtTop(compVisual);
+    if (index == 0) {
+      containerChildren.InsertAtBottom(compVisual);
       return;
     }
     auto insertAfter = containerChildren.First();
@@ -581,7 +581,6 @@ struct CompRoundedRectangleVisual : winrt::implements<
   void Size(winrt::Windows::Foundation::Numerics::float2 const &size) noexcept {
     m_size = size;
     Super::m_visual.Size(size);
-    Super::m_visual.CenterPoint({m_size.x / 2.0f, m_size.y / 2.0f, 0.0f});
     updateGeometry();
   }
 
@@ -594,10 +593,10 @@ struct CompRoundedRectangleVisual : winrt::implements<
   void RelativeSizeWithOffset(
       winrt::Windows::Foundation::Numerics::float2 size,
       winrt::Windows::Foundation::Numerics::float2 relativeSizeAdjustment) noexcept {
-    assert(false); // Does not correctly handle relativeSizeAdjustment - since the geometry doesn't handle it
+    assert(false); // Does not correctly handle relativeSizeAdjustment - since geometry does not support
+                   // RelativeSizeAdjustment
     m_size = size;
     Super::m_visual.Size(size);
-    Super::m_visual.CenterPoint({m_size.x / 2.0f, m_size.y / 2.0f, 0.0f});
     updateGeometry();
 
     Super::m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
@@ -733,8 +732,8 @@ struct CompScrollerVisual : winrt::implements<
   void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
     auto containerChildren = m_contentVisual.Children();
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
-    if (index == 0 || containerChildren.Count() == 0) {
-      containerChildren.InsertAtTop(compVisual);
+    if (index == 0) {
+      containerChildren.InsertAtBottom(compVisual);
       return;
     }
     auto insertAfter = containerChildren.First();
@@ -1028,8 +1027,8 @@ struct CompActivityVisual : winrt::implements<
   void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
     auto containerChildren = m_contentVisual.Children();
     auto compVisual = typename TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
-    if (index == 0 || containerChildren.Count() == 0) {
-      containerChildren.InsertAtTop(compVisual);
+    if (index == 0) {
+      containerChildren.InsertAtBottom(compVisual);
       return;
     }
     auto insertAfter = containerChildren.First();

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1818,9 +1818,8 @@ bool walkTree(
       uint32_t index;
       bool success = parent.Children().IndexOf(current, index);
       assert(success);
-      --index;
-      if (index >= 0) {
-        auto lastChild = lastDeepChild(parent.Children().GetAt(index));
+      if (index > 0) {
+        auto lastChild = lastDeepChild(parent.Children().GetAt(index - 1));
         if (fn(lastChild))
           return true;
         return walkTree(lastChild, false, fn);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -224,7 +224,7 @@ struct ScrollBarComponent {
     auto maxThumbLength = calulateMaxThumbLength();
     auto scrollRange = getScrollRange();
     auto viewportSize = getViewportSize();
-    return ::MulDiv(std::min(scrollRange, viewportSize), maxThumbLength, scrollRange);
+    return std::max(::MulDiv(std::min(scrollRange, viewportSize), maxThumbLength, scrollRange), 0);
   }
 
   float scrollOffsetFromThumbPos(int thumbPos) const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -13,7 +13,7 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 namespace SwitchConstants {
-// https://github.com/microsoft/microsoft-ui-xaml/blob/winui2/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+// https://github.com/microsoft/microsoft-ui-xaml/blob/winui3/release/1.5-experimental1/controls/dev/CommonStyles/ToggleSwitch_themeresources.xaml
 constexpr float thumbMargin = 4.0f;
 constexpr float thumbWidth = 12.0f;
 constexpr float thumbWidthHover = 14.0f;
@@ -105,6 +105,12 @@ void SwitchComponentView::updateLayoutMetrics(
   if (oldLayoutMetrics.pointScaleFactor != layoutMetrics.pointScaleFactor) {
     handleScaleChange();
   }
+
+  auto frame{m_layoutMetrics.frame.size};
+  m_trackVisual.Offset(
+      {(frame.width - SwitchConstants::trackWidth) * m_layoutMetrics.pointScaleFactor / 2.0f,
+       (frame.height - SwitchConstants::trackHeight) * m_layoutMetrics.pointScaleFactor / 2.0f,
+       0.0f});
 }
 
 void SwitchComponentView::handleScaleChange() noexcept {
@@ -112,11 +118,6 @@ void SwitchComponentView::handleScaleChange() noexcept {
       {SwitchConstants::trackWidth * m_layoutMetrics.pointScaleFactor,
        SwitchConstants::trackHeight * m_layoutMetrics.pointScaleFactor});
 
-  auto frame{m_layoutMetrics.frame.size};
-  m_trackVisual.Offset(
-      {(frame.width - SwitchConstants::trackWidth) * m_layoutMetrics.pointScaleFactor / 2.0f,
-       (frame.height - SwitchConstants::trackHeight) * m_layoutMetrics.pointScaleFactor / 2.0f,
-       0.0f});
   m_trackVisual.CornerRadius(
       {SwitchConstants::trackCornerRadius * m_layoutMetrics.pointScaleFactor,
        SwitchConstants::trackCornerRadius * m_layoutMetrics.pointScaleFactor});
@@ -256,7 +257,7 @@ void SwitchComponentView::ensureVisual() noexcept {
 
     m_thumbVisual = m_compContext.CreateRoundedRectangleVisual();
     m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb);
-    m_trackVisual.InsertAt(m_thumbVisual, 1);
+    m_trackVisual.InsertAt(m_thumbVisual, 0);
 
     handleScaleChange();
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -12,6 +12,18 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
+namespace SwitchConstants {
+// https://github.com/microsoft/microsoft-ui-xaml/blob/winui2/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
+constexpr float thumbMargin = 4.0f;
+constexpr float thumbWidth = 12.0f;
+constexpr float thumbWidthHover = 14.0f;
+constexpr float thumbWidthPressed = 17.0f;
+constexpr float trackWidth = 40.0f;
+constexpr float trackHeight = 20.0f;
+constexpr float trackCornerRadius = 10.0f;
+constexpr float trackStrokeThickness = 1.0f;
+} // namespace SwitchConstants
+
 SwitchComponentView::SwitchComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
@@ -59,7 +71,7 @@ void SwitchComponentView::updateProps(
   if (oldViewProps.backgroundColor != newViewProps.backgroundColor ||
       oldViewProps.thumbTintColor != newViewProps.thumbTintColor || oldViewProps.value != newViewProps.value ||
       oldViewProps.disabled != newViewProps.disabled) {
-    m_drawingSurface = nullptr;
+    m_visualUpdateRequired = true;
   }
   if (oldViewProps.testId != newViewProps.testId) {
     m_visual.Comment(winrt::to_hstring(newViewProps.testId));
@@ -89,150 +101,143 @@ void SwitchComponentView::updateLayoutMetrics(
   m_visual.Size(
       {layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
        layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
+
+  if (oldLayoutMetrics.pointScaleFactor != layoutMetrics.pointScaleFactor) {
+    handleScaleChange();
+  }
+}
+
+void SwitchComponentView::handleScaleChange() noexcept {
+  m_trackVisual.Size(
+      {SwitchConstants::trackWidth * m_layoutMetrics.pointScaleFactor,
+       SwitchConstants::trackHeight * m_layoutMetrics.pointScaleFactor});
+
+  auto frame{m_layoutMetrics.frame.size};
+  m_trackVisual.Offset(
+      {(frame.width - SwitchConstants::trackWidth) * m_layoutMetrics.pointScaleFactor / 2.0f,
+       (frame.height - SwitchConstants::trackHeight) * m_layoutMetrics.pointScaleFactor / 2.0f,
+       0.0f});
+  m_trackVisual.CornerRadius(
+      {SwitchConstants::trackCornerRadius * m_layoutMetrics.pointScaleFactor,
+       SwitchConstants::trackCornerRadius * m_layoutMetrics.pointScaleFactor});
+
+  m_visualUpdateRequired = true;
+}
+
+void SwitchComponentView::updateVisuals() noexcept {
+  const auto switchProps = std::static_pointer_cast<const facebook::react::SwitchProps>(m_props);
+  auto &theme = *this->theme();
+  winrt::Microsoft::ReactNative::Composition::IBrush defaultColor;
+  winrt::Microsoft::ReactNative::Composition::IBrush fillColor;
+  winrt::Microsoft::ReactNative::Composition::IBrush thumbFill;
+
+  auto thumbWidth = SwitchConstants::thumbWidth;
+  auto thumbHeight = SwitchConstants::thumbWidth;
+
+  if (switchProps->value) {
+    if (switchProps->disabled) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOnDisabled");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOnDisabled");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnDisabled");
+    } else if (m_pressed) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOnPressed");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOnPressed");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnPressed");
+    } else if (m_hovered) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOnPointerOver");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOnPointerOver");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnPointerOver");
+    } else {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOn");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOn");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOn");
+    }
+  } else {
+    if (switchProps->disabled) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOffDisabled");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOffDisabled");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffDisabled");
+    } else if (m_pressed) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOffPressed");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOffPressed");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffPressed");
+    } else if (m_hovered) {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOffPointerOver");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOffPointerOver");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffPointerOver");
+    } else {
+      defaultColor = theme.PlatformBrush("ToggleSwitchStrokeOff");
+      fillColor = theme.PlatformBrush("ToggleSwitchFillOff");
+      thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOff");
+    }
+  }
+
+  if (switchProps->disabled) {
+    thumbWidth = SwitchConstants::thumbWidth;
+  } else if (m_pressed) {
+    thumbWidth = SwitchConstants::thumbWidthPressed;
+    thumbHeight = SwitchConstants::thumbWidthHover;
+  } else if (m_hovered) {
+    thumbWidth = SwitchConstants::thumbWidthHover;
+    thumbHeight = SwitchConstants::thumbWidthHover;
+  } else {
+    thumbWidth = SwitchConstants::thumbWidth;
+  }
+
+  if (!switchProps->disabled && switchProps->thumbTintColor) {
+    thumbFill = theme.Brush(*switchProps->thumbTintColor);
+  }
+
+  if (!switchProps->disabled && switchProps->onTintColor && switchProps->value) {
+    fillColor = theme.Brush(*switchProps->onTintColor);
+  } else if (!switchProps->disabled && switchProps->tintColor && !switchProps->value) {
+    fillColor = theme.Brush(*switchProps->tintColor);
+  }
+
+  // switch track - outline
+  if ((!switchProps->onTintColor && switchProps->value) || (!switchProps->tintColor && !switchProps->value)) {
+    m_trackVisual.StrokeThickness(std::round(SwitchConstants::trackStrokeThickness * m_layoutMetrics.pointScaleFactor));
+    m_trackVisual.StrokeBrush(defaultColor);
+  } else {
+    m_trackVisual.StrokeThickness(0.0f);
+  }
+
+  m_trackVisual.Brush(fillColor);
+
+  float offsetY = ((SwitchConstants::trackHeight - thumbHeight) * m_layoutMetrics.pointScaleFactor) / 2.0f;
+
+  if (m_supressAnimationForNextFrame) {
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::None);
+  }
+
+  if (switchProps->value) {
+    m_thumbVisual.Offset(
+        {(SwitchConstants::trackWidth - (SwitchConstants::thumbMargin + thumbWidth)) * m_layoutMetrics.pointScaleFactor,
+         offsetY,
+         0.0f});
+  } else {
+    m_thumbVisual.Offset({SwitchConstants::thumbMargin * m_layoutMetrics.pointScaleFactor, offsetY, 0.0f});
+  }
+  m_thumbVisual.Size({thumbWidth * m_layoutMetrics.pointScaleFactor, thumbHeight * m_layoutMetrics.pointScaleFactor});
+  m_thumbVisual.CornerRadius(
+      {(thumbHeight * m_layoutMetrics.pointScaleFactor) / 2.0f,
+       (thumbHeight * m_layoutMetrics.pointScaleFactor) / 2.0f});
+  m_thumbVisual.Brush(thumbFill);
+
+  if (m_supressAnimationForNextFrame) {
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb);
+    m_supressAnimationForNextFrame = false;
+  }
 }
 
 void SwitchComponentView::finalizeUpdates(
     winrt::Microsoft::ReactNative::implementation::RNComponentViewUpdateMask updateMask) noexcept {
-  ensureDrawingSurface();
+  if (m_visualUpdateRequired) {
+    m_visualUpdateRequired = false;
+    updateVisuals();
+  }
+
   Super::finalizeUpdates(updateMask);
-}
-
-void SwitchComponentView::Draw() noexcept {
-  POINT offset;
-
-  if (theme()->IsEmpty()) {
-    return;
-  }
-
-  ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, &offset);
-  if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
-    const auto switchProps = std::static_pointer_cast<const facebook::react::SwitchProps>(m_props);
-    auto &theme = *this->theme();
-
-    if (m_props->backgroundColor) {
-      d2dDeviceContext->Clear(theme.D2DColor(*m_props->backgroundColor));
-    } else {
-      d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
-    }
-
-    float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
-    float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);
-
-    // https://github.com/microsoft/microsoft-ui-xaml/blob/winui2/main/dev/CommonStyles/ToggleSwitch_themeresources.xaml
-    constexpr float thumbMargin = 3.0f;
-    constexpr float thumbRadius = 7.0f;
-    constexpr float trackWidth = 40.0f;
-    constexpr float trackHeight = 20.0f;
-    constexpr float trackCornerRadius = 10.0f;
-
-    auto frame{m_layoutMetrics.frame.size};
-    float trackMarginX = (frame.width - trackWidth) / 2;
-    float trackMarginY = (frame.height - trackHeight) / 2;
-
-    D2D1_RECT_F trackRect = D2D1::RectF(
-        offsetX + trackMarginX,
-        offsetY + trackMarginY,
-        offsetX + trackMarginX + trackWidth,
-        offsetY + trackMarginY + trackHeight);
-
-    winrt::com_ptr<ID2D1SolidColorBrush> defaultBrush;
-
-    D2D1_COLOR_F defaultColor;
-    D2D1_COLOR_F fillColor;
-    winrt::Microsoft::ReactNative::Composition::IBrush thumbFill;
-
-    if (switchProps->value) {
-      if (switchProps->disabled) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOnDisabled");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOnDisabled");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnDisabled");
-      } else if (m_pressed) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOnPressed");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOnPressed");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnPressed");
-      } else if (m_hovered) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOnPointerOver");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOnPointerOver");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOnPointerOver");
-      } else {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOn");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOn");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOn");
-      }
-    } else {
-      if (switchProps->disabled) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOffDisabled");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOffDisabled");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffDisabled");
-      } else if (m_pressed) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOffPressed");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOffPressed");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffPressed");
-      } else if (m_hovered) {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOffPointerOver");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOffPointerOver");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOffPointerOver");
-      } else {
-        defaultColor = theme.D2DPlatformColor("ToggleSwitchStrokeOff");
-        fillColor = theme.D2DPlatformColor("ToggleSwitchFillOff");
-        thumbFill = theme.PlatformBrush("ToggleSwitchKnobFillOff");
-      }
-    }
-
-    winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(defaultColor, defaultBrush.put()));
-
-    if (!switchProps->disabled && switchProps->thumbTintColor) {
-      thumbFill = theme.Brush(*switchProps->thumbTintColor);
-    }
-
-    if (!switchProps->disabled && switchProps->onTintColor && switchProps->value) {
-      fillColor = theme.D2DColor(*switchProps->onTintColor);
-    } else if (!switchProps->disabled && switchProps->tintColor && !switchProps->value) {
-      fillColor = theme.D2DColor(*switchProps->tintColor);
-    }
-
-    const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
-    float oldDpiX, oldDpiY;
-    d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-    d2dDeviceContext->SetDpi(dpi, dpi);
-
-    // switch track - outline
-    D2D1_ROUNDED_RECT track = D2D1::RoundedRect(trackRect, trackCornerRadius, trackCornerRadius);
-    if ((!switchProps->onTintColor && switchProps->value) || (!switchProps->tintColor && !switchProps->value)) {
-      d2dDeviceContext->DrawRoundedRectangle(track, defaultBrush.get());
-    }
-
-    // switch track - fill
-    winrt::com_ptr<ID2D1SolidColorBrush> trackBrush;
-    winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(fillColor, trackBrush.put()));
-    d2dDeviceContext->FillRoundedRectangle(track, trackBrush.get());
-
-    // switch thumb - made with composition
-    float thumbX = (trackMarginX + thumbMargin) * m_layoutMetrics.pointScaleFactor;
-    float thumbY = (trackMarginY + thumbMargin) * m_layoutMetrics.pointScaleFactor;
-
-    if (switchProps->value) {
-      thumbX = (trackMarginX + trackWidth - thumbRadius - thumbRadius - thumbMargin) * m_layoutMetrics.pointScaleFactor;
-    }
-
-    // handles various mouse events
-    if (m_pressed && !switchProps->disabled) {
-      m_thumbVisual.AnimatePosition({thumbX - 0.8f, thumbY - 0.8f});
-    } else if (m_hovered && !switchProps->disabled) {
-      m_thumbVisual.Size(
-          {thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f,
-           thumbRadius * m_layoutMetrics.pointScaleFactor + 0.8f});
-    } else {
-      m_thumbVisual.Size(
-          {thumbRadius * m_layoutMetrics.pointScaleFactor, thumbRadius * m_layoutMetrics.pointScaleFactor});
-      m_thumbVisual.AnimatePosition({thumbX, thumbY});
-    }
-
-    m_thumbVisual.Brush(thumbFill);
-
-    // Restore old dpi setting
-    d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);
-  }
 }
 
 void SwitchComponentView::prepareForRecycle() noexcept {}
@@ -245,27 +250,15 @@ void SwitchComponentView::ensureVisual() noexcept {
   if (!m_visual) {
     m_visual = m_compContext.CreateSpriteVisual();
     OuterVisual().InsertAt(m_visual, 0);
-  }
 
-  if (!m_thumbVisual) {
-    m_thumbVisual = m_compContext.CreateSwitchThumbVisual();
-    m_visual.InsertAt(m_thumbVisual.InnerVisual(), 0);
-  }
-}
+    m_trackVisual = m_compContext.CreateRoundedRectangleVisual();
+    m_visual.InsertAt(m_trackVisual, 0);
 
-void SwitchComponentView::ensureDrawingSurface() noexcept {
-  if (!m_drawingSurface) {
-    winrt::Windows::Foundation::Size surfaceSize = {
-        m_layoutMetrics.frame.size.width * m_layoutMetrics.pointScaleFactor,
-        m_layoutMetrics.frame.size.height * m_layoutMetrics.pointScaleFactor};
-    m_drawingSurface = m_compContext.CreateDrawingSurfaceBrush(
-        surfaceSize,
-        winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
-        winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
+    m_thumbVisual = m_compContext.CreateRoundedRectangleVisual();
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb);
+    m_trackVisual.InsertAt(m_thumbVisual, 1);
 
-    Draw();
-
-    m_visual.Brush(m_drawingSurface);
+    handleScaleChange();
   }
 }
 
@@ -291,7 +284,7 @@ winrt::Microsoft::ReactNative::Composition::IVisual SwitchComponentView::Visual(
 }
 
 void SwitchComponentView::onThemeChanged() noexcept {
-  Draw();
+  updateVisuals();
   Super::onThemeChanged();
 }
 
@@ -306,15 +299,13 @@ void SwitchComponentView::onPointerPressed(
 
   if (!switchProps->disabled) {
     m_pressed = true;
+    m_supressAnimationForNextFrame = true;
 
     if (auto root = rootComponentView()) {
       root->TrySetFocusedComponent(*get_strong());
     }
-    if (toggle()) {
-      args.Handled(true);
-    }
 
-    Draw();
+    updateVisuals();
   }
 }
 
@@ -324,19 +315,28 @@ void SwitchComponentView::onPointerReleased(
   if (!args.GetCurrentPoint(-1).Properties().IsPrimary()) {
     return;
   }
+
+  if (toggle()) {
+    args.Handled(true);
+  } else {
+    m_supressAnimationForNextFrame = true;
+  }
+
   m_pressed = false;
 }
 
 void SwitchComponentView::onPointerEntered(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = true;
-  Draw();
+  m_supressAnimationForNextFrame = true;
+  updateVisuals();
 }
 
 void SwitchComponentView::onPointerExited(
     const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept {
   m_hovered = false;
-  Draw();
+  m_supressAnimationForNextFrame = true;
+  updateVisuals();
 }
 
 void SwitchComponentView::onKeyUp(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -65,17 +65,19 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, Compositi
 
  private:
   void ensureVisual() noexcept;
-  void Draw() noexcept;
-  void ensureDrawingSurface() noexcept;
   bool toggle() noexcept;
+  void handleScaleChange() noexcept;
+  void updateVisuals() noexcept;
 
   bool m_hovered{false};
   bool m_pressed{false};
+  bool m_supressAnimationForNextFrame{false};
+  bool m_visualUpdateRequired{true};
   facebook::react::Size m_contentSize;
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_trackVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_thumbVisual{nullptr};
   facebook::react::SharedViewProps m_props;
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_drawingSurface;
-  winrt::Microsoft::ReactNative::Composition::ISwitchThumbVisual m_thumbVisual;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation


### PR DESCRIPTION
## Description
Update Switch to have the newer fluent visuals (In particular the change of the thumb to a rounded rectangle rather than an ellipse when in the pressed state)
Also switched switch to use the more generic RoundedRectangleVisual rather than having to have a switch specific visual type in the compositionswitcher.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12631)