### PR TITLE
Add delegate property to configure the IHttpFilter underlying HttpModule

### DIFF
--- a/vnext/Shared/Networking/HttpFilterFactorySettings.cpp
+++ b/vnext/Shared/Networking/HttpFilterFactorySettings.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#undef WINRT_LEAN_AND_MEAN
+
+#include "HttpFilterFactorySettings.h"
+#include <ReactPropertyBag.h>
+#include "RedirectHttpFilter.h"
+
+#include <winrt/Windows.Web.Http.Filters.h>
+#include <winrt/Windows.Web.Http.h>
+
+namespace Microsoft::React::Networking {
+
+winrt::Microsoft::ReactNative::ReactPropertyId<
+    winrt::Microsoft::ReactNative::ReactNonAbiValue<HttpFilterFactoryDelegate>>
+HttpFilterFactoryDelegateProperty() noexcept {
+  winrt::Microsoft::ReactNative::ReactPropertyId<
+      winrt::Microsoft::ReactNative::ReactNonAbiValue<HttpFilterFactoryDelegate>>
+      propId{L"ReactNative.Http", L"HttpFilterFactory"};
+  return propId;
+}
+
+void SetHttpFilterFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    HttpFilterFactoryDelegate const &value) noexcept {
+  properties.Set(HttpFilterFactoryDelegateProperty(), value);
+}
+const HttpFilterFactoryDelegate GetHttpFilterFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept {
+  const auto delegate = properties.Get(HttpFilterFactoryDelegateProperty());
+  if (!delegate) {
+    return nullptr;
+  }
+  return delegate.Value();
+}
+
+} // namespace Microsoft::React::Networking

--- a/vnext/Shared/Networking/HttpFilterFactorySettings.h
+++ b/vnext/Shared/Networking/HttpFilterFactorySettings.h
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include <winrt/Windows.Web.Http.Filters.h>
+#include <winrt/Windows.Web.Http.h>
+#include <winrt/base.h>
+
+#include <ReactPropertyBag.h>
+
+namespace Microsoft::React::Networking {
+
+using HttpFilterFactoryDelegate =
+    std::function<winrt::Windows::Web::Http::Filters::IHttpFilter()>;
+
+void SetHttpFilterFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties,
+    HttpFilterFactoryDelegate const& value) noexcept;
+const HttpFilterFactoryDelegate GetHttpFilterFactoryDelegate(
+    winrt::Microsoft::ReactNative::ReactPropertyBag properties) noexcept;
+
+} // namespace Microsoft::React::Networking

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -198,7 +198,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\WindowsImageManager.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\SchedulerSettings.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\SchedulerSettings.cpp"/>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\AsynchronousEventBeat.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -198,7 +198,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\WindowsImageManager.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\SchedulerSettings.cpp"/>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\SchedulerSettings.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\AsynchronousEventBeat.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
@@ -242,6 +242,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\StatusBarManagerModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\WebSocketModule.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\DefaultBlobResource.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Networking\HttpFilterFactorySettings.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\OriginPolicyHttpFilter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\RedirectHttpFilter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\WinRTHttpResource.cpp" />
@@ -384,6 +385,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\NetworkingModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Modules\WebSocketTurboModule.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\DefaultBlobResource.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Networking\HttpFilterFactorySettings.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IBlobResource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IHttpResource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)Networking\IRedirectEventSource.h" />

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -297,12 +297,18 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ThemeUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\DebuggingOverlayComponentView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.cpp" />
+<<<<<<< HEAD
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiComponentDescriptor.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
+=======
+    <ClCompile Include="$(MSBuildThisFileDirectory)Networking\HttpFilterFactorySettings.cpp">
+      <Filter>Source Files\Networking</Filter>
+    </ClCompile>
+>>>>>>> 9f5197092 (Add factory to configure a custom IHttpFilter for underlying HttpModule)
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">
@@ -790,6 +796,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)V8JSIRuntimeHolder.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\Modal\WindowsModalHostViewSate.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)Networking\HttpFilterFactorySettings.h">
+      <Filter>Header Files\Networking</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)tracing\rnw.wprp">

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -297,18 +297,15 @@
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Utils\ThemeUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\DebuggingOverlayComponentView.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.cpp" />
-<<<<<<< HEAD
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiComponentDescriptor.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\AbiShadowNode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\PlatformConstantsWinModule.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\ExceptionsManager.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\SourceCode.cpp" />
     <ClCompile Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Modules\Timing.cpp" />
-=======
     <ClCompile Include="$(MSBuildThisFileDirectory)Networking\HttpFilterFactorySettings.cpp">
       <Filter>Source Files\Networking</Filter>
     </ClCompile>
->>>>>>> 9f5197092 (Add factory to configure a custom IHttpFilter for underlying HttpModule)
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
In order for XHRRequests from javascript layer to request to certificate protected endpoints, a client certificate must be added to the underlying WinRT HttpClient.

Certificate configuration is performed through the [HttpBaseProtocolFilter](https://learn.microsoft.com/en-us/uwp/api/windows.web.http.filters.httpbaseprotocolfilter?view=winrt-22621) object via the [HttpBaseProtocolFilter::ClientCertificate](https://learn.microsoft.com/en-us/uwp/api/windows.web.http.filters.httpbaseprotocolfilter.clientcertificate?view=winrt-22621#windows-web-http-filters-httpbaseprotocolfilter-clientcertificate) property. The `HttpBaseProtocolFilter`, or more generally an `IHttpFilter`, is passed into `HttpClient` at construction.

Applications need to configure the http stack's `HttpFilter` before `HttpClient` construction. New API is a novel property set on the `ReactInstanceSettings::Properties()` property bag. The property value is a delegate of type `winrt::Windows::Web::Http::Filters::IHttpFilter()`. If the property is set, the delegate is called during `HttpClient` configuration in `IHttpResource::Make` to allow application code to supply the `IHttpFilter`s for the underlying `RedirectHttpFilter`, which is then passed to `HttpClient` constructor during `HttpModule` init.

Alternatives designs considered were:
- Crafting a static storage mechanism for the delegate to bypass react machinery. Discarded due to object lifetime risk.
- Creating a factory for `HttpClient`. Discarded as not minimum viable, and additional complexities with overriding current `OriginPolicy` configuration of `HttpClient`.
- Creating WinRT wrapper type & delegate type to store delegate for broader compatibility. Discarded due to uncertainty about applicability on non-C++ applications.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
Enterprise applications often have to access protected endpoints which can be guarded by a certificate. In order for javascript layer to access certificate protected endpoints, the React Native Windows http stack needs to be configured to include the certificate.

React Native Windows uses WinRT's HttpClient to facilitate network requests from javascript layer. HttpClient needs to be configured with certificate in order to facilitate javascript requests to certificate protected endpoints.

Resolves #12744

### What
Adds `HttpBaseProtocolFilterModifierSettings.h/cpp` to expose getters/setters of delegate property. `IHttpResource::Make` is then modified to 

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
Playground on main branch is currently broken, confirmed HttpBaseProtocolFilterModifierSettings.cpp and WinRTHttpResource.cpp compile cleanly.

Confirmed delegate is called & certificate configuration is successful in internal branches.

## Changelog
Should this change be included in the release notes: yes

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12745)