### PR TITLE
Add missing sstream includes

### DIFF
--- a/change/react-native-windows-e5e178ee-29d3-4576-a7a2-9c156569188c.json
+++ b/change/react-native-windows-e5e178ee-29d3-4576-a7a2-9c156569188c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add missing sstream includes",
+  "packageName": "react-native-windows",
+  "email": "julio.rocha@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Common/Utilities.cpp
+++ b/vnext/Common/Utilities.cpp
@@ -13,6 +13,8 @@
 #include <winrt/Windows.Security.Cryptography.h>
 
 // Standard Library
+#include <sstream>
+
 using std::string;
 using std::string_view;
 using std::wstring_view;

--- a/vnext/Desktop.UnitTests/UtilsTest.cpp
+++ b/vnext/Desktop.UnitTests/UtilsTest.cpp
@@ -5,6 +5,9 @@
 #include <Utils.h>
 #include <utilities.h>
 
+// Windows API
+#include <winrt/base.h>
+
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using std::string;

--- a/vnext/Shared/Modules/FileReaderModule.cpp
+++ b/vnext/Shared/Modules/FileReaderModule.cpp
@@ -5,7 +5,6 @@
 
 #include <CreateModules.h>
 #include <ReactPropertyBag.h>
-#include <sstream>
 
 // React Native
 #include <cxxreact/JsArgumentHelpers.h>

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -19,9 +19,6 @@
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Security.Cryptography.h>
 
-// Standard Library
-#include <sstream>
-
 using Microsoft::Common::Utilities::CheckedReinterpretCast;
 
 using std::function;


### PR DESCRIPTION
## Description

Add missing Standard Libirary includes for compiling Base64 encoding functions.


### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
C++17 won't infer the missing entries automatically.
This would break compilation in non-`main` branches.

### What
Add `winrt/` and `sstream` header includes 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12713)