### PR TITLE
Fix `run-windows` to use 64-bit MSBuild (like VS 2022)

### DIFF
--- a/change/@react-native-windows-cli-91d05574-6a9e-4835-951a-28821d7838b7.json
+++ b/change/@react-native-windows-cli-91d05574-6a9e-4835-951a-28821d7838b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix `run-windows` to use 64-bit MSBuild",
+  "packageName": "@react-native-windows/cli",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
+++ b/packages/@react-native-windows/cli/src/utils/msbuildtools.ts
@@ -39,10 +39,10 @@ export default class MSBuildTools {
   ) {}
 
   /**
-   * @returns directory where x86 msbuild can be found
+   * @returns directory where x64 msbuild can be found
    */
   msbuildPath() {
-    return path.join(this.installationPath, 'MSBuild/Current/Bin');
+    return path.join(this.installationPath, 'MSBuild/Current/Bin/amd64');
   }
 
   cleanProject(slnFile: string) {
@@ -226,7 +226,7 @@ export default class MSBuildTools {
 
     const toolsPath = path.join(
       vsInstallation.installationPath,
-      'MSBuild/Current/Bin',
+      'MSBuild/Current/Bin/amd64',
     );
 
     if (fs.existsSync(toolsPath)) {


### PR DESCRIPTION
## Description

VS 2022 uses the 64-bit MSBuild by default. It's also what we use in CI when building. For some reason, `run-windows` is still using 32-bit MSBuild, which is unnecessary and puts memory limits on our compilation tasks.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why

In PR #12798 I'm trying to update our version of CppWinRT, and in some scenarios (namely release fabric builds) we've hit the 32-bit memory limit for linking.

### What
Changed the CLI to use the 64-bit msbuild exe instead of the 32-bit one it was hardcoded to use.

## Screenshots
N/A

## Testing
Verified everything still builds.

## Changelog
Should this change be included in the release notes: yes

The CLI build command `run-windows` now uses the same 64-bit MSBuild VS 2022 uses by default
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12849)