### PR TITLE
Fix loading images from `file://` URIs 

### DIFF
--- a/change/react-native-windows-4fa3799d-8c88-4d16-9663-28b1dd4f7b26.json
+++ b/change/react-native-windows-4fa3799d-8c88-4d16-9663-28b1dd4f7b26.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix loading images from `file://` URIs",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/ImageUtils.cpp
@@ -35,9 +35,7 @@ winrt::IAsyncOperation<winrt::IRandomAccessStream> GetImageStreamAsync(ReactImag
       winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::StorageFile> getFileSync{nullptr};
 
       if (isFile) {
-        auto path = winrt::to_string(uri.Path());
-        std::replace(path.begin(), path.end(), '/', '\\');
-        getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(winrt::to_hstring(path));
+        getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromPathAsync(uri.AbsoluteCanonicalUri());
       } else {
         getFileSync = winrt::Windows::Storage::StorageFile::GetFileFromApplicationUriAsync(uri);
       }


### PR DESCRIPTION
## Description

Fixes the loading of images via `file://` URIs, which is what is used for asset files in (unpackaged) Fabric apps.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why
To fix image loading.

Resolves #12755

### What
The API we use to load the image can support `file://` URI's directly, we were doing a bunch of (now no longer necessary?) path processing that ultimately wasn't working. This change removes that processing.

## Screenshots
Before: 

![image](https://github.com/microsoft/react-native-windows/assets/10852185/dd634958-e2a0-4edf-9a60-5c5c74c1d2e6)


After:
![image](https://github.com/microsoft/react-native-windows/assets/10852185/5a51785b-0829-4d3a-8210-5fa5257f9ad0)


## Testing
Verified images started loading.

## Changelog
Should this change be included in the release notes: _yes_

Fixed loading images from `file://` URIs (as used for assets in on-disk bundles)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12757)