### PR TITLE
[Fabric] Mouse wheel handling when use WM_MSG hosting uses wrong mouse position

### DIFF
--- a/change/react-native-windows-10fada60-92a0-45bc-aa00-f41836b229eb.json
+++ b/change/react-native-windows-10fada60-92a0-45bc-aa00-f41836b229eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Mouse wheel handling when use WM_MSG hosting uses wrong mouse position",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Composition.Input.cpp
@@ -464,7 +464,7 @@ winrt::Windows::Foundation::Point PointerPoint::Position() const noexcept {
   POINT clientPoint{
       m_pi.pointerId ? m_pi.ptPixelLocation.x : GET_X_LPARAM(m_lParam),
       m_pi.pointerId ? m_pi.ptPixelLocation.y : GET_Y_LPARAM(m_lParam)};
-  if (m_pi.pointerId) {
+  if (m_pi.pointerId || m_msg == WM_MOUSEWHEEL || m_msg == WM_MOUSEHWHEEL) {
     ScreenToClient(m_hwnd, &clientPoint);
   }
   return winrt::Windows::Foundation::Point{


### PR DESCRIPTION
## Description
WM_MOUSEWHEEL handling was using the mouse position as a client coordinates, even though it comes through in screen coords.