### PR TITLE
[0.72] Include line/column numbers on syntax error

### DIFF
--- a/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
+++ b/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Include line/column numbers on syntax error",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
+++ b/change/react-native-windows-6dacc619-c892-4699-a1c5-699dcb40ed6b.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Include line/column numbers on syntax error",
   "packageName": "react-native-windows",
   "email": "4123478+tido64@users.noreply.github.com",

--- a/vnext/Shared/JSI/ChakraRuntime.cpp
+++ b/vnext/Shared/JSI/ChakraRuntime.cpp
@@ -9,6 +9,7 @@
 
 #include <cxxreact/MessageQueueThread.h>
 
+#include <strsafe.h>
 #include <cstring>
 #include <limits>
 #include <mutex>
@@ -698,8 +699,37 @@ void ChakraRuntime::RewriteErrorMessage(JsValueRef jsError) {
     JsGetAndClearException(&ignoreJSError);
   } else if (GetValueType(message) == JsValueType::JsString) {
     // JSI unit tests expect V8 or JSC like message for stack overflow.
-    if (StringToPointer(message) == L"Out of stack space") {
+    std::wstring_view errorMessage = StringToPointer(message);
+    if (errorMessage == L"Out of stack space") {
       SetProperty(jsError, m_propertyId.message, PointerToString(L"RangeError : Maximum call stack size exceeded"));
+    } else if (errorMessage == L"Syntax error") {
+      JsValueRef result;
+      JsPropertyIdRef property;
+
+      JsGetPropertyIdFromName(L"line", &property);
+      if (JsGetProperty(jsError, property, &result) != JsNoError) {
+        // If the 'line' property getter throws, clear the exception and ignore it.
+        JsValueRef ignoreJSError{JS_INVALID_REFERENCE};
+        JsGetAndClearException(&ignoreJSError);
+        return;
+      }
+
+      // Line numbers start from zero
+      const int32_t line = NumberToInt(result) + 1;
+      wchar_t buf[1024] = {};
+
+      JsGetPropertyIdFromName(L"column", &property);
+      if (JsGetProperty(jsError, property, &result) != JsNoError) {
+        // If the 'column' property getter throws, clear the exception and ignore it.
+        JsValueRef ignoreJSError{JS_INVALID_REFERENCE};
+        JsGetAndClearException(&ignoreJSError);
+        StringCchPrintf(buf, std::size(buf), L"Syntax error at line %i", line);
+      } else {
+        const int32_t column = NumberToInt(result);
+        StringCchPrintf(buf, std::size(buf), L"Syntax error at line %i column %i", line, column);
+      }
+
+      SetProperty(jsError, m_propertyId.message, PointerToString(buf));
     }
   }
 }


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

When Chakra encounters a syntax error, it does not provide line/column numbers, making it hard to determine what went wrong.

### What

This change extracts line/column from the error and appends it to the error message.

Cherry-picks #12644

## Screenshots

| Before | After |
| :-: | :-: |
| ![image](https://github.com/microsoft/react-native-windows/assets/4123478/c2f1b1fb-bfa9-43a4-9bc3-1750a6b8383a) | ![image](https://github.com/microsoft/react-native-windows/assets/4123478/956b7a33-ce27-4c98-b845-dbef77a87684) |

## Testing

Add a valid JS line that Chakra does not recognize at the top of `index.js`, e.g.:

```js
test ??= 1;
```

## Changelog

Include line/column numbers when Chakra encounters a syntax error

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12652)