### PR TITLE
[0.72] [NetUI] Missed property when adding win32 specific text type info

### DIFF
--- a/change/@office-iss-react-native-win32-8d81cf2e-bf87-4fdc-940e-e3a1bdada473.json
+++ b/change/@office-iss-react-native-win32-8d81cf2e-bf87-4fdc-940e-e3a1bdada473.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "[0.72] Missed property when adding win32 specific text type info",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.d.ts
+++ b/packages/@office-iss/react-native-win32/src/Libraries/Text/Text.d.ts
@@ -48,6 +48,11 @@ export interface TextPropsIOS {
     | undefined;
 
   /**
+   * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
+   */
+  minimumFontScale?: number | undefined;
+
+  /**
    * When `true`, no visual change is made when text is pressed down. By
    * default, a gray oval highlights the text on press down.
    */


### PR DESCRIPTION
I missed a property from the type info when forking the text TS type info.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12846)