### PR TITLE
Cleanup const qualifier on constexpr

### DIFF
--- a/change/react-native-windows-a0922e31-5eb5-4bcd-ac1d-5586b82479c2.json
+++ b/change/react-native-windows-a0922e31-5eb5-4bcd-ac1d-5586b82479c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Cleanup const qualifier on constexpr",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/future/details/executor.h
+++ b/vnext/Mso/future/details/executor.h
@@ -86,7 +86,7 @@ struct DefaultThenArgValidator {
   static auto CheckArgs() -> decltype(CheckArgs0(std::declval<TCallback>(), 0, 0, 0, 0));
 
   template <class TCallback>
-  constexpr static const CallbackArgKind GetArgKind() noexcept {
+  constexpr static CallbackArgKind GetArgKind() noexcept {
     static_assert(
         decltype(CheckArgs<TCallback>())::value != CallbackArgKind::Invalid,
         "Callback valid parameters: T&&, const T&, T, Maybe<T>&&, or Maybe<T>&.");


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
This fixes up a clang warning about const qualifiers that have no effect. Since this is already a constexpr, the const qualifier is not needed.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12684)