### PR TITLE
Pass RuntimeSchedulerCallInvoker to C++ TurboModule initialization

### DIFF
--- a/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
+++ b/vnext/Microsoft.ReactNative.Cxx/TurboModuleProvider.h
@@ -10,8 +10,10 @@
 
 namespace winrt::Microsoft::ReactNative {
 
-// Creates CallInvoker based on JSDispatcher.
-std::shared_ptr<facebook::react::CallInvoker> MakeAbiCallInvoker(IReactDispatcher const &jsDispatcher) noexcept;
+void SetCallInvoker(
+    IReactPropertyBag const &properties,
+    std::weak_ptr<facebook::react::CallInvoker> const &callInvoker) noexcept;
+std::shared_ptr<facebook::react::CallInvoker> GetCallInvokerFromContext(IReactContext const &context) noexcept;
 
 template <
     typename TTurboModule,
@@ -23,7 +25,7 @@ void AddTurboModuleProvider(IReactPackageBuilder const &packageBuilder, std::wst
         // We expect the initializer to be called immediately for TurboModules
         moduleBuilder.AddInitializer([&abiTurboModule](IReactContext const &context) mutable {
           TryGetOrCreateContextRuntime(ReactContext{context}); // Ensure the JSI runtime is created.
-          auto callInvoker = MakeAbiCallInvoker(context.JSDispatcher());
+          auto callInvoker = GetCallInvokerFromContext(context);
           auto turboModule = std::make_shared<TTurboModule>(callInvoker);
           abiTurboModule = winrt::make<JsiHostObjectWrapper>(std::move(turboModule));
         });

--- a/vnext/Shared/OInstance.cpp
+++ b/vnext/Shared/OInstance.cpp
@@ -43,6 +43,7 @@
 #include <ReactPropertyBag.h>
 #include <SchedulerSettings.h>
 #include <Shlwapi.h>
+#include <TurboModuleProvider.h>
 #include <WebSocketJSExecutorFactory.h>
 #include <safeint.h>
 #include "PackagerConnection.h"
@@ -513,10 +514,13 @@ InstanceImpl::InstanceImpl(
       if (runtimeScheduler) {
         RuntimeSchedulerBinding::createAndInstallIfNeeded(*runtimeHolder->getRuntime(), runtimeScheduler);
       }
-      auto turboModuleManager = std::make_shared<TurboModuleManager>(
-          turboModuleRegistry,
-          runtimeScheduler ? std::make_shared<RuntimeSchedulerCallInvoker>(runtimeScheduler)
-                           : innerInstance->getJSCallInvoker());
+
+      const auto callInvoker = runtimeScheduler ? std::make_shared<RuntimeSchedulerCallInvoker>(runtimeScheduler)
+                                                : innerInstance->getJSCallInvoker();
+
+      auto turboModuleManager = std::make_shared<TurboModuleManager>(turboModuleRegistry, callInvoker);
+
+      SetCallInvoker(propertyBag, callInvoker);
 
       // TODO: The binding here should also add the proxys that convert cxxmodules into turbomodules
       // [@vmoroz] Note, that we must not use the RN TurboCxxModule.h code because it uses global


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Rather than creating a CallInvoker that posts to the JSDispatcher, this passes the same CallInvoker used for core TurboModules to 3rd party TurboModules and dispatches actions using the RuntimeScheduler if enabled.

## Changelog
Should this change be included in the release notes: _no_
