### PR TITLE
Add UIBatchingQueue to bridgeless mode

### DIFF
--- a/change/react-native-windows-d9b2af2c-5b3c-4c5a-ba6c-147f72845e47.json
+++ b/change/react-native-windows-d9b2af2c-5b3c-4c5a-ba6c-147f72845e47.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add UIBatchingQueue to bridgeless mode",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/test/__snapshots__/ViewComponentTest.test.ts.snap
+++ b/packages/e2e-test-app-fabric/test/__snapshots__/ViewComponentTest.test.ts.snap
@@ -6325,7 +6325,7 @@ exports[`View Tests Views can have layout conformance 1`] = `
             ],
             "Opacity": 1,
             "Size": [
-              60,
+              0,
               30,
             ],
             "Visual Type": "SpriteVisual",
@@ -6351,7 +6351,7 @@ exports[`View Tests Views can have layout conformance 1`] = `
         ],
         "Opacity": 1,
         "Size": [
-          60,
+          0,
           30,
         ],
         "Visual Type": "SpriteVisual",

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -79,9 +79,11 @@ void CompositionReactViewInstance::UpdateRootView() noexcept {
 }
 
 void CompositionReactViewInstance::UninitRootView() noexcept {
-  assert(m_uiDispatcher.HasThreadAccess());
-  if (auto rootControl = m_weakRootControl.get()) {
-    rootControl->UninitRootView();
+  if (m_uiDispatcher) {
+    assert(m_uiDispatcher.HasThreadAccess());
+    if (auto rootControl = m_weakRootControl.get()) {
+      rootControl->UninitRootView();
+    }
   }
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
@@ -20,10 +20,8 @@ void CompositionUIService::SetCompositionContext(
     ICompositionContext const &compositionContext) noexcept {
   ReactPropertyBag(properties).Set(CompositionContextPropertyId(), compositionContext);
   // Default to using Bridgeless mode when using fabric
-  /*
   winrt::Microsoft::ReactNative::implementation::QuirkSettings::SetIsBridgeless(
       ReactPropertyBag(properties), !!compositionContext);
-  */
 }
 
 ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &properties) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/Timing.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Timing.cpp
@@ -84,22 +84,20 @@ TimerRegistry::~TimerRegistry() {
   m_timingModule->DetachBridgeless();
 }
 
+double SchedulingTimeNow() {
+  const int64_t msFrom1601to1970 = 11644473600000;
+  return std::chrono::duration<double, std::milli>(TDateTime::clock::now().time_since_epoch()).count() -
+      msFrom1601to1970;
+}
+
 void TimerRegistry::createTimer(uint32_t timerID, double delayMS) {
-  m_timingModule->createTimer(
-      timerID,
-      delayMS * 1000.0,
-      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count(),
-      false);
+  m_timingModule->createTimer(timerID, delayMS, SchedulingTimeNow(), false);
 }
 void TimerRegistry::deleteTimer(uint32_t timerID) {
   m_timingModule->deleteTimer(timerID);
 }
 void TimerRegistry::createRecurringTimer(uint32_t timerID, double delayMS) {
-  m_timingModule->createTimer(
-      timerID,
-      delayMS * 1000.0,
-      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count(),
-      true);
+  m_timingModule->createTimer(timerID, delayMS, SchedulingTimeNow(), true);
 }
 
 void TimerRegistry::callTimers(const vector<uint32_t> &ids) noexcept {

--- a/vnext/Microsoft.ReactNative/Modules/Timing.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Timing.cpp
@@ -85,13 +85,21 @@ TimerRegistry::~TimerRegistry() {
 }
 
 void TimerRegistry::createTimer(uint32_t timerID, double delayMS) {
-  m_timingModule->createTimer(timerID, delayMS / 1000.0, 0.0f, false);
+  m_timingModule->createTimer(
+      timerID,
+      delayMS * 1000.0,
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count(),
+      false);
 }
 void TimerRegistry::deleteTimer(uint32_t timerID) {
   m_timingModule->deleteTimer(timerID);
 }
 void TimerRegistry::createRecurringTimer(uint32_t timerID, double delayMS) {
-  m_timingModule->createTimer(timerID, delayMS / 1000.0, 0.0f, true);
+  m_timingModule->createTimer(
+      timerID,
+      delayMS * 1000.0,
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now().time_since_epoch()).count(),
+      true);
 }
 
 void TimerRegistry::callTimers(const vector<uint32_t> &ids) noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -559,9 +559,6 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
   m_uiMessageThread.Exchange(std::make_shared<MessageDispatchQueue2>(
       *m_uiQueue, Mso::MakeWeakMemberFunctor(this, &ReactInstanceWin::OnError)));
 
-  auto batchingUIThread = Microsoft::ReactNative::MakeBatchingQueueThread(m_uiMessageThread.Load());
-  m_batchingUIThread = batchingUIThread;
-
   ReactPropertyBag(m_reactContext->Properties())
       .Set(
           winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::PostToUIBatchingQueueProperty(),
@@ -601,6 +598,7 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
                 Mso::Copy(m_whenDestroyed)));
 
             m_jsMessageThread.Load()->runOnQueueSync([&]() {
+              ::SetThreadDescription(GetCurrentThread(), L"React-Native JavaScript Thread");
               auto timerRegistry = ::Microsoft::ReactNative::TimerRegistry::CreateTimerRegistry(
                   m_options.Properties.Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>());
               auto timerRegistryRaw = timerRegistry.get();

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -1299,7 +1299,12 @@ void ReactInstanceWin::DrainJSCallQueue() noexcept {
       }
     }
 
-    if (auto instance = m_instance.LoadWithLock()) {
+#ifdef USE_FABRIC
+    if (m_bridgelessReactInstance) {
+      m_bridgelessReactInstance->callFunctionOnModule(entry.ModuleName, entry.MethodName, entry.Args);
+    } else
+#endif
+        if (auto instance = m_instance.LoadWithLock()) {
       instance->callJSFunction(std::move(entry.ModuleName), std::move(entry.MethodName), std::move(entry.Args));
     }
   }

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -651,6 +651,7 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
             FireInstanceCreatedCallback();
 
             LoadJSBundlesBridgeless(devSettings);
+            SetupHMRClient();
 
           } catch (std::exception &e) {
             OnErrorWithMessage(e.what());
@@ -831,18 +832,7 @@ void ReactInstanceWin::InitializeWithBridge() noexcept {
 
             FireInstanceCreatedCallback();
             LoadJSBundles();
-
-            if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
-              folly::dynamic params = folly::dynamic::array(
-                  winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::GetPlatformName(
-                      m_reactContext->Properties()),
-                  DebugBundlePath(),
-                  SourceBundleHost(),
-                  SourceBundlePort(),
-                  m_isFastReloadEnabled,
-                  "ws");
-              m_instance.Load()->callJSFunction("HMRClient", "setup", std::move(params));
-            }
+            SetupHMRClient();
 
           } catch (std::exception &e) {
             OnErrorWithMessage(e.what());
@@ -857,6 +847,20 @@ void ReactInstanceWin::InitializeWithBridge() noexcept {
       });
     };
   });
+}
+
+void ReactInstanceWin::SetupHMRClient() noexcept {
+  if (UseDeveloperSupport() && State() != ReactInstanceState::HasError) {
+    folly::dynamic params = folly::dynamic::array(
+        winrt::Microsoft::ReactNative::implementation::ReactCoreInjection::GetPlatformName(
+            m_reactContext->Properties()),
+        DebugBundlePath(),
+        SourceBundleHost(),
+        SourceBundlePort(),
+        m_isFastReloadEnabled,
+        "ws");
+    CallJsFunction("HMRClient", "setup", std::move(params));
+  }
 }
 
 void ReactInstanceWin::LoadJSBundles() noexcept {

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -109,7 +109,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   void LoadJSBundles() noexcept;
   void InitJSMessageThread() noexcept;
   void InitNativeMessageThread() noexcept;
-  void InitUIMessageThread() noexcept;
+  void InitUIMessageThread(bool haveBridge) noexcept;
 #ifndef CORE_ABI
   void InitUIManager() noexcept;
 #endif

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -109,7 +109,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   void LoadJSBundles() noexcept;
   void InitJSMessageThread() noexcept;
   void InitNativeMessageThread() noexcept;
-  void InitUIMessageThread(bool haveBridge) noexcept;
+  void InitUIMessageThread() noexcept;
   void SetupHMRClient() noexcept;
 #ifndef CORE_ABI
   void InitUIManager() noexcept;

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.h
@@ -110,6 +110,7 @@ class ReactInstanceWin final : public Mso::ActiveObject<IReactInstanceInternal> 
   void InitJSMessageThread() noexcept;
   void InitNativeMessageThread() noexcept;
   void InitUIMessageThread(bool haveBridge) noexcept;
+  void SetupHMRClient() noexcept;
 #ifndef CORE_ABI
   void InitUIManager() noexcept;
 #endif


### PR DESCRIPTION
## Description
Prior to this, there was no UIBatchingQueue being created when in bridgeless mode, which would cause the animation module to crash when used.

Updated snapshots to account for the layout conformance property which works correctly in bridgeless mode

Fixed an issue if you set a ReactViewHost on a CompositionRootView before the ReactHost was loaded

Fixed an issue in the Bridgeless timing module that was causing all timers to immediately fire

Moved some of the JS runtime initialization in bridgeless to be run on the JS thread synchronously to align with how we init it in bridge mode.

Fixed an issue where we wouldn't start the HMRClient in bridgeless mode

Fixed an issue where calls to JSFunctions hit during initialization may not get triggered when the runtime completed its initialization.


Resolves #12810