### PR TITLE
[Fabric] Allow unimplemented native views to have children

### DIFF
--- a/change/react-native-windows-aa56d537-586f-4d5b-8e8b-4c227f738d1b.json
+++ b/change/react-native-windows-aa56d537-586f-4d5b-8e8b-4c227f738d1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Allow unimplemented native views to have children",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -79,7 +79,7 @@ namespace Microsoft.ReactNative.Composition
   [experimental]
   [webhosthidden]
   [default_interface]
-  unsealed runtimeclass UnimplementedNativeViewComponentView : ComponentView {
+  unsealed runtimeclass UnimplementedNativeViewComponentView : ViewComponentView {
   };
 
   [experimental]

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -17,14 +17,9 @@ UnimplementedNativeViewComponentView::UnimplementedNativeViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : base_type(
-          compContext,
-          tag,
-          reactContext,
-          (CompositionComponentViewFeatures::Default & ~CompositionComponentViewFeatures::NativeBorder)) {
-  static auto const defaultProps = std::make_shared<facebook::react::UnimplementedNativeViewProps const>();
-  m_props = defaultProps;
-  m_visual = compContext.CreateSpriteVisual();
+    : base_type(compContext, tag, reactContext) {
+  m_labelVisual = compContext.CreateSpriteVisual();
+  OuterVisual().InsertAt(m_labelVisual, 1);
 }
 
 winrt::Microsoft::ReactNative::ComponentView UnimplementedNativeViewComponentView::Create(
@@ -32,20 +27,6 @@ winrt::Microsoft::ReactNative::ComponentView UnimplementedNativeViewComponentVie
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<UnimplementedNativeViewComponentView>(compContext, tag, reactContext);
-}
-
-void UnimplementedNativeViewComponentView::mountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {}
-
-void UnimplementedNativeViewComponentView::unmountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {}
-
-void UnimplementedNativeViewComponentView::updateProps(
-    facebook::react::Props::Shared const &props,
-    facebook::react::Props::Shared const &oldProps) noexcept {
-  m_props = std::static_pointer_cast<facebook::react::UnimplementedNativeViewProps const>(props);
 }
 
 void UnimplementedNativeViewComponentView::updateLayoutMetrics(
@@ -72,9 +53,9 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
     drawingSurface.HorizontalAlignmentRatio(0.f);
     drawingSurface.VerticalAlignmentRatio(0.f);
     drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
-    m_visual.Brush(drawingSurface);
-    m_visual.Size(surfaceSize);
-    m_visual.Offset({
+    m_labelVisual.Brush(drawingSurface);
+    m_labelVisual.Size(surfaceSize);
+    m_labelVisual.Offset({
         layoutMetrics.frame.origin.x * layoutMetrics.pointScaleFactor,
         layoutMetrics.frame.origin.y * layoutMetrics.pointScaleFactor,
         0.0f,
@@ -113,8 +94,8 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
             static_cast<float>(offset.x), static_cast<float>(offset.y), width + offset.x, height + offset.y};
         // const D2D1_RECT_F rect = {0.f, 0.f, width, height};
 
-        auto label =
-            ::Microsoft::Common::Unicode::Utf8ToUtf16(std::string("Unimplemented component: ") + m_props->name);
+        auto props = std::static_pointer_cast<facebook::react::UnimplementedNativeViewProps const>(viewProps());
+        auto label = ::Microsoft::Common::Unicode::Utf8ToUtf16(std::string("Unimplemented component: ") + props->name);
         d2dDeviceContext->DrawText(
             label.c_str(),
             static_cast<UINT32>(label.length()),
@@ -127,42 +108,7 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
     }
   }
 
-  Super::updateLayoutMetrics(layoutMetrics, oldLayoutMetrics);
-}
-
-void UnimplementedNativeViewComponentView::updateState(
-    facebook::react::State::Shared const &state,
-    facebook::react::State::Shared const &oldState) noexcept {}
-
-void UnimplementedNativeViewComponentView::prepareForRecycle() noexcept {}
-
-facebook::react::SharedViewProps UnimplementedNativeViewComponentView::viewProps() noexcept {
-  return m_props;
-}
-
-winrt::Microsoft::ReactNative::Composition::IVisual UnimplementedNativeViewComponentView::Visual() const noexcept {
-  return m_visual;
-}
-
-winrt::Microsoft::ReactNative::Composition::IVisual UnimplementedNativeViewComponentView::OuterVisual() const noexcept {
-  return m_visual;
-}
-
-facebook::react::Tag UnimplementedNativeViewComponentView::hitTest(
-    facebook::react::Point pt,
-    facebook::react::Point &localPt,
-    bool ignorePointerEvents) const noexcept {
-  facebook::react::Point ptLocal{pt.x - m_layoutMetrics.frame.origin.x, pt.y - m_layoutMetrics.frame.origin.y};
-
-  if ((ignorePointerEvents || m_props->pointerEvents == facebook::react::PointerEventsMode::Auto ||
-       m_props->pointerEvents == facebook::react::PointerEventsMode::BoxOnly) &&
-      ptLocal.x >= 0 && ptLocal.x <= m_layoutMetrics.frame.size.width && ptLocal.y >= 0 &&
-      ptLocal.y <= m_layoutMetrics.frame.size.height) {
-    localPt = ptLocal;
-    return Tag();
-  }
-
-  return -1;
+  base_type::updateLayoutMetrics(layoutMetrics, oldLayoutMetrics);
 }
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -29,7 +29,9 @@ winrt::Microsoft::ReactNative::ComponentView UnimplementedNativeViewComponentVie
   return winrt::make<UnimplementedNativeViewComponentView>(compContext, tag, reactContext);
 }
 
-void UnimplementedNativeViewComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
+void UnimplementedNativeViewComponentView::handleCommand(
+    std::string const &commandName,
+    folly::dynamic const &arg) noexcept {
   // Do not call base to avoid unknown command asserts
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -29,6 +29,10 @@ winrt::Microsoft::ReactNative::ComponentView UnimplementedNativeViewComponentVie
   return winrt::make<UnimplementedNativeViewComponentView>(compContext, tag, reactContext);
 }
 
+void UnimplementedNativeViewComponentView::handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept {
+  // Do not call base to avoid unknown command asserts
+}
+
 void UnimplementedNativeViewComponentView::updateLayoutMetrics(
     facebook::react::LayoutMetrics const &layoutMetrics,
     facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
@@ -15,37 +15,15 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 struct UnimplementedNativeViewComponentView
-    : public winrt::Microsoft::ReactNative::Composition::implementation::
-          UnimplementedNativeViewComponentViewT<UnimplementedNativeViewComponentView, CompositionBaseComponentView> {
-  using Super = winrt::Microsoft::ReactNative::Composition::implementation::
-      UnimplementedNativeViewComponentViewT<UnimplementedNativeViewComponentView, CompositionBaseComponentView>;
-
+    : public UnimplementedNativeViewComponentViewT<UnimplementedNativeViewComponentView, CompositionViewComponentView> {
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
-      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-      uint32_t index) noexcept override;
-  void unmountChildComponentView(
-      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-      uint32_t index) noexcept override;
-
-  void updateState(facebook::react::State::Shared const &state, facebook::react::State::Shared const &oldState) noexcept
-      override;
-
-  void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept
-      override;
   void updateLayoutMetrics(
       facebook::react::LayoutMetrics const &layoutMetrics,
       facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept override;
-  void prepareForRecycle() noexcept override;
-  facebook::react::SharedViewProps viewProps() noexcept override;
-  facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
-      const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual OuterVisual() const noexcept override;
 
   UnimplementedNativeViewComponentView(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
@@ -54,7 +32,7 @@ struct UnimplementedNativeViewComponentView
 
  private:
   std::shared_ptr<facebook::react::UnimplementedNativeViewProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_labelVisual{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
@@ -25,6 +25,8 @@ struct UnimplementedNativeViewComponentView
       facebook::react::LayoutMetrics const &layoutMetrics,
       facebook::react::LayoutMetrics const &oldLayoutMetrics) noexcept override;
 
+  void handleCommand(std::string const &commandName, folly::dynamic const &arg) noexcept override;
+
   UnimplementedNativeViewComponentView(
       const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
       facebook::react::Tag tag,


### PR DESCRIPTION
Aligns the implementation of `UnimplementedNativeViewComponentView` better with the core implementation.  In particular, making it behave like a normal view, but with an extra overlay displaying the "UnimplementedView" error.  This allows more functionality to work in the case of an unimplemented view for a better developer experience.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12650)