### PR TITLE
Fix clang warnings for non-portable Yoga includes

### DIFF
--- a/change/react-native-windows-82238772-4d82-4442-8dcf-de8b46c20a75.json
+++ b/change/react-native-windows-82238772-4d82-4442-8dcf-de8b46c20a75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix clang warnings for non-portable Yoga includes",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/CxxReactIncludes.h
+++ b/vnext/Microsoft.ReactNative/Base/CxxReactIncludes.h
@@ -13,6 +13,6 @@
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/MessageQueueThread.h>
 #include <fbsystrace.h>
-#include <yoga/yoga.h>
+#include <yoga/Yoga.h>
 
 #include <ReactCommon/TurboModule.h>

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -8,7 +8,7 @@
 #include <Views/ViewManagerBase.h>
 
 #include <folly/dynamic.h>
-#include <yoga/yoga.h>
+#include <yoga/Yoga.h>
 
 #include <ReactHost/React.h>
 #include <ReactRootView.h>

--- a/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ShadowNodeBase.h
@@ -7,7 +7,7 @@
 #include <XamlView.h>
 
 #include <folly/dynamic.h>
-#include <yoga/yoga.h>
+#include <yoga/Yoga.h>
 
 #include <Shared/ReactWindowsAPI.h>
 #include "KeyboardEventHandler.h"

--- a/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
+++ b/vnext/Microsoft.ReactNative/Views/ViewManagerBase.h
@@ -8,7 +8,7 @@
 #include <Views/ViewManager.h>
 #include <XamlView.h>
 #include <folly/dynamic.h>
-#include <yoga/yoga.h>
+#include <yoga/Yoga.h>
 #include "Utils/BatchingEventEmitter.h"
 
 namespace Microsoft::ReactNative {


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
We see errors like:
```
Views\ShadowNodeBase.h:10:10: error: non-portable path to file '<yoga/Yoga.h>'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]
         ^~~~~~~~~~~~~
         <yoga/Yoga.h>
1 error generated.
```

When compiling with clang. This cleans up all the invalid Yoga includes.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12686)