### PR TITLE
[Fabric] Add onSubmitEditing and clearTextOnSubmit

### DIFF
--- a/change/react-native-windows-8be51422-0198-43a0-bbab-29659d755e48.json
+++ b/change/react-native-windows-8be51422-0198-43a0-bbab-29659d755e48.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "sumbitkeyevents working with shift",
+  "packageName": "react-native-windows",
+  "email": "tatianakapos@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
+++ b/packages/e2e-test-app-fabric/test/TextInputComponentTest.test.ts
@@ -264,6 +264,28 @@ describe('TextInput Tests', () => {
       'textinput-clear-on-submit',
     );
     await component.waitForDisplayed({timeout: 5000});
+    await app.waitUntil(
+      async () => {
+        await component.setValue('Hello World');
+        return (await component.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+    await app.waitUntil(
+      async () => {
+        await component.setValue('\uE007');
+        return (await component.getText()) === '';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
     const dump = await dumpVisualTree('textinput-clear-on-submit');
     expect(dump).toMatchSnapshot();
   });
@@ -283,11 +305,33 @@ describe('TextInput Tests', () => {
     const dump = await dumpVisualTree('textinput-clear-on-submit-3');
     expect(dump).toMatchSnapshot();
   });
-  test('TextInputs can submit with custom key', async () => {
+  test('TextInputs can submit with custom key, multilined and submit with enter', async () => {
     const component = await app.findElementByTestID(
       'textinput-clear-on-submit-4',
     );
     await component.waitForDisplayed({timeout: 5000});
+    await app.waitUntil(
+      async () => {
+        await component.setValue('Hello World');
+        return (await component.getText()) === 'Hello World';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
+    await app.waitUntil(
+      async () => {
+        await component.setValue('\uE007');
+        return (await component.getText()) === '';
+      },
+      {
+        interval: 1500,
+        timeout: 5000,
+        timeoutMsg: `Unable to enter correct text.`,
+      },
+    );
     const dump = await dumpVisualTree('textinput-clear-on-submit-4');
     expect(dump).toMatchSnapshot();
   });

--- a/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/TextInputComponentTest.test.ts.snap
@@ -2421,8 +2421,8 @@ exports[`TextInput Tests TextInputs can clear on submit 1`] = `
         ],
         "Opacity": 0,
         "Size": [
-          0,
-          0,
+          1,
+          19,
         ],
         "Visual Type": "SpriteVisual",
       },
@@ -6071,7 +6071,7 @@ exports[`TextInput Tests TextInputs can set their readOnly prop to true 1`] = `
 }
 `;
 
-exports[`TextInput Tests TextInputs can submit with custom key 1`] = `
+exports[`TextInput Tests TextInputs can submit with custom key, multilined and submit with enter 1`] = `
 {
   "Automation Tree": {
     "AutomationId": "textinput-clear-on-submit-4",
@@ -6096,8 +6096,8 @@ exports[`TextInput Tests TextInputs can submit with custom key 1`] = `
         ],
         "Opacity": 0,
         "Size": [
-          0,
-          0,
+          1,
+          19,
         ],
         "Visual Type": "SpriteVisual",
       },

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -109,6 +109,8 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
   void updateCursorColor(
       const facebook::react::SharedColor &cursorColor,
       const facebook::react::SharedColor &foregroundColor) noexcept;
+  bool ShouldSubmit(
+      const winrt::Microsoft::ReactNative::Composition::Input::CharacterReceivedRoutedEventArgs &args) noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
@@ -132,6 +134,10 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
   int m_cDrawBlock{0};
   bool m_needsRedraw{false};
   bool m_drawing{false};
+  bool m_clearTextOnSubmit{false};
+  bool m_multiline{false};
+  bool m_shiftDown{false};
+  std::vector<facebook::react::CompWindowsTextInputSubmitKeyEventsStruct> m_submitKeyEvents;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -110,6 +110,7 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
       const facebook::react::SharedColor &cursorColor,
       const facebook::react::SharedColor &foregroundColor) noexcept;
   bool ShouldSubmit(
+      const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
       const winrt::Microsoft::ReactNative::Composition::Input::CharacterReceivedRoutedEventArgs &args) noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
@@ -136,7 +137,6 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
   bool m_drawing{false};
   bool m_clearTextOnSubmit{false};
   bool m_multiline{false};
-  bool m_shiftDown{false};
   std::vector<facebook::react::CompWindowsTextInputSubmitKeyEventsStruct> m_submitKeyEvents;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.cpp
@@ -28,4 +28,14 @@ void WindowsTextInputEventEmitter::onSelectionChange(const OnSelectionChange &ev
   });
 }
 
+void WindowsTextInputEventEmitter::onSubmitEditing(OnSubmitEditing event) const {
+  dispatchEvent("textInputSubmitEditing", [event = std::move(event)](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "eventCount", event.eventCount);
+    payload.setProperty(runtime, "target", event.target);
+    payload.setProperty(runtime, "text", event.text);
+    return payload;
+  });
+}
+
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h
@@ -26,8 +26,15 @@ class WindowsTextInputEventEmitter : public ViewEventEmitter {
     Selection selection;
   };
 
+  struct OnSubmitEditing {
+    int eventCount;
+    int target;
+    std::string text;
+  };
+
   void onChange(OnChange value) const;
   void onSelectionChange(const OnSelectionChange &value) const;
+  void onSubmitEditing(OnSubmitEditing value) const;
 };
 
 } // namespace facebook::react

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputProps.h
@@ -33,10 +33,10 @@ static inline std::string toString(const CompWindowsTextInputSelectionStruct &va
 }
 
 struct CompWindowsTextInputSubmitKeyEventsStruct {
-  bool altKey;
-  bool ctrlKey;
-  bool metaKey;
-  bool shiftKey;
+  bool altKey{false};
+  bool ctrlKey{false};
+  bool metaKey{false};
+  bool shiftKey{false};
   std::string code;
 };
 


### PR DESCRIPTION
## Description
Adds onSumbitEditing and clearTextOnSubmit to TextInput

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
TextInput parity

### What
Adds onSumbitEditing event to TextInput and keeps track of if the shift key is pressed.

## Screenshots

https://github.com/microsoft/react-native-windows/assets/42554868/bc25e23c-da05-4759-9d3f-af581f2658b7


## Testing
tested locally

## Changelog
no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12746)