### PR TITLE
[Fabric] fix visual issue when quickly dragging scrollthumb before it finishes animating in

### DIFF
--- a/change/react-native-windows-d81c3da7-477e-4def-8b2c-cb306856b83a.json
+++ b/change/react-native-windows-d81c3da7-477e-4def-8b2c-cb306856b83a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] fix visual issue when quickly dragging scrollthumb before it finishes animating in",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -305,10 +305,10 @@ struct ScrollBarComponent {
   }
 
   void stopTrackingThumb() noexcept {
-      m_nTrackInputOffset = -1;
-      m_thumbVisual.AnimationClass(
+    m_nTrackInputOffset = -1;
+    m_thumbVisual.AnimationClass(
         m_vertical ? winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical
-                 : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
+                   : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
   }
 
   void handleMoveThumb(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -296,12 +296,19 @@ struct ScrollBarComponent {
         pt.Properties().PointerUpdateKind() ==
             winrt::Microsoft::ReactNative::Composition::Input::PointerUpdateKind::LeftButtonReleased) {
       handleMoveThumb(args);
-      m_nTrackInputOffset = -1;
+      stopTrackingThumb();
       m_outer.ReleasePointerCapture(args.Pointer());
 
       auto reg = HitTest(pt.Position());
       updateShy(reg == ScrollbarHitRegion::Unknown);
     }
+  }
+
+  void stopTrackingThumb() noexcept {
+      m_nTrackInputOffset = -1;
+      m_thumbVisual.AnimationClass(
+        m_vertical ? winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical
+                 : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
   }
 
   void handleMoveThumb(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
@@ -358,6 +365,7 @@ struct ScrollBarComponent {
         case ScrollbarHitRegion::Thumb: {
           m_outer.CapturePointer(args.Pointer());
           m_nTrackInputOffset = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_thumbPos;
+          m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::None);
           handleMoveThumb(args);
         }
       }
@@ -384,7 +392,7 @@ struct ScrollBarComponent {
     if (!m_visible)
       return;
 
-    m_nTrackInputOffset = -1;
+    stopTrackingThumb();
     updateShy(true);
   }
 


### PR DESCRIPTION
## Description
The scroll thumb will end up slightly offset if the user grabs the scrollthumb and starts moving it before the animation from shy scrollbar to the full scrollbar completed.

The fix is to turn off all thumb animations when moving it through manual scrollbar thumb drag.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12671)