### PR TITLE
[Fabric] Expose (un)MountChildComponentView to 3P components

### DIFF
--- a/change/react-native-windows-e8be0ae0-0b26-45e7-8ec8-ddff443c2546.json
+++ b/change/react-native-windows-e8be0ae0-0b26-45e7-8ec8-ddff443c2546.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Expose (un)MountChildComponentView to 3P components",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -16,9 +16,9 @@
 #include <winrt/Microsoft.UI.interop.h>
 #endif
 
-#include "YogaXamlPanel.h"
-
 #include "App.CustomComponent.g.h"
+#include <NativeModules.h>
+#include "YogaXamlPanel.h"
 
 namespace winrt::PlaygroundApp::implementation {
 
@@ -26,20 +26,16 @@ namespace winrt::PlaygroundApp::implementation {
  * Custom Properties can be passed from JS to this native component
  * This struct will eventually be codegen'd from the JS spec file
  */
+REACT_STRUCT(CustomXamlComponentProps)
 struct CustomXamlComponentProps
     : winrt::implements<CustomXamlComponentProps, winrt::Microsoft::ReactNative::IComponentProps> {
   CustomXamlComponentProps(winrt::Microsoft::ReactNative::ViewProps props) : m_props(props) {}
 
   void SetProp(uint32_t hash, winrt::hstring propName, winrt::Microsoft::ReactNative::IJSValueReader value) noexcept {
-    if (propName == L"label") {
-      if (!value) {
-        label.clear();
-      } else {
-        label = value.GetString();
-      }
-    }
+    winrt::Microsoft::ReactNative::ReadProp(hash, propName, value, *this);
   }
 
+  REACT_FIELD(label);
   winrt::hstring label;
   winrt::Microsoft::ReactNative::ViewProps m_props;
 };

--- a/vnext/Microsoft.ReactNative/ComponentView.idl
+++ b/vnext/Microsoft.ReactNative/ComponentView.idl
@@ -77,6 +77,8 @@ namespace Microsoft.ReactNative
     IVectorView<ComponentView> Children { get; };
     IReactContext ReactContext { get;};
 
+    overridable void MountChildComponentView(ComponentView childComponentView, UInt32 index);
+    overridable void UnmountChildComponentView(ComponentView childComponentView, UInt32 index);
     overridable void HandleCommand(String commandName, IJSValueReader args);
     overridable void UpdateProps(IComponentProps props);
     overridable void UpdateState(IComponentState state);

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.cpp
@@ -43,13 +43,19 @@ ComponentView::supplementalComponentDescriptorProviders() noexcept {
   return {};
 }
 
-void ComponentView::mountChildComponentView(
+void ComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-    uint32_t index) noexcept {}
+    uint32_t index) noexcept {
+  m_children.InsertAt(index, childComponentView);
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(*this);
+}
 
-void ComponentView::unmountChildComponentView(
+void ComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-    uint32_t index) noexcept {}
+    uint32_t index) noexcept {
+  m_children.RemoveAt(index);
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(nullptr);
+}
 
 void ComponentView::updateProps(
     facebook::react::Props::Shared const &props,

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -62,12 +62,6 @@ struct ComponentView : public ComponentViewT<ComponentView> {
       bool customComponent);
 
   virtual std::vector<facebook::react::ComponentDescriptorProvider> supplementalComponentDescriptorProviders() noexcept;
-  virtual void mountChildComponentView(
-      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-      uint32_t index) noexcept;
-  virtual void unmountChildComponentView(
-      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
-      uint32_t index) noexcept;
   virtual void updateProps(
       facebook::react::Props::Shared const &props,
       facebook::react::Props::Shared const &oldProps) noexcept;
@@ -117,6 +111,12 @@ struct ComponentView : public ComponentViewT<ComponentView> {
       facebook::react::Props::Shared const &props) noexcept;
 
   // Publicaly overridable APIs
+  virtual void MountChildComponentView(
+      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+      uint32_t index) noexcept;
+  virtual void UnmountChildComponentView(
+      const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+      uint32_t index) noexcept;
   virtual void HandleCommand(
       winrt::hstring commandName,
       const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -28,16 +28,18 @@ ActivityIndicatorComponentView::ActivityIndicatorComponentView(
   m_props = std::make_shared<facebook::react::ActivityIndicatorViewProps const>();
 }
 
-void ActivityIndicatorComponentView::mountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
+void ActivityIndicatorComponentView::MountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void ActivityIndicatorComponentView::unmountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
+void ActivityIndicatorComponentView::UnmountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void ActivityIndicatorComponentView::updateProgressColor(const facebook::react::SharedColor &color) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
@@ -21,10 +21,10 @@ struct ActivityIndicatorComponentView : ActivityIndicatorComponentViewT<Activity
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1508,27 +1508,22 @@ winrt::Microsoft::ReactNative::ComponentView ViewComponentView::Create(
   return winrt::make<ViewComponentView>(compContext, tag, reactContext, false);
 }
 
-void ViewComponentView::mountChildComponentView(
+void ViewComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
-  m_children.InsertAt(index, childComponentView);
+  base_type::MountChildComponentView(childComponentView, index);
 
   indexOffsetForBorder(index);
-
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(*this);
-
   ensureVisual();
   m_visual.InsertAt(childComponentView.as<ComponentView>()->OuterVisual(), index);
 }
 
-void ViewComponentView::unmountChildComponentView(
+void ViewComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
-  m_children.RemoveAt(index);
+  base_type::UnmountChildComponentView(childComponentView, index);
 
   indexOffsetForBorder(index);
-
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(nullptr);
   m_visual.Remove(childComponentView.as<ComponentView>()->OuterVisual());
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -181,10 +181,10 @@ struct ViewComponentView : public ViewComponentViewT<ViewComponentView, Componen
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -12,16 +12,18 @@ DebuggingOverlayComponentView::DebuggingOverlayComponentView(
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : base_type(compContext, tag, reactContext, false) {}
 
-void DebuggingOverlayComponentView::mountChildComponentView(
+void DebuggingOverlayComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void DebuggingOverlayComponentView::unmountChildComponentView(
+void DebuggingOverlayComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 winrt::Microsoft::ReactNative::ComponentView DebuggingOverlayComponentView::Create(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
@@ -17,10 +17,10 @@ struct DebuggingOverlayComponentView
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -57,16 +57,18 @@ ImageComponentView::ImageComponentView(
   m_props = defaultProps;
 }
 
-void ImageComponentView::mountChildComponentView(
+void ImageComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void ImageComponentView::unmountChildComponentView(
+void ImageComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void ImageComponentView::ImageLoadStart() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -36,10 +36,10 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -28,16 +28,18 @@ WindowsModalHostComponentView::WindowsModalHostComponentView(
   m_visual = compContext.CreateSpriteVisual();
 }
 
-void WindowsModalHostComponentView::mountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
-  // assert(false);
+void WindowsModalHostComponentView::MountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void WindowsModalHostComponentView::unmountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
-  // assert(false);
+void WindowsModalHostComponentView::UnmountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
+  assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void WindowsModalHostComponentView::HandleCommand(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.h
@@ -22,10 +22,10 @@ struct WindowsModalHostComponentView : WindowsModalHostComponentViewT<WindowsMod
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -26,19 +26,18 @@ ParagraphComponentView::ParagraphComponentView(
   m_props = defaultProps;
 }
 
-void ParagraphComponentView::mountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
-  // auto v = static_cast<ParagraphComponentView &>(childComponentView);
+void ParagraphComponentView::MountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
-  // m_element.Children().InsertAt(index, v.Element());
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void ParagraphComponentView::unmountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
+void ParagraphComponentView::UnmountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
-  // m_element.Children().RemoveAt(index);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void ParagraphComponentView::updateProps(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -25,10 +25,10 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -675,26 +675,22 @@ ScrollViewComponentView::ScrollViewComponentView(
         */
 }
 
-void ScrollViewComponentView::mountChildComponentView(
+void ScrollViewComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
+  base_type::MountChildComponentView(childComponentView, index);
+
   ensureVisual();
-
-  m_children.InsertAt(index, childComponentView);
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(*this);
-
   m_scrollVisual.InsertAt(
       childComponentView.as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()->OuterVisual(),
       index);
 }
 
-void ScrollViewComponentView::unmountChildComponentView(
+void ScrollViewComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
-  m_children.RemoveAt(index);
-
+  base_type::UnmountChildComponentView(childComponentView, index);
   m_scrollVisual.Remove(childComponentView.as<ComponentView>()->OuterVisual());
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(childComponentView)->parent(nullptr);
 }
 
 void ScrollViewComponentView::updateBackgroundColor(const facebook::react::SharedColor &color) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -58,10 +58,10 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -39,16 +39,18 @@ winrt::Microsoft::ReactNative::ComponentView SwitchComponentView::Create(
   return winrt::make<SwitchComponentView>(compContext, tag, reactContext);
 }
 
-void SwitchComponentView::mountChildComponentView(
+void SwitchComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void SwitchComponentView::unmountChildComponentView(
+void SwitchComponentView::UnmountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
     uint32_t index) noexcept {
   assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void SwitchComponentView::HandleCommand(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -21,10 +21,10 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, Component
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -832,16 +832,18 @@ void WindowsTextInputComponentView::OnCharacterReceived(
   }
 }
 
-void WindowsTextInputComponentView::mountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
+void WindowsTextInputComponentView::MountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
+  base_type::MountChildComponentView(childComponentView, index);
 }
 
-void WindowsTextInputComponentView::unmountChildComponentView(
-    const winrt::Microsoft::ReactNative::ComponentView & /*childComponentView*/,
-    uint32_t /*index*/) noexcept {
+void WindowsTextInputComponentView::UnmountChildComponentView(
+    const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
+    uint32_t index) noexcept {
   assert(false);
+  base_type::UnmountChildComponentView(childComponentView, index);
 }
 
 void WindowsTextInputComponentView::onFocusLost() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -29,10 +29,10 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
-  void mountChildComponentView(
+  void MountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
-  void unmountChildComponentView(
+  void UnmountChildComponentView(
       const winrt::Microsoft::ReactNative::ComponentView &childComponentView,
       uint32_t index) noexcept override;
   void updateProps(facebook::react::Props::Shared const &props, facebook::react::Props::Shared const &oldProps) noexcept

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -240,8 +240,7 @@ void FabricUIManager::RCTPerformMountInstructions(
         newChildComponentView->updateLayoutMetrics(newChildShadowView.layoutMetrics, oldChildShadowView.layoutMetrics);
         newChildViewDescriptor.view.FinalizeUpdates(winrt::Microsoft::ReactNative::ComponentViewUpdateMask::All);
 
-        winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(parentViewDescriptor.view)
-            ->mountChildComponentView(*newChildComponentView, mutation.index);
+        parentViewDescriptor.view.MountChildComponentView(*newChildComponentView, mutation.index);
         break;
       }
 
@@ -250,11 +249,7 @@ void FabricUIManager::RCTPerformMountInstructions(
         auto &parentShadowView = mutation.parentShadowView;
         auto &oldChildViewDescriptor = m_registry.componentViewDescriptorWithTag(oldChildShadowView.tag);
         auto &parentViewDescriptor = m_registry.componentViewDescriptorWithTag(parentShadowView.tag);
-        winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(parentViewDescriptor.view)
-            ->unmountChildComponentView(
-                *winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(
-                    oldChildViewDescriptor.view),
-                mutation.index);
+        parentViewDescriptor.view.UnmountChildComponentView(oldChildViewDescriptor.view, mutation.index);
         break;
       }
 


### PR DESCRIPTION
## Description
Added ability for 3rd party components to customize MountChildComponentView and UnmountChildComponentView.
Added a new helper ReadProp to allow simple implementation of IComponentProps::SetProp.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12720)