### PR TITLE
Add unbroken exclusion to unblock CI

### DIFF
--- a/.unbroken_exclusions
+++ b/.unbroken_exclusions
@@ -22,3 +22,4 @@ File not found edge:/inspect while parsing packages/playground/README_compositio
 !packages/@rnw-scripts/format-files/node_modules
 !packages/@rnw-scripts/promote-release/node_modules
 !.github/ISSUE_TEMPLATE
+!.github/security.md


### PR DESCRIPTION
The Linting PR CI job is timing out while running the "check web links in .md files" task. 

For some reason unbroken hangs when it gets to the .github/security.md file. 

Neither security.md nor unbroken have changed in several years. Adding it to the exclusion list would unblock CI for now. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12695)