### PR TITLE
Rename WindowsCompositionContextHelper -> SystemCompositionContextHelper

### DIFF
--- a/change/react-native-windows-a60caa73-ecea-4299-a8e8-53287da9c616.json
+++ b/change/react-native-windows-a60caa73-ecea-4299-a8e8-53287da9c616.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename WindowsCompositionContextHelper -> SystemCompositionContextHelper",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -114,7 +114,7 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
 #ifdef USE_EXPERIMENTAL_WINUI3
 
     auto parentSystemVisual =
-        winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper::InnerVisual(m_visual)
+        winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::InnerVisual(m_visual)
             .as<winrt::Windows::UI::Composition::ContainerVisual>();
 
     auto hwnd = reinterpret_cast<HWND>(

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -213,11 +213,11 @@ struct WindowData {
               bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
 
             } else if (!m_target) {
-              // By using the WindowsCompositionContextHelper here, React Native Windows will use System Visuals for its
+              // By using the SystemCompositionContextHelper here, React Native Windows will use System Visuals for its
               // tree.
               winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
                   InstanceSettings().Properties(),
-                  winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper::CreateContext(
+                  winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateContext(
                       g_compositor));
 
               auto interop = g_compositor.as<ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
@@ -235,7 +235,7 @@ struct WindowData {
               m_target.Root(root);
               m_compRootView.SetWindow(reinterpret_cast<uint64_t>(hwnd));
               m_compRootView.RootVisual(
-                  winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper::CreateVisual(root));
+                  winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateVisual(root));
               m_compRootView.ScaleFactor(ScaleFactor(hwnd));
               m_compRootView.Size({m_width / ScaleFactor(hwnd), m_height / ScaleFactor(hwnd)});
             }

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -10,7 +10,7 @@ void* winrt_make_Microsoft_ReactNative_CompositionRootView();
 #ifdef USE_WINUI3
 void *winrt_make_Microsoft_ReactNative_Composition_MicrosoftCompositionContextHelper();
 #endif
-void *winrt_make_Microsoft_ReactNative_Composition_WindowsCompositionContextHelper();
+void *winrt_make_Microsoft_ReactNative_Composition_SystemCompositionContextHelper();
 void *winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
@@ -54,8 +54,8 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
       return winrt_make_Microsoft_ReactNative_Composition_MicrosoftCompositionContextHelper();
     }
 #endif
-    if (requal(name, L"Microsoft.ReactNative.Composition.WindowsCompositionContextHelper")) {
-      return winrt_make_Microsoft_ReactNative_Composition_WindowsCompositionContextHelper();
+    if (requal(name, L"Microsoft.ReactNative.Composition.SystemCompositionContextHelper")) {
+      return winrt_make_Microsoft_ReactNative_Composition_SystemCompositionContextHelper();
     }
     if (requal(name, L"Microsoft.ReactNative.Composition.CompositionUIService")) {
       return winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();

--- a/vnext/Microsoft.ReactNative/CompositionContext.idl
+++ b/vnext/Microsoft.ReactNative/CompositionContext.idl
@@ -11,7 +11,7 @@ namespace Microsoft.ReactNative.Composition
   [default_interface]
   [experimental]
   DOC_STRING("A helper static class for to create a @ICompositionContext based on Windows.Composition Visuals.  And to access the underlying Windows.Composition objects from the abstraction.")
-  static runtimeclass WindowsCompositionContextHelper
+  static runtimeclass SystemCompositionContextHelper
   {
     DOC_STRING(
       "Creates a @ICompositionContext from a Compositor")

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1,8 +1,8 @@
 
 #include "pch.h"
 #include "CompositionContextHelper.h"
-#if __has_include("Composition.WindowsCompositionContextHelper.g.cpp")
-#include "Composition.WindowsCompositionContextHelper.g.cpp"
+#if __has_include("Composition.SystemCompositionContextHelper.g.cpp")
+#include "Composition.SystemCompositionContextHelper.g.cpp"
 #endif
 #ifdef USE_WINUI3
 #if __has_include("Composition.MicrosoftCompositionContextHelper.g.cpp")
@@ -81,7 +81,7 @@ struct CompositionTypeTraits<WindowsTypeTag> {
   using IInnerCompositionVisual = IWindowsCompositionVisual;
   using IInnerCompositionBrush = IWindowsCompositionBrush;
   using IInnerCompositionDrawingSurface = IWindowsCompositionDrawingSurfaceInner;
-  using CompositionContextHelper = winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper;
+  using CompositionContextHelper = winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper;
 };
 using WindowsTypeRedirects = CompositionTypeTraits<WindowsTypeTag>;
 
@@ -1562,44 +1562,44 @@ using MicrosoftCompContext = CompContext<MicrosoftTypeRedirects>;
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-ICompositionContext WindowsCompositionContextHelper::CreateContext(
+ICompositionContext SystemCompositionContextHelper::CreateContext(
     winrt::Windows::UI::Composition::Compositor const &compositor) noexcept {
   return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompContext>(compositor);
 }
 
-IVisual WindowsCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &visual) noexcept {
+IVisual SystemCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &visual) noexcept {
   if (auto spriteVisual = visual.try_as<winrt::Windows::UI::Composition::SpriteVisual>())
     return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompSpriteVisual>(spriteVisual);
   return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompVisual>(visual);
 }
 
-winrt::Windows::UI::Composition::Compositor WindowsCompositionContextHelper::InnerCompositor(
+winrt::Windows::UI::Composition::Compositor SystemCompositionContextHelper::InnerCompositor(
     ICompositionContext context) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionCompositor> s;
   context.try_as(s);
   return s ? s->InnerCompositor() : nullptr;
 }
 
-winrt::Windows::UI::Composition::Visual WindowsCompositionContextHelper::InnerVisual(IVisual visual) noexcept {
+winrt::Windows::UI::Composition::Visual SystemCompositionContextHelper::InnerVisual(IVisual visual) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionVisual> s;
   visual.try_as(s);
   return s ? s->InnerVisual() : nullptr;
 }
 
-winrt::Windows::UI::Composition::DropShadow WindowsCompositionContextHelper::InnerDropShadow(
+winrt::Windows::UI::Composition::DropShadow SystemCompositionContextHelper::InnerDropShadow(
     IDropShadow shadow) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionDropShadow> s;
   shadow.try_as(s);
   return s ? s->InnerShadow() : nullptr;
 }
 
-winrt::Windows::UI::Composition::CompositionBrush WindowsCompositionContextHelper::InnerBrush(IBrush brush) noexcept {
+winrt::Windows::UI::Composition::CompositionBrush SystemCompositionContextHelper::InnerBrush(IBrush brush) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionBrush> s;
   brush.try_as(s);
   return s ? s->InnerBrush() : nullptr;
 }
 
-winrt::Windows::UI::Composition::ICompositionSurface WindowsCompositionContextHelper::InnerSurface(
+winrt::Windows::UI::Composition::ICompositionSurface SystemCompositionContextHelper::InnerSurface(
     IDrawingSurfaceBrush surface) noexcept {
   winrt::com_ptr<::Microsoft::ReactNative::Composition::IWindowsCompositionDrawingSurfaceInner> s;
   surface.try_as(s);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
@@ -5,7 +5,7 @@
 #ifdef USE_WINUI3
 #include "Composition.MicrosoftCompositionContextHelper.g.h"
 #endif
-#include "Composition.WindowsCompositionContextHelper.g.h"
+#include "Composition.SystemCompositionContextHelper.g.h"
 
 #include <d2d1_1.h>
 #include <windows.ui.composition.interop.h>
@@ -16,14 +16,14 @@ namespace winrt::Microsoft::ReactNative::Composition {
 #ifdef USE_WINUI3
 using CompositionContextHelper = MicrosoftCompositionContextHelper;
 #else
-using CompositionContextHelper = WindowsCompositionContextHelper;
+using CompositionContextHelper = SystemCompositionContextHelper;
 #endif
 } // namespace winrt::Microsoft::ReactNative::Composition
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-struct WindowsCompositionContextHelper : WindowsCompositionContextHelperT<WindowsCompositionContextHelper> {
-  WindowsCompositionContextHelper() = default;
+struct SystemCompositionContextHelper : SystemCompositionContextHelperT<SystemCompositionContextHelper> {
+  SystemCompositionContextHelper() = default;
 
   static ICompositionContext CreateContext(winrt::Windows::UI::Composition::Compositor const &compositor) noexcept;
   static IVisual CreateVisual(winrt::Windows::UI::Composition::Visual const &visual) noexcept;
@@ -52,9 +52,9 @@ struct MicrosoftCompositionContextHelper : MicrosoftCompositionContextHelperT<Mi
 
 namespace winrt::Microsoft::ReactNative::Composition::factory_implementation {
 
-struct WindowsCompositionContextHelper : WindowsCompositionContextHelperT<
-                                             WindowsCompositionContextHelper,
-                                             implementation::WindowsCompositionContextHelper> {};
+struct SystemCompositionContextHelper
+    : SystemCompositionContextHelperT<SystemCompositionContextHelper, implementation::SystemCompositionContextHelper> {
+};
 
 #ifdef USE_WINUI3
 struct MicrosoftCompositionContextHelper : MicrosoftCompositionContextHelperT<

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -1,8 +1,8 @@
 
 #include "pch.h"
 #include "CompositionContextHelper.h"
-#if __has_include("Composition.WindowsCompositionContextHelper.g.cpp")
-#include "Composition.WindowsCompositionContextHelper.g.cpp"
+#if __has_include("Composition.SystemCompositionContextHelper.g.cpp")
+#include "Composition.SystemCompositionContextHelper.g.cpp"
 #endif
 #ifdef USE_WINUI3
 #if __has_include("Composition.MicrosoftCompositionContextHelper.g.cpp")
@@ -12,33 +12,33 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-ICompositionContext WindowsCompositionContextHelper::CreateContext(
+ICompositionContext SystemCompositionContextHelper::CreateContext(
     winrt::Windows::UI::Composition::Compositor const &) noexcept {
   return nullptr;
 }
 
-IVisual WindowsCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &) noexcept {
+IVisual SystemCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::Compositor WindowsCompositionContextHelper::InnerCompositor(
+winrt::Windows::UI::Composition::Compositor SystemCompositionContextHelper::InnerCompositor(
     ICompositionContext) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::Visual WindowsCompositionContextHelper::InnerVisual(IVisual) noexcept {
+winrt::Windows::UI::Composition::Visual SystemCompositionContextHelper::InnerVisual(IVisual) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::DropShadow WindowsCompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
+winrt::Windows::UI::Composition::DropShadow SystemCompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::CompositionBrush WindowsCompositionContextHelper::InnerBrush(IBrush) noexcept {
+winrt::Windows::UI::Composition::CompositionBrush SystemCompositionContextHelper::InnerBrush(IBrush) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::ICompositionSurface WindowsCompositionContextHelper::InnerSurface(
+winrt::Windows::UI::Composition::ICompositionSurface SystemCompositionContextHelper::InnerSurface(
     IDrawingSurfaceBrush) noexcept {
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -59,7 +59,7 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
 
 #endif
     auto compositor =
-        winrt::Microsoft::ReactNative::Composition::implementation::WindowsCompositionContextHelper::InnerCompositor(
+        winrt::Microsoft::ReactNative::Composition::implementation::SystemCompositionContextHelper::InnerCompositor(
             compositionContext);
     auto interop = compositor.as<ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
     winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{nullptr};
@@ -75,7 +75,7 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
     target.Root(root);
 
     m_compRootView.RootVisual(
-        winrt::Microsoft::ReactNative::Composition::WindowsCompositionContextHelper::CreateVisual(target.Root()));
+        winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateVisual(target.Root()));
 
 #if USE_WINUI3
   }
@@ -101,7 +101,6 @@ void CompositionHwndHost::UpdateSize() noexcept {
       // Do not relayout when minimized
       if (!IsIconic(m_hwnd)) {
         m_compRootView.Size(size);
-        m_compRootView.Measure(size);
         m_compRootView.Arrange(size);
       }
     }


### PR DESCRIPTION
## Description
Aligning naming of the system version of CompositionContextHelper with how WindowsAppSDK names APIs that work against the system APIs.  APIs that work against system APIs in windowsAppSDK use a System prefix.  I previously used a Windows prefix to align with the system namespace.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12796)