### PR TITLE
[0.72] Fix UIScheduler deadlock on shutdown

### DIFF
--- a/change/react-native-windows-061fcd4e-4f2d-4428-bb66-aba914446681.json
+++ b/change/react-native-windows-061fcd4e-4f2d-4428-bb66-aba914446681.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix UIScheduler deadlock on shutdown",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -278,7 +278,9 @@ void UISchedulerWinRT::Shutdown() noexcept {
 
 void UISchedulerWinRT::AwaitTermination() noexcept {
   Shutdown();
-  m_terminationEvent.Wait();
+  if (m_threadId != std::this_thread::get_id()) {
+    m_terminationEvent.Wait();
+  }
 }
 
 /*static*/ DispatchQueue UISchedulerWinRT::GetOrCreateUIThreadQueue() noexcept {
@@ -343,7 +345,7 @@ void UISchedulerWinRT::CleanupContext::CheckTermination() noexcept {
 }
 
 //=============================================================================
-// DispatchQueueStatic::MakeCurrentThreadUIScheduler implementation
+// DispatchQueueStatic::GetCurrentUIThreadQueue implementation
 //=============================================================================
 
 DispatchQueue DispatchQueueStatic::GetCurrentUIThreadQueue() noexcept {

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -271,8 +271,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\DefaultBlobResource.cpp">
       <Filter>Source Files\Networking</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewProps.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewEventEmitter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>


### PR DESCRIPTION
Currently UI Dispatcher Queue deadlocks on shutdown if its last reference is released before the last UI task is completed.
The reason is that the UIScheduler waits for a signal that the last Windows UI `DispatcherQueue` task is completed. 
The signal cannot come because the wait happens while the last task is being executed, since the last release happens inside of the last task.

In this PR we:
- address the issue by avoiding the wait if the UIScheduler `AwaitTermination()` is called from UI thread.
- add new unit tests for Serial and UI Dispatcher Queues to test different shutdown conditions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12736)