### PR TITLE
Adds ARIA role support to Paper UIManager

### DIFF
--- a/change/react-native-windows-b20ce41b-73cf-4c53-b96a-5bf1118b6135.json
+++ b/change/react-native-windows-b20ce41b-73cf-4c53-b96a-5bf1118b6135.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds ARIA role support to Paper UIManager",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -61,7 +61,7 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
   //   "none": Group (based on "presentation")
   //   "rowgroup": Group (based on "group" mapping)
   //   "searchbox": Group (based on "group" mapping)
-  //   "summary": Unknown (based on missing ARIA documentation)
+  //   "summary": N/A (based on missing ARIA documentation)
   //   "switch": CheckBox (based on "checkbox" mapping)
   //   "table": Grid (based on "grid" mapping)
   //   "term": Group (based on "definition" mapping)
@@ -170,14 +170,12 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
       return winrt::AutomationControlType::Spinner;
     case winrt::Microsoft::ReactNative::AriaRole::Status:
       return winrt::AutomationControlType::StatusBar;
-    case winrt::Microsoft::ReactNative::AriaRole::Summary:
-      return winrt::AutomationControlType::Unknown;
     case winrt::Microsoft::ReactNative::AriaRole::Switch:
       return winrt::AutomationControlType::CheckBox;
     case winrt::Microsoft::ReactNative::AriaRole::Tab:
       return winrt::AutomationControlType::TabItem;
     case winrt::Microsoft::ReactNative::AriaRole::Table:
-      return winrt::AutomationControlType::Grid;
+      return winrt::AutomationControlType::DataGrid;
     case winrt::Microsoft::ReactNative::AriaRole::TabList:
       return winrt::AutomationControlType::Tab;
     case winrt::Microsoft::ReactNative::AriaRole::TabPanel:
@@ -196,9 +194,11 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
       return winrt::AutomationControlType::DataGrid;
     case winrt::Microsoft::ReactNative::AriaRole::TreeItem:
       return winrt::AutomationControlType::TreeItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Summary:
+    case winrt::Microsoft::ReactNative::AriaRole::Unknown:
+    default:
+      return std::nullopt;
   }
-
-  return std::nullopt;
 }
 
 winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeFromAccessibilityRole() const {
@@ -497,7 +497,7 @@ winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationPeer::GetAcce
   } catch (...) {
   }
 
-  return winrt::Microsoft::ReactNative::AccessibilityRoles::Unknown;
+  return winrt::Microsoft::ReactNative::AccessibilityRoles::None;
 }
 
 winrt::Microsoft::ReactNative::AriaRole DynamicAutomationPeer::GetAriaRole() const {

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -50,30 +50,19 @@ winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore
 
 std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomationControlTypeFromAriaRole() const {
   const auto ariaRole = GetAriaRole();
-  // Unless otherwise specified, mappings sourced from:
-  //   https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-ariaspecification#w3c-aria-role-mapped-to-microsoft-active-accessibility-and-ui-automation
-  // Remaining mappings are:
-  //   "cell": DataItem (based on "gridcell" mapping)
-  //   "feed": List (based on "directory" mapping)
-  //   "figure": Image (based on "img" mapping)
-  //   "math": Group (based on "definition" mapping)
-  //   "meter": Pane (based on "timer" mapping)
-  //   "none": Group (based on "presentation")
-  //   "rowgroup": Group (based on "group" mapping)
-  //   "searchbox": Group (based on "group" mapping)
-  //   "summary": N/A (based on missing ARIA documentation)
-  //   "switch": CheckBox (based on "checkbox" mapping)
-  //   "table": Grid (based on "grid" mapping)
-  //   "term": Group (based on "definition" mapping)
+  // Sourced from: https://www.w3.org/TR/core-aam-1.2
+  // Remaining unmapped roles are:
+  // - "none"
+  // - "presentation"
   switch (ariaRole) {
     case winrt::Microsoft::ReactNative::AriaRole::Alert:
-      return winrt::AutomationControlType::Text;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::AlertDialog:
       return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::Application:
       return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::Article:
-      return winrt::AutomationControlType::Document;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Banner:
       return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Button:
@@ -99,9 +88,9 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
     case winrt::Microsoft::ReactNative::AriaRole::Document:
       return winrt::AutomationControlType::Document;
     case winrt::Microsoft::ReactNative::AriaRole::Feed:
-      return winrt::AutomationControlType::List;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Figure:
-      return winrt::AutomationControlType::Image;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Form:
       return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Grid:
@@ -133,45 +122,46 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
     case winrt::Microsoft::ReactNative::AriaRole::MenuItem:
       return winrt::AutomationControlType::MenuItem;
     case winrt::Microsoft::ReactNative::AriaRole::Meter:
-      return winrt::AutomationControlType::Group;
+      return winrt::AutomationControlType::ProgressBar;
     case winrt::Microsoft::ReactNative::AriaRole::Navigation:
       return winrt::AutomationControlType::Group;
-    case winrt::Microsoft::ReactNative::AriaRole::None:
-      return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::Note:
       return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Option:
       return winrt::AutomationControlType::ListItem;
-    case winrt::Microsoft::ReactNative::AriaRole::Presentation:
-      return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::ProgressBar:
       return winrt::AutomationControlType::ProgressBar;
     case winrt::Microsoft::ReactNative::AriaRole::Radio:
       return winrt::AutomationControlType::RadioButton;
     case winrt::Microsoft::ReactNative::AriaRole::RadioGroup:
-      return winrt::AutomationControlType::Group;
+      return winrt::AutomationControlType::List;
     case winrt::Microsoft::ReactNative::AriaRole::Region:
-      return winrt::AutomationControlType::Pane;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Row:
       return winrt::AutomationControlType::DataItem;
     case winrt::Microsoft::ReactNative::AriaRole::RowGroup:
       return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::RowHeader:
-      return winrt::AutomationControlType::DataItem;
+      return winrt::AutomationControlType::HeaderItem;
     case winrt::Microsoft::ReactNative::AriaRole::ScrollBar:
       return winrt::AutomationControlType::ScrollBar;
     case winrt::Microsoft::ReactNative::AriaRole::SearchBox:
-      return winrt::AutomationControlType::Group;
+      return winrt::AutomationControlType::Edit;
     case winrt::Microsoft::ReactNative::AriaRole::Separator:
+      if (auto const &viewControl = Owner().try_as<winrt::Microsoft::ReactNative::ViewControl>()) {
+        if (viewControl.IsTabStop()) {
+          return winrt::AutomationControlType::Thumb;
+        }
+      }
       return winrt::AutomationControlType::Separator;
     case winrt::Microsoft::ReactNative::AriaRole::Slider:
       return winrt::AutomationControlType::Slider;
     case winrt::Microsoft::ReactNative::AriaRole::SpinButton:
       return winrt::AutomationControlType::Spinner;
     case winrt::Microsoft::ReactNative::AriaRole::Status:
-      return winrt::AutomationControlType::StatusBar;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Switch:
-      return winrt::AutomationControlType::CheckBox;
+      return winrt::AutomationControlType::Button;
     case winrt::Microsoft::ReactNative::AriaRole::Tab:
       return winrt::AutomationControlType::TabItem;
     case winrt::Microsoft::ReactNative::AriaRole::Table:
@@ -181,9 +171,9 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
     case winrt::Microsoft::ReactNative::AriaRole::TabPanel:
       return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::Term:
-      return winrt::AutomationControlType::Group;
+      return winrt::AutomationControlType::Text;
     case winrt::Microsoft::ReactNative::AriaRole::Timer:
-      return winrt::AutomationControlType::Pane;
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::ToolBar:
       return winrt::AutomationControlType::ToolBar;
     case winrt::Microsoft::ReactNative::AriaRole::ToolTip:
@@ -194,8 +184,8 @@ std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomation
       return winrt::AutomationControlType::DataGrid;
     case winrt::Microsoft::ReactNative::AriaRole::TreeItem:
       return winrt::AutomationControlType::TreeItem;
-    case winrt::Microsoft::ReactNative::AriaRole::Summary:
-    case winrt::Microsoft::ReactNative::AriaRole::Unknown:
+    case winrt::Microsoft::ReactNative::AriaRole::None:
+    case winrt::Microsoft::ReactNative::AriaRole::Presentation:
     default:
       return std::nullopt;
   }

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -44,6 +44,117 @@ winrt::hstring DynamicAutomationPeer::GetNameCore() const {
 }
 
 winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore() const {
+  const auto automationControlType = GetAutomationControlTypeFromAriaRole();
+  return automationControlType ? automationControlType.value() : GetAutomationControlTypeFromAccessibilityRole();
+}
+
+std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomationControlTypeFromAriaRole() const {
+  const auto ariaRole = GetAriaRole();
+  switch (ariaRole) {
+    case winrt::Microsoft::ReactNative::AriaRole::Button:
+      return winrt::AutomationControlType::Button;
+    case winrt::Microsoft::ReactNative::AriaRole::CheckBox:
+      return winrt::AutomationControlType::CheckBox;
+    case winrt::Microsoft::ReactNative::AriaRole::ComboBox:
+      return winrt::AutomationControlType::ComboBox;
+    case winrt::Microsoft::ReactNative::AriaRole::Cell:
+      return winrt::AutomationControlType::DataItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Grid:
+    case winrt::Microsoft::ReactNative::AriaRole::Row:
+      return winrt::AutomationControlType::DataGrid;
+    case winrt::Microsoft::ReactNative::AriaRole::Article:
+    case winrt::Microsoft::ReactNative::AriaRole::Document:
+      return winrt::AutomationControlType::Document;
+    case winrt::Microsoft::ReactNative::AriaRole::SearchBox:
+      return winrt::AutomationControlType::Edit;
+    case winrt::Microsoft::ReactNative::AriaRole::Application:
+    case winrt::Microsoft::ReactNative::AriaRole::Group:
+    case winrt::Microsoft::ReactNative::AriaRole::None:
+    case winrt::Microsoft::ReactNative::AriaRole::RadioGroup:
+    case winrt::Microsoft::ReactNative::AriaRole::Region:
+    case winrt::Microsoft::ReactNative::AriaRole::RowGroup:
+    case winrt::Microsoft::ReactNative::AriaRole::Switch:
+    case winrt::Microsoft::ReactNative::AriaRole::TabPanel:
+    case winrt::Microsoft::ReactNative::AriaRole::Timer:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::ColumnHeader:
+    case winrt::Microsoft::ReactNative::AriaRole::RowHeader:
+      return winrt::AutomationControlType::HeaderItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Link:
+      return winrt::AutomationControlType::Hyperlink;
+    case winrt::Microsoft::ReactNative::AriaRole::Figure:
+    case winrt::Microsoft::ReactNative::AriaRole::Img:
+      return winrt::AutomationControlType::Image;
+    case winrt::Microsoft::ReactNative::AriaRole::List:
+      return winrt::AutomationControlType::List;
+    case winrt::Microsoft::ReactNative::AriaRole::ListItem:
+      return winrt::AutomationControlType::ListItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Menu:
+      return winrt::AutomationControlType::Menu;
+    case winrt::Microsoft::ReactNative::AriaRole::MenuBar:
+      return winrt::AutomationControlType::MenuBar;
+    case winrt::Microsoft::ReactNative::AriaRole::MenuItem:
+      return winrt::AutomationControlType::MenuItem;
+    case winrt::Microsoft::ReactNative::AriaRole::ProgressBar:
+      return winrt::AutomationControlType::ProgressBar;
+    case winrt::Microsoft::ReactNative::AriaRole::Radio:
+      return winrt::AutomationControlType::RadioButton;
+    case winrt::Microsoft::ReactNative::AriaRole::ScrollBar:
+      return winrt::AutomationControlType::ScrollBar;
+    case winrt::Microsoft::ReactNative::AriaRole::Separator:
+      return winrt::AutomationControlType::Separator;
+    case winrt::Microsoft::ReactNative::AriaRole::Slider:
+      return winrt::AutomationControlType::Slider;
+    case winrt::Microsoft::ReactNative::AriaRole::SpinButton:
+      return winrt::AutomationControlType::Spinner;
+    case winrt::Microsoft::ReactNative::AriaRole::TabList:
+      return winrt::AutomationControlType::Tab;
+    case winrt::Microsoft::ReactNative::AriaRole::Tab:
+      return winrt::AutomationControlType::TabItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Table:
+      return winrt::AutomationControlType::Table;
+    case winrt::Microsoft::ReactNative::AriaRole::Alert:
+    case winrt::Microsoft::ReactNative::AriaRole::Banner:
+    case winrt::Microsoft::ReactNative::AriaRole::Complementary:
+    case winrt::Microsoft::ReactNative::AriaRole::ContentInfo:
+    case winrt::Microsoft::ReactNative::AriaRole::Definition:
+    case winrt::Microsoft::ReactNative::AriaRole::Heading:
+    case winrt::Microsoft::ReactNative::AriaRole::Note:
+    case winrt::Microsoft::ReactNative::AriaRole::Status:
+    case winrt::Microsoft::ReactNative::AriaRole::Summary:
+      return winrt::AutomationControlType::Text;
+    case winrt::Microsoft::ReactNative::AriaRole::ToolBar:
+      return winrt::AutomationControlType::ToolBar;
+    case winrt::Microsoft::ReactNative::AriaRole::ToolTip:
+      return winrt::AutomationControlType::ToolTip;
+    case winrt::Microsoft::ReactNative::AriaRole::Tree:
+    case winrt::Microsoft::ReactNative::AriaRole::TreeGrid:
+      return winrt::AutomationControlType::Tree;
+    case winrt::Microsoft::ReactNative::AriaRole::TreeItem:
+      return winrt::AutomationControlType::TreeItem;
+    case winrt::Microsoft::ReactNative::AriaRole::AlertDialog:
+    case winrt::Microsoft::ReactNative::AriaRole::Dialog:
+      return winrt::AutomationControlType::Window;
+    case winrt::Microsoft::ReactNative::AriaRole::Directory:
+    case winrt::Microsoft::ReactNative::AriaRole::Feed:
+    case winrt::Microsoft::ReactNative::AriaRole::Form:
+    case winrt::Microsoft::ReactNative::AriaRole::Log:
+    case winrt::Microsoft::ReactNative::AriaRole::Main:
+    case winrt::Microsoft::ReactNative::AriaRole::Marquee:
+    case winrt::Microsoft::ReactNative::AriaRole::Math:
+    case winrt::Microsoft::ReactNative::AriaRole::Meter:
+    case winrt::Microsoft::ReactNative::AriaRole::Navigation:
+    case winrt::Microsoft::ReactNative::AriaRole::Option:
+    case winrt::Microsoft::ReactNative::AriaRole::Presentation:
+    case winrt::Microsoft::ReactNative::AriaRole::Term:
+    case winrt::Microsoft::ReactNative::AriaRole::Unknown:
+      break;
+  }
+
+  return std::nullopt;
+}
+
+winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeFromAccessibilityRole() const {
   auto accessibilityRole = GetAccessibilityRole();
 
   switch (accessibilityRole) {
@@ -340,6 +451,15 @@ winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationPeer::GetAcce
   }
 
   return winrt::Microsoft::ReactNative::AccessibilityRoles::None;
+}
+
+winrt::Microsoft::ReactNative::AriaRole DynamicAutomationPeer::GetAriaRole() const {
+  try {
+    return DynamicAutomationProperties::GetAriaRole(Owner());
+  } catch (...) {
+  }
+
+  return winrt::Microsoft::ReactNative::AriaRole::Unknown;
 }
 
 bool DynamicAutomationPeer::HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const {

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.cpp
@@ -50,105 +50,152 @@ winrt::AutomationControlType DynamicAutomationPeer::GetAutomationControlTypeCore
 
 std::optional<winrt::AutomationControlType> DynamicAutomationPeer::GetAutomationControlTypeFromAriaRole() const {
   const auto ariaRole = GetAriaRole();
+  // Unless otherwise specified, mappings sourced from:
+  //   https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-ariaspecification#w3c-aria-role-mapped-to-microsoft-active-accessibility-and-ui-automation
+  // Remaining mappings are:
+  //   "cell": DataItem (based on "gridcell" mapping)
+  //   "feed": List (based on "directory" mapping)
+  //   "figure": Image (based on "img" mapping)
+  //   "math": Group (based on "definition" mapping)
+  //   "meter": Pane (based on "timer" mapping)
+  //   "none": Group (based on "presentation")
+  //   "rowgroup": Group (based on "group" mapping)
+  //   "searchbox": Group (based on "group" mapping)
+  //   "summary": Unknown (based on missing ARIA documentation)
+  //   "switch": CheckBox (based on "checkbox" mapping)
+  //   "table": Grid (based on "grid" mapping)
+  //   "term": Group (based on "definition" mapping)
   switch (ariaRole) {
+    case winrt::Microsoft::ReactNative::AriaRole::Alert:
+      return winrt::AutomationControlType::Text;
+    case winrt::Microsoft::ReactNative::AriaRole::AlertDialog:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Application:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Article:
+      return winrt::AutomationControlType::Document;
+    case winrt::Microsoft::ReactNative::AriaRole::Banner:
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Button:
       return winrt::AutomationControlType::Button;
-    case winrt::Microsoft::ReactNative::AriaRole::CheckBox:
-      return winrt::AutomationControlType::CheckBox;
-    case winrt::Microsoft::ReactNative::AriaRole::ComboBox:
-      return winrt::AutomationControlType::ComboBox;
     case winrt::Microsoft::ReactNative::AriaRole::Cell:
       return winrt::AutomationControlType::DataItem;
-    case winrt::Microsoft::ReactNative::AriaRole::Grid:
-    case winrt::Microsoft::ReactNative::AriaRole::Row:
-      return winrt::AutomationControlType::DataGrid;
-    case winrt::Microsoft::ReactNative::AriaRole::Article:
+    case winrt::Microsoft::ReactNative::AriaRole::CheckBox:
+      return winrt::AutomationControlType::CheckBox;
+    case winrt::Microsoft::ReactNative::AriaRole::ColumnHeader:
+      return winrt::AutomationControlType::DataItem;
+    case winrt::Microsoft::ReactNative::AriaRole::ComboBox:
+      return winrt::AutomationControlType::ComboBox;
+    case winrt::Microsoft::ReactNative::AriaRole::Complementary:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::ContentInfo:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Definition:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Dialog:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Directory:
+      return winrt::AutomationControlType::List;
     case winrt::Microsoft::ReactNative::AriaRole::Document:
       return winrt::AutomationControlType::Document;
-    case winrt::Microsoft::ReactNative::AriaRole::SearchBox:
-      return winrt::AutomationControlType::Edit;
-    case winrt::Microsoft::ReactNative::AriaRole::Application:
-    case winrt::Microsoft::ReactNative::AriaRole::Group:
-    case winrt::Microsoft::ReactNative::AriaRole::None:
-    case winrt::Microsoft::ReactNative::AriaRole::RadioGroup:
-    case winrt::Microsoft::ReactNative::AriaRole::Region:
-    case winrt::Microsoft::ReactNative::AriaRole::RowGroup:
-    case winrt::Microsoft::ReactNative::AriaRole::Switch:
-    case winrt::Microsoft::ReactNative::AriaRole::TabPanel:
-    case winrt::Microsoft::ReactNative::AriaRole::Timer:
-      return winrt::AutomationControlType::Group;
-    case winrt::Microsoft::ReactNative::AriaRole::ColumnHeader:
-    case winrt::Microsoft::ReactNative::AriaRole::RowHeader:
-      return winrt::AutomationControlType::HeaderItem;
-    case winrt::Microsoft::ReactNative::AriaRole::Link:
-      return winrt::AutomationControlType::Hyperlink;
+    case winrt::Microsoft::ReactNative::AriaRole::Feed:
+      return winrt::AutomationControlType::List;
     case winrt::Microsoft::ReactNative::AriaRole::Figure:
+      return winrt::AutomationControlType::Image;
+    case winrt::Microsoft::ReactNative::AriaRole::Form:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Grid:
+      return winrt::AutomationControlType::DataGrid;
+    case winrt::Microsoft::ReactNative::AriaRole::Group:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Heading:
+      return winrt::AutomationControlType::Text;
     case winrt::Microsoft::ReactNative::AriaRole::Img:
       return winrt::AutomationControlType::Image;
+    case winrt::Microsoft::ReactNative::AriaRole::Link:
+      return winrt::AutomationControlType::Hyperlink;
     case winrt::Microsoft::ReactNative::AriaRole::List:
       return winrt::AutomationControlType::List;
     case winrt::Microsoft::ReactNative::AriaRole::ListItem:
       return winrt::AutomationControlType::ListItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Log:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Main:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Marquee:
+      return winrt::AutomationControlType::Text;
+    case winrt::Microsoft::ReactNative::AriaRole::Math:
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Menu:
       return winrt::AutomationControlType::Menu;
     case winrt::Microsoft::ReactNative::AriaRole::MenuBar:
       return winrt::AutomationControlType::MenuBar;
     case winrt::Microsoft::ReactNative::AriaRole::MenuItem:
       return winrt::AutomationControlType::MenuItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Meter:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Navigation:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::None:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Note:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Option:
+      return winrt::AutomationControlType::ListItem;
+    case winrt::Microsoft::ReactNative::AriaRole::Presentation:
+      return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::ProgressBar:
       return winrt::AutomationControlType::ProgressBar;
     case winrt::Microsoft::ReactNative::AriaRole::Radio:
       return winrt::AutomationControlType::RadioButton;
+    case winrt::Microsoft::ReactNative::AriaRole::RadioGroup:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Region:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Row:
+      return winrt::AutomationControlType::DataItem;
+    case winrt::Microsoft::ReactNative::AriaRole::RowGroup:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::RowHeader:
+      return winrt::AutomationControlType::DataItem;
     case winrt::Microsoft::ReactNative::AriaRole::ScrollBar:
       return winrt::AutomationControlType::ScrollBar;
+    case winrt::Microsoft::ReactNative::AriaRole::SearchBox:
+      return winrt::AutomationControlType::Group;
     case winrt::Microsoft::ReactNative::AriaRole::Separator:
       return winrt::AutomationControlType::Separator;
     case winrt::Microsoft::ReactNative::AriaRole::Slider:
       return winrt::AutomationControlType::Slider;
     case winrt::Microsoft::ReactNative::AriaRole::SpinButton:
       return winrt::AutomationControlType::Spinner;
-    case winrt::Microsoft::ReactNative::AriaRole::TabList:
-      return winrt::AutomationControlType::Tab;
+    case winrt::Microsoft::ReactNative::AriaRole::Status:
+      return winrt::AutomationControlType::StatusBar;
+    case winrt::Microsoft::ReactNative::AriaRole::Summary:
+      return winrt::AutomationControlType::Unknown;
+    case winrt::Microsoft::ReactNative::AriaRole::Switch:
+      return winrt::AutomationControlType::CheckBox;
     case winrt::Microsoft::ReactNative::AriaRole::Tab:
       return winrt::AutomationControlType::TabItem;
     case winrt::Microsoft::ReactNative::AriaRole::Table:
-      return winrt::AutomationControlType::Table;
-    case winrt::Microsoft::ReactNative::AriaRole::Alert:
-    case winrt::Microsoft::ReactNative::AriaRole::Banner:
-    case winrt::Microsoft::ReactNative::AriaRole::Complementary:
-    case winrt::Microsoft::ReactNative::AriaRole::ContentInfo:
-    case winrt::Microsoft::ReactNative::AriaRole::Definition:
-    case winrt::Microsoft::ReactNative::AriaRole::Heading:
-    case winrt::Microsoft::ReactNative::AriaRole::Note:
-    case winrt::Microsoft::ReactNative::AriaRole::Status:
-    case winrt::Microsoft::ReactNative::AriaRole::Summary:
-      return winrt::AutomationControlType::Text;
+      return winrt::AutomationControlType::Grid;
+    case winrt::Microsoft::ReactNative::AriaRole::TabList:
+      return winrt::AutomationControlType::Tab;
+    case winrt::Microsoft::ReactNative::AriaRole::TabPanel:
+      return winrt::AutomationControlType::Pane;
+    case winrt::Microsoft::ReactNative::AriaRole::Term:
+      return winrt::AutomationControlType::Group;
+    case winrt::Microsoft::ReactNative::AriaRole::Timer:
+      return winrt::AutomationControlType::Pane;
     case winrt::Microsoft::ReactNative::AriaRole::ToolBar:
       return winrt::AutomationControlType::ToolBar;
     case winrt::Microsoft::ReactNative::AriaRole::ToolTip:
       return winrt::AutomationControlType::ToolTip;
     case winrt::Microsoft::ReactNative::AriaRole::Tree:
-    case winrt::Microsoft::ReactNative::AriaRole::TreeGrid:
       return winrt::AutomationControlType::Tree;
+    case winrt::Microsoft::ReactNative::AriaRole::TreeGrid:
+      return winrt::AutomationControlType::DataGrid;
     case winrt::Microsoft::ReactNative::AriaRole::TreeItem:
       return winrt::AutomationControlType::TreeItem;
-    case winrt::Microsoft::ReactNative::AriaRole::AlertDialog:
-    case winrt::Microsoft::ReactNative::AriaRole::Dialog:
-      return winrt::AutomationControlType::Window;
-    case winrt::Microsoft::ReactNative::AriaRole::Directory:
-    case winrt::Microsoft::ReactNative::AriaRole::Feed:
-    case winrt::Microsoft::ReactNative::AriaRole::Form:
-    case winrt::Microsoft::ReactNative::AriaRole::Log:
-    case winrt::Microsoft::ReactNative::AriaRole::Main:
-    case winrt::Microsoft::ReactNative::AriaRole::Marquee:
-    case winrt::Microsoft::ReactNative::AriaRole::Math:
-    case winrt::Microsoft::ReactNative::AriaRole::Meter:
-    case winrt::Microsoft::ReactNative::AriaRole::Navigation:
-    case winrt::Microsoft::ReactNative::AriaRole::Option:
-    case winrt::Microsoft::ReactNative::AriaRole::Presentation:
-    case winrt::Microsoft::ReactNative::AriaRole::Term:
-    case winrt::Microsoft::ReactNative::AriaRole::Unknown:
-      break;
   }
 
   return std::nullopt;
@@ -450,7 +497,7 @@ winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationPeer::GetAcce
   } catch (...) {
   }
 
-  return winrt::Microsoft::ReactNative::AccessibilityRoles::None;
+  return winrt::Microsoft::ReactNative::AccessibilityRoles::Unknown;
 }
 
 winrt::Microsoft::ReactNative::AriaRole DynamicAutomationPeer::GetAriaRole() const {

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationPeer.h
@@ -72,6 +72,11 @@ struct DynamicAutomationPeer : DynamicAutomationPeerT<DynamicAutomationPeer> {
  private:
   winrt::hstring GetContentName() const;
   winrt::Microsoft::ReactNative::AccessibilityRoles GetAccessibilityRole() const;
+  winrt::Microsoft::ReactNative::AriaRole GetAriaRole() const;
+
+  std::optional<xaml::Automation::Peers::AutomationControlType> GetAutomationControlTypeFromAriaRole() const;
+  xaml::Automation::Peers::AutomationControlType GetAutomationControlTypeFromAccessibilityRole() const;
+
   bool HasAccessibilityState(winrt::Microsoft::ReactNative::AccessibilityStates state) const;
   bool HasAccessibilityValue(winrt::Microsoft::ReactNative::AccessibilityValue value) const;
   double GetAccessibilityValueRange(winrt::Microsoft::ReactNative::AccessibilityValue value) const;

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.cpp
@@ -48,6 +48,26 @@ winrt::Microsoft::ReactNative::AccessibilityRoles DynamicAutomationProperties::G
       element.GetValue(AccessibilityRoleProperty()));
 }
 
+xaml::DependencyProperty DynamicAutomationProperties::AriaRoleProperty() {
+  static xaml::DependencyProperty s_ariaRoleProperty = xaml::DependencyProperty::RegisterAttached(
+      L"AriaRole",
+      winrt::xaml_typename<winrt::Microsoft::ReactNative::AriaRole>(),
+      dynamicAutomationTypeName,
+      winrt::PropertyMetadata(winrt::box_value(winrt::Microsoft::ReactNative::AriaRole::Unknown)));
+
+  return s_ariaRoleProperty;
+}
+
+void DynamicAutomationProperties::SetAriaRole(
+    xaml::UIElement const &element,
+    winrt::Microsoft::ReactNative::AriaRole const &value) {
+  element.SetValue(AriaRoleProperty(), winrt::box_value<Microsoft::ReactNative::AriaRole>(value));
+}
+
+winrt::Microsoft::ReactNative::AriaRole DynamicAutomationProperties::GetAriaRole(xaml::UIElement const &element) {
+  return winrt::unbox_value<winrt::Microsoft::ReactNative::AriaRole>(element.GetValue(AriaRoleProperty()));
+}
+
 xaml::DependencyProperty DynamicAutomationProperties::AccessibilityStateSelectedProperty() {
   static xaml::DependencyProperty s_AccessibilityStateSelectedProperty = xaml::DependencyProperty::RegisterAttached(
       L"AccessibilityStateSelected",

--- a/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
+++ b/vnext/Microsoft.ReactNative/Views/DynamicAutomationProperties.h
@@ -26,6 +26,10 @@ struct DynamicAutomationProperties : DynamicAutomationPropertiesT<DynamicAutomat
       winrt::Microsoft::ReactNative::AccessibilityRoles const &value);
   static AccessibilityRoles GetAccessibilityRole(xaml::UIElement const &element);
 
+  static xaml::DependencyProperty AriaRoleProperty();
+  static void SetAriaRole(xaml::UIElement const &element, winrt::Microsoft::ReactNative::AriaRole const &value);
+  static AriaRole GetAriaRole(xaml::UIElement const &element);
+
   static xaml::DependencyProperty AccessibilityStateSelectedProperty();
   static void SetAccessibilityStateSelected(xaml::UIElement const &element, bool value);
   static bool GetAccessibilityStateSelected(xaml::UIElement const &element);

--- a/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/FrameworkElementViewManager.cpp
@@ -126,6 +126,7 @@ void FrameworkElementViewManager::GetNativeProps(const winrt::Microsoft::ReactNa
 
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"accessible", L"boolean");
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"accessibilityRole", L"string");
+  winrt::Microsoft::ReactNative::WriteProperty(writer, L"role", L"string");
   writer.WritePropertyName(L"accessibilityState");
   GetAccessibilityStateProps(writer);
   winrt::Microsoft::ReactNative::WriteProperty(writer, L"accessibilityHint", L"string");
@@ -432,6 +433,142 @@ bool FrameworkElementViewManager::UpdateProperty(
               element, winrt::Microsoft::ReactNative::AccessibilityRoles::Unknown);
       } else if (propertyValue.IsNull()) {
         element.ClearValue(DynamicAutomationProperties::AccessibilityRoleProperty());
+      }
+    } else if (propertyName == "role") {
+      if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::String) {
+        const std::string &role = propertyValue.AsString();
+        if (role == "alert")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Alert);
+        else if (role == "alertdialog")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::AlertDialog);
+        else if (role == "application")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Application);
+        else if (role == "article")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Article);
+        else if (role == "banner")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Banner);
+        else if (role == "button")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Button);
+        else if (role == "cell")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Cell);
+        else if (role == "checkbox")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::CheckBox);
+        else if (role == "columnheader")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ColumnHeader);
+        else if (role == "combobox")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ComboBox);
+        else if (role == "complementary")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Complementary);
+        else if (role == "contentinfo")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ContentInfo);
+        else if (role == "definition")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Definition);
+        else if (role == "dialog")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Dialog);
+        else if (role == "directory")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Directory);
+        else if (role == "document")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Document);
+        else if (role == "feed")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Feed);
+        else if (role == "figure")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Figure);
+        else if (role == "form")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Form);
+        else if (role == "grid")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Grid);
+        else if (role == "group")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Group);
+        else if (role == "heading")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Heading);
+        else if (role == "img")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Img);
+        else if (role == "link")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Link);
+        else if (role == "list")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::List);
+        else if (role == "listitem")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ListItem);
+        else if (role == "log")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Log);
+        else if (role == "main")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Main);
+        else if (role == "marquee")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Marquee);
+        else if (role == "math")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Math);
+        else if (role == "menu")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Menu);
+        else if (role == "menubar")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::MenuBar);
+        else if (role == "menuitem")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::MenuItem);
+        else if (role == "meter")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Meter);
+        else if (role == "navigation")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Navigation);
+        else if (role == "none")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::None);
+        else if (role == "note")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Note);
+        else if (role == "option")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Option);
+        else if (role == "presentation")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Presentation);
+        else if (role == "progressbar")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ProgressBar);
+        else if (role == "radio")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Radio);
+        else if (role == "radiogroup")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::RadioGroup);
+        else if (role == "region")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Region);
+        else if (role == "row")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Row);
+        else if (role == "rowgroup")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::RowGroup);
+        else if (role == "rowheader")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::RowHeader);
+        else if (role == "scrollbar")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ScrollBar);
+        else if (role == "searchbox")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::SearchBox);
+        else if (role == "separator")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Separator);
+        else if (role == "slider")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Slider);
+        else if (role == "spinbutton")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::SpinButton);
+        else if (role == "status")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Status);
+        else if (role == "summary")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Summary);
+        else if (role == "switch")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Switch);
+        else if (role == "tab")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Tab);
+        else if (role == "tablist")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::TabList);
+        else if (role == "tabpanel")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::TabPanel);
+        else if (role == "term")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Term);
+        else if (role == "timer")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Timer);
+        else if (role == "toolbar")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ToolBar);
+        else if (role == "tooltip")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::ToolTip);
+        else if (role == "tree")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Tree);
+        else if (role == "treegrid")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::TreeGrid);
+        else if (role == "treeitem")
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::TreeItem);
+        else
+          DynamicAutomationProperties::SetAriaRole(element, winrt::Microsoft::ReactNative::AriaRole::Unknown);
+      } else if (propertyValue.IsNull()) {
+        element.ClearValue(DynamicAutomationProperties::AriaRoleProperty());
       }
     } else if (propertyName == "accessibilityState") {
       if (propertyValue.Type() == winrt::Microsoft::ReactNative::JSValueType::Object) {

--- a/vnext/Microsoft.ReactNative/Views/cppwinrt/DynamicAutomationPeer.idl
+++ b/vnext/Microsoft.ReactNative/Views/cppwinrt/DynamicAutomationPeer.idl
@@ -36,11 +36,82 @@ namespace Microsoft.ReactNative
     Tab,
     TabList,
     Timer,
-    ToggleButton, 
+    ToggleButton,
     ToolBar,
     List, // RNW extension
     ListItem, // RNW extension
     Unknown, // Catch-all
+    CountRoles
+  };
+
+  enum AriaRole
+  {
+    Unknown = 0, // Catch-all
+    Alert,
+    AlertDialog,
+    Application,
+    Article,
+    Banner,
+    Button,
+    Cell,
+    CheckBox,
+    ColumnHeader,
+    ComboBox,
+    Complementary,
+    ContentInfo,
+    Definition,
+    Dialog,
+    Directory,
+    Document,
+    Feed,
+    Figure,
+    Form,
+    Grid,
+    Group,
+    Heading,
+    Img,
+    Link,
+    List,
+    ListItem,
+    Log,
+    Main,
+    Marquee,
+    Math,
+    Menu,
+    MenuBar,
+    MenuItem,
+    Meter,
+    Navigation,
+    None,
+    Note,
+    Option,
+    Presentation,
+    ProgressBar,
+    Radio,
+    RadioGroup,
+    Region,
+    Row,
+    RowGroup,
+    RowHeader,
+    ScrollBar,
+    SearchBox,
+    Separator,
+    Slider,
+    SpinButton,
+    Status,
+    Summary,
+    Switch,
+    Tab,
+    Table,
+    TabList,
+    TabPanel,
+    Term,
+    Timer,
+    ToolBar,
+    ToolTip,
+    Tree,
+    TreeGrid,
+    TreeItem,
     CountRoles
   };
 
@@ -82,6 +153,10 @@ namespace Microsoft.ReactNative
     static XAML_NAMESPACE.DependencyProperty AccessibilityRoleProperty { get; };
     static void SetAccessibilityRole(XAML_NAMESPACE.UIElement element, AccessibilityRoles value);
     static AccessibilityRoles GetAccessibilityRole(XAML_NAMESPACE.UIElement element);
+
+    static XAML_NAMESPACE.DependencyProperty AriaRoleProperty { get; };
+    static void SetAriaRole(XAML_NAMESPACE.UIElement element, AriaRole value);
+    static AriaRole GetAriaRole(XAML_NAMESPACE.UIElement element);
 
     static XAML_NAMESPACE.DependencyProperty AccessibilityStateSelectedProperty { get; };
     static void SetAccessibilityStateSelected(XAML_NAMESPACE.UIElement element, Boolean value);
@@ -138,7 +213,7 @@ namespace Microsoft.ReactNative
     XAML_NAMESPACE.Automation.Peers.FrameworkElementAutomationPeer,
     XAML_NAMESPACE.Automation.Provider.IInvokeProvider,
     XAML_NAMESPACE.Automation.Provider.ISelectionProvider,
-    XAML_NAMESPACE.Automation.Provider.ISelectionItemProvider, 
+    XAML_NAMESPACE.Automation.Provider.ISelectionItemProvider,
     XAML_NAMESPACE.Automation.Provider.IToggleProvider,
     XAML_NAMESPACE.Automation.Provider.IExpandCollapseProvider,
     XAML_NAMESPACE.Automation.Provider.IRangeValueProvider


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
In react-native v0.73, the `role` prop was switched from setting its value to `accessibilityRole` to a standalone native prop.

Resolves #11886

### What
This wires up the native prop behavior in the Paper UIManager for react-native-windows.

Uses ARIA role to UIA mappings defined here:
https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-ariaspecification#w3c-aria-role-mapped-to-microsoft-active-accessibility-and-ui-automation

Some ARIA roles are not explicitly defined in the linked document. The remaining mappings were interpolated from other ARIA role mappings (e.g., `term` and `definition` go hand-in-hand, `table` mentions `grid` should be used in some circumstances, `none` and `presentation` are interchangeable, and there is no documentation on `summary`).

## Changelog
Should this change be included in the release notes: _yes_

Adds role prop support to react-native-windows.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12792)