### PR TITLE
[0.72] Move publish builds back to node 16

### DIFF
--- a/.ado/continuous.yml
+++ b/.ado/continuous.yml
@@ -17,6 +17,9 @@ parameters:
       Medium:
         name: rnw-pool-4
         demands: ImageOverride -equals rnw-img-vs2022-node18
+      MediumNode16:
+        name: rnw-pool-4
+        demands: ImageOverride -equals rnw-img-vs2022
       Large:
         name: rnw-pool-8
         demands: ImageOverride -equals rnw-img-vs2022-node18

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -18,10 +18,10 @@ parameters:
   default:
     Medium:
       name: rnw-pool-4-microsoft
-      demands: ImageOverride -equals rnw-img-vs2022-node18
+      demands: ImageOverride -equals rnw-img-vs2022
     Large:
       name: rnw-pool-8-microsoft
-      demands: ImageOverride -equals rnw-img-vs2022-node18
+      demands: ImageOverride -equals rnw-img-vs2022
 
 - name: desktopBuildMatrix
   type: object


### PR DESCRIPTION
Publish appears to break running on node 18.  I moved to 18 primarily for the cli init tests, which publish doesn't run - so this should be fine.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12698)