### PR TITLE
[Fabric] Do not run a 0,0 layout when minimizing the window

### DIFF
--- a/change/react-native-windows-018bcc99-b1e5-44c5-a42f-6c946eaedad5.json
+++ b/change/react-native-windows-018bcc99-b1e5-44c5-a42f-6c946eaedad5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Do not run a 0,0 layout when minimizing the window",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -50,8 +50,12 @@ void UpdateRootViewSizeToAppWindow(
   auto scaleFactor = ScaleFactor(hwnd);
   winrt::Windows::Foundation::Size size{
       window.ClientSize().Width / scaleFactor, window.ClientSize().Height / scaleFactor};
-  rootView.Arrange(size);
-  rootView.Size(size);
+  // Do not relayout when minimized
+  if (window.Presenter().as<winrt::Microsoft::UI::Windowing::OverlappedPresenter>().State() !=
+      winrt::Microsoft::UI::Windowing::OverlappedPresenterState::Minimized) {
+    rootView.Arrange(size);
+    rootView.Size(size);
+  }
 }
 
 // Create and configure the ReactNativeHost

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -285,8 +285,10 @@ struct WindowData {
 
         if (m_compRootView) {
           winrt::Windows::Foundation::Size size{m_width / ScaleFactor(hwnd), m_height / ScaleFactor(hwnd)};
-          m_compRootView.Arrange(size);
-          m_compRootView.Size(size);
+          if (!IsIconic(hwnd)) {
+            m_compRootView.Arrange(size);
+            m_compRootView.Size(size);
+          }
         }
       }
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -81,9 +81,12 @@ void CompositionHwndHost::UpdateSize() noexcept {
       m_width = rc.right - rc.left;
       winrt::Windows::Foundation::Size size{
           static_cast<float>(m_width / ScaleFactor()), static_cast<float>(m_height / ScaleFactor())};
-      m_compRootView.Size(size);
-      m_compRootView.Measure(size);
-      m_compRootView.Arrange(size);
+      // Do not relayout when minimized
+      if (!IsIconic(m_hwnd)) {
+        m_compRootView.Size(size);
+        m_compRootView.Measure(size);
+        m_compRootView.Arrange(size);
+      }
     }
   }
 }

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
@@ -34,8 +34,13 @@ void UpdateRootViewSizeToAppWindow(
   auto scaleFactor = ScaleFactor(hwnd);
   winrt::Windows::Foundation::Size size{
       window.ClientSize().Width / scaleFactor, window.ClientSize().Height / scaleFactor};
-  rootView.Arrange(size);
-  rootView.Size(size);
+  // Do not relayout when minimized
+  if (window.Presenter().as<winrt::Microsoft::UI::Windowing::OverlappedPresenter>().State() 
+    != winrt::Microsoft::UI::Windowing::OverlappedPresenterState::Minimized)
+  {
+    rootView.Arrange(size);
+    rootView.Size(size);
+  }
 }
 
 // Create and configure the ReactNativeHost


### PR DESCRIPTION
## Description
Currently the default app template and our various fabric apps run layout with 0,0 constraint when the window is minimized.  This change prevents the extra layout.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12634)