### PR TITLE
Add new SecurePullRequest Build Environment in ADO

### DIFF
--- a/.ado/jobs/cli-init-windows.yml
+++ b/.ado/jobs/cli-init-windows.yml
@@ -4,6 +4,7 @@ parameters:
     default: PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/jobs/cli-init.yml
+++ b/.ado/jobs/cli-init.yml
@@ -4,6 +4,7 @@ parameters:
     default: PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -4,6 +4,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
 
   - name: AgentPool

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -5,6 +5,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/jobs/integration-test.yml
+++ b/.ado/jobs/integration-test.yml
@@ -4,6 +4,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/jobs/linting.yml
+++ b/.ado/jobs/linting.yml
@@ -4,6 +4,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
 
   - name: AgentPool

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -4,6 +4,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
 
   - name: AgentPool

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -10,43 +10,95 @@ parameters:
   - name: buildMatrix
     type: object
     default:
-      - BuildEnvironment: PullRequest
-        Matrix:
-          - Name: X86DebugUniversal
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground.sln
-          - Name: X64ReleaseUniversal
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground.sln
-          - Name: X64DebugUniversal
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: Playground.sln
-            RunWack: true
-            UploadAppx: true
-          - Name: X86DebugComposition
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-          - Name: X64DebugComposition
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-          - Name: X64ReleaseComposition
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-          - ${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
+      - ${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
+        - BuildEnvironment: PullRequest
+          Matrix:
             - Name: X86DebugCompositionExperimentalWinUI3
+                BuildConfiguration: Debug
+                BuildPlatform: x86
+                SolutionFile: Playground-Composition.sln
+                UseExperimentalWinUI3: true
+              - Name: X64DebugCompositionExperimentalWinUI3
+                BuildConfiguration: Debug
+                BuildPlatform: x64
+                SolutionFile: Playground-Composition.sln
+                UseExperimentalWinUI3: true
+              - Name: X64ReleaseCompositionExperimentalWinUI3
+                BuildConfiguration: Release
+                BuildPlatform: x64
+                SolutionFile: Playground-Composition.sln
+                UseExperimentalWinUI3: true
+      - ${{ else }}: # Only add these configurations for Secure PR
+        - BuildEnvironment: PullRequest
+          Matrix:
+            - Name: X86DebugUniversal
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground.sln
+            - Name: X64ReleaseUniversal
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground.sln
+            - Name: X64DebugUniversal
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              SolutionFile: Playground.sln
+              RunWack: true
+              UploadAppx: true
+            - Name: X86DebugComposition
               BuildConfiguration: Debug
               BuildPlatform: x86
               SolutionFile: Playground-Composition.sln
-              UseExperimentalWinUI3: true
-            - Name: X64DebugCompositionExperimentalWinUI3
+            - Name: X64DebugComposition
               BuildConfiguration: Debug
               BuildPlatform: x64
+              SolutionFile: Playground-Composition.sln
+            - Name: X64ReleaseComposition
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground-Composition.sln
+            - Name: X86DebugWin32
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground-Win32.sln
+            - Name: X64ReleaseWin32
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground-Win32.sln
+            - Name: X64DebugCoreApp
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              SolutionFile: ..\CoreApp\CoreApp.sln
+        - BuildEnvironment: Continuous
+          Matrix:
+            - Name: X86DebugUniversal
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground.sln
+              UploadAppx: true
+            - Name: X64ReleaseUniversal
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground.sln
+              RunWack: true
+              UploadAppx: true
+            - Name: X64DebugUniversal
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              SolutionFile: Playground.sln
+              RunWack: true
+              UploadAppx: true
+            - Name: X86DebugComposition
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground-Composition.sln
+            - Name: X64ReleaseComposition
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground-Composition.sln
+            - Name: X86DebugCompositionExperimentalWinUI3
+              BuildConfiguration: Debug
+              BuildPlatform: x86
               SolutionFile: Playground-Composition.sln
               UseExperimentalWinUI3: true
             - Name: X64ReleaseCompositionExperimentalWinUI3
@@ -54,67 +106,18 @@ parameters:
               BuildPlatform: x64
               SolutionFile: Playground-Composition.sln
               UseExperimentalWinUI3: true
-          - Name: X86DebugWin32
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Win32.sln
-          - Name: X64ReleaseWin32
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Win32.sln
-          - Name: X64DebugCoreApp
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: ..\CoreApp\CoreApp.sln
-      - BuildEnvironment: Continuous
-        Matrix:
-          - Name: X86DebugUniversal
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground.sln
-            UploadAppx: true
-          - Name: X64ReleaseUniversal
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground.sln
-            RunWack: true
-            UploadAppx: true
-          - Name: X64DebugUniversal
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: Playground.sln
-            RunWack: true
-            UploadAppx: true
-          - Name: X86DebugComposition
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-          - Name: X64ReleaseComposition
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-          - Name: X86DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64ReleaseCompositionExperimentalWinUI3
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X86DebugWin32
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Win32.sln
-          - Name: X64ReleaseWin32
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Win32.sln
-          - Name: X64DebugCoreApp
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: ..\CoreApp\CoreApp.sln
+            - Name: X86DebugWin32
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground-Win32.sln
+            - Name: X64ReleaseWin32
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground-Win32.sln
+            - Name: X64DebugCoreApp
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              SolutionFile: ..\CoreApp\CoreApp.sln
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -38,7 +38,7 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          -${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
+          - ${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
             - Name: X86DebugCompositionExperimentalWinUI3
               BuildConfiguration: Debug
               BuildPlatform: x86

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -38,21 +38,21 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          # - Name: X86DebugCompositionExperimentalWinUI3
-          #   BuildConfiguration: Debug
-          #   BuildPlatform: x86
-          #   SolutionFile: Playground-Composition.sln
-          #   UseExperimentalWinUI3: true
-          # - Name: X64DebugCompositionExperimentalWinUI3
-          #   BuildConfiguration: Debug
-          #   BuildPlatform: x64
-          #   SolutionFile: Playground-Composition.sln
-          #   UseExperimentalWinUI3: true
-          # - Name: X64ReleaseCompositionExperimentalWinUI3
-          #   BuildConfiguration: Release
-          #   BuildPlatform: x64
-          #   SolutionFile: Playground-Composition.sln
-          #   UseExperimentalWinUI3: true
+          - Name: X86DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -143,19 +143,23 @@ jobs:
                 parameters:
                   certificateName: playgroundEncodedKey
 
-            - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
+            - ${{ if and(eq(matrix.UseExperimentalWinUI3, true), eq(variables.System.DefinitionId, 627) }}:
+              - template:  ../templates/set-experimental-feature.yml
+                parameters:
+                  package: packages\playground
+                  feature: UseExperimentalWinUI3
+                  value: true
+
               - task: PowerShell@2
                 displayName: Enable the internal WinAppSDK Feed
                 inputs:
                   targetType: filePath # filePath | inline
                   filePath: $(Build.SourcesDirectory)\vnext\Scripts\EnableInternalWinAppSDKFeed.ps1
-                condition: eq(variables['EnableInternalWinAppSDKFeed'], 'true')
-                
+
               - task: NuGetAuthenticate@1
                 displayName: 'NuGet Authenticate Internal WinAppSDK Feed'
                 inputs:
                   nuGetServiceConnections: $(InternalWinAppSDKFeedServiceConnection)
-                condition: eq(variables['EnableInternalWinAppSDKFeed'], 'true')
 
             # NuGet ignores packages.config if it detects <PackageReference>.
             # Use restore packages.config directly to keep compabitility with ReactNativePicker.

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -38,21 +38,22 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             SolutionFile: Playground-Composition.sln
-          - Name: X86DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x86
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64DebugCompositionExperimentalWinUI3
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
-          - Name: X64ReleaseCompositionExperimentalWinUI3
-            BuildConfiguration: Release
-            BuildPlatform: x64
-            SolutionFile: Playground-Composition.sln
-            UseExperimentalWinUI3: true
+          -${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
+            - Name: X86DebugCompositionExperimentalWinUI3
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              SolutionFile: Playground-Composition.sln
+              UseExperimentalWinUI3: true
+            - Name: X64DebugCompositionExperimentalWinUI3
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              SolutionFile: Playground-Composition.sln
+              UseExperimentalWinUI3: true
+            - Name: X64ReleaseCompositionExperimentalWinUI3
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              SolutionFile: Playground-Composition.sln
+              UseExperimentalWinUI3: true
           - Name: X86DebugWin32
             BuildConfiguration: Debug
             BuildPlatform: x86
@@ -143,7 +144,7 @@ jobs:
                 parameters:
                   certificateName: playgroundEncodedKey
 
-            - ${{ if and(eq(matrix.UseExperimentalWinUI3, true), eq(variables.System.DefinitionId, 627)) }}:
+            - ${{ if eq(matrix.UseExperimentalWinUI3, true) }}:
               - template:  ../templates/set-experimental-feature.yml
                 parameters:
                   package: packages\playground

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -139,10 +139,7 @@ jobs:
               parameters:
                 platform: ${{ matrix.BuildPlatform }}
                 configuration: ${{ matrix.BuildConfiguration }}
-                ${{ if eq(config.BuildEnvironment, 'SecurePullRequest')}}:
-                  buildEnvironment: 'PullRequest'
-                ${{ else }}:
-                  buildEnvironment: ${{ config.BuildEnvironment }}
+                buildEnvironment: ${{ config.BuildEnvironment }}
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -139,9 +139,9 @@ jobs:
               parameters:
                 platform: ${{ matrix.BuildPlatform }}
                 configuration: ${{ matrix.BuildConfiguration }}
-                - ${{ if eq(config.BuildEnvironment, 'SecurePullRequest')}}:
+                ${{ if eq(config.BuildEnvironment, 'SecurePullRequest')}}:
                   buildEnvironment: 'PullRequest'
-                - ${{ else }}:
+                ${{ else }}:
                   buildEnvironment: ${{ config.BuildEnvironment }}
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -143,7 +143,7 @@ jobs:
                 parameters:
                   certificateName: playgroundEncodedKey
 
-            - ${{ if and(eq(matrix.UseExperimentalWinUI3, true), eq(variables.System.DefinitionId, 627) }}:
+            - ${{ if and(eq(matrix.UseExperimentalWinUI3, true), eq(variables.System.DefinitionId, 627)) }}:
               - template:  ../templates/set-experimental-feature.yml
                 parameters:
                   package: packages\playground

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -54,20 +54,20 @@ parameters:
       - BuildEnvironment: SecurePullRequest
         Matrix:
           - Name: X86DebugCompositionExperimentalWinUI3
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground-Composition.sln
-              UseExperimentalWinUI3: true
-            - Name: X64DebugCompositionExperimentalWinUI3
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: Playground-Composition.sln
-              UseExperimentalWinUI3: true
-            - Name: X64ReleaseCompositionExperimentalWinUI3
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground-Composition.sln
-              UseExperimentalWinUI3: true
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
       - BuildEnvironment: Continuous
         Matrix:
           - Name: X86DebugUniversal

--- a/.ado/jobs/playground.yml
+++ b/.ado/jobs/playground.yml
@@ -4,101 +4,63 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object
   - name: buildMatrix
     type: object
     default:
-      - ${{ if eq(variables.System.DefinitionId, 627) }}: # Only add these configurations for Secure PR
-        - BuildEnvironment: PullRequest
-          Matrix:
-            - Name: X86DebugCompositionExperimentalWinUI3
-                BuildConfiguration: Debug
-                BuildPlatform: x86
-                SolutionFile: Playground-Composition.sln
-                UseExperimentalWinUI3: true
-              - Name: X64DebugCompositionExperimentalWinUI3
-                BuildConfiguration: Debug
-                BuildPlatform: x64
-                SolutionFile: Playground-Composition.sln
-                UseExperimentalWinUI3: true
-              - Name: X64ReleaseCompositionExperimentalWinUI3
-                BuildConfiguration: Release
-                BuildPlatform: x64
-                SolutionFile: Playground-Composition.sln
-                UseExperimentalWinUI3: true
-      - ${{ else }}: # Only add these configurations for Secure PR
-        - BuildEnvironment: PullRequest
-          Matrix:
-            - Name: X86DebugUniversal
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground.sln
-            - Name: X64ReleaseUniversal
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground.sln
-            - Name: X64DebugUniversal
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: Playground.sln
-              RunWack: true
-              UploadAppx: true
-            - Name: X86DebugComposition
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground-Composition.sln
-            - Name: X64DebugComposition
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: Playground-Composition.sln
-            - Name: X64ReleaseComposition
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground-Composition.sln
-            - Name: X86DebugWin32
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground-Win32.sln
-            - Name: X64ReleaseWin32
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground-Win32.sln
-            - Name: X64DebugCoreApp
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: ..\CoreApp\CoreApp.sln
-        - BuildEnvironment: Continuous
-          Matrix:
-            - Name: X86DebugUniversal
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground.sln
-              UploadAppx: true
-            - Name: X64ReleaseUniversal
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground.sln
-              RunWack: true
-              UploadAppx: true
-            - Name: X64DebugUniversal
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: Playground.sln
-              RunWack: true
-              UploadAppx: true
-            - Name: X86DebugComposition
+      - BuildEnvironment: PullRequest
+        Matrix:
+          - Name: X86DebugUniversal
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground.sln
+          - Name: X64ReleaseUniversal
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+          - Name: X64DebugUniversal
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            RunWack: true
+            UploadAppx: true
+          - Name: X86DebugComposition
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+          - Name: X64DebugComposition
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X64ReleaseComposition
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X86DebugWin32
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Win32.sln
+          - Name: X64ReleaseWin32
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Win32.sln
+          - Name: X64DebugCoreApp
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: ..\CoreApp\CoreApp.sln
+      - BuildEnvironment: SecurePullRequest
+        Matrix:
+          - Name: X86DebugCompositionExperimentalWinUI3
               BuildConfiguration: Debug
               BuildPlatform: x86
               SolutionFile: Playground-Composition.sln
-            - Name: X64ReleaseComposition
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground-Composition.sln
-            - Name: X86DebugCompositionExperimentalWinUI3
+              UseExperimentalWinUI3: true
+            - Name: X64DebugCompositionExperimentalWinUI3
               BuildConfiguration: Debug
-              BuildPlatform: x86
+              BuildPlatform: x64
               SolutionFile: Playground-Composition.sln
               UseExperimentalWinUI3: true
             - Name: X64ReleaseCompositionExperimentalWinUI3
@@ -106,18 +68,55 @@ parameters:
               BuildPlatform: x64
               SolutionFile: Playground-Composition.sln
               UseExperimentalWinUI3: true
-            - Name: X86DebugWin32
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              SolutionFile: Playground-Win32.sln
-            - Name: X64ReleaseWin32
-              BuildConfiguration: Release
-              BuildPlatform: x64
-              SolutionFile: Playground-Win32.sln
-            - Name: X64DebugCoreApp
-              BuildConfiguration: Debug
-              BuildPlatform: x64
-              SolutionFile: ..\CoreApp\CoreApp.sln
+      - BuildEnvironment: Continuous
+        Matrix:
+          - Name: X86DebugUniversal
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground.sln
+            UploadAppx: true
+          - Name: X64ReleaseUniversal
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            RunWack: true
+            UploadAppx: true
+          - Name: X64DebugUniversal
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: Playground.sln
+            RunWack: true
+            UploadAppx: true
+          - Name: X86DebugComposition
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+          - Name: X64ReleaseComposition
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+          - Name: X86DebugCompositionExperimentalWinUI3
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X64ReleaseCompositionExperimentalWinUI3
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Composition.sln
+            UseExperimentalWinUI3: true
+          - Name: X86DebugWin32
+            BuildConfiguration: Debug
+            BuildPlatform: x86
+            SolutionFile: Playground-Win32.sln
+          - Name: X64ReleaseWin32
+            BuildConfiguration: Release
+            BuildPlatform: x64
+            SolutionFile: Playground-Win32.sln
+          - Name: X64DebugCoreApp
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            SolutionFile: ..\CoreApp\CoreApp.sln
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -140,7 +139,10 @@ jobs:
               parameters:
                 platform: ${{ matrix.BuildPlatform }}
                 configuration: ${{ matrix.BuildConfiguration }}
-                buildEnvironment: ${{ config.BuildEnvironment }}
+                - ${{ if eq(config.BuildEnvironment, 'SecurePullRequest')}}:
+                  buildEnvironment: 'PullRequest'
+                - ${{ else }}:
+                  buildEnvironment: ${{ config.BuildEnvironment }}
 
             - ${{if eq(config.BuildEnvironment, 'Continuous')}}:
               - template: ../templates/write-certificate.yml

--- a/.ado/jobs/sample-apps.yml
+++ b/.ado/jobs/sample-apps.yml
@@ -4,6 +4,7 @@ parameters:
     default : PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/jobs/setup.yml
+++ b/.ado/jobs/setup.yml
@@ -3,6 +3,7 @@ parameters:
     type: string
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
 
 jobs:
@@ -35,7 +36,7 @@ jobs:
           $beachballErrors | ForEach { Write-Host "##vso[task.logissue type=warning]POSSIBLE $_" }
         displayName: Warn for possible invalid change files
 
-      - ${{ if eq(parameters.buildEnvironment, 'PullRequest') }}:
+      - ${{ if endsWith(parameters.buildEnvironment, 'PullRequest') }}:
         - script: npx beachball check --branch origin/$(BeachBallBranchName) --verbose --changehint "##vso[task.logissue type=error]Run \"yarn change\" from root of repo to generate a change file."
           displayName: Check for change files
 

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -4,6 +4,7 @@
       default : PullRequest
       values:
         - PullRequest
+        - SecurePullRequest
         - Continuous
     - name: AgentPool
       type: object

--- a/.ado/scripts/setVersionEnvVars.js
+++ b/.ado/scripts/setVersionEnvVars.js
@@ -11,7 +11,7 @@ const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
 const commitId = child_process.execSync(`git rev-list HEAD -n 1`).toString().trim();
 
 const buildEnvironment = process.argv[2];
-let isPr = buildEnvironment === "PullRequest";
+let isPr = buildEnvironment.endsWith("PullRequest");
 let isCi = buildEnvironment === "Continuous"
 if (!isPr && !isCi) {
   throw new Error("Must pass argument indicating if this is for a 'PullRequest' or 'Continuous");

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -4,6 +4,7 @@ parameters:
     default: PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: AgentPool
     type: object

--- a/.ado/templates/react-native-init-windows.yml
+++ b/.ado/templates/react-native-init-windows.yml
@@ -27,6 +27,7 @@ parameters:
     default: PullRequest
     values: 
      - PullRequest
+     - SecurePullRequest
      - Continuous
 
 steps:

--- a/.ado/templates/react-native-init.yml
+++ b/.ado/templates/react-native-init.yml
@@ -41,6 +41,7 @@ parameters:
     default: PullRequest
     values: 
      - PullRequest
+     - SecurePullRequest
      - Continuous
 
 steps:

--- a/.ado/templates/run-windows-with-certificates.yml
+++ b/.ado/templates/run-windows-with-certificates.yml
@@ -4,6 +4,7 @@ parameters:
     default: PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
   - name: certificateName
     type: string
@@ -44,7 +45,7 @@ steps:
       displayName: run-windows (Debug)
       workingDirectory: ${{ parameters.workingDirectory }}
 
-  - ${{ if and(eq(parameters.buildConfiguration, 'Release'), eq(parameters.buildEnvironment, 'PullRequest')) }}:
+  - ${{ if and(eq(parameters.buildConfiguration, 'Release'), endsWith(parameters.buildEnvironment, 'PullRequest')) }}:
     - script: >
         yarn react-native run-windows
         --arch ${{ parameters.buildPlatform }}

--- a/.ado/templates/set-appx-platforms.yml
+++ b/.ado/templates/set-appx-platforms.yml
@@ -25,6 +25,6 @@ parameters:
 # only build a single platform. This is only done in PRs, to allow testing the
 # un-overriden path in official tests.
 steps:
-  - ${{ if and(eq(parameters.buildEnvironment, 'PullRequest'), eq(parameters.configuration, 'Release')) }}:
+  - ${{ if and(endsWith(parameters.buildEnvironment, 'PullRequest'), eq(parameters.configuration, 'Release')) }}:
     - powershell: $env:AppxBundlePlatforms = "${{ parameters.platform }}"
       displayName: Set AppxBundlePlatforms to "${{ parameters.platform }}"

--- a/.ado/templates/set-version-vars.yml
+++ b/.ado/templates/set-version-vars.yml
@@ -5,6 +5,7 @@ parameters:
     default: PullRequest
     values:
       - PullRequest
+      - SecurePullRequest
       - Continuous
 
 steps:

--- a/.ado/windows-vs-pr-secure.yml
+++ b/.ado/windows-vs-pr-secure.yml
@@ -1,0 +1,31 @@
+name: $(Date:yyyyMMdd).$(Rev:r)
+
+trigger: none # will disable CI builds entirely
+
+pr:
+  - main
+  - master
+  - "*-stable"
+
+variables:
+  - group: platform-override-zero-permission-token
+
+parameters:
+  - name: AgentPool
+    type: object
+    default:
+      Small:
+        name: rnw-pool-2
+        demands: ImageOverride -equals rnw-img-vs2022-node18
+      Medium:
+        name: rnw-pool-4
+        demands: ImageOverride -equals rnw-img-vs2022-node18
+      Large:
+        name: rnw-pool-8
+        demands: ImageOverride -equals rnw-img-vs2022-node18
+
+stages:
+  - template: stages.yml
+    parameters:
+      buildEnvironment: SecurePullRequest
+      AgentPool: ${{ parameters.AgentPool }}


### PR DESCRIPTION
## Description

This PR adds a `SecurePullRequest` to the `PullRequest` and `Continuous` build environment in our ADO pipelines. This `SecurePullRequest` will be used to enable build configurations that need access to secure resources (such as internal ADO feeds) and will only be run when using `/azp run`

### Type of Change

- New feature (non-breaking change which adds functionality)

### Why
To enable PRs testing against internal nugets.

Resolves #12676
Resolves #12677

### What
See above.

## Screenshots
N/A

## Testing
Verified existing PRs still work

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12726)