### PR TITLE
Fixes clang warnings for non-portable folly includes

### DIFF
--- a/change/react-native-windows-5159d78a-73cf-403d-98ad-9345e6333418.json
+++ b/change/react-native-windows-5159d78a-73cf-403d-98ad-9345e6333418.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes clang warnings for non-portable folly includes",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/FollyIncludes.h
+++ b/vnext/Microsoft.ReactNative/Base/FollyIncludes.h
@@ -12,12 +12,12 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4324) // 'folly::max_align_t': structure was padded due to alignment specifier
-#include <folly/lang/align.h>
+#include <folly/lang/Align.h>
 #pragma warning(pop)
 
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
-#include <folly/container/detail/f14table.h>
+#include <folly/container/detail/F14table.h>
 #pragma warning(pop)
 
 #include <folly/Memory.h>

--- a/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/IReactInstance.h
@@ -5,7 +5,7 @@
 #include <InstanceManager.h>
 
 #include <DevSettings.h>
-#include <Folly/dynamic.h>
+#include <folly/dynamic.h>
 #include "XamlView.h"
 
 #include <functional>


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Updating the casing of various folly includes in react-native-windows to clean up clang warnings related to non-portable includes.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12682)