### PR TITLE
Support WinAppSDK + cppwinrt 2.240111.5

### DIFF
--- a/change/react-native-windows-cf526fee-a8ea-4093-a2b9-326406f5c5ac.json
+++ b/change/react-native-windows-cf526fee-a8ea-4093-a2b9-326406f5c5ac.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Support WinAppSDK + cppwinrt 2.240111.5",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -319,7 +319,11 @@ void TextInputShadowNode::registerEvents() {
       }
     }
 
+#ifdef USE_WINUI3
+    auto contentElement = control.as<xaml::Controls::IControlProtected>().GetTemplateChild(L"ContentElement");
+#else
     auto contentElement = control.GetTemplateChild(L"ContentElement");
+#endif
     auto textBoxView = contentElement.as<xaml::Controls::ScrollViewer>();
     if (textBoxView) {
       m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(

--- a/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
+++ b/vnext/Microsoft.ReactNative/Views/TextInputViewManager.cpp
@@ -319,11 +319,7 @@ void TextInputShadowNode::registerEvents() {
       }
     }
 
-#ifdef USE_WINUI3
     auto contentElement = control.as<xaml::Controls::IControlProtected>().GetTemplateChild(L"ContentElement");
-#else
-    auto contentElement = control.GetTemplateChild(L"ContentElement");
-#endif
     auto textBoxView = contentElement.as<xaml::Controls::ScrollViewer>();
     if (textBoxView) {
       m_scrollViewerViewChangingRevoker = textBoxView.ViewChanging(


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
See https://github.com/microsoft/cppwinrt/issues/1393

### What
We need to first convert the WinUI 3 control to IControlProtected to access GetTemplateChild.

## Testing
Compiled with WinAppSDK and cppwinrt v2.0.240111.5

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12862)