### PR TITLE
[Fabric] Add additional functionality to support implementing more advanced custom compontents

### DIFF
--- a/change/react-native-windows-61b73514-686c-4f9a-b4bd-eb692a86e52b.json
+++ b/change/react-native-windows-61b73514-686c-4f9a-b4bd-eb692a86e52b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Add AbiShadowNode for non View custom components",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -67,7 +67,9 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
     base_type::HandleCommand(commandName, args);
   }
 
-  void UpdateProps(const winrt::Microsoft::ReactNative::IComponentProps &props) {
+  void UpdateProps(
+      const winrt::Microsoft::ReactNative::IComponentProps &props,
+      const winrt::Microsoft::ReactNative::IComponentProps &oldProps) {
     auto myProps = props.as<CustomXamlComponentProps>();
 
     m_buttonLabelTextBlock.Text(myProps->label);
@@ -76,10 +78,10 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
     m_state = state;
   }
 
-  void UpdateLayoutMetrics(const winrt::Microsoft::ReactNative::LayoutMetrics &layoutMetrics) {
-    m_visual.Size(
-        {layoutMetrics.Frame.Width * layoutMetrics.PointScaleFactor,
-         layoutMetrics.Frame.Height * layoutMetrics.PointScaleFactor});
+  void UpdateLayoutMetrics(
+      const winrt::Microsoft::ReactNative::LayoutMetrics &layoutMetrics,
+      const winrt::Microsoft::ReactNative::LayoutMetrics &oldLayoutMetrics) {
+    base_type::UpdateLayoutMetrics(layoutMetrics, oldLayoutMetrics);
 #ifdef USE_EXPERIMENTAL_WINUI3
     auto site = m_siteBridge.Site();
     auto siteWindow = site.Environment();
@@ -185,7 +187,7 @@ static void RegisterViewComponent(winrt::Microsoft::ReactNative::IReactPackageBu
         });
         auto compBuilder =
             builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
-        compBuilder.SetCreateComponentView(
+        compBuilder.SetCreateViewComponentView(
             [](const winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs &args) noexcept {
               return winrt::make<CustomComponent>(true, args);
             });
@@ -225,7 +227,7 @@ static void RegisterViewComponent(winrt::Microsoft::ReactNative::IReactPackageBu
         });
         auto compBuilder =
             builder.as<winrt::Microsoft::ReactNative::Composition::IReactCompositionViewComponentBuilder>();
-        compBuilder.SetCreateComponentView(
+        compBuilder.SetCreateViewComponentView(
             [](const winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs &args) noexcept {
               return winrt::make<CustomComponent>(false, args);
             });

--- a/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
@@ -3,6 +3,8 @@
 
 #include <winrt/Microsoft.ReactNative.Composition.h>
 
+#include <CompositionSwitcher.interop.h>
+
 namespace Microsoft::ReactNative::Composition {
 
 class AutoDrawDrawingSurface {

--- a/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.interop.h
+++ b/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.interop.h
@@ -1,4 +1,3 @@
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
@@ -10,30 +9,25 @@
 #include <d2d1_1.h>
 #include <d3d11.h>
 #include <d3d11_4.h>
-#include <guid/msoGuid.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
 
 namespace Microsoft::ReactNative::Composition {
 
-MSO_STRUCT_GUID(ICompositionDrawingSurfaceInterop, "941FDD90-ED27-49CE-A1CD-86ECB2D4A0FA")
-struct ICompositionDrawingSurfaceInterop : public IUnknown {
+struct __declspec(uuid("941FDD90-ED27-49CE-A1CD-86ECB2D4A0FA")) ICompositionDrawingSurfaceInterop : public IUnknown {
   virtual HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, POINT *offset) noexcept = 0;
   virtual HRESULT EndDraw() noexcept = 0;
 };
 
-MSO_STRUCT_GUID(IRenderingDeviceReplacedListener, "93A6d34A-0A09-4BE3-94FC-FA3A79D0E0E9")
-struct IRenderingDeviceReplacedListener : IUnknown {
+struct __declspec(uuid("93A6d34A-0A09-4BE3-94FC-FA3A79D0E0E9")) IRenderingDeviceReplacedListener : IUnknown {
   virtual void OnRenderingDeviceLost() = 0;
 };
 
-MSO_STRUCT_GUID(IVisualInterop, "50E66581-E917-45F4-AC22-1BC953CFA2A8")
-struct IVisualInterop : IUnknown {
+struct __declspec(uuid("50E66581-E917-45F4-AC22-1BC953CFA2A8")) IVisualInterop : IUnknown {
   virtual void SetClippingPath(ID2D1Geometry *clippingPath) noexcept = 0;
 };
 
-MSO_STRUCT_GUID(ICompositionContextInterop, "4742F122-3EE0-48AA-9EA9-44A00147B55F")
-struct ICompositionContextInterop : IUnknown {
+struct __declspec(uuid("4742F122-3EE0-48AA-9EA9-44A00147B55F")) ICompositionContextInterop : IUnknown {
   virtual void D2DFactory(ID2D1Factory1 **outD2DFactory) noexcept = 0;
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueComposition.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueComposition.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#ifndef MICROSOFT_REACTNATIVE_JSVALUECOMPOSITION
+#define MICROSOFT_REACTNATIVE_JSVALUECOMPOSITION
+#include <winrt/Microsoft.ReactNative.h>
+#include "JSValue.h"
+
+namespace winrt::Microsoft::ReactNative {
+
+inline void ReadValue(IJSValueReader const &reader, Color &value) noexcept {
+  value = winrt::Microsoft::ReactNative::Color::ReadValue(reader);
+}
+
+inline void WriteValue(IJSValueWriter const &writer, const Color &value) noexcept {
+  winrt::Microsoft::ReactNative::Color::WriteValue(writer, value);
+}
+
+} // namespace winrt::Microsoft::ReactNative
+
+#endif // MICROSOFT_REACTNATIVE_JSVALUECOMPOSITION

--- a/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
+++ b/vnext/Microsoft.ReactNative.Cxx/JSValueXaml.h
@@ -14,7 +14,7 @@ inline void ReadValue(JSValue const &jsValue, xaml::Media::Brush &value) noexcep
   value = XamlHelper::BrushFrom([&jsValue](IJSValueWriter const &writer) noexcept { jsValue.WriteTo(writer); });
 }
 
-inline void ReadValue(JSValue const &jsValue, Windows::UI::Color &value) noexcept {
+inline void ReadValue(JSValue const &jsValue, winrt::Windows::UI::Color &value) noexcept {
   value = XamlHelper::ColorFrom([&jsValue](IJSValueWriter const &writer) noexcept { jsValue.WriteTo(writer); });
 }
 #endif

--- a/vnext/Microsoft.ReactNative/ComponentView.idl
+++ b/vnext/Microsoft.ReactNative/ComponentView.idl
@@ -80,9 +80,9 @@ namespace Microsoft.ReactNative
     overridable void MountChildComponentView(ComponentView childComponentView, UInt32 index);
     overridable void UnmountChildComponentView(ComponentView childComponentView, UInt32 index);
     overridable void HandleCommand(String commandName, IJSValueReader args);
-    overridable void UpdateProps(IComponentProps props);
+    overridable void UpdateProps(IComponentProps props, IComponentProps oldProps);
     overridable void UpdateState(IComponentState state);
-    overridable void UpdateLayoutMetrics(LayoutMetrics metrics);
+    overridable void UpdateLayoutMetrics(LayoutMetrics metrics, LayoutMetrics oldMetrics);
     overridable void FinalizeUpdates(ComponentViewUpdateMask updateMask);
 
     DOC_STRING("Used to handle key down events when this component is focused, or if a child component did not handle the key down")

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -11,10 +11,25 @@ import "CompositionSwitcher.idl";
 
 namespace Microsoft.ReactNative.Composition
 {
+
+  [flags]
+  [webhosthidden]
+  [experimental]
+  enum ComponentViewFeatures
+  {
+    None          = 0x00000000,
+    NativeBorder  = 0x00000001,
+    ShadowProps   = 0x00000002,
+    Background    = 0x00000004,
+
+    Default       = 0x00000007, // ShadowProps | NativeBorder | Background
+  };
+
   [experimental]
   [webhosthidden]
   runtimeclass CreateCompositionComponentViewArgs : Microsoft.ReactNative.CreateComponentViewArgs {
     ICompositionContext CompositionContext { get; };
+    ComponentViewFeatures Features;
   };
 
   [experimental]
@@ -24,6 +39,7 @@ namespace Microsoft.ReactNative.Composition
 
     ICompositionContext CompositionContext { get; };
     Theme Theme;
+    overridable void OnThemeChanged();
     Boolean CapturePointer(Microsoft.ReactNative.Composition.Input.Pointer pointer);
     void ReleasePointerCapture(Microsoft.ReactNative.Composition.Input.Pointer pointer);
   };

--- a/vnext/Microsoft.ReactNative/Fabric/AbiComponentDescriptor.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiComponentDescriptor.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "AbiComponentDescriptor.h"
+
+#include <Fabric/WindowsComponentDescriptorRegistry.h>
+#include <ReactContext.h>
+#include "DynamicReader.h"
+
+namespace Microsoft::ReactNative {
+
+AbiComponentDescriptor::AbiComponentDescriptor(facebook::react::ComponentDescriptorParameters const &parameters)
+    : ComponentDescriptor(parameters) {
+  auto flavor = std::static_pointer_cast<std::string const>(this->flavor_);
+  m_builder = WindowsComponentDescriptorRegistry::FromProperties(
+                  parameters.contextContainer->at<winrt::Microsoft::ReactNative::ReactContext>("MSRN.ReactContext")
+                      .Properties())
+                  ->GetDescriptor(flavor);
+
+  rawPropsParser_.prepare<ConcreteProps>();
+}
+
+facebook::react::ComponentHandle AbiComponentDescriptor::getComponentHandle() const {
+  return reinterpret_cast<facebook::react::ComponentHandle>(getComponentName());
+}
+
+facebook::react::ComponentName AbiComponentDescriptor::getComponentName() const {
+  return std::static_pointer_cast<std::string const>(this->flavor_)->c_str();
+}
+
+facebook::react::ShadowNodeTraits AbiComponentDescriptor::getTraits() const {
+  auto traits = ShadowNodeT::BaseTraits();
+  if (winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(m_builder)
+          ->MeasureContentHandler()) {
+    traits.set(facebook::react::ShadowNodeTraits::LeafYogaNode);
+    traits.set(facebook::react::ShadowNodeTraits::MeasurableYogaNode);
+  }
+  return traits;
+}
+
+std::shared_ptr<facebook::react::ShadowNode> AbiComponentDescriptor::createShadowNode(
+    const facebook::react::ShadowNodeFragment &fragment,
+    facebook::react::ShadowNodeFamily::Shared const &family) const {
+  auto shadowNode = std::make_shared<ShadowNodeT>(fragment, family, getTraits());
+
+  shadowNode->Proxy(winrt::make<winrt::Microsoft::ReactNative::implementation::ShadowNode>(shadowNode));
+  winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(m_builder)
+      ->CreateShadowNode(shadowNode->Proxy());
+
+  adopt(*shadowNode);
+  return shadowNode;
+}
+
+facebook::react::ShadowNode::Unshared AbiComponentDescriptor::cloneShadowNode(
+    const facebook::react::ShadowNode &sourceShadowNode,
+    const facebook::react::ShadowNodeFragment &fragment) const {
+  auto shadowNode = std::make_shared<ShadowNodeT>(sourceShadowNode, fragment);
+
+  shadowNode->Proxy(winrt::make<winrt::Microsoft::ReactNative::implementation::ShadowNode>(shadowNode));
+  winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(m_builder)
+      ->CloneShadowNode(shadowNode->Proxy(), static_cast<const ShadowNodeT &>(sourceShadowNode).Proxy());
+
+  adopt(*shadowNode);
+  return shadowNode;
+}
+
+void AbiComponentDescriptor::appendChild(
+    const facebook::react::ShadowNode::Shared &parentShadowNode,
+    const facebook::react::ShadowNode::Shared &childShadowNode) const {
+  auto concreteParentShadowNode = std::static_pointer_cast<const ShadowNodeT>(parentShadowNode);
+  auto concreteNonConstParentShadowNode = std::const_pointer_cast<ShadowNodeT>(concreteParentShadowNode);
+  concreteNonConstParentShadowNode->appendChild(childShadowNode);
+}
+
+facebook::react::Props::Shared AbiComponentDescriptor::cloneProps(
+    const facebook::react::PropsParserContext &context,
+    const facebook::react::Props::Shared &props,
+    facebook::react::RawProps rawProps) const {
+  // Optimization:
+  // Quite often nodes are constructed with default/empty props: the base
+  // `props` object is `null` (there no base because it's not cloning) and the
+  // `rawProps` is empty. In this case, we can return the default props object
+  // of a concrete type entirely bypassing parsing.
+  if (!props && rawProps.isEmpty()) {
+    return ShadowNodeT::defaultSharedProps();
+  }
+
+  if (facebook::react::CoreFeatures::excludeYogaFromRawProps) {
+    if (ShadowNodeT::IdentifierTrait() == facebook::react::ShadowNodeTraits::Trait::YogaLayoutableKind) {
+      rawProps.filterYogaStylePropsInDynamicConversion();
+    }
+  }
+
+  rawProps.parse(rawPropsParser_);
+
+  // Call old-style constructor
+  // auto shadowNodeProps = std::make_shared<ShadowNodeT::Props>(context, rawProps, props);
+  auto shadowNodeProps = std::make_shared<winrt::Microsoft::ReactNative::implementation::AbiProps>(
+      context,
+      props ? static_cast<winrt::Microsoft::ReactNative::implementation::AbiProps const &>(*props)
+            : *ShadowNodeT::defaultSharedProps(),
+      rawProps);
+  auto userProps =
+      winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(m_builder)
+          ->CreateProps(nullptr);
+  shadowNodeProps->SetUserProps(userProps);
+
+  rawProps.iterateOverValues(
+      [&](facebook::react::RawPropsPropNameHash hash, const char *propName, facebook::react::RawValue const &fn) {
+        shadowNodeProps.get()->setProp(context, hash, propName, fn);
+        userProps.SetProp(
+            hash,
+            winrt::to_hstring(propName),
+            winrt::make<winrt::Microsoft::ReactNative::DynamicReader>(folly::dynamic(fn)));
+      });
+
+  return shadowNodeProps;
+};
+
+AbiComponentDescriptor::ConcreteStateData AbiComponentDescriptor::initialStateData(
+    const facebook::react::Props::Shared &props,
+    const facebook::react::ShadowNodeFamily::Shared & /*family*/,
+    const facebook::react::ComponentDescriptor &componentDescriptor) noexcept {
+  return {winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(
+              static_cast<const AbiComponentDescriptor &>(componentDescriptor).m_builder)
+              ->InitialStateData(
+                  std::static_pointer_cast<winrt::Microsoft::ReactNative::implementation::AbiProps const>(props)
+                      ->UserProps())};
+}
+
+facebook::react::State::Shared AbiComponentDescriptor::createInitialState(
+    facebook::react::Props::Shared const &props,
+    facebook::react::ShadowNodeFamily::Shared const &family) const {
+  if (std::is_same<ConcreteStateData, facebook::react::StateData>::value) {
+    // Default case: Returning `null` for nodes that don't use `State`.
+    return nullptr;
+  }
+
+  return std::make_shared<ConcreteState>(
+      std::make_shared<ConcreteStateData const>(AbiComponentDescriptor::initialStateData(props, family, *this)),
+      family);
+}
+
+facebook::react::State::Shared AbiComponentDescriptor::createState(
+    facebook::react::ShadowNodeFamily const &family,
+    facebook::react::StateData::Shared const &data) const {
+  if (std::is_same<ConcreteStateData, facebook::react::StateData>::value) {
+    // Default case: Returning `null` for nodes that don't use `State`.
+    return nullptr;
+  }
+
+  react_native_assert(data && "Provided `data` is nullptr.");
+
+  return std::make_shared<ConcreteState const>(
+      std::static_pointer_cast<ConcreteStateData const>(data), *family.getMostRecentState());
+}
+
+facebook::react::ShadowNodeFamily::Shared AbiComponentDescriptor::createFamily(
+    facebook::react::ShadowNodeFamilyFragment const &fragment) const {
+  auto eventEmitter = std::make_shared<const ConcreteEventEmitter>(
+      std::make_shared<facebook::react::EventTarget>(fragment.instanceHandle), eventDispatcher_);
+  return std::make_shared<facebook::react::ShadowNodeFamily>(
+      fragment, std::move(eventEmitter), eventDispatcher_, *this);
+}
+
+/*
+ * Called immediately after `ShadowNode` is created or cloned.
+ *
+ * Override this method to pass information from custom `ComponentDescriptor`
+ * to new instance of `ShadowNode`.
+ *
+ * Example usages:
+ *   - Inject image manager to `ImageShadowNode` in
+ * `ImageComponentDescriptor`.
+ *   - Set `ShadowNode`'s size from state in
+ * `ModalHostViewComponentDescriptor`.
+ */
+void AbiComponentDescriptor::adopt(facebook::react::ShadowNode &shadowNode) const {
+  react_native_assert(shadowNode.getComponentHandle() == getComponentHandle());
+
+  auto &abiShadowNode = static_cast<AbiShadowNode &>(shadowNode);
+  abiShadowNode.Builder(m_builder);
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/AbiComponentDescriptor.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiComponentDescriptor.h
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/core/ComponentDescriptor.h>
+#include "AbiShadowNode.h"
+#include "AbiViewProps.h"
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace Microsoft::ReactNative {
+
+class AbiComponentDescriptor : public facebook::react::ComponentDescriptor {
+  using ShadowNodeT = AbiShadowNode;
+  using SharedShadowNodeT = std::shared_ptr<const ShadowNodeT>;
+
+ public:
+  using ConcreteShadowNode = ShadowNodeT;
+  using ConcreteProps = typename ShadowNodeT::ConcreteProps;
+  using SharedConcreteProps = typename ShadowNodeT::SharedConcreteProps;
+  using ConcreteEventEmitter = typename ShadowNodeT::ConcreteEventEmitter;
+  using SharedConcreteEventEmitter = typename ShadowNodeT::SharedConcreteEventEmitter;
+  using ConcreteState = typename ShadowNodeT::ConcreteState;
+  using ConcreteStateData = typename ShadowNodeT::ConcreteState::Data;
+
+  AbiComponentDescriptor(facebook::react::ComponentDescriptorParameters const &parameters);
+
+  facebook::react::ComponentHandle getComponentHandle() const override;
+  facebook::react::ComponentName getComponentName() const override;
+  facebook::react::ShadowNodeTraits getTraits() const override;
+  std::shared_ptr<facebook::react::ShadowNode> createShadowNode(
+      const facebook::react::ShadowNodeFragment &fragment,
+      facebook::react::ShadowNodeFamily::Shared const &family) const override;
+  facebook::react::ShadowNode::Unshared cloneShadowNode(
+      const facebook::react::ShadowNode &sourceShadowNode,
+      const facebook::react::ShadowNodeFragment &fragment) const override;
+
+  void appendChild(
+      const facebook::react::ShadowNode::Shared &parentShadowNode,
+      const facebook::react::ShadowNode::Shared &childShadowNode) const override;
+  virtual facebook::react::Props::Shared cloneProps(
+      const facebook::react::PropsParserContext &context,
+      const facebook::react::Props::Shared &props,
+      facebook::react::RawProps rawProps) const override;
+  virtual facebook::react::State::Shared createInitialState(
+      facebook::react::Props::Shared const &props,
+      facebook::react::ShadowNodeFamily::Shared const &family) const override;
+  virtual facebook::react::State::Shared createState(
+      facebook::react::ShadowNodeFamily const &family,
+      facebook::react::StateData::Shared const &data) const override;
+
+  facebook::react::ShadowNodeFamily::Shared createFamily(
+      facebook::react::ShadowNodeFamilyFragment const &fragment) const override;
+
+ protected:
+  /*
+   * Called immediately after `ShadowNode` is created or cloned.
+   *
+   * Override this method to pass information from custom `ComponentDescriptor`
+   * to new instance of `ShadowNode`.
+   *
+   * Example usages:
+   *   - Inject image manager to `ImageShadowNode` in
+   * `ImageComponentDescriptor`.
+   *   - Set `ShadowNode`'s size from state in
+   * `ModalHostViewComponentDescriptor`.
+   */
+  virtual void adopt(facebook::react::ShadowNode &shadowNode) const;
+
+ private:
+  static ConcreteStateData initialStateData(
+      const facebook::react::Props::Shared & /*props*/,
+      const facebook::react::ShadowNodeFamily::Shared & /*family*/,
+      const facebook::react::ComponentDescriptor & /*componentDescriptor*/) noexcept;
+
+  winrt::Microsoft::ReactNative::IReactViewComponentBuilder m_builder;
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "AbiShadowNode.h"
+
+#include <Fabric/Composition/ReactCompositionViewComponentBuilder.h>
+#include <react/debug/react_native_assert.h>
+#include <react/renderer/core/TraitCast.h>
+#include <react/renderer/core/conversions.h>
+
+#include <utility>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+AbiProps::AbiProps(
+    const facebook::react::PropsParserContext &context,
+    const AbiProps &sourceProps,
+    const facebook::react::RawProps &rawProps)
+    : facebook::react::Props(context, sourceProps, rawProps) {}
+
+AbiProps::~AbiProps() {}
+
+void AbiProps::SetUserProps(winrt::Microsoft::ReactNative::IComponentProps componentProps) noexcept {
+  m_componentProps = componentProps;
+}
+
+winrt::Microsoft::ReactNative::IComponentProps AbiProps::UserProps() const noexcept {
+  return m_componentProps;
+}
+
+ShadowNode::ShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept : m_shadowNode(shadowNode) {}
+
+void ShadowNode::EnsureUnsealed() noexcept {
+  m_shadowNode->ensureUnsealed();
+}
+
+winrt::IInspectable ShadowNode::Tag() const noexcept {
+  return m_tag;
+}
+
+void ShadowNode::Tag(winrt::IInspectable tag) noexcept {
+  m_tag = tag;
+}
+
+winrt::IInspectable ShadowNode::StateData() const noexcept {
+  auto state = m_shadowNode->getState();
+  react_native_assert(state && "State must not be `nullptr`.");
+  auto abiStateData =
+      static_cast<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData> *>(state.get())
+          ->getData();
+  return abiStateData.userdata;
+}
+
+void ShadowNode::StateData(winrt::IInspectable tag) noexcept {
+  m_shadowNode->ensureUnsealed();
+
+  auto &state = const_cast<facebook::react::State::Shared &>(m_shadowNode->getState());
+  state = std::make_shared<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData>>(
+      std::make_shared<const ::Microsoft::ReactNative::AbiStateData>(tag), *state);
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace Microsoft::ReactNative {
+
+extern const char AbiComponentName[] = "Abi";
+
+void AbiShadowNode::Builder(winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder) noexcept {
+  m_builder = builder;
+}
+
+winrt::Microsoft::ReactNative::IReactViewComponentBuilder AbiShadowNode::Builder() const noexcept {
+  return m_builder;
+}
+
+void AbiShadowNode::Proxy(winrt::Microsoft::ReactNative::ShadowNode proxy) noexcept {
+  m_proxy = proxy;
+}
+
+winrt::Microsoft::ReactNative::ShadowNode AbiShadowNode::Proxy() const noexcept {
+  return m_proxy;
+}
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiShadowNode.h
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "LayoutContext.g.h"
+#include "ShadowNode.g.h"
+#include "YogaLayoutableShadowNode.g.h"
+#include <react/components/rnwcore/EventEmitters.h>
+#include <unordered_map>
+#include "AbiState.h"
+#include "AbiViewProps.h"
+
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/core/LayoutContext.h>
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+class AbiProps final : public facebook::react::Props {
+ public:
+  AbiProps() = default;
+  AbiProps(
+      const facebook::react::PropsParserContext &context,
+      const AbiProps &sourceProps,
+      const facebook::react::RawProps &rawProps);
+  ~AbiProps();
+
+  void SetUserProps(winrt::Microsoft::ReactNative::IComponentProps componentProps) noexcept;
+  winrt::Microsoft::ReactNative::IComponentProps UserProps() const noexcept;
+
+ private:
+  winrt::Microsoft::ReactNative::IComponentProps m_componentProps{nullptr};
+};
+
+struct ShadowNode : ShadowNodeT<ShadowNode> {
+  ShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept;
+
+  void EnsureUnsealed() noexcept;
+  winrt::IInspectable Tag() const noexcept;
+  void Tag(winrt::IInspectable tag) noexcept;
+
+  winrt::IInspectable StateData() const noexcept;
+  void StateData(winrt::IInspectable tag) noexcept;
+
+ protected:
+  facebook::react::ShadowNode::Shared m_shadowNode;
+  winrt::IInspectable m_tag;
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace Microsoft::ReactNative {
+
+extern const char AbiComponentName[];
+
+class AbiShadowNode final : public facebook::react::ConcreteShadowNode<
+                                AbiComponentName,
+                                facebook::react::ShadowNode,
+                                winrt::Microsoft::ReactNative::implementation::AbiProps,
+                                facebook::react::EventEmitter,
+                                Microsoft::ReactNative::AbiStateData> {
+ public:
+  using ConcreteShadowNode::ConcreteShadowNode;
+
+  static facebook::react::ShadowNodeTraits BaseTraits() {
+    auto traits = facebook::react::ShadowNode::BaseTraits();
+    traits.set(facebook::react::ShadowNodeTraits::Trait::FormsStackingContext);
+    traits.set(facebook::react::ShadowNodeTraits::Trait::FormsView);
+    return traits;
+  }
+
+  void OnClone(const facebook::react::ShadowNode &sourceShadowNode) noexcept;
+  void Builder(winrt::Microsoft::ReactNative::IReactViewComponentBuilder builder) noexcept;
+  winrt::Microsoft::ReactNative::IReactViewComponentBuilder Builder() const noexcept;
+  void Proxy(winrt::Microsoft::ReactNative::ShadowNode handle) noexcept;
+  winrt::Microsoft::ReactNative::ShadowNode Proxy() const noexcept;
+
+ private:
+  winrt::Microsoft::ReactNative::ShadowNode m_proxy{nullptr};
+  winrt::Microsoft::ReactNative::IReactViewComponentBuilder m_builder{nullptr};
+};
+
+} // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Color.g.h"
 #include "ViewProps.g.h"
 
 #include <react/renderer/components/view/ViewProps.h>
@@ -34,10 +35,31 @@ class AbiViewProps final : public facebook::react::ViewProps {
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
+struct Color : ColorT<Color> {
+  Color(facebook::react::SharedColor color);
+
+  winrt::Windows::UI::Color AsWindowsColor(const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
+  winrt::Microsoft::ReactNative::Composition::IBrush AsBrush(
+      const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept;
+
+  static winrt::Microsoft::ReactNative::Color ReadValue(
+      const winrt::Microsoft::ReactNative::IJSValueReader &reader) noexcept;
+  static void WriteValue(
+      const winrt::Microsoft::ReactNative::IJSValueWriter &writer,
+      const winrt::Microsoft::ReactNative::Color &value) noexcept;
+  static winrt::Microsoft::ReactNative::Color Transparent() noexcept;
+  static winrt::Microsoft::ReactNative::Color Black() noexcept;
+  static winrt::Microsoft::ReactNative::Color White() noexcept;
+
+ private:
+  facebook::react::SharedColor m_color;
+};
+
 struct UserViewProps : ViewPropsT<UserViewProps> {
   UserViewProps(std::shared_ptr<::Microsoft::ReactNative::AbiViewProps const> viewProps) noexcept;
 
   float Opacity() noexcept;
+  winrt::Microsoft::ReactNative::Color BackgroundColor() noexcept;
 
   void Disconnect() noexcept;
 
@@ -50,9 +72,16 @@ struct ViewProps : ViewPropsT<ViewProps> {
   ViewProps(facebook::react::SharedViewProps props) noexcept;
 
   float Opacity() noexcept;
+  winrt::Microsoft::ReactNative::Color BackgroundColor() noexcept;
 
  private:
   facebook::react::SharedViewProps m_props;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+
+struct Color : ColorT<Color, implementation::Color> {};
+
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.cpp
@@ -14,37 +14,6 @@
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-ShadowNode::ShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept : m_shadowNode(shadowNode) {}
-
-void ShadowNode::EnsureUnsealed() noexcept {
-  m_shadowNode->ensureUnsealed();
-}
-
-winrt::IInspectable ShadowNode::Tag() const noexcept {
-  return m_tag;
-}
-
-void ShadowNode::Tag(winrt::IInspectable tag) noexcept {
-  m_tag = tag;
-}
-
-winrt::IInspectable ShadowNode::StateData() const noexcept {
-  auto state = m_shadowNode->getState();
-  react_native_assert(state && "State must not be `nullptr`.");
-  auto abiStateData =
-      static_cast<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData> *>(state.get())
-          ->getData();
-  return abiStateData.userdata;
-}
-
-void ShadowNode::StateData(winrt::IInspectable tag) noexcept {
-  m_shadowNode->ensureUnsealed();
-
-  auto &state = const_cast<facebook::react::State::Shared &>(m_shadowNode->getState());
-  state = std::make_shared<const facebook::react::ConcreteState<::Microsoft::ReactNative::AbiStateData>>(
-      std::make_shared<const ::Microsoft::ReactNative::AbiStateData>(tag), *state);
-}
-
 YogaLayoutableShadowNode::YogaLayoutableShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept
     : base_type(shadowNode) {}
 

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewShadowNode.h
@@ -8,6 +8,7 @@
 #include "YogaLayoutableShadowNode.g.h"
 #include <react/components/rnwcore/EventEmitters.h>
 #include <unordered_map>
+#include "AbiShadowNode.h"
 #include "AbiState.h"
 #include "AbiViewProps.h"
 
@@ -45,21 +46,6 @@ struct LayoutContext : LayoutContextT<LayoutContext> {
   }
 
   facebook::react::LayoutContext m_layoutContext;
-};
-
-struct ShadowNode : ShadowNodeT<ShadowNode> {
-  ShadowNode(facebook::react::ShadowNode::Shared shadowNode) noexcept;
-
-  void EnsureUnsealed() noexcept;
-  winrt::IInspectable Tag() const noexcept;
-  void Tag(winrt::IInspectable tag) noexcept;
-
-  winrt::IInspectable StateData() const noexcept;
-  void StateData(winrt::IInspectable tag) noexcept;
-
- protected:
-  facebook::react::ShadowNode::Shared m_shadowNode;
-  winrt::IInspectable m_tag;
 };
 
 struct YogaLayoutableShadowNode : YogaLayoutableShadowNodeT<YogaLayoutableShadowNode, implementation::ShadowNode> {

--- a/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/ComponentView.h
@@ -120,9 +120,11 @@ struct ComponentView : public ComponentViewT<ComponentView> {
   virtual void HandleCommand(
       winrt::hstring commandName,
       const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept;
-  virtual void UpdateProps(const winrt::Microsoft::ReactNative::IComponentProps &props) noexcept;
+  virtual void UpdateProps(
+      const winrt::Microsoft::ReactNative::IComponentProps &props,
+      const winrt::Microsoft::ReactNative::IComponentProps &oldProps) noexcept;
   virtual void UpdateState(const winrt::Microsoft::ReactNative::IComponentState &state) noexcept;
-  virtual void UpdateLayoutMetrics(LayoutMetrics metrics) noexcept;
+  virtual void UpdateLayoutMetrics(const LayoutMetrics &metrics, const LayoutMetrics &oldMetrics) noexcept;
   virtual void FinalizeUpdates(winrt::Microsoft::ReactNative::ComponentViewUpdateMask updateMask) noexcept;
   virtual void OnPointerEntered(
       const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) noexcept;
@@ -150,6 +152,8 @@ struct ComponentView : public ComponentViewT<ComponentView> {
  protected:
   const bool m_customComponent; // Is a user custom component, and so needs to call external override functions
   const facebook::react::Tag m_tag;
+  winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView *m_rootView{nullptr};
+  mutable winrt::Microsoft::ReactNative::Composition::implementation::Theme *m_theme{nullptr};
   const winrt::Microsoft::ReactNative::ReactContext m_reactContext;
   winrt::Microsoft::ReactNative::ComponentView m_parent{nullptr};
   winrt::Windows::Foundation::Collections::IVector<winrt::Microsoft::ReactNative::ComponentView> m_children{

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -24,7 +24,7 @@ ActivityIndicatorComponentView::ActivityIndicatorComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(compContext, tag, reactContext, ComponentViewFeatures::Default, false) {
   m_props = std::make_shared<facebook::react::ActivityIndicatorViewProps const>();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <Composition/CompositionSwitcher.interop.h>
+#include <CompositionSwitcher.interop.h>
 #include <winrt/Windows.UI.Composition.h>
 
 namespace Microsoft::ReactNative {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -10,7 +10,14 @@ DebuggingOverlayComponentView::DebuggingOverlayComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : base_type(compContext, tag, reactContext, false) {}
+    : base_type(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default &
+              ~(ComponentViewFeatures::Background | ComponentViewFeatures::ShadowProps |
+                ComponentViewFeatures::NativeBorder),
+          false) {}
 
 void DebuggingOverlayComponentView::MountChildComponentView(
     const winrt::Microsoft::ReactNative::ComponentView &childComponentView,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -13,6 +13,7 @@
 
 #include <react/renderer/components/image/ImageEventEmitter.h>
 
+#include <AutoDraw.h>
 #include <Fabric/FabricUIManagerModule.h>
 #include <Utils/ImageUtils.h>
 #include <shcore.h>
@@ -20,7 +21,6 @@
 #include <winrt/Windows.UI.Composition.h>
 #include <winrt/Windows.Web.Http.Headers.h>
 #include <winrt/Windows.Web.Http.h>
-#include "Composition/AutoDraw.h"
 #include "CompositionDynamicAutomationProvider.h"
 #include "CompositionHelpers.h"
 #include "RootComponentView.h"
@@ -52,7 +52,12 @@ ImageComponentView::ImageComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   static auto const defaultProps = std::make_shared<facebook::react::ImageProps const>();
   m_props = defaultProps;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -6,9 +6,9 @@
 
 #include "WindowsModalHostViewComponentView.h"
 
+#include <AutoDraw.h>
 #include <Fabric/DWriteHelpers.h>
 #include "../CompositionDynamicAutomationProvider.h"
-#include "Composition/AutoDraw.h"
 #include "Unicode.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
@@ -23,7 +23,12 @@ WindowsModalHostComponentView::WindowsModalHostComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   m_props = std::make_shared<facebook::react::ModalHostViewProps const>();
   m_visual = compContext.CreateSpriteVisual();
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -6,12 +6,12 @@
 
 #include "ParagraphComponentView.h"
 
+#include <AutoDraw.h>
 #include <Utils/ValueUtils.h>
 #include <react/renderer/components/text/ParagraphShadowNode.h>
 #include <react/renderer/components/text/ParagraphState.h>
 #include <unicode.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
-#include "Composition/AutoDraw.h"
 #include "CompositionDynamicAutomationProvider.h"
 #include "CompositionHelpers.h"
 
@@ -21,7 +21,12 @@ ParagraphComponentView::ParagraphComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   static auto const defaultProps = std::make_shared<facebook::react::ParagraphProps const>();
   m_props = defaultProps;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -46,8 +46,15 @@ LayoutHandler ReactCompositionViewComponentBuilder::LayoutHandler() const noexce
   return m_layoutHandler;
 }
 
-void ReactCompositionViewComponentBuilder::SetCreateComponentView(CompositionComponentFactory impl) noexcept {
+void ReactCompositionViewComponentBuilder::SetCreateComponentView(ComponentViewFactory impl) noexcept {
+  m_createComponentView = impl;
+  assert(!m_createView); // Only SetCreateComponentView OR SetCreateViewComponentView should be called
+}
+
+void ReactCompositionViewComponentBuilder::SetCreateViewComponentView(
+    CompositionViewComponentViewFactory impl) noexcept {
   m_createView = impl;
+  assert(!m_createComponentView); // Only SetCreateComponentView OR SetCreateViewComponentView should be called
 }
 // (Object handle, Microsoft.ReactNative.IComponentState state) => void
 // void ReactCompositionViewComponentBuilder::SetStateUpdater(StateUpdater impl) noexcept {
@@ -90,8 +97,18 @@ winrt::Microsoft::ReactNative::ComponentView ReactCompositionViewComponentBuilde
     const IReactContext &reactContext,
     int32_t tag,
     const ICompositionContext &context) noexcept {
-  auto args = winrt::make<implementation::CreateCompositionComponentViewArgs>(reactContext, tag, context);
-  return m_createView(args);
+  if (m_createView) {
+    auto args = winrt::make<implementation::CreateCompositionComponentViewArgs>(reactContext, tag, context);
+    return m_createView(args);
+  } else {
+    assert(m_createComponentView);
+    auto args = winrt::make<winrt::Microsoft::ReactNative::implementation::CreateComponentViewArgs>(reactContext, tag);
+    return m_createComponentView(args);
+  }
+}
+
+bool ReactCompositionViewComponentBuilder::IsViewComponent() const noexcept {
+  return m_createView != nullptr;
 }
 
 } // namespace winrt::Microsoft::ReactNative::Composition

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -15,6 +15,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   ReactCompositionViewComponentBuilder() noexcept;
 
  public: // IReactViewComponentBuilder
+  void SetCreateComponentView(ComponentViewFactory impl) noexcept;
   void SetCreateProps(ViewPropsFactory impl) noexcept;
 
   // (Object handle, Microsoft.ReactNative.IComponentState state) => void
@@ -27,8 +28,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   void SetLayoutHandler(LayoutHandler impl) noexcept;
 
  public: // Composition::IReactCompositionViewComponentBuilder
-  // (ICompositionContext) => ComponentView
-  void SetCreateComponentView(CompositionComponentFactory impl) noexcept;
+  void SetCreateViewComponentView(CompositionViewComponentViewFactory impl) noexcept;
 
  public:
   IComponentProps CreateProps(ViewProps props) noexcept;
@@ -38,6 +38,7 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
       winrt::Microsoft::ReactNative::IComponentProps props) noexcept;
   MeasureContentHandler MeasureContentHandler() const noexcept;
   LayoutHandler LayoutHandler() const noexcept;
+  bool IsViewComponent() const noexcept;
 
   winrt::Microsoft::ReactNative::ComponentView
   CreateView(const IReactContext &reactContext, facebook::react::Tag tag, const ICompositionContext &context) noexcept;
@@ -50,7 +51,8 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   winrt::Microsoft::ReactNative::MeasureContentHandler m_measureContent;
   winrt::Microsoft::ReactNative::LayoutHandler m_layoutHandler;
 
-  CompositionComponentFactory m_createView;
+  ComponentViewFactory m_createComponentView{nullptr};
+  CompositionViewComponentViewFactory m_createView{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -17,7 +17,14 @@ RootComponentView::RootComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : base_type(compContext, tag, reactContext, false) {}
+    : base_type(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default &
+              ~(ComponentViewFeatures::Background | ComponentViewFeatures::ShadowProps |
+                ComponentViewFeatures::NativeBorder),
+          false) {}
 
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::Create(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -16,9 +16,9 @@
 
 #include <windows.ui.composition.interop.h>
 
+#include <AutoDraw.h>
 #include <Fabric/DWriteHelpers.h>
 #include <unicode.h>
-#include "Composition/AutoDraw.h"
 #include "CompositionDynamicAutomationProvider.h"
 #include "JSValueReader.h"
 #include "RootComponentView.h"
@@ -582,7 +582,12 @@ ScrollViewComponentView::ScrollViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   static auto const defaultProps = std::make_shared<facebook::react::ScrollViewProps const>();
   m_props = defaultProps;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -5,8 +5,8 @@
 #pragma once
 
 #include "SwitchComponentView.h"
+#include <AutoDraw.h>
 #include <Fabric/AbiViewProps.h>
-#include "Composition/AutoDraw.h"
 #include "CompositionDynamicAutomationProvider.h"
 #include "RootComponentView.h"
 
@@ -28,7 +28,12 @@ SwitchComponentView::SwitchComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : base_type(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : base_type(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   m_props = std::make_shared<facebook::react::SwitchProps const>();
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -5,6 +5,7 @@
 
 #include "WindowsTextInputComponentView.h"
 
+#include <AutoDraw.h>
 #include <Fabric/Composition/CompositionDynamicAutomationProvider.h>
 #include <Fabric/Composition/UiaHelpers.h>
 #include <Utils/ValueUtils.h>
@@ -14,7 +15,6 @@
 #include <winrt/Windows.UI.h>
 #include "../CompositionHelpers.h"
 #include "../RootComponentView.h"
-#include "Composition/AutoDraw.h"
 #include "JSValueReader.h"
 #include "WindowsTextInputShadowNode.h"
 #include "WindowsTextInputState.h"
@@ -483,7 +483,12 @@ WindowsTextInputComponentView::WindowsTextInputComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : Super(compContext, tag, reactContext, CompositionComponentViewFeatures::Default, false) {
+    : Super(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default & ~ComponentViewFeatures::Background,
+          false) {
   static auto const defaultProps = std::make_shared<facebook::react::WindowsTextInputProps const>();
   m_props = defaultProps;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -6,8 +6,8 @@
 
 #include "UnimplementedNativeViewComponentView.h"
 
+#include <AutoDraw.h>
 #include <Fabric/DWriteHelpers.h>
-#include "Composition/AutoDraw.h"
 #include "CompositionDynamicAutomationProvider.h"
 #include "Unicode.h"
 
@@ -17,7 +17,14 @@ UnimplementedNativeViewComponentView::UnimplementedNativeViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
-    : base_type(compContext, tag, reactContext, false) {
+    : base_type(
+          compContext,
+          tag,
+          reactContext,
+          ComponentViewFeatures::Default &
+              ~(ComponentViewFeatures::Background | ComponentViewFeatures::ShadowProps |
+                ComponentViewFeatures::NativeBorder),
+          false) {
   m_labelVisual = compContext.CreateSpriteVisual();
   OuterVisual().InsertAt(m_labelVisual, 1);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsComponentDescriptorRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsComponentDescriptorRegistry.cpp
@@ -4,6 +4,7 @@
 
 #include "WindowsComponentDescriptorRegistry.h"
 
+#include <Fabric/AbiComponentDescriptor.h>
 #include <Fabric/AbiViewComponentDescriptor.h>
 #include <Fabric/Composition/Modal/WindowsModalHostViewComponentDescriptor.h>
 #include <Fabric/Composition/TextInput/WindowsTextInputComponentDescriptor.h>
@@ -67,11 +68,15 @@ void WindowsComponentDescriptorRegistry::Add(
       facebook::react::ComponentName(m_descriptorFlavors.back()->c_str()));
   m_builderByName.emplace(m_descriptorFlavors.back(), builder);
   m_builderByHandle.emplace(handle, builder);
+
   m_componentDescriptorRegistry->add(
       {handle,
        m_descriptorFlavors.back()->c_str(),
        std::static_pointer_cast<void const>(m_descriptorFlavors.back()),
-       &facebook::react::concreteComponentDescriptorConstructor<AbiViewComponentDescriptor>});
+       winrt::get_self<winrt::Microsoft::ReactNative::Composition::ReactCompositionViewComponentBuilder>(builder)
+               ->IsViewComponent()
+           ? &facebook::react::concreteComponentDescriptorConstructor<AbiViewComponentDescriptor>
+           : &facebook::react::concreteComponentDescriptorConstructor<AbiComponentDescriptor>});
 }
 
 winrt::Microsoft::ReactNative::IReactViewComponentBuilder WindowsComponentDescriptorRegistry::GetDescriptor(

--- a/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactCompositionViewComponentBuilder.idl
@@ -14,16 +14,15 @@ import "CompositionComponentView.idl";
 namespace Microsoft.ReactNative.Composition
 {
   [experimental]
-  DOC_STRING("Provides a factory method to create an instance of a ViewComponent. See @IReactCompositionViewComponentBuilder.SetCreateView")
-  delegate Microsoft.ReactNative.ComponentView CompositionComponentFactory(CreateCompositionComponentViewArgs args);
+  DOC_STRING("Provides a factory method to create an instance of a ViewComponentView. See @IReactCompositionViewComponentBuilder.SetCreateViewComponentView")
+  delegate Microsoft.ReactNative.Composition.ViewComponentView CompositionViewComponentViewFactory(CreateCompositionComponentViewArgs args);
 
   [webhosthidden]
   [experimental]
   DOC_STRING(".")
   interface IReactCompositionViewComponentBuilder
   {
-    // (ICompositionContext) => Handle
-    void SetCreateComponentView(CompositionComponentFactory impl);
+    void SetCreateViewComponentView(CompositionViewComponentViewFactory impl);
   };
 
 } // namespace Microsoft.ReactNative

--- a/vnext/Microsoft.ReactNative/IReactViewComponentBuilder.idl
+++ b/vnext/Microsoft.ReactNative/IReactViewComponentBuilder.idl
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import "ViewProps.idl";
+import "ComponentView.idl";
 
 #include "DocString.h"
 
@@ -50,13 +51,18 @@ namespace Microsoft.ReactNative
   delegate void ViewShadowNodeCloner(ShadowNode shadowNode, ShadowNode sourceShadowNode);
 
   [experimental]
-  delegate Object InitialStateDataFactory(Microsoft.ReactNative.IComponentProps props);
+  delegate Object InitialStateDataFactory(IComponentProps props);
 
+  [experimental]
+  DOC_STRING("Provides a factory method to create an instance of a ComponentView. See @IReactViewComponentBuilder.SetCreateView")
+  delegate ComponentView ComponentViewFactory(CreateComponentViewArgs args);
 
   [webhosthidden]
   [experimental]
   interface IReactViewComponentBuilder
   {
+    void SetCreateComponentView(ComponentViewFactory impl);
+
     DOC_STRING("Create an implementation of your custom Props type that will be passed to your components @Composition.ICompositionViewComponent.UpdateProps method.")
     void SetCreateProps(ViewPropsFactory impl);
 

--- a/vnext/Microsoft.ReactNative/ViewProps.idl
+++ b/vnext/Microsoft.ReactNative/ViewProps.idl
@@ -3,8 +3,23 @@
 
 #include "DocString.h"
 import "IJSValueReader.idl";
+import "IJSValueWriter.idl";
+import "Theme.idl";
 
 namespace Microsoft.ReactNative {
+
+  [webhosthidden]
+  [experimental]
+  runtimeclass Color {
+    Windows.UI.Color AsWindowsColor(Microsoft.ReactNative.Composition.Theme theme);
+    Microsoft.ReactNative.Composition.IBrush AsBrush(Microsoft.ReactNative.Composition.Theme theme);
+
+    static Color Black();
+    static Color Transparent();
+    static Color ReadValue(IJSValueReader reader);
+    static void WriteValue(IJSValueWriter writer, Color color);
+  };
+
   [webhosthidden]
   [experimental]
   DOC_STRING("Interface to implement custom view component properties.")
@@ -23,6 +38,8 @@ namespace Microsoft.ReactNative {
   runtimeclass ViewProps
   {
     Single Opacity { get; };
+
+    Color BackgroundColor { get; };
 
     // TODO add accessors to all the properties on ViewProps
   };

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -46,8 +46,6 @@
     <file src="$nugetroot$\inc\stubs\**\*.*" target="inc" />
 
     <file src="$nugetroot$\inc\Shared\AbiSafe.h" target="inc"/>
-    <file src="$nugetroot$\inc\Shared\Composition\AutoDraw.h" target="inc"/>
-    <file src="$nugetroot$\inc\Shared\Composition\CompositionSwitcher.interop.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\DevSettings.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWin32\INativeUIManagerLegacy.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\InstanceManager.h" target="inc"/>

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -141,10 +141,16 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UiaHelpers.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiComponentDescriptor.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiViewComponentDescriptor.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiViewProps.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiViewShadowNode.cpp">

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -297,6 +297,8 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ThemeUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\DebuggingOverlayComponentView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiComponentDescriptor.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
Adding additional functionality that would be required / useful for custom components (as hit trying to implement react-native-svg)

 -  Add AbiShadowNode for non View custom components
Currently all custom componentviews are View components.  For some components such as react-native-svg which make use of a bunch of native components, most of which do not need to be views, making them all ViewComponents adds to the overhead of creating all those nodes.

 - Updated the `UpdateProps` and `UpdateLayoutMetrics` overrides to provide both the old and new values aligning with core.

- Expose ICompositionDrawingSurfaceInterop interface in MS.RN.Cxx project to allow custom rendering to visuals.

 - Add a Microsoft::ReactNative::Color object that exposes facebook::react::Color to the ABI

 - Expose ComponentViewFeatures to custom components to allow them to opt in/out of default behavior

 - Add OnThemeChanged override for custom components
