### PR TITLE
Add ARM64 to new arch templates

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -22,6 +22,11 @@ parameters:
             configuration: Debug
             platform: x86
             additionalRunArguments: --no-autolink
+          - Name: FabricArm64Release
+            template: cpp-app
+            configuration: Release
+            platform: ARM64
+            additionalRunArguments: --no-autolink
           - Name: FabricLibX64Release
             template: cpp-lib
             configuration: Release
@@ -31,6 +36,11 @@ parameters:
             template: cpp-lib
             configuration: Debug
             platform: x86
+            additionalRunArguments:
+          - Name: FabricLibArm64Release
+            template: cpp-lib
+            configuration: Release
+            platform: ARM64
             additionalRunArguments:
       - BuildEnvironment: Continuous
         Matrix:
@@ -53,6 +63,15 @@ parameters:
             template: cpp-app
             configuration: Release
             platform: x86
+          - Name: FabricArm64Debug
+            template: cpp-app
+            configuration: Debug
+            platform: ARM64
+            additionalRunArguments: --no-autolink
+          - Name: FabricArm64Release
+            template: cpp-app
+            configuration: Release
+            platform: ARM64
             additionalRunArguments: --no-autolink
           - Name: FabricLibX64Debug
             template: cpp-lib
@@ -73,6 +92,16 @@ parameters:
             template: cpp-lib
             configuration: Release
             platform: x86
+            additionalRunArguments:
+          - Name: FabricLibArm64Debug
+            template: cpp-lib
+            configuration: Debug
+            platform: ARM64
+            additionalRunArguments:
+          - Name: FabricLibArm64Release
+            template: cpp-lib
+            configuration: Release
+            platform: ARM64
             additionalRunArguments:
 jobs:
   - ${{ each config in parameters.buildMatrix }}:

--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -26,7 +26,7 @@ parameters:
             template: cpp-app
             configuration: Release
             platform: ARM64
-            additionalRunArguments: --no-autolink
+            additionalRunArguments: --no-autolink --no-deploy
           - Name: FabricLibX64Release
             template: cpp-lib
             configuration: Release
@@ -41,7 +41,7 @@ parameters:
             template: cpp-lib
             configuration: Release
             platform: ARM64
-            additionalRunArguments:
+            additionalRunArguments: --no-deploy
       - BuildEnvironment: Continuous
         Matrix:
           - Name: FabricX64Debug
@@ -67,12 +67,12 @@ parameters:
             template: cpp-app
             configuration: Debug
             platform: ARM64
-            additionalRunArguments: --no-autolink
+            additionalRunArguments: --no-autolink --no-deploy
           - Name: FabricArm64Release
             template: cpp-app
             configuration: Release
             platform: ARM64
-            additionalRunArguments: --no-autolink
+            additionalRunArguments: --no-autolink --no-deploy
           - Name: FabricLibX64Debug
             template: cpp-lib
             configuration: Debug
@@ -97,12 +97,12 @@ parameters:
             template: cpp-lib
             configuration: Debug
             platform: ARM64
-            additionalRunArguments:
+            additionalRunArguments: --no-deploy
           - Name: FabricLibArm64Release
             template: cpp-lib
             configuration: Release
             platform: ARM64
-            additionalRunArguments:
+            additionalRunArguments: --no-deploy
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
     - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -145,7 +145,7 @@
   "clang-format.executable": "${workspaceRoot}/node_modules/.bin/clang-format",
   "typescript.tsdk": "node_modules\\typescript\\lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "dotnet.defaultSolution": "disable"
 }

--- a/change/react-native-windows-d83c7f4b-e898-4530-bbc4-027b2cc19b54.json
+++ b/change/react-native-windows-d83c7f4b-e898-4530-bbc4-027b2cc19b54.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ARM64 to new arch templates",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.vcxproj
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.vcxproj
@@ -36,13 +36,15 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
@@ -109,8 +111,10 @@
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/vnext/templates/cpp-lib/windows/MyLib/MyLib.vcxproj
+++ b/vnext/templates/cpp-lib/windows/MyLib/MyLib.vcxproj
@@ -37,6 +37,14 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>


### PR DESCRIPTION
## Description

This PR fixes up the new `cpp-lib` and `cpp-app` templates to support targeting ARM64, and adds ARM64 builds to the CI/PR matrix.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
To enable native builds of ARM64

Closes #12633 

### What
Added the proper configurations to 

## Screenshots
N/A

## Testing
Verified the apps build in CI

## Changelog
Should this change be included in the release notes: _yes_

Updated the experimental `cpp-lib` and `cpp-app` templates to support targeting ARM64.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12635)