### PR TITLE
[Fabric] Implement LoadingUI and DebuggingOverlay

### DIFF
--- a/change/react-native-windows-75e893cc-3425-4200-95f1-84827cb03aa7.json
+++ b/change/react-native-windows-75e893cc-3425-4200-95f1-84827cb03aa7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Implement LoadingUI and DebuggingOverlay",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -23,6 +23,7 @@
 #include "CompositionContextHelper.h"
 #include "CompositionHelpers.h"
 #include "CompositionRootAutomationProvider.h"
+#include "CompositionUIService.h"
 #include "ReactNativeHost.h"
 #include "RootComponentView.h"
 
@@ -79,9 +80,14 @@ void CompositionReactViewInstance::UpdateRootView() noexcept {
 }
 
 void CompositionReactViewInstance::UninitRootView() noexcept {
-  assert(m_uiDispatcher.HasThreadAccess());
-  if (auto rootControl = m_weakRootControl.get()) {
-    rootControl->UninitRootView();
+  // m_uiDispatcher will not be initialized if InitRootView has not been run in which case we do not need to run UninitRootView
+  if (m_uiDispatcher) 
+  {
+    assert(m_uiDispatcher.HasThreadAccess());
+    if (auto rootControl = m_weakRootControl.get())
+    {
+      rootControl->UninitRootView();
+    }
   }
 }
 
@@ -145,6 +151,18 @@ void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition:
     assert(!m_rootVisual);
     m_rootVisual = value;
   }
+}
+
+void CompositionRootView::AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept {
+  assert(!m_hasRenderedVisual);
+  RootVisual().InsertAt(visual, 0);
+  m_hasRenderedVisual = true;
+}
+
+void CompositionRootView::RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept {
+  assert(m_hasRenderedVisual);
+  RootVisual().Remove(visual);
+  m_hasRenderedVisual = false;
 }
 
 winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
@@ -229,10 +247,6 @@ winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
     }
   }
   return m_uiaProvider;
-}
-
-winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::GetVisual() const noexcept {
-  return m_rootVisual;
 }
 
 std::string CompositionRootView::JSComponentName() const noexcept {
@@ -375,7 +389,14 @@ void CompositionRootView::UninitRootView() noexcept {
   m_isInitialized = false;
 }
 
-void CompositionRootView::ClearLoadingUI() noexcept {}
+void CompositionRootView::ClearLoadingUI() noexcept {
+  if (!m_loadingVisual)
+    return;
+
+  RootVisual().Remove(m_loadingVisual);
+
+  m_loadingVisual = nullptr;
+}
 
 void CompositionRootView::EnsureLoadingUI() noexcept {}
 
@@ -399,13 +420,36 @@ void CompositionRootView::ShowInstanceLoaded() noexcept {
   }
 }
 
-void CompositionRootView::ShowInstanceError() noexcept {}
+void CompositionRootView::ShowInstanceError() noexcept {
+  ClearLoadingUI();
+}
 
 void CompositionRootView::ShowInstanceLoading() noexcept {
   if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle()))
     return;
 
-  // TODO: Show loading UI here
+  if (m_loadingVisual)
+    return;
+
+  auto compContext =
+      winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
+          m_context.Properties().Handle());
+
+  auto brush = compContext.CreateColorBrush({0x80, 0x03, 0x29, 0x29});
+  m_loadingVisual = compContext.CreateSpriteVisual();
+  m_loadingVisual.RelativeSizeWithOffset({0.0f, 50.0f}, {1.0f, 0.0f});
+  m_loadingVisual.Offset({0.0f, -25.0f, 0.0f}, {0.0f, 0.5f, 0.0f});
+  m_loadingVisual.Brush(brush);
+
+  auto foregroundBrush = compContext.CreateColorBrush({255, 255, 255, 255});
+
+  auto activity = compContext.CreateActivityVisual();
+  activity.Size(15.0f);
+  activity.Brush(foregroundBrush);
+  activity.Offset({-50.0f, 5.0f, 0.0f}, {0.5f, 0.0f, 0.0f});
+  m_loadingVisual.InsertAt(activity, 0);
+
+  RootVisual().InsertAt(m_loadingVisual, m_hasRenderedVisual ? 1 : 0);
 }
 
 winrt::Windows::Foundation::Size CompositionRootView::Measure(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -80,12 +80,11 @@ void CompositionReactViewInstance::UpdateRootView() noexcept {
 }
 
 void CompositionReactViewInstance::UninitRootView() noexcept {
-  // m_uiDispatcher will not be initialized if InitRootView has not been run in which case we do not need to run UninitRootView
-  if (m_uiDispatcher) 
-  {
+  // m_uiDispatcher will not be initialized if InitRootView has not been run in which case we do not need to run
+  // UninitRootView
+  if (m_uiDispatcher) {
     assert(m_uiDispatcher.HasThreadAccess());
-    if (auto rootControl = m_weakRootControl.get())
-    {
+    if (auto rootControl = m_weakRootControl.get()) {
       rootControl->UninitRootView();
     }
   }
@@ -153,13 +152,15 @@ void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition:
   }
 }
 
-void CompositionRootView::AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept {
+void CompositionRootView::AddRenderedVisual(
+    const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept {
   assert(!m_hasRenderedVisual);
   RootVisual().InsertAt(visual, 0);
   m_hasRenderedVisual = true;
 }
 
-void CompositionRootView::RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept {
+void CompositionRootView::RemoveRenderedVisual(
+    const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept {
   assert(m_hasRenderedVisual);
   RootVisual().Remove(visual);
   m_hasRenderedVisual = false;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -64,8 +64,8 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   float ScaleFactor() noexcept;
   void ScaleFactor(float value) noexcept;
 
-  void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept;
-  void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept;
+  void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept;
+  void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept;
 
   winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -64,6 +64,9 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   float ScaleFactor() noexcept;
   void ScaleFactor(float value) noexcept;
 
+  void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept;
+  void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual& visual) noexcept;
+
   winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;
 
@@ -88,9 +91,6 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
       const winrt::Microsoft::ReactNative::Composition::Input::Pointer &pointer,
       facebook::react::Tag tag) noexcept;
 
- public: // ICompositionRootView
-  winrt::Microsoft::ReactNative::Composition::IVisual GetVisual() const noexcept override;
-
  public: // IReactRootView
   std::string JSComponentName() const noexcept override;
   int64_t GetActualHeight() const noexcept override;
@@ -114,6 +114,8 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   HWND m_hwnd{0};
   bool m_isInitialized{false};
   bool m_isJSViewAttached{false};
+  bool m_hasRenderedVisual{false};
+  bool m_showingLoadingUI{false};
   IReactDispatcher m_uiDispatcher{nullptr};
   winrt::IInspectable m_uiaProvider{nullptr};
   int64_t m_rootTag{-1};
@@ -124,6 +126,7 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   winrt::Microsoft::ReactNative::ReactViewOptions m_reactViewOptions;
   std::shared_ptr<::Microsoft::ReactNative::CompositionEventHandler> m_CompositionEventHandler;
   winrt::Microsoft::ReactNative::Composition::IVisual m_rootVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_loadingVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme m_theme{nullptr};
   winrt::Microsoft::ReactNative::ReactNotificationSubscription m_themeChangedSubscription{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme::ThemeChanged_revoker m_themeChangedRevoker;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -62,10 +62,6 @@ winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::GetVisual() const noexcept {
-  return nullptr;
-}
-
 std::string CompositionRootView::JSComponentName() const noexcept {
   return {};
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -4,6 +4,10 @@
 
 #include "DebuggingOverlayComponentView.h"
 
+#include <JSValueComposition.h>
+#include <JSValueReader.h>
+#include "RootComponentView.h"
+
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 DebuggingOverlayComponentView::DebuggingOverlayComponentView(
@@ -40,13 +44,66 @@ winrt::Microsoft::ReactNative::ComponentView DebuggingOverlayComponentView::Crea
   return winrt::make<DebuggingOverlayComponentView>(compContext, tag, reactContext);
 }
 
+REACT_STRUCT(ElementRectangle)
+struct ElementRectangle {
+  REACT_FIELD(x)
+  float x;
+  REACT_FIELD(y)
+  float y;
+  REACT_FIELD(width)
+  float width;
+  REACT_FIELD(height)
+  float height;
+};
+
+REACT_STRUCT(TraceUpdate)
+struct TraceUpdate {
+  REACT_FIELD(id)
+  double id;
+  REACT_FIELD(rectangle)
+  ElementRectangle rectangle;
+  REACT_FIELD(color)
+  winrt::Microsoft::ReactNative::Color color{nullptr};
+};
+
 void DebuggingOverlayComponentView::HandleCommand(
     winrt::hstring commandName,
     const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept {
-  if (commandName == L"draw") {
-    // The current spec has a Draw command -- but this will be replaced with some different commands in
-    // https://github.com/facebook/react-native/pull/42119
-    // There is little point in attempting to implement these commands until then.
+  if (commandName == L"highlightTraceUpdates") {
+    std::vector<TraceUpdate> updates;
+    winrt::Microsoft::ReactNative::ReadArgs(args, updates);
+    // TODO should create visuals that get removed after 2 seconds
+    return;
+  }
+  if (commandName == L"highlightElements") {
+    std::vector<ElementRectangle> elements;
+    winrt::Microsoft::ReactNative::ReadArgs(args, elements);
+
+    if (auto root = rootComponentView()) {
+      auto rootVisual = root->OuterVisual();
+      auto brush = m_compContext.CreateColorBrush({204, 200, 230, 255});
+      for (auto &element : elements) {
+        auto overlayVisual = m_compContext.CreateSpriteVisual();
+        overlayVisual.Size({element.width, element.height});
+        overlayVisual.Offset({element.x, element.y, 0.0f});
+        overlayVisual.Brush(brush);
+
+        rootVisual.InsertAt(overlayVisual, root->overlayIndex() + m_activeOverlays);
+        ++m_activeOverlays;
+      }
+    }
+    return;
+  }
+  if (commandName == L"clearElementsHighlights") {
+    if (auto root = rootComponentView()) {
+      auto rootVisual = root->OuterVisual();
+
+      while (m_activeOverlays != 0) {
+        auto visual = rootVisual.GetAt(root->overlayIndex() + m_activeOverlays);
+        rootVisual.Remove(visual);
+        --m_activeOverlays;
+      }
+    }
     return;
   }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
@@ -31,6 +31,9 @@ struct DebuggingOverlayComponentView
 
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept
       override;
+
+ private:
+  uint32_t m_activeOverlays{0};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -27,9 +27,9 @@ RootComponentView::RootComponentView(
           false) {}
 
 RootComponentView::~RootComponentView() {
-  if (auto rootView = m_wkRootView.get())
-  {
-    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->RemoveRenderedVisual(OuterVisual());
+  if (auto rootView = m_wkRootView.get()) {
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->RemoveRenderedVisual(
+        OuterVisual());
   }
 }
 
@@ -161,7 +161,8 @@ uint32_t RootComponentView::overlayIndex() noexcept {
 }
 
 void RootComponentView::start(const winrt::Microsoft::ReactNative::CompositionRootView &rootView) noexcept {
-  winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->AddRenderedVisual(OuterVisual());
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->AddRenderedVisual(
+      OuterVisual());
   m_wkRootView = rootView;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -26,6 +26,13 @@ RootComponentView::RootComponentView(
                 ComponentViewFeatures::NativeBorder),
           false) {}
 
+RootComponentView::~RootComponentView() {
+  if (auto rootView = m_wkRootView.get())
+  {
+    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->RemoveRenderedVisual(OuterVisual());
+  }
+}
+
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::Create(
     const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
     facebook::react::Tag tag,
@@ -147,6 +154,15 @@ HRESULT RootComponentView::GetFragmentRoot(IRawElementProviderFragmentRoot **pRe
   }
 
   return S_OK;
+}
+
+uint32_t RootComponentView::overlayIndex() noexcept {
+  return 1;
+}
+
+void RootComponentView::start(const winrt::Microsoft::ReactNative::CompositionRootView &rootView) noexcept {
+  winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->AddRenderedVisual(OuterVisual());
+  m_wkRootView = rootView;
 }
 
 winrt::IInspectable RootComponentView::UiaProviderFromPoint(const POINT &ptPixels) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
@@ -35,6 +35,10 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
 
   RootComponentView *rootComponentView() noexcept override;
 
+  // Index that visuals can be inserted into OuterVisual for debugging UI
+  uint32_t overlayIndex() noexcept;
+  void start(const winrt::Microsoft::ReactNative::CompositionRootView &rootView) noexcept;
+
   HRESULT GetFragmentRoot(IRawElementProviderFragmentRoot **pRetVal) noexcept;
   winrt::Microsoft::ReactNative::implementation::ClipState getClipState() noexcept override;
 
@@ -45,11 +49,14 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
+  virtual ~RootComponentView();
+
  private:
   // should this be a ReactTaggedView? - It shouldn't actually matter since if the view is going away it should always
   // be clearing its focus But being a reactTaggedView might make it easier to identify cases where that isn't
   // happening.
   winrt::Microsoft::ReactNative::ComponentView m_focusedComponent{nullptr};
+  winrt::weak_ref<winrt::Microsoft::ReactNative::CompositionRootView> m_wkRootView{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.cpp
@@ -146,7 +146,7 @@ void FabricUIManager::startSurface(
     facebook::react::SurfaceId surfaceId,
     const std::string &moduleName,
     const folly::dynamic &initialProps) noexcept {
-  m_surfaceRegistry.insert({surfaceId, {rootView.RootVisual(), rootView}});
+  m_surfaceRegistry.insert({surfaceId, {rootView}});
 
   m_context.UIDispatcher().Post([self = shared_from_this(), surfaceId, rootView]() {
     auto &rootComponentViewDescriptor = self->m_registry.dequeueComponentViewWithComponentHandle(
@@ -155,8 +155,7 @@ void FabricUIManager::startSurface(
     auto root = rootComponentViewDescriptor.view
                     .as<winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView>();
     root->theme(winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(rootView.Theme()));
-
-    self->m_surfaceRegistry.at(surfaceId).rootVisual.InsertAt(root->OuterVisual(), 0);
+    root->start(rootView);
   });
 
   facebook::react::LayoutContext context;

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
@@ -72,7 +72,6 @@ struct FabricUIManager final : public std::enable_shared_from_this<FabricUIManag
 
   ComponentViewRegistry m_registry;
   struct SurfaceInfo {
-    winrt::Microsoft::ReactNative::Composition::IVisual rootVisual{nullptr};
     winrt::weak_ref<winrt::Microsoft::ReactNative::CompositionRootView> wkRootView{nullptr};
   };
 

--- a/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/DeviceInfoModule.cpp
@@ -157,7 +157,7 @@ void DeviceInfoHolder::SetCallback(
 }
 
 void DeviceInfoHolder::updateDeviceInfo() noexcept {
-  if (xaml::Window::Current()) {
+  if (xaml::TryGetCurrentApplication() && xaml::Window::Current()) {
     auto const window = xaml::Window::Current().CoreWindow();
 
     m_windowWidth = window.Bounds().Width;

--- a/vnext/Microsoft.ReactNative/Views/ICompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Views/ICompositionRootView.h
@@ -12,7 +12,6 @@
 namespace Microsoft::ReactNative {
 
 struct ICompositionRootView : public facebook::react::IReactRootView {
-  virtual winrt::Microsoft::ReactNative::Composition::IVisual GetVisual() const noexcept = 0;
   virtual float ScaleFactor() noexcept = 0;
 };
 


### PR DESCRIPTION
## Description
- Implement `DebuggingOverlayComponentView` commands which means `react-devtools` can now highlight elements in fabric apps
- Add loading UI for `CompositionRootView`
- Prevent MS.UI.Xaml.dll loading when the app is not otherwise using xaml by adding an addition check in DeviceInfo.
- Fix a leak of a the Visual that was added by `RootComponentView` to the `CompositionRootView`, and never removed which would cause a Visual to be leaked on every instance reload.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12809)