### PR TITLE
Fix issue with new arch cpp-app apps not finding the bundle in release builds

### DIFF
--- a/change/react-native-windows-aa8367b6-17de-4644-b985-dfabfe7c393d.json
+++ b/change/react-native-windows-aa8367b6-17de-4644-b985-dfabfe7c393d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix issue with new arch cpp-app apps not finding the bundle in release builds",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -69,7 +69,7 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
   auto host = winrt::Microsoft::ReactNative::ReactNativeHost();
 
   // Include any autolinked modules
-  //RegisterAutolinkedNativeModulePackages(host.PackageProviders());
+  // RegisterAutolinkedNativeModulePackages(host.PackageProviders());
 
   host.PackageProviders().Append(winrt::make<RNTesterAppReactPackageProvider>());
   host.PackageProviders().Append(winrt::AutomationChannel::ReactPackageProvider());

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
@@ -12,11 +12,10 @@
 #define WINRT_LEAN_AND_MEAN 1
 
 // Windows Header Files
-#include <pathcch.h>
 #include <windows.h>
-
-#pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime
+#include <pathcch.h>
+#include <unknwn.h>
 
 // Playground pch.h
 #include <CppWinRTIncludes.h>
@@ -32,5 +31,4 @@
 #include <tchar.h>
 
 // reference additional headers your program requires here
-#include <unknwn.h>
 #include <winrt/base.h>

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
@@ -13,6 +13,7 @@
 
 // Windows Header Files
 #include <windows.h>
+#include <pathcch.h>
 
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
@@ -22,7 +22,6 @@
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.Foundation.h>
-#pragma pop_macro("GetCurrentTime")
 
 // C RunTime Header Files
 #include <malloc.h>

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/pch.h
@@ -12,8 +12,8 @@
 #define WINRT_LEAN_AND_MEAN 1
 
 // Windows Header Files
-#include <windows.h>
 #include <pathcch.h>
+#include <windows.h>
 
 #pragma push_macro("GetCurrentTime")
 #undef GetCurrentTime

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -150,7 +150,8 @@ struct WindowData {
 
           host.InstanceSettings().JavaScriptBundleFile(m_bundleFile);
 
-          host.InstanceSettings().BundleRootPath(std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
+          host.InstanceSettings().BundleRootPath(
+              std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
           host.InstanceSettings().UseDeveloperSupport(true);
 
           // Currently there is only SystemVisualSiteBridge which supports hosing ContentIslands within System

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -140,8 +140,9 @@ struct WindowData {
         if (!m_bundleFile.empty()) {
           PCWSTR appName = (m_bundleFile == LR"(Samples\rntester)") ? L"RNTesterApp" : L"Bootstrap";
 
-          WCHAR workingDir[MAX_PATH];
-          GetCurrentDirectory(MAX_PATH, workingDir);
+          WCHAR appDirectory[MAX_PATH];
+          GetModuleFileNameW(NULL, appDirectory, MAX_PATH);
+          PathCchRemoveFileSpec(appDirectory, MAX_PATH);
 
           auto host = Host();
           // Disable until we have a 3rd party story for custom components
@@ -149,8 +150,7 @@ struct WindowData {
 
           host.InstanceSettings().JavaScriptBundleFile(m_bundleFile);
 
-          host.InstanceSettings().BundleRootPath(
-              std::wstring(L"file:").append(workingDir).append(L"\\Bundle\\").c_str());
+          host.InstanceSettings().BundleRootPath(std::wstring(L"file://").append(appDirectory).append(L"\\Bundle\\").c_str());
           host.InstanceSettings().UseDeveloperSupport(true);
 
           // Currently there is only SystemVisualSiteBridge which supports hosing ContentIslands within System

--- a/packages/playground/windows/playground-composition/pch.h
+++ b/packages/playground/windows/playground-composition/pch.h
@@ -5,6 +5,7 @@
 #define WINRT_LEAN_AND_MEAN 1
 
 #include <windows.h>
+#include <pathcch.h>
 
 // When WINAPI_FAMILY is DESKTOP_APP, windows.h creates a macro for GetCurrentTime, which conflicts with other headers
 #undef GetCurrentTime

--- a/packages/playground/windows/playground-composition/pch.h
+++ b/packages/playground/windows/playground-composition/pch.h
@@ -4,12 +4,10 @@
 #define WIN32_LEAN_AND_MEAN 1
 #define WINRT_LEAN_AND_MEAN 1
 
-#include <pathcch.h>
 #include <windows.h>
-
 // When WINAPI_FAMILY is DESKTOP_APP, windows.h creates a macro for GetCurrentTime, which conflicts with other headers
 #undef GetCurrentTime
-
+#include <pathcch.h>
 #include <unknwn.h>
 
 #include <CppWinRTIncludes.h>

--- a/packages/playground/windows/playground-composition/pch.h
+++ b/packages/playground/windows/playground-composition/pch.h
@@ -4,8 +4,8 @@
 #define WIN32_LEAN_AND_MEAN 1
 #define WINRT_LEAN_AND_MEAN 1
 
-#include <windows.h>
 #include <pathcch.h>
+#include <windows.h>
 
 // When WINAPI_FAMILY is DESKTOP_APP, windows.h creates a macro for GetCurrentTime, which conflicts with other headers
 #undef GetCurrentTime

--- a/vnext/templates/cpp-app/windows/MyApp/pch.h
+++ b/vnext/templates/cpp-app/windows/MyApp/pch.h
@@ -14,6 +14,7 @@
 // Windows Header Files
 #include <unknwn.h>
 #include <windows.h>
+#include <pathcch.h>
 #undef GetCurrentTime
 
 // WinRT Header Files

--- a/vnext/templates/cpp-app/windows/MyApp/pch.h
+++ b/vnext/templates/cpp-app/windows/MyApp/pch.h
@@ -12,10 +12,10 @@
 #define WINRT_LEAN_AND_MEAN 1
 
 // Windows Header Files
-#include <unknwn.h>
 #include <windows.h>
-#include <pathcch.h>
 #undef GetCurrentTime
+#include <pathcch.h>
+#include <unknwn.h>
 
 // WinRT Header Files
 #include <winrt/base.h>

--- a/vnext/templates/cpp-lib/windows/MyLib/pch.h
+++ b/vnext/templates/cpp-lib/windows/MyLib/pch.h
@@ -12,9 +12,9 @@
 #define WINRT_LEAN_AND_MEAN 1
 
 // Windows Header Files
-#include <unknwn.h>
 #include <windows.h>
 #undef GetCurrentTime
+#include <unknwn.h>
 
 // WinRT Header Files
 #include <winrt/base.h>


### PR DESCRIPTION
## Description

The new cpp-app template (and related apps `playground-composition` and `e2e-test-app-fabric`) were all set with an invalid `BundleRootPath`. This causes the app to throw an error because it can't parse the given path from the URI, furthermore, since it was a URI based on the current working directory, it might not even be the right directory to load the bundle from.

This PR fixes the issue by instead using the correct `file://` URI scheme and also looking for the bundle path relative to the location of the app exe itself. This PR also re-aligns the apps to use the similar instance settings setup of the older UWP app (using both the `BUNDLE` and `_DEBUG` macros appropriately).

Partially resolves #12752

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
So that release builds work for the apps using the new template.


### What
See above.

## Screenshots
![image](https://github.com/microsoft/react-native-windows/assets/10852185/4a839f09-996b-464d-ada3-1878bdf835e6)

## Testing
Tested a new app works with the changes.

## Changelog
Should this change be included in the release notes: _yes_

Fixed issue with new arch cpp-app apps not finding the bundle in release builds
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12754)