### PR TITLE
[Fabric] Capture pointer input during scroll thumb drag

### DIFF
--- a/change/react-native-windows-824d287e-442d-44d6-8e7d-e6f0f6cb3b12.json
+++ b/change/react-native-windows-824d287e-442d-44d6-8e7d-e6f0f6cb3b12.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Capture pointer input during scroll thumb drag",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Composition.Input.idl
+++ b/vnext/Microsoft.ReactNative/Composition.Input.idl
@@ -62,6 +62,12 @@ namespace Microsoft.ReactNative.Composition.Input
       XButton2Released,
   };
 
+  runtimeclass Pointer
+  {
+    PointerDeviceType PointerDeviceType { get; };
+    UInt32 PointerId{ get; };
+  };
+
   runtimeclass PointerPointProperties
   {
     Windows.Foundation.Rect ContactRect { get; };
@@ -103,6 +109,7 @@ namespace Microsoft.ReactNative.Composition.Input
   runtimeclass PointerRoutedEventArgs : RoutedEventArgs
   {
     PointerPoint GetCurrentPoint(Int32 tag);
+    Pointer Pointer { get; };
     Boolean Handled;
     Windows.System.VirtualKeyModifiers KeyModifiers { get; };
   };

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -4,6 +4,7 @@
 import "ComponentView.idl";
 import "Theme.idl";
 import "ViewProps.idl";
+import "Composition.Input.idl";
 
 #include "DocString.h"
 
@@ -14,6 +15,8 @@ namespace Microsoft.ReactNative.Composition
   [webhosthidden]
   unsealed runtimeclass ComponentView : Microsoft.ReactNative.ComponentView {
     Theme Theme;
+    Boolean CapturePointer(Microsoft.ReactNative.Composition.Input.Pointer pointer);
+    void ReleasePointerCapture(Microsoft.ReactNative.Composition.Input.Pointer pointer);
   };
 
   [experimental]

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -103,6 +103,7 @@ struct ComponentView : public ComponentViewT<ComponentView> {
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept = 0;
   virtual void onPointerWheelChanged(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept = 0;
+  virtual void onPointerCaptureLost() noexcept = 0;
   virtual void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept = 0;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
@@ -122,6 +122,17 @@ winrt::Windows::UI::Core::CorePhysicalKeyStatus CharacterReceivedRoutedEventArgs
   return m_keyStatus;
 }
 
+Pointer::Pointer(winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType type, uint32_t id)
+    : m_type(type), m_id(id) {}
+
+winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType Pointer::PointerDeviceType() const noexcept {
+  return m_type;
+}
+
+uint32_t Pointer::PointerId() const noexcept {
+  return m_id;
+}
+
 #ifdef USE_WINUI3
 PointerPointProperties::PointerPointProperties(const winrt::Microsoft::UI::Input::PointerPointProperties &ppp)
     : m_sysPointerPointProps(ppp) {}
@@ -388,7 +399,7 @@ PointerPoint::PointerPoint(
 PointerPoint::PointerPoint(HWND hwnd, uint32_t msg, uint64_t wParam, int64_t lParam, float scaleFactor)
     : PointerPoint(hwnd, msg, wParam, lParam, scaleFactor, {0, 0}) {}
 
-uint32_t PointerPoint::FrameId() noexcept {
+uint32_t PointerPoint::FrameId() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return m_sysPointerPoint.FrameId();
@@ -397,7 +408,7 @@ uint32_t PointerPoint::FrameId() noexcept {
   return m_pi.frameId;
 }
 
-bool PointerPoint::IsInContact() noexcept {
+bool PointerPoint::IsInContact() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return m_sysPointerPoint.IsInContact();
@@ -406,7 +417,7 @@ bool PointerPoint::IsInContact() noexcept {
   return ((m_pi.pointerFlags & POINTER_FLAG_INCONTACT) == POINTER_FLAG_INCONTACT);
 }
 
-winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType PointerPoint::PointerDeviceType() noexcept {
+winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType PointerPoint::PointerDeviceType() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return static_cast<winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType>(
@@ -432,7 +443,7 @@ winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType PointerPoin
   return winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse;
 }
 
-uint32_t PointerPoint::PointerId() noexcept {
+uint32_t PointerPoint::PointerId() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return m_sysPointerPoint.PointerId();
@@ -441,7 +452,7 @@ uint32_t PointerPoint::PointerId() noexcept {
   return (m_pi.pointerId ? m_pi.pointerId : 1 /* MOUSE */);
 }
 
-winrt::Windows::Foundation::Point PointerPoint::Position() noexcept {
+winrt::Windows::Foundation::Point PointerPoint::Position() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     auto pos = m_sysPointerPoint.Position();
@@ -461,7 +472,7 @@ winrt::Windows::Foundation::Point PointerPoint::Position() noexcept {
       static_cast<float>(clientPoint.y / m_scaleFactor) - (m_offset.Y / m_scaleFactor)};
 }
 
-winrt::Microsoft::ReactNative::Composition::Input::PointerPointProperties PointerPoint::Properties() noexcept {
+winrt::Microsoft::ReactNative::Composition::Input::PointerPointProperties PointerPoint::Properties() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return winrt::make<PointerPointProperties>(m_sysPointerPoint.Properties());
@@ -583,7 +594,7 @@ winrt::Microsoft::ReactNative::Composition::Input::PointerPointProperties Pointe
   );
 }
 
-uint64_t PointerPoint::Timestamp() noexcept {
+uint64_t PointerPoint::Timestamp() const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return m_sysPointerPoint.Timestamp();
@@ -593,7 +604,7 @@ uint64_t PointerPoint::Timestamp() noexcept {
 }
 
 winrt::Microsoft::ReactNative::Composition::Input::PointerPoint PointerPoint::GetOffsetPoint(
-    const winrt::Windows::Foundation::Point &offset) noexcept {
+    const winrt::Windows::Foundation::Point &offset) const noexcept {
 #ifdef USE_WINUI3
   if (m_sysPointerPoint) {
     return winrt::make<PointerPoint>(m_sysPointerPoint, m_scaleFactor, offset);
@@ -602,7 +613,7 @@ winrt::Microsoft::ReactNative::Composition::Input::PointerPoint PointerPoint::Ge
   return winrt::make<PointerPoint>(m_hwnd, m_msg, m_wParam, m_lParam, m_scaleFactor, offset);
 }
 
-bool PointerPoint::IsPointerMessage(uint32_t message) noexcept {
+bool PointerPoint::IsPointerMessage(uint32_t message) const noexcept {
   constexpr uint32_t WM_POINTERFIRST = 0x0245;
   constexpr uint32_t WM_POINTERLAST = 0x0257;
   return (message >= WM_POINTERFIRST && message <= WM_POINTERLAST);
@@ -637,6 +648,11 @@ winrt::Microsoft::ReactNative::Composition::Input::PointerPoint PointerRoutedEve
           ->getClientRect();
 
   return m_pointerPoint.GetOffsetPoint({static_cast<float>(clientRect.left), static_cast<float>(clientRect.top)});
+}
+
+winrt::Microsoft::ReactNative::Composition::Input::Pointer PointerRoutedEventArgs::Pointer() const noexcept {
+  return winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::Pointer>(
+      m_pointerPoint.PointerDeviceType(), m_pointerPoint.PointerId());
 }
 
 bool PointerRoutedEventArgs::Handled() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include "Composition.Input.Pointer.g.h"
 #include "Composition.Input.PointerPoint.g.h"
 #include "Composition.Input.PointerPointProperties.g.h"
 #include "Composition.Input.PointerRoutedEventArgs.g.h"
@@ -63,6 +64,17 @@ struct CharacterReceivedRoutedEventArgs
   bool m_handled{false};
   int32_t m_keycode;
   winrt::Windows::UI::Core::CorePhysicalKeyStatus m_keyStatus;
+};
+
+struct Pointer : PointerT<Pointer> {
+  Pointer(winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType type, uint32_t id);
+
+  winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType PointerDeviceType() const noexcept;
+  uint32_t PointerId() const noexcept;
+
+ private:
+  winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType m_type;
+  uint32_t m_id;
 };
 
 struct PointerPointProperties : PointerPointPropertiesT<PointerPointProperties> {
@@ -159,18 +171,18 @@ struct PointerPoint : PointerPointT<PointerPoint> {
       float scaleFactor,
       const winrt::Windows::Foundation::Point &offset);
 
-  uint32_t FrameId() noexcept;
-  bool IsInContact() noexcept;
-  PointerDeviceType PointerDeviceType() noexcept;
-  uint32_t PointerId() noexcept;
-  winrt::Windows::Foundation::Point Position() noexcept;
-  winrt::Microsoft::ReactNative::Composition::Input::PointerPointProperties Properties() noexcept;
-  uint64_t Timestamp() noexcept;
+  uint32_t FrameId() const noexcept;
+  bool IsInContact() const noexcept;
+  PointerDeviceType PointerDeviceType() const noexcept;
+  uint32_t PointerId() const noexcept;
+  winrt::Windows::Foundation::Point Position() const noexcept;
+  winrt::Microsoft::ReactNative::Composition::Input::PointerPointProperties Properties() const noexcept;
+  uint64_t Timestamp() const noexcept;
   winrt::Microsoft::ReactNative::Composition::Input::PointerPoint GetOffsetPoint(
-      const winrt::Windows::Foundation::Point &offset) noexcept;
+      const winrt::Windows::Foundation::Point &offset) const noexcept;
 
  private:
-  bool IsPointerMessage(uint32_t message) noexcept;
+  bool IsPointerMessage(uint32_t message) const noexcept;
 
   // Windows::Input
 #ifdef USE_WINUI3
@@ -198,6 +210,7 @@ struct PointerRoutedEventArgs : PointerRoutedEventArgsT<PointerRoutedEventArgs> 
 
   int32_t OriginalSource() noexcept;
   winrt::Microsoft::ReactNative::Composition::Input::PointerPoint GetCurrentPoint(int32_t tag) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Input::Pointer Pointer() const noexcept;
   bool Handled() noexcept;
   void Handled(bool value) noexcept;
   winrt::Windows::System::VirtualKeyModifiers KeyModifiers() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -23,6 +23,7 @@ using namespace Windows::Foundation;
 
 namespace Microsoft::ReactNative {
 
+struct FabricUIManager;
 struct winrt::Microsoft::ReactNative::implementation::ComponentView;
 typedef int PointerId;
 
@@ -37,6 +38,14 @@ class CompositionEventHandler {
   void RemoveTouchHandlers();
   winrt::Windows::UI::Core::CoreVirtualKeyStates GetKeyState(winrt::Windows::System::VirtualKey key) noexcept;
 
+  bool CapturePointer(
+      const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+      facebook::react::Tag tag) noexcept;
+  bool ReleasePointerCapture(
+      const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+      facebook::react::Tag tag) noexcept;
+  facebook::react::Tag PointerCapturingComponent() noexcept;
+
  private:
   void onPointerPressed(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
@@ -50,6 +59,9 @@ class CompositionEventHandler {
   void onPointerWheelChanged(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
       winrt::Windows::System::VirtualKeyModifiers keyModifiers) noexcept;
+  void onPointerCaptureLost(
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+      winrt::Windows::System::VirtualKeyModifiers keyModifiers) noexcept;
   void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept;
@@ -60,8 +72,16 @@ class CompositionEventHandler {
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::CharacterReceivedRoutedEventArgs &args) noexcept;
 
-  facebook::react::SurfaceId SurfaceId() noexcept;
-  winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView &RootComponentView() noexcept;
+  void getTargetPointerArgs(
+      const std::shared_ptr<FabricUIManager> &fabricuiManager,
+      const winrt::Microsoft::ReactNative::Composition::Input::PointerPoint &pointerPoint,
+      facebook::react::Tag &tag,
+      facebook::react::Point &ptScaled,
+      facebook::react::Point &ptLocal) const noexcept;
+  bool releasePointerCapture(PointerId pointerId, facebook::react::Tag tag) noexcept;
+
+  facebook::react::SurfaceId SurfaceId() const noexcept;
+  winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView &RootComponentView() const noexcept;
 
   enum class UITouchType {
     Mouse,
@@ -137,11 +157,15 @@ class CompositionEventHandler {
   winrt::Microsoft::ReactNative::CompositionRootView m_compRootView{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
 
+  facebook::react::Tag m_pointerCapturingComponentTag{-1}; // Component that has captured input
+  std::vector<PointerId> m_capturedPointers;
+
 #ifdef USE_WINUI3
   winrt::event_token m_pointerPressedToken;
   winrt::event_token m_pointerReleasedToken;
   winrt::event_token m_pointerMovedToken;
   winrt::event_token m_pointerWheelChangedToken;
+  winrt::event_token m_pointerCaptureLostToken;
   winrt::event_token m_keyDownToken;
   winrt::event_token m_keyUpToken;
   winrt::event_token m_characterReceivedToken;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -271,6 +271,27 @@ int64_t CompositionRootView::SendMessage(uint32_t msg, uint64_t wParam, int64_t 
   return 0;
 }
 
+bool CompositionRootView::CapturePointer(
+    const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+    facebook::react::Tag tag) noexcept {
+  if (m_hwnd) {
+    SetCapture(m_hwnd);
+  }
+  return m_CompositionEventHandler->CapturePointer(pointer, tag);
+}
+
+void CompositionRootView::ReleasePointerCapture(
+    const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+    facebook::react::Tag tag) noexcept {
+  if (m_CompositionEventHandler->ReleasePointerCapture(pointer, tag)) {
+    if (m_hwnd) {
+      if (m_hwnd == GetCapture()) {
+        ReleaseCapture();
+      }
+    }
+  }
+}
+
 void CompositionRootView::InitRootView(
     winrt::Microsoft::ReactNative::IReactContext &&context,
     winrt::Microsoft::ReactNative::ReactViewOptions &&viewOptions) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -81,6 +81,13 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   void SetWindow(uint64_t hwnd) noexcept;
   int64_t SendMessage(uint32_t msg, uint64_t wParam, int64_t lParam) noexcept;
 
+  bool CapturePointer(
+      const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+      facebook::react::Tag tag) noexcept;
+  void ReleasePointerCapture(
+      const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
+      facebook::react::Tag tag) noexcept;
+
  public: // ICompositionRootView
   winrt::Microsoft::ReactNative::Composition::IVisual GetVisual() const noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -7,6 +7,8 @@
 #include "CompositionViewComponentView.h"
 
 #include <Fabric/AbiViewProps.h>
+#include <Fabric/Composition/CompositionRootView.h>
+#include <Fabric/FabricUIManagerModule.h>
 #include <UI.Xaml.Controls.h>
 #include <Utils/KeyboardUtils.h>
 #include <Utils/ValueUtils.h>
@@ -292,6 +294,46 @@ void CompositionBaseComponentView::onPointerWheelChanged(
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_parent)->onPointerWheelChanged(
         args);
   }
+}
+
+void CompositionBaseComponentView::onPointerCaptureLost() noexcept {}
+
+bool CompositionBaseComponentView::CapturePointer(
+    const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept {
+  auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties());
+  if (uiManager == nullptr)
+    return false;
+
+  auto root = rootComponentView();
+  if (!root)
+    return false;
+
+  auto rootView = uiManager->GetCompositionRootView(root->Tag());
+  if (!rootView) {
+    return false;
+  }
+
+  return winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->CapturePointer(
+      pointer, static_cast<facebook::react::Tag>(Tag()));
+}
+
+void CompositionBaseComponentView::ReleasePointerCapture(
+    const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept {
+  auto uiManager = ::Microsoft::ReactNative::FabricUIManager::FromProperties(m_context.Properties());
+  if (uiManager == nullptr)
+    return;
+
+  auto root = rootComponentView();
+  if (!root)
+    return;
+
+  auto rootView = uiManager->GetCompositionRootView(root->Tag());
+  if (!rootView) {
+    return;
+  }
+
+  return winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)
+      ->ReleasePointerCapture(pointer, static_cast<facebook::react::Tag>(Tag()));
 }
 
 RECT CompositionBaseComponentView::getClientRect() const noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -72,8 +72,11 @@ struct CompositionBaseComponentView : public ComponentViewT<
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerMoved(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void onPointerCaptureLost() noexcept override;
   void onPointerWheelChanged(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  bool CapturePointer(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;
+  void ReleasePointerCapture(const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer) noexcept;
 
   void onKeyDown(
       const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -129,8 +129,12 @@ HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRe
   if (uiManager == nullptr)
     return UIA_E_ELEMENTNOTAVAILABLE;
 
-  auto uiaProvider = uiManager->GetUiaFragmentProvider(Tag());
-  auto spFragmentRoot = uiaProvider.as<IRawElementProviderFragmentRoot>();
+  auto rootView = uiManager->GetCompositionRootView(Tag());
+  if (!rootView) {
+    return UIA_E_ELEMENTNOTAVAILABLE;
+  }
+
+  auto spFragmentRoot = rootView.GetUiaProvider().as<IRawElementProviderFragmentRoot>();
   if (spFragmentRoot) {
     *pRetVal = spFragmentRoot.detach();
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -92,8 +92,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
   void onPointerWheelChanged(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
-  void onPointerExited(
-      const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept override;
+  void onPointerCaptureLost() noexcept override;
 
   void StartBringIntoView(winrt::Microsoft::ReactNative::implementation::BringIntoViewOptions &&args) noexcept override;
   virtual std::string DefaultControlType() const noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -179,11 +179,9 @@ void FabricUIManager::stopSurface(facebook::react::SurfaceId surfaceId) noexcept
   m_surfaceManager->stopSurface(surfaceId);
 }
 
-winrt::IInspectable FabricUIManager::GetUiaFragmentProvider(facebook::react::SurfaceId surfaceId) const noexcept {
-  if (auto strong = m_surfaceRegistry.at(surfaceId).wkRootView.get()) {
-    return strong.GetUiaProvider();
-  }
-  return nullptr;
+winrt::Microsoft::ReactNative::CompositionRootView FabricUIManager::GetCompositionRootView(
+    facebook::react::SurfaceId surfaceId) const noexcept {
+  return m_surfaceRegistry.at(surfaceId).wkRootView.get();
 }
 
 facebook::react::Size FabricUIManager::measureSurface(

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
@@ -48,7 +48,8 @@ struct FabricUIManager final : public std::enable_shared_from_this<FabricUIManag
 
   const IComponentViewRegistry &GetViewRegistry() const noexcept;
 
-  winrt::IInspectable GetUiaFragmentProvider(facebook::react::SurfaceId surfaceId) const noexcept;
+  winrt::Microsoft::ReactNative::CompositionRootView GetCompositionRootView(
+      facebook::react::SurfaceId surfaceId) const noexcept;
 
  private:
   void installFabricUIManager() noexcept;


### PR DESCRIPTION
## Description
Adds infra to provide pointer capture to ViewComponents.
Uses that infra to capture pointer input while performing scrollbar thumb drags, which allows the user to not have to keep the pointer within the ScrollView while dragging the scrollbar thumb.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12642)