### PR TITLE
Include line/column numbers on syntax error

### DIFF
--- a/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
+++ b/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Include line/column numbers on syntax error",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/JSI/ChakraRuntime.cpp
+++ b/vnext/Shared/JSI/ChakraRuntime.cpp
@@ -726,7 +726,8 @@ void ChakraRuntime::RewriteErrorMessage(JsValueRef jsError) {
     JsGetAndClearException(&ignoreJSError);
   } else if (GetValueType(message) == JsValueType::JsString) {
     // JSI unit tests expect V8 or JSC like message for stack overflow.
-    if (StringToPointer(message) == L"Out of stack space") {
+    std::wstring_view errorMessage = StringToPointer(message);
+    if (errorMessage == L"Out of stack space") {
       SetProperty(jsError, m_propertyId.message, PointerToString(L"RangeError : Maximum call stack size exceeded"));
     } else if (errorMessage == L"Syntax error") {
       JsValueRef result;


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

When Chakra encounters a syntax error, it does not provide line/column numbers, making it hard to determine what went wrong.

### What

This change extracts line/column from the error and appends it to the error message.

## Screenshots

| Before | After |
| :-: | :-: |
| ![image](https://github.com/microsoft/react-native-windows/assets/4123478/c2f1b1fb-bfa9-43a4-9bc3-1750a6b8383a) | ![image](https://github.com/microsoft/react-native-windows/assets/4123478/956b7a33-ce27-4c98-b845-dbef77a87684) |

## Testing

Add a valid JS line that Chakra does not recognize at the top of `index.js`, e.g.:

```js
test ??= 1;
```

## Changelog

Include line/column numbers when Chakra encounters a syntax error
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12644)