### PR TITLE
chore: remove unused globals from Fabric template

### DIFF
--- a/change/react-native-windows-20bf6698-68e4-4c9f-b7d4-e2a6b667b687.json
+++ b/change/react-native-windows-20bf6698-68e4-4c9f-b7d4-e2a6b667b687.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove unused globals from Fabric template",
+  "packageName": "react-native-windows",
+  "email": "4123478+tido64@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
@@ -20,9 +20,6 @@ struct CompReactPackageProvider
 constexpr PCWSTR windowTitle = L"{{ mainComponentName }}";
 constexpr PCWSTR mainComponentName = L"{{ mainComponentName }}";
 
-HWND global_hwnd;
-winrt::Microsoft::ReactNative::CompositionRootView *global_rootView{nullptr};
-
 float ScaleFactor(HWND hwnd) noexcept {
   return GetDpiForWindow(hwnd) / static_cast<float>(USER_DEFAULT_SCREEN_DPI);
 }
@@ -106,7 +103,6 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   window.Resize({1000, 1000});
   window.Show();
   auto hwnd = winrt::Microsoft::UI::GetWindowFromWindowId(window.Id());
-  global_hwnd = hwnd;
   auto scaleFactor = ScaleFactor(hwnd);
 
   auto host = CreateReactNativeHost(hwnd, compositor);


### PR DESCRIPTION
## Description

Remove unused globals from Fabric template

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

There are unused globals in the Fabric template.

### What

We shouldn't have globals if we can't help it. Since these were unused, they were removed.

## Screenshots

n/a

## Testing

n/a

## Changelog

Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12815)