### PR TITLE
[Fabric] Fix issue causing PointerMove events to have incorrect position when using WM_msg input

### DIFF
--- a/change/react-native-windows-da0c1993-6a72-42cd-b8a2-7ebe3cab80fa.json
+++ b/change/react-native-windows-da0c1993-6a72-42cd-b8a2-7ebe3cab80fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix issue causing PointerMove events to have incorrect position when using WM_msg input",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
@@ -453,7 +453,9 @@ winrt::Windows::Foundation::Point PointerPoint::Position() noexcept {
   POINT clientPoint{
       m_pi.pointerId ? m_pi.ptPixelLocation.x : GET_X_LPARAM(m_lParam),
       m_pi.pointerId ? m_pi.ptPixelLocation.y : GET_Y_LPARAM(m_lParam)};
-  ScreenToClient(m_hwnd, &clientPoint);
+  if (m_pi.pointerId) {
+    ScreenToClient(m_hwnd, &clientPoint);
+  }
   return winrt::Windows::Foundation::Point{
       static_cast<float>(clientPoint.x / m_scaleFactor) - (m_offset.X / m_scaleFactor),
       static_cast<float>(clientPoint.y / m_scaleFactor) - (m_offset.Y / m_scaleFactor)};


### PR DESCRIPTION
## Description
When using input from window messages, events from WM_POINTER* get incorrect positions, which causes scrollbars to not work correctly.  This is due to WM_POINTER events coming in screen coordinates, vs the WM_MOUSE events which come in client coordinates.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12638)