### PR TITLE
Fix UIScheduler deadlock on shutdown

### DIFF
--- a/change/react-native-windows-3f32eace-b18b-47b9-bc5d-0a51b9daf1c8.json
+++ b/change/react-native-windows-3f32eace-b18b-47b9-bc5d-0a51b9daf1c8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix UIScheduler deadlock on shutdown",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
+++ b/vnext/Mso/src/dispatchQueue/uiScheduler_winrt.cpp
@@ -337,7 +337,9 @@ void UISchedulerWinRT<TDispatcherTraits>::Shutdown() noexcept {
 template <typename TDispatcherTraits>
 void UISchedulerWinRT<TDispatcherTraits>::AwaitTermination() noexcept {
   Shutdown();
-  m_terminationEvent.Wait();
+  if (m_threadId != std::this_thread::get_id()) {
+    m_terminationEvent.Wait();
+  }
 }
 
 template <typename TDispatcherTraits>
@@ -411,7 +413,7 @@ void UISchedulerWinRT<TDispatcherTraits>::CleanupContext::CheckTermination() noe
 }
 
 //=============================================================================
-// DispatchQueueStatic::MakeCurrentThreadUIScheduler implementation
+// DispatchQueueStatic::GetCurrentUIThreadQueue implementation
 //=============================================================================
 
 DispatchQueue DispatchQueueStatic::GetCurrentUIThreadQueue() noexcept {


### PR DESCRIPTION
Currently UI Dispatcher Queue deadlocks on shutdown if its last reference is released before the last UI task is completed.
The reason is that the UIScheduler waits for a signal that the last Windows UI `DispatcherQueue` task is completed. 
The signal cannot come because the wait happens while the last task is being executed, since the last release happens inside of the last task.

In this PR we:
- address the issue by avoiding the wait if the UIScheduler `AwaitTermination()` is called from UI thread.
- add new unit tests for Serial and UI Dispatcher Queues to test different shutdown conditions.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12738)