### PR TITLE
Minor clean up of headers for Office consumption

### DIFF
--- a/change/react-native-windows-8ec5fa94-501b-40f4-a05c-c7a591e9583f.json
+++ b/change/react-native-windows-8ec5fa94-501b-40f4-a05c-c7a591e9583f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Minor clean up for headers for Office consumption",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -49,6 +49,7 @@
     <file src="$nugetroot$\inc\Shared\DevSettings.h" target="inc"/>
     <file src="$nugetroot$\inc\ReactWin32\INativeUIManagerLegacy.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\InstanceManager.h" target="inc"/>
+    <file src="$nugetroot$\inc\Shared\IDevSupportManager.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\IReactRootView.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\IRedBoxHandler.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\JSBigAbiString.h" target="inc"/>

--- a/vnext/Shared/DevServerHelper.h
+++ b/vnext/Shared/DevServerHelper.h
@@ -8,9 +8,6 @@
 namespace facebook {
 namespace react {
 
-using JSECreator =
-    std::function<std::unique_ptr<JSExecutor>(std::shared_ptr<ExecutorDelegate>, std::shared_ptr<MessageQueueThread>)>;
-
 class DevServerHelper {
  public:
   DevServerHelper() = default;

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -3,14 +3,16 @@
 
 #pragma once
 
-#include "DevServerHelper.h"
-
+#include <cxxreact/JSExecutor.h>
 #include <functional>
 #include <memory>
 #include <string>
 
 namespace facebook {
 namespace react {
+
+using JSECreator =
+    std::function<std::unique_ptr<JSExecutor>(std::shared_ptr<ExecutorDelegate>, std::shared_ptr<MessageQueueThread>)>;
 
 struct DevSettings;
 

--- a/vnext/Shared/WebSocketJSExecutorFactory.h
+++ b/vnext/Shared/WebSocketJSExecutorFactory.h
@@ -5,6 +5,7 @@
 
 #include <cxxreact/JSExecutor.h>
 #include "DevServerHelper.h"
+#include "IDevSupportManager.h"
 
 namespace facebook {
 namespace react {


### PR DESCRIPTION
Cleaning up the #includes to avoid having to bring too many additional headers into Office consumption.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12820)