### PR TITLE
[0.73] Add disabled property to props being passed into Pressable component

### DIFF
--- a/change/react-native-windows-92d439dc-c4c3-4708-894f-c2312a70d71e.json
+++ b/change/react-native-windows-92d439dc-c4c3-4708-894f-c2312a70d71e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "backport disabled prop change",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
+++ b/vnext/src/Libraries/Components/Pressable/Pressable.windows.js
@@ -325,6 +325,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     accessibilityLiveRegion,
     accessibilityLabel,
     accessibilityState: _accessibilityState,
+    disabled: disabled == true,
     focusable: focusable !== false,
     accessibilityValue,
     hitSlop,

--- a/vnext/src/Libraries/Pressability/Pressability.windows.js
+++ b/vnext/src/Libraries/Pressability/Pressability.windows.js
@@ -642,14 +642,15 @@ export default class Pressability {
         this._isKeyDown = false;
       },
       onKeyDown: (event: KeyEvent): void => {
-        const {onKeyDown} = this._config;
+        const {onKeyDown, disabled} = this._config;
         onKeyDown && onKeyDown(event);
 
         if (
           (event.nativeEvent.code === 'Space' ||
             event.nativeEvent.code === 'Enter' ||
             event.nativeEvent.code === 'GamepadA') &&
-          event.defaultPrevented != true
+          event.defaultPrevented !== true &&
+          disabled !== true
         ) {
           const {onPressIn} = this._config;
           this._isKeyDown = true;


### PR DESCRIPTION
## Description
Backports #12799 into 0.73-stable.

Adds the value of the disabled property to props that are being passed into the Pressable component native code. Additionally, also adds a disabled property check before calling the onKeyDown event handler.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves https://github.com/microsoft/react-native-gallery/issues/364
Resolves https://github.com/microsoft/react-native-gallery/issues/363

### What
Added statement to set Boolean value of prop before passed into Pressable component, and disabled property conditional check to onKeyDown handler.

## Testing
Tested in RNTester and standalone example Pressable component. 

Sample Pressable component code:
```
<Pressable
  accessibilityRole="button"
  accessibilityLabel={'example disabled pressable'}
  style={{
    width: 140,
    height: 50,
    borderRadius: 2,
    backgroundColor:'silver',
    opacity: 0.5,
  }}
  disabled={true}>
  {({pressed}) => (
    <Text
      style={{
        textAlign: 'center',
        paddingVertical: 15,
        color: 'black',
      }}>
      {pressed ? 'This will never be triggered.' : 'Disabled Pressable'}
    </Text>
  )}
</Pressable>
```

## Changelog
Should this change be included in the release notes: yes
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12799)