### PR TITLE
Update bot to Add New/Old Architecture labels if a New/Old Area label is added

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -492,8 +492,8 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel:
-          - label: 'New Architecture'
+        hasLabel:
+          label: 'New Architecture'
       - or:
         - labelAdded:
             label: 'Area: Fabric'
@@ -510,8 +510,8 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel:
-          - label: 'Old Architecture'
+        hasLabel:
+          label: 'Old Architecture'
       - or:
         - labelAdded:
             label: 'Area: Paper'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -489,9 +489,6 @@ configuration:
     - description: Mark issues labeled with new architecture Areas as New Architecture
       if:
       - payloadType: Issues
-      - not:
-        hasLabel:
-          label: 'New Architecture'
       - or:
         - labelAdded:
             label: 'Area: Fabric'
@@ -499,6 +496,9 @@ configuration:
             label: 'Area: Component Views'
         - labelAdded:
             label: 'Area: Turbo Modules'
+      - not:
+        hasLabel:
+          label: 'New Architecture'
       then:
       - addLabel:
           label: 'New Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -489,16 +489,16 @@ configuration:
     - description: Mark issues labeled with new architecture Areas as New Architecture
       if:
       - payloadType: Issues
-      - or:
-        - labelAdded:
-            label: 'Area: Fabric'
-        - labelAdded:
-            label: 'Area: Component Views'
-        - labelAdded:
-            label: 'Area: Turbo Modules'
-      - not:
-        hasLabel:
-          label: 'New Architecture'
+      # - or:
+      #   - labelAdded:
+      #       label: 'Area: Fabric'
+      #   - labelAdded:
+      #       label: 'Area: Component Views'
+      #   - labelAdded:
+      #       label: 'Area: Turbo Modules'
+      # - not:
+      #   hasLabel:
+      #     label: 'New Architecture'
       then:
       - addLabel:
           label: 'New Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -486,11 +486,9 @@ configuration:
       - addReply:
           reply: There is no immediate intention to take a fix for this issue. In an intent to create clear expectations, the issue has been closed. The issue still exists and may be referred to and commented on. If additional justification is made, it may be reactivated in the future.
       - closeIssue
-    - description: Mark items labeled with new architecture Areas as New Architecture
+    - description: Mark issues labeled with new architecture Areas as New Architecture
       if:
-      - or:
-        - payloadType: Issues
-        - payloadType: Pull_Request
+      - payloadType: Issues
       - not:
         hasLabel:
           label: 'New Architecture'
@@ -504,11 +502,41 @@ configuration:
       then:
       - addLabel:
           label: 'New Architecture'
-    - description: Mark items labeled with old architecture Areas as Old Architecture
+    - description: Mark PRs labeled with new architecture Areas as New Architecture
       if:
+      - payloadType: Pull_Request
+      - not:
+        hasLabel:
+          label: 'New Architecture'
       - or:
-        - payloadType: Issues
-        - payloadType: Pull_Request
+        - labelAdded:
+            label: 'Area: Fabric'
+        - labelAdded:
+            label: 'Area: Component Views'
+        - labelAdded:
+            label: 'Area: Turbo Modules'
+      then:
+      - addLabel:
+          label: 'New Architecture'
+    - description: Mark issues labeled with old architecture Areas as Old Architecture
+      if:
+      - payloadType: Issues
+      - not:
+        hasLabel:
+          label: 'Old Architecture'
+      - or:
+        - labelAdded:
+            label: 'Area: Paper'
+        - labelAdded:
+            label: 'Area: View Managers'
+        - labelAdded:
+            label: 'Area: Native Modules'
+      then:
+      - addLabel:
+          label: 'Old Architecture'
+    - description: Mark PRs labeled with old architecture Areas as Old Architecture
+      if:
+      - payloadType: Pull_Request
       - not:
         hasLabel:
           label: 'Old Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -492,7 +492,7 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel:
+          hasLabel:
             label: 'New Architecture'
       - or:
         - labelAdded:
@@ -510,7 +510,7 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel:
+          hasLabel:
             label: 'Old Architecture'
       - or:
         - labelAdded:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -499,8 +499,8 @@ configuration:
       #   - labelAdded:
       #       label: 'Area: Turbo Modules'
       - not:
-        hasLabel:
-          label: 'New Architecture'
+          hasLabel:
+              label: 'New Architecture'
       then:
       - addLabel:
           label: 'New Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -496,9 +496,9 @@ configuration:
       #       label: 'Area: Component Views'
       #   - labelAdded:
       #       label: 'Area: Turbo Modules'
-      # - not:
-      #   hasLabel:
-      #     label: 'New Architecture'
+      - not:
+        hasLabel:
+          label: 'New Architecture'
       then:
       - addLabel:
           label: 'New Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -492,7 +492,8 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel: 'New Architecture'
+        - hasLabel:
+          - label: 'New Architecture'
       - or:
         - labelAdded:
             label: 'Area: Fabric'
@@ -509,7 +510,8 @@ configuration:
         - payloadType: Issues
         - payloadType: Pull_Request
       - not:
-        - hasLabel: 'Old Architecture'
+        - hasLabel:
+          - label: 'Old Architecture'
       - or:
         - labelAdded:
             label: 'Area: Paper'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -489,6 +489,8 @@ configuration:
     - description: Mark issues labeled with new architecture Areas as New Architecture
       if:
       - payloadType: Issues
+      - isAction:
+          action: Opened
       # - or:
       #   - labelAdded:
       #       label: 'Area: Fabric'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -486,69 +486,39 @@ configuration:
       - addReply:
           reply: There is no immediate intention to take a fix for this issue. In an intent to create clear expectations, the issue has been closed. The issue still exists and may be referred to and commented on. If additional justification is made, it may be reactivated in the future.
       - closeIssue
-    - description: Mark issues labeled with new architecture Areas as New Architecture
+    - description: Mark items labeled with new architecture Areas as New Architecture
       if:
-      - payloadType: Issues
-      - isAction:
-          action: Opened
-      # - or:
-      #   - labelAdded:
-      #       label: 'Area: Fabric'
-      #   - labelAdded:
-      #       label: 'Area: Component Views'
-      #   - labelAdded:
-      #       label: 'Area: Turbo Modules'
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
       - not:
-          hasLabel:
-              label: 'New Architecture'
+        - hasLabel:
+            label: 'New Architecture'
+      - or:
+        - labelAdded:
+              label: 'Area: Fabric'
+        - labelAdded:
+              label: 'Area: Component Views'
+        - labelAdded:
+              label: 'Area: Turbo Modules'
       then:
       - addLabel:
           label: 'New Architecture'
-    - description: Mark PRs labeled with new architecture Areas as New Architecture
+    - description: Mark items labeled with old architecture Areas as Old Architecture
       if:
-      - payloadType: Pull_Request
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
       - not:
-        hasLabel:
-          label: 'New Architecture'
+        - hasLabel:
+            label: 'Old Architecture'
       - or:
         - labelAdded:
-            label: 'Area: Fabric'
+              label: 'Area: Paper'
         - labelAdded:
-            label: 'Area: Component Views'
+              label: 'Area: View Managers'
         - labelAdded:
-            label: 'Area: Turbo Modules'
-      then:
-      - addLabel:
-          label: 'New Architecture'
-    - description: Mark issues labeled with old architecture Areas as Old Architecture
-      if:
-      - payloadType: Issues
-      - not:
-        hasLabel:
-          label: 'Old Architecture'
-      - or:
-        - labelAdded:
-            label: 'Area: Paper'
-        - labelAdded:
-            label: 'Area: View Managers'
-        - labelAdded:
-            label: 'Area: Native Modules'
-      then:
-      - addLabel:
-          label: 'Old Architecture'
-    - description: Mark PRs labeled with old architecture Areas as Old Architecture
-      if:
-      - payloadType: Pull_Request
-      - not:
-        hasLabel:
-          label: 'Old Architecture'
-      - or:
-        - labelAdded:
-            label: 'Area: Paper'
-        - labelAdded:
-            label: 'Area: View Managers'
-        - labelAdded:
-            label: 'Area: Native Modules'
+              label: 'Area: Native Modules'
       then:
       - addLabel:
           label: 'Old Architecture'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -417,6 +417,10 @@ configuration:
           pattern: Breaking Change
       - labelSync:
           pattern: Backport
+      - labelSync:
+          pattern: 'Parity:'
+      - labelSync:
+          pattern: Architecture
     - description: Close issues resolved as being better served by Stack Overflow
       if:
       - payloadType: Issues
@@ -482,5 +486,39 @@ configuration:
       - addReply:
           reply: There is no immediate intention to take a fix for this issue. In an intent to create clear expectations, the issue has been closed. The issue still exists and may be referred to and commented on. If additional justification is made, it may be reactivated in the future.
       - closeIssue
+    - description: Mark items labeled with new architecture Areas as New Architecture
+      if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - not:
+        - hasLabel: 'New Architecture'
+      - or:
+        - labelAdded:
+            label: 'Area: Fabric'
+        - labelAdded:
+            label: 'Area: Component Views'
+        - labelAdded:
+            label: 'Area: Turbo Modules'
+      then:
+      - addLabel:
+          label: 'New Architecture'
+    - description: Mark items labeled with old architecture Areas as Old Architecture
+      if:
+      - or:
+        - payloadType: Issues
+        - payloadType: Pull_Request
+      - not:
+        - hasLabel: 'Old Architecture'
+      - or:
+        - labelAdded:
+            label: 'Area: Paper'
+        - labelAdded:
+            label: 'Area: View Managers'
+        - labelAdded:
+            label: 'Area: Native Modules'
+      then:
+      - addLabel:
+          label: 'Old Architecture'
 onFailure: 
 onSuccess: 


### PR DESCRIPTION
## Description

Updates our bot to add "New Architecture" or "Old Architecture" if it detects a relevant Area being added to an issue/PR. The rule is purely additive: it does not remove any labels.

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
We're currently using the "Area: Fabric" label as a catch-all for any new architecture / composition / WinAppSDK work, when really it should just be for the UI layer, not everything else.

### What
There are now new "Old Architecture" and "New Architecture" labels, this PR updates our bot to update new issues/PRs with the new labels when a matching category of Area label is applied.

## Screenshots
N/A

## Testing
N/A

## Changelog
Should this change be included in the release notes: no

Add a brief summary of the change to use in the release notes for the next release.