### PR TITLE
Return null for missing view manager constants

### DIFF
--- a/change/react-native-windows-ccf12cc0-5edc-4a16-a5a7-7cc0926c46d9.json
+++ b/change/react-native-windows-ccf12cc0-5edc-4a16-a5a7-7cc0926c46d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Return null for missing view manager constants",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.cpp
@@ -111,8 +111,11 @@ class UIManagerModule : public std::enable_shared_from_this<UIManagerModule>, pu
     m_nativeUIManager->setHost(this);
   }
 
-  React::JSValueObject getConstantsForViewManager(std::string &&viewManagerName) noexcept {
+  React::JSValue getConstantsForViewManager(std::string &&viewManagerName) noexcept {
     const IViewManager *vm = GetViewManager(viewManagerName);
+    if (vm == nullptr) {
+      return {};
+    }
 
     auto writer = winrt::Microsoft::ReactNative::MakeJSValueTreeWriter();
     writer.WriteObjectBegin();
@@ -543,11 +546,11 @@ void UIManager::Initialize(winrt::Microsoft::ReactNative::ReactContext const &re
   m_module->Initialize(reactContext);
 }
 
-React::JSValueObject UIManager::getConstantsForViewManager(std::string viewManagerName) noexcept {
+React::JSValue UIManager::getConstantsForViewManager(std::string viewManagerName) noexcept {
   return m_module->getConstantsForViewManager(std::move(viewManagerName));
 }
 
-React::JSValueObject UIManager::getViewManagerConfig(std::string viewManagerName) noexcept {
+React::JSValue UIManager::getViewManagerConfig(std::string viewManagerName) noexcept {
   return getConstantsForViewManager(std::move(viewManagerName));
 }
 
@@ -562,8 +565,7 @@ React::JSValueArray UIManager::getDefaultEventTypes() noexcept {
   return {};
 }
 
-React::JSValueObject UIManager::lazilyLoadView(std::string name) noexcept {
-  assert(false);
+React::JSValue UIManager::lazilyLoadView(std::string name) noexcept {
   // TODO
   return {};
 }

--- a/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Modules/PaperUIManagerModule.h
@@ -54,17 +54,17 @@ struct UIManager final {
   void ConstantsViaConstantsProvider(winrt::Microsoft::ReactNative::ReactConstantProvider &constants) noexcept;
 
   REACT_SYNC_METHOD(getConstantsForViewManager)
-  winrt::Microsoft::ReactNative::JSValueObject getConstantsForViewManager(std::string viewManagerName) noexcept;
+  winrt::Microsoft::ReactNative::JSValue getConstantsForViewManager(std::string viewManagerName) noexcept;
 
   // Not part of the spec, but core polyfils this on the JS side.
   REACT_SYNC_METHOD(getViewManagerConfig)
-  winrt::Microsoft::ReactNative::JSValueObject getViewManagerConfig(std::string viewManagerName) noexcept;
+  winrt::Microsoft::ReactNative::JSValue getViewManagerConfig(std::string viewManagerName) noexcept;
 
   REACT_SYNC_METHOD(getDefaultEventTypes)
   winrt::Microsoft::ReactNative::JSValueArray getDefaultEventTypes() noexcept;
 
   REACT_SYNC_METHOD(lazilyLoadView)
-  winrt::Microsoft::ReactNative::JSValueObject lazilyLoadView(std::string name) noexcept;
+  winrt::Microsoft::ReactNative::JSValue lazilyLoadView(std::string name) noexcept;
 
   REACT_METHOD(createView)
   void createView(


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
react-native-windows currently returns an empty object for UIManager::getConstantsForViewManager. This breaks the hasViewManagerConfig checks in JS, which may be used to determine whether a view should attempt to render or not (or to gate a requireNativeComponent call, in the case of DebuggingOverlay). Having this behavior would have prevented the need to introduce the stub DebuggingOverlay view manager.

## Changelog
Should this change be included in the release notes: _yes_

Fixes bug where hasViewManagerConfig checks may have returned truthy values
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12685)