### PR TITLE
Ensure Hermes Inspector in bridgeless

### DIFF
--- a/change/react-native-windows-2b0ebf99-bb7f-46f5-b276-1944aeafd68e.json
+++ b/change/react-native-windows-2b0ebf99-bb7f-46f5-b276-1944aeafd68e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure Hermes Inspector in bridgeless",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -611,7 +611,8 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
               };
 
               if (devSettings->useDirectDebugger) {
-                ::Microsoft::ReactNative::GetSharedDevManager()->EnsureHermesInspector(devSettings->sourceBundleHost, devSettings->sourceBundlePort);
+                ::Microsoft::ReactNative::GetSharedDevManager()->EnsureHermesInspector(
+                    devSettings->sourceBundleHost, devSettings->sourceBundlePort);
               }
 
               m_jsiRuntimeHolder = std::make_shared<Microsoft::ReactNative::HermesRuntimeHolder>(

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -610,6 +610,10 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
                 OnJSError(std::move(errorMap));
               };
 
+              if (devSettings->useDirectDebugger) {
+                ::Microsoft::ReactNative::GetSharedDevManager()->EnsureHermesInspector(devSettings->sourceBundleHost, devSettings->sourceBundlePort);
+              }
+
               m_jsiRuntimeHolder = std::make_shared<Microsoft::ReactNative::HermesRuntimeHolder>(
                   devSettings, m_jsMessageThread.Load(), CreateHermesPreparedScriptStore());
               auto jsRuntime = std::make_unique<Microsoft::ReactNative::HermesJSRuntime>(m_jsiRuntimeHolder);


### PR DESCRIPTION
Bridgeless code path was missing code to ensure the Hermes inspector connection to metro.

This is part of the fix for #12834.  The app will now show up in the list returned at `http://localhost:8081/json`.  But that doesn't appear to be sufficient for edge to be able to find the instance at `edge://inspect`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12847)