### PR TITLE
Enable custom timer factory to be provided

### DIFF
--- a/change/react-native-windows-286662e9-d377-48ce-8d82-95e92de04270.json
+++ b/change/react-native-windows-286662e9-d377-48ce-8d82-95e92de04270.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Enable custom timer factory to be provided",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
+++ b/vnext/Microsoft.ReactNative/Microsoft.ReactNative.vcxproj
@@ -310,6 +310,10 @@
       <DependentUpon>ReactNativeHost.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClInclude>
+    <ClInclude Include="Timer.h">
+      <DependentUpon>Timer.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClInclude>
     <ClInclude Include="Utils\AccessibilityUtils.h" />
     <ClInclude Include="Utils\Helpers.h" />
     <ClInclude Include="Utils\KeyboardUtils.h" />

--- a/vnext/Microsoft.ReactNative/Modules/Timing.h
+++ b/vnext/Microsoft.ReactNative/Modules/Timing.h
@@ -57,7 +57,7 @@ class TimerQueue {
 
 struct TimerRegistry : public facebook::react::PlatformTimerRegistry {
   static std::unique_ptr<TimerRegistry> CreateTimerRegistry(
-      const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher) noexcept;
+      const winrt::Microsoft::ReactNative::IReactPropertyBag &properties) noexcept;
 
   ~TimerRegistry();
 
@@ -86,7 +86,7 @@ struct Timing : public std::enable_shared_from_this<Timing> {
 
   void InitializeBridgeless(
       TimerRegistry *timerRegistry,
-      const winrt::Microsoft::ReactNative::IReactDispatcher &uiDispatcher) noexcept;
+      const winrt::Microsoft::ReactNative::IReactPropertyBag &properties) noexcept;
   void DetachBridgeless();
 
   REACT_METHOD(createTimer)
@@ -101,7 +101,7 @@ struct Timing : public std::enable_shared_from_this<Timing> {
   void createTimerOnQueue(uint32_t id, double duration, double jsSchedulingTime, bool repeat) noexcept;
   void deleteTimerOnQueue(uint32_t id) noexcept;
   void OnTick();
-  winrt::dispatching::DispatcherQueueTimer EnsureDispatcherTimer();
+  winrt::Microsoft::ReactNative::ITimer EnsureDispatcherTimer();
   void StartRendering();
   void PostRenderFrame() noexcept;
   void StartDispatcherTimer();
@@ -109,9 +109,10 @@ struct Timing : public std::enable_shared_from_this<Timing> {
 
   winrt::Microsoft::ReactNative::ReactContext m_context; // !bridgeless
   TimerRegistry *m_timerRegistry{nullptr}; // bridgeless
+  winrt::Microsoft::ReactNative::IReactPropertyBag m_properties{nullptr};
   TimerQueue m_timerQueue;
   xaml::Media::CompositionTarget::Rendering_revoker m_rendering;
-  winrt::dispatching::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
+  winrt::Microsoft::ReactNative::ITimer m_dispatcherQueueTimer{nullptr};
   winrt::weak_ref<winrt::Microsoft::ReactNative::IReactDispatcher> m_uiDispatcher;
   bool m_usingRendering{false};
   bool m_usePostForRendering{false};

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.cpp
@@ -109,6 +109,21 @@ void ReactCoreInjection::SetTopLevelWindowId(const IReactPropertyBag &properties
   ReactPropertyBag(properties).Set(TopLevelWindowIdPropertyId(), windowId);
 }
 
+static const ReactPropertyId<TimerFactory> &TimerFactoryPropertyId() noexcept {
+  static const ReactPropertyId<TimerFactory> prop{L"ReactNative.Injection", L"TimerFactory"};
+  return prop;
+}
+
+void ReactCoreInjection::SetTimerFactory(
+    const IReactPropertyBag &properties,
+    const TimerFactory &timerFactory) noexcept {
+  ReactPropertyBag(properties).Set(TimerFactoryPropertyId(), timerFactory);
+}
+
+TimerFactory ReactCoreInjection::GetTimerFactory(const IReactPropertyBag &properties) noexcept {
+  return ReactPropertyBag(properties).Get(TimerFactoryPropertyId()).value_or(nullptr);
+}
+
 ReactViewHost::ReactViewHost(
     const ReactNative::ReactNativeHost &host,
     Mso::React::IReactViewHost &viewHost,

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.h
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.h
@@ -52,6 +52,10 @@ struct ReactCoreInjection : ReactCoreInjectionT<ReactCoreInjection> {
 
   static uint64_t GetTopLevelWindowId(const IReactPropertyBag &properties) noexcept;
   static void SetTopLevelWindowId(const IReactPropertyBag &properties, uint64_t windowId) noexcept;
+
+  static ITimer CreateTimer(const IReactPropertyBag &properties);
+  static TimerFactory GetTimerFactory(const IReactPropertyBag &properties) noexcept;
+  static void SetTimerFactory(const IReactPropertyBag &properties, const TimerFactory &timerFactory) noexcept;
 };
 
 struct ReactViewHost : public winrt::implements<ReactViewHost, IReactViewHost> {

--- a/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
+++ b/vnext/Microsoft.ReactNative/ReactCoreInjection.idl
@@ -4,6 +4,7 @@
 import "IReactContext.idl";
 import "ReactNativeHost.idl";
 import "IJSValueReader.idl";
+import "Timer.idl";
 
 #include "DocString.h"
 
@@ -26,6 +27,10 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
       get; set;
     };
   };
+
+  [experimental]
+  [webhosthidden]
+  delegate ITimer TimerFactory();
 
   [experimental]
   [webhosthidden]
@@ -102,6 +107,9 @@ DOC_STRING("Settings per each IReactViewHost associated with an IReactHost insta
       "This must be manually provided to the @ReactInstanceSettings object when using ReactNativeWindows"
       "without XAML for certain APIs work correctly.")
     static void SetTopLevelWindowId(IReactPropertyBag properties, UInt64 windowId);
+
+    DOC_STRING("Sets a factory method for creating custom timers, in environments where system dispatch timers should not be used.")
+    static void SetTimerFactory(IReactPropertyBag properties, TimerFactory timerFactory);
   }
 
 

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -599,8 +599,7 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
 
             m_jsMessageThread.Load()->runOnQueueSync([&]() {
               ::SetThreadDescription(GetCurrentThread(), L"React-Native JavaScript Thread");
-              auto timerRegistry = ::Microsoft::ReactNative::TimerRegistry::CreateTimerRegistry(
-                  m_options.Properties.Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>());
+              auto timerRegistry = ::Microsoft::ReactNative::TimerRegistry::CreateTimerRegistry(m_options.Properties);
               auto timerRegistryRaw = timerRegistry.get();
 
               auto timerManager = std::make_shared<facebook::react::TimerManager>(std::move(timerRegistry));

--- a/vnext/Microsoft.ReactNative/Timer.cpp
+++ b/vnext/Microsoft.ReactNative/Timer.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "Timer.h"
+#include "Timer.g.cpp"
+
+#include <CppWinRTIncludes.h>
+#include "ReactCoreInjection.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+// Implementation of ITimer based on Windows' DispatcherQueue
+struct ReactTimer : winrt::implements<ReactTimer, ITimer> {
+  ReactTimer(const IReactPropertyBag &properties) {
+    const auto queue = winrt::dispatching::DispatcherQueue::GetForCurrentThread();
+    m_dispatcherQueueTimer = queue.CreateTimer();
+  }
+
+  winrt::Windows::Foundation::TimeSpan Interval() noexcept {
+    return m_dispatcherQueueTimer.Interval();
+  }
+
+  void Interval(winrt::Windows::Foundation::TimeSpan value) noexcept {
+    m_dispatcherQueueTimer.Interval(value);
+  }
+
+  void Start() noexcept {
+    return m_dispatcherQueueTimer.Start();
+  }
+
+  void Stop() noexcept {
+    return m_dispatcherQueueTimer.Stop();
+  }
+
+  winrt::event_token Tick(const winrt::Windows::Foundation::EventHandler<IInspectable> &handler) {
+    return m_dispatcherQueueTimer.Tick([handler](auto sender, auto args) { handler(sender, args); });
+  }
+
+  void Tick(winrt::event_token const &token) {
+    m_dispatcherQueueTimer.Tick(token);
+  }
+
+ private:
+  winrt::dispatching::DispatcherQueueTimer m_dispatcherQueueTimer{nullptr};
+};
+
+Timer::Timer() noexcept {}
+
+ITimer Timer::Create(const IReactPropertyBag &properties) {
+  auto dispatcher = properties.Get(ReactDispatcherHelper::UIDispatcherProperty()).try_as<IReactDispatcher>();
+  if (!dispatcher.HasThreadAccess()) {
+    throw winrt::hresult_wrong_thread();
+  }
+
+  if (auto customTimerFactory = implementation::ReactCoreInjection::GetTimerFactory(properties)) {
+    return customTimerFactory();
+  } else {
+    return winrt::make<ReactTimer>(properties);
+  }
+}
+
+} // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Timer.h
+++ b/vnext/Microsoft.ReactNative/Timer.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Timer.g.h"
+
+#include "winrt/Microsoft.ReactNative.h"
+
+namespace winrt::Microsoft::ReactNative::implementation {
+
+struct Timer : TimerT<Timer> {
+  Timer() noexcept;
+
+  static ITimer Create(const IReactPropertyBag &properties);
+};
+
+} // namespace winrt::Microsoft::ReactNative::implementation
+
+namespace winrt::Microsoft::ReactNative::factory_implementation {
+struct Timer : TimerT<Timer, implementation::Timer> {};
+} // namespace winrt::Microsoft::ReactNative::factory_implementation

--- a/vnext/Microsoft.ReactNative/Timer.idl
+++ b/vnext/Microsoft.ReactNative/Timer.idl
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "DocString.h"
+import "IJSValueReader.idl";
+import "IJSValueWriter.idl";
+import "Theme.idl";
+
+namespace Microsoft.ReactNative {
+
+  [webhosthidden]
+  interface ITimer
+  {
+    Windows.Foundation.TimeSpan Interval;
+    void Start();
+    void Stop();
+
+    event Windows.Foundation.EventHandler<Object> Tick;
+  }
+
+  [default_interface]
+  [webhosthidden]
+  DOC_STRING(
+    "Used to create timers.")
+  runtimeclass Timer
+  {
+    DOC_STRING(
+      "Creates a UI timer.  Must be called on the UI thread.  Using this rather than "
+      "System/Windows.DispatcherQueue.CreateTimer works when applications have provided "
+      "custom Timer implementations using @ReactCoreInjection.SetTimerFactory")
+    static ITimer Create(IReactPropertyBag properties);
+  }
+
+} // namespace Microsoft.ReactNative

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -357,6 +357,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\JSDispatcherWriter.cpp">
       <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\IJSValueWriter.idl</DependentUpon>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Timer.cpp">
+      <DependentUpon>$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Timer.idl</DependentUpon>
+    </ClCompile>
     <ClInclude Include="$(MSBuildThisFileDirectory)AbiSafe.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)BaseFileReaderResource.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)CppRuntimeOptions.h" />
@@ -605,6 +608,7 @@
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactInstanceSettings.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\ReactNativeHost.idl" />
     <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\RedBoxHandler.idl" />
+    <Midl Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Timer.idl" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'">
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ComponentView.idl" />


### PR DESCRIPTION
## Description
New method `Microsoft.ReactNative.ReactCoreInjection.SetTimerFactory` exposed that allows applications to provide a custom timer implementation.  This can be useful when using a custom `ICompositionContext` implementation to run React-Native-Windows in environments which may not have a `Microsoft.UI.Dispatching.DispatcherQueue` running.

Modules requiring native timers should use `Microsoft.ReactNative.Timer.Create(properties)` instead of `Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().CreateTimer()` to ensure compatibility with applications using custom timers.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12856)