### PR TITLE
[Fabric] Fix ScrollView crashing on minimized

### DIFF
--- a/change/react-native-windows-d4c5a209-f0fb-454c-9f04-8e43e5d7b122.json
+++ b/change/react-native-windows-d4c5a209-f0fb-454c-9f04-8e43e5d7b122.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add minimized check",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -250,6 +250,11 @@ struct ScrollBarComponent {
 
     const int computedPixelThumbSize = getComputedPixelThumbSize();
 
+    // check if app is minimized
+    if (computedPixelThumbSize < 0) {
+      return;
+    }
+
     m_thumbSize = 0;
     int thumbCorrection = 0;
 


### PR DESCRIPTION
## Description
ScrollView crashes when minimized because it's trying to draw composition on an non-existing surface. This adds a check before drawing.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Fix crash on e2e-tester-app 

## Testing
tested locally 

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12632)