### PR TITLE
[Fabric] LogBox crashes when running lifted composition

### DIFF
--- a/change/react-native-windows-a4bd116e-b944-4372-ad29-cdf37e39b336.json
+++ b/change/react-native-windows-a4bd116e-b944-4372-ad29-cdf37e39b336.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] LogBox crashes when running lifted composition",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
+++ b/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
@@ -32,6 +32,8 @@ namespace Microsoft.ReactNative
     FocusNavigationResult NavigateFocus(FocusNavigationRequest request);
 
     Int64 TranslateMessage(UInt32 msg, UInt64 wParam, Int64 lParam);
+
+    Object UiaProvider { get; };
   }
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
+++ b/vnext/Microsoft.ReactNative/CompositionHwndHost.idl
@@ -32,10 +32,6 @@ namespace Microsoft.ReactNative
     FocusNavigationResult NavigateFocus(FocusNavigationRequest request);
 
     Int64 TranslateMessage(UInt32 msg, UInt64 wParam, Int64 lParam);
-
-    Object UiaProvider { get; };
-
-    Windows.UI.Composition.Visual RootVisual();
   }
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -17,55 +17,72 @@
 #include "CompositionRootAutomationProvider.h"
 #include "CompositionRootView.h"
 
+#if USE_WINUI3
+#include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.interop.h>
+#endif
+
 WINUSERAPI UINT WINAPI GetDpiForWindow(_In_ HWND hwnd);
 
 namespace winrt::Microsoft::ReactNative::implementation {
-
-winrt::Windows::UI::Composition::Visual CompositionHwndHost::RootVisual() const noexcept {
-  return m_target.Root();
-}
-
-winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget CompositionHwndHost::Target() const noexcept {
-  assert(m_target);
-  return m_target;
-}
-
-void CompositionHwndHost::CreateDesktopWindowTarget(HWND window) {
-  namespace abi = ABI::Windows::UI::Composition::Desktop;
-
-  auto interop = Compositor().as<abi::ICompositorDesktopInterop>();
-  winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{nullptr};
-  check_hresult(interop->CreateDesktopWindowTarget(
-      window, false, reinterpret_cast<abi::IDesktopWindowTarget **>(put_abi(target))));
-  m_target = target;
-}
-
-void CompositionHwndHost::CreateCompositionRoot() {
-  auto root = Compositor().CreateContainerVisual();
-  root.RelativeSizeAdjustment({1.0f, 1.0f});
-  root.Offset({0, 0, 0});
-  root.Comment(L"Root Visual");
-  m_target.Root(root);
-}
 
 CompositionHwndHost::CompositionHwndHost() noexcept {}
 
 void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
   m_hwnd = (HWND)hwnd;
 
-  m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView();
-  m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
+  auto compositionContext =
+      winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
+          ReactViewHost().ReactNativeHost().InstanceSettings().Properties());
+#if USE_WINUI3
+  if (auto liftedCompositor = winrt::Microsoft::ReactNative::Composition::implementation::
+          MicrosoftCompositionContextHelper::InnerCompositor(compositionContext)) {
+    m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView(liftedCompositor);
+    m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
 
-  CreateDesktopWindowTarget(m_hwnd);
-  CreateCompositionRoot();
+    auto bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
+        liftedCompositor, winrt::Microsoft::UI::GetWindowIdFromWindow(m_hwnd));
+
+    auto island = m_compRootView.Island();
+
+    auto invScale = 1.0f / ScaleFactor();
+    m_compRootView.RootVisual().Scale({invScale, invScale, invScale});
+
+    bridge.Connect(island);
+    bridge.Show();
+
+    m_compRootView.ScaleFactor(ScaleFactor());
+    bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
+  } else {
+    m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView();
+    m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
+
+#endif
+    auto compositor =
+        winrt::Microsoft::ReactNative::Composition::implementation::WindowsCompositionContextHelper::InnerCompositor(
+            compositionContext);
+    auto interop = compositor.as<ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
+    winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{nullptr};
+    check_hresult(interop->CreateDesktopWindowTarget(
+        m_hwnd,
+        false,
+        reinterpret_cast<ABI::Windows::UI::Composition::Desktop::IDesktopWindowTarget **>(put_abi(target))));
+
+    auto root = compositor.CreateContainerVisual();
+    root.RelativeSizeAdjustment({1.0f, 1.0f});
+    root.Offset({0, 0, 0});
+    root.Comment(L"Root Visual");
+    target.Root(root);
+
+    m_compRootView.RootVisual(
+        winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper::CreateVisual(target.Root()));
+
+#if USE_WINUI3
+  }
+#endif
 
   m_compRootView.ReactViewHost(std::move(m_reactViewHost));
-
   m_compRootView.ScaleFactor(ScaleFactor());
-  m_compRootView.RootVisual(
-      winrt::Microsoft::ReactNative::Composition::implementation::WindowsCompositionContextHelper::CreateVisual(
-          RootVisual()));
-
   UpdateSize();
 }
 
@@ -98,20 +115,15 @@ LRESULT CompositionHwndHost::TranslateMessage(int msg, uint64_t wParam, int64_t 
   switch (msg) {
     case WM_WINDOWPOSCHANGED: {
       UpdateSize();
-      /*
-      winrt::Windows::Foundation::Size size{
-          static_cast<float>(reinterpret_cast<const WINDOWPOS *>(lParam)->cx),
-          static_cast<float>(reinterpret_cast<const WINDOWPOS *>(lParam)->cy)};
-      m_compRootView.Size(size);
-      m_compRootView.Measure(size);
-      m_compRootView.Arrange(size);
-      */
       return 0;
     }
   }
 
   if (m_compRootView) {
-    return static_cast<LRESULT>(m_compRootView.SendMessage(msg, wParam, lParam));
+#if USE_WINUI3
+    if (!m_compRootView.Island()) // When using Island hosting we dont need to forward window messages
+#endif
+      return static_cast<LRESULT>(m_compRootView.SendMessage(msg, wParam, lParam));
   }
   return 0;
 }
@@ -131,15 +143,6 @@ void CompositionHwndHost::ReactViewHost(ReactNative::IReactViewHost const &value
   } else {
     m_reactViewHost = value;
   }
-}
-
-winrt::Windows::UI::Composition::Compositor CompositionHwndHost::Compositor() const noexcept {
-  auto compositionContext =
-      winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
-          m_reactViewHost.ReactNativeHost().InstanceSettings().Properties());
-
-  return winrt::Microsoft::ReactNative::Composition::implementation::WindowsCompositionContextHelper::InnerCompositor(
-      compositionContext);
 }
 
 IInspectable CompositionHwndHost::UiaProvider() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.h
@@ -23,26 +23,17 @@ struct CompositionHwndHost : CompositionHwndHostT<CompositionHwndHost> {
   // property UiaProvider
   IInspectable UiaProvider() noexcept;
 
-  winrt::Windows::UI::Composition::Visual RootVisual() const noexcept;
-
   winrt::Microsoft::ReactNative::FocusNavigationResult NavigateFocus(
       const winrt::Microsoft::ReactNative::FocusNavigationRequest &request) noexcept;
 
   LRESULT TranslateMessage(int msg, uint64_t wParam, int64_t lParam) noexcept;
 
  private:
-  // Possibly should be public..
-  winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget Target() const noexcept;
-  winrt::Windows::UI::Composition::Compositor Compositor() const noexcept;
-
-  void CreateDesktopWindowTarget(HWND window);
-  void CreateCompositionRoot();
   void UpdateSize() noexcept;
   float ScaleFactor() noexcept;
 
   HWND m_hwnd;
   winrt::Microsoft::ReactNative::CompositionRootView m_compRootView{nullptr};
-  winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget m_target{nullptr};
   LONG m_height{0};
   LONG m_width{0};
 


### PR DESCRIPTION
## Description
CompositionHwndHost which is used internally by LogBox only had an implementation for system composition.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12725)