### PR TITLE
Add Playground Composition CI Builds with UseExperimentalWinUI3 enabled

### DIFF
--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -38,6 +38,21 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
+          - Name: X86DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -128,7 +143,7 @@ jobs:
                 parameters:
                   certificateName: playgroundEncodedKey
 
-            - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
+            - ${{ if and(eq(matrix.UseExperimentalWinUI3, true), eq(variables['EnableInternalWinAppSDKFeed'], true)) }}:
               - task: PowerShell@2
                 displayName: Enable the internal WinAppSDK Feed
                 inputs:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -65,6 +65,7 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -105,6 +106,13 @@ jobs:
               - template: ../templates/write-certificate.yml
                 parameters:
                   certificateName: playgroundEncodedKey
+
+            - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
+              - task: PowerShell@2
+                displayName: Enable the internal WinAppSDK Feed
+                inputs:
+                  targetType: filePath # filePath | inline
+                  filePath: $(Build.SourcesDirectory)\vnext\Scripts\EnableInternalWinAppSDKFeed.ps1
 
             # NuGet ignores packages.config if it detects <PackageReference>.
             # Use restore packages.config directly to keep compabitility with ReactNativePicker.

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -38,21 +38,6 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          - Name: X86DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64ReleaseCompositionExperimentalWinUI3
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -30,6 +30,29 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             SolutionFile: Playground-Composition.sln
+          - Name: X64DebugComposition
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X64ReleaseComposition
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X86DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -64,6 +87,19 @@ parameters:
           - Name: X86DebugComposition
             BuildConfiguration: Debug
             BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+          - Name: X64ReleaseComposition
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X86DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
             UseExperimentalWinUI3: true
           - Name: X86DebugWin32

--- a/change/react-native-windows-40fd0d43-fac7-435f-ab0a-2c0c7e55c981.json
+++ b/change/react-native-windows-40fd0d43-fac7-435f-ab0a-2c0c7e55c981.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Secure CI",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-40fd0d43-fac7-435f-ab0a-2c0c7e55c981.json
+++ b/change/react-native-windows-40fd0d43-fac7-435f-ab0a-2c0c7e55c981.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Secure CI",
+  "comment": "Add Playground Composition CI Builds with UseExperimentalWinUI3 enabled",
   "packageName": "react-native-windows",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -20,7 +20,6 @@
 
   <PropertyGroup Label="WinUI3 for fabric" Condition="'$(SolutionName)'=='playground-composition'">
     <UseWinUI3>true</UseWinUI3>
-    <UseExperimentalWinUI3>true</UseExperimentalWinUI3>
   </PropertyGroup>
 
 </Project>

--- a/vnext/Scripts/EnableInternalWinAppSDKFeed.ps1
+++ b/vnext/Scripts/EnableInternalWinAppSDKFeed.ps1
@@ -1,0 +1,21 @@
+param(
+)
+
+[string] $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
+
+$StartingLocation = Get-Location
+Set-Location -Path $RepoRoot
+
+try
+{
+    [xml] $nugetConfig = Get-Content "NuGet.Config"
+    $newFeed = $nugetConfig.configuration.packageSources.add.clone()
+    $newFeed.key = "Project.Reunion.nuget.internal";
+    $newFeed.value = "https://microsoft.pkgs.visualstudio.com/ProjectReunion/_packaging/Project.Reunion.nuget.internal/nuget/v3/index.json";
+    $nugetConfig.configuration.packageSources.AppendChild($newFeed)
+    $nugetConfig.Save("NuGet.Config")
+}
+finally
+{
+    Set-Location -Path "$StartingLocation"
+}


### PR DESCRIPTION
## Description

This PR:

1. Removes the hardcoded UseExperimentalWinUI3 == true flag in the Playground Composition project
2. Adds new configurations to the CI matrix to set it to true for Playground Composition
3. Adds a new script to enable access to the internal WinUI3 builds, and runs it if the `EnableInternalWinAppSDKFeed` variable is set

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
We need to build playground with both the release WinUI and internal experimental versions.


### What
See above.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: _no_