### PR TITLE
Ensure react-native-windows-init still works on Node 16

### DIFF
--- a/change/@react-native-windows-fs-00c3c8c9-831c-49c5-ba9d-1649bffe54bf.json
+++ b/change/@react-native-windows-fs-00c3c8c9-831c-49c5-ba9d-1649bffe54bf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure react-native-windows-init still works on Node 16",
+  "packageName": "@react-native-windows/fs",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-7d014f54-a40e-4c1a-8c2c-ba9e04d9cedf.json
+++ b/change/@react-native-windows-telemetry-7d014f54-a40e-4c1a-8c2c-ba9e04d9cedf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure react-native-windows-init still works on Node 16",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-e2368ae7-35ec-488c-97d3-2731769bc2f1.json
+++ b/change/react-native-windows-init-e2368ae7-35ec-488c-97d3-2731769bc2f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Ensure react-native-windows-init still works on Node 16",
+  "packageName": "react-native-windows-init",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -43,8 +43,5 @@
       "patch"
     ]
   },
-  "promoteRelease": true,
-  "engines": {
-    "node": ">= 18"
-  }
+  "promoteRelease": true
 }

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -18,7 +18,8 @@
     "watch": "rnw-scripts watch"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.0-canary.30",
+    "@azure/core-auth": "1.5.0",
+    "@react-native-windows/fs": "0.0.0-canary.30",
     "@xmldom/xmldom": "^0.7.7",
     "applicationinsights": "2.9.1",
     "ci-info": "^3.2.0",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -59,8 +59,5 @@
     ]
   },
   "promoteRelease": true,
-  "windowsOnly": true,
-  "engines": {
-    "node": ">= 18"
-  }
+  "windowsOnly": true
 }

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -22,8 +22,8 @@
     "react-native-windows-init": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.0-canary.30",
-    "@react-native-windows/telemetry": "^0.0.0-canary.81",
+    "@react-native-windows/fs": "0.0.0-canary.30",
+    "@react-native-windows/telemetry": "0.0.0-canary.81",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.0",
@@ -65,8 +65,5 @@
     "disallowedChangeTypes": [
       "prerelease"
     ]
-  },
-  "engines": {
-    "node": ">= 18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,7 +22,7 @@
   dependencies:
     tslib "^2.0.0"
 
-"@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0":
+"@azure/core-auth@1.5.0", "@azure/core-auth@^1.4.0", "@azure/core-auth@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.5.0.tgz#a41848c5c31cb3b7c84c409885267d55a2c92e44"
   integrity sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==


### PR DESCRIPTION
## Descriptions

Fixes `react-native-windows-init` to still work on Node 16.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
RNW 0.72 still required Node 16 and so this script still needs to work on Node 16 machines.

Resolves #12711 

### What
Removed the engine requirement on `react-native-windows-init` and the two packages of ours it requires to make sure we never pull in a dependency that requires Node 18.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12712)