### PR TITLE
[Farbic] Extract RenderText into helper function + clean up Loading visuals

### DIFF
--- a/change/react-native-windows-af6a8175-d270-491f-86c3-ee4c84fe4eb5.json
+++ b/change/react-native-windows-af6a8175-d270-491f-86c3-ee4c84fe4eb5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Extract RenderText into helper function",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -5,6 +5,7 @@
 #include "CompositionRootView.g.cpp"
 #include "FocusNavigationRequest.g.cpp"
 
+#include <AutoDraw.h>
 #include <DynamicWriter.h>
 #include <Fabric/FabricUIManagerModule.h>
 #include <IReactInstance.h>
@@ -15,8 +16,10 @@
 #include <Utils/Helpers.h>
 #include <dispatchQueue/dispatchQueue.h>
 #include <eventWaitHandle/eventWaitHandle.h>
+#include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Microsoft.ReactNative.h>
 #include <winrt/Windows.UI.Core.h>
@@ -26,12 +29,19 @@
 #include "CompositionUIService.h"
 #include "ReactNativeHost.h"
 #include "RootComponentView.h"
+#include "TextDrawing.h"
 
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Content.h>
 #endif
 
 namespace winrt::Microsoft::ReactNative::implementation {
+
+constexpr float loadingActivitySize = 12.0f;
+constexpr float loadingActivityHorizontalOffset = 16.0f;
+constexpr float loadingBarHeight = 36.0f;
+constexpr float loadingBarFontSize = 20.0f;
+constexpr float loadingTextHorizontalOffset = 48.0f;
 
 //! This class ensures that we access ReactRootView from UI thread.
 struct CompositionReactViewInstance
@@ -149,6 +159,7 @@ void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition:
   if (m_rootVisual != value) {
     assert(!m_rootVisual);
     m_rootVisual = value;
+    UpdateRootVisualSize();
   }
 }
 
@@ -172,6 +183,28 @@ winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
 
 void CompositionRootView::Size(winrt::Windows::Foundation::Size value) noexcept {
   m_size = value;
+  UpdateRootVisualSize();
+}
+
+void CompositionRootView::UpdateRootVisualSize() noexcept {
+  if (m_rootVisual)
+    m_rootVisual.Size({m_size.Width * m_scaleFactor, m_size.Height * m_scaleFactor});
+
+  UpdateLoadingVisualSize();
+}
+
+void CompositionRootView::UpdateLoadingVisualSize() noexcept {
+  if (m_loadingVisual) {
+    auto drawingSurface = CreateLoadingVisualBrush();
+    m_loadingVisual.Brush(drawingSurface);
+    m_loadingVisual.Offset({0.0f, -(loadingBarHeight * m_scaleFactor / 2.0f), 0.0f}, {0.0f, 0.5f, 0.0f});
+    m_loadingVisual.Size({m_size.Width * m_scaleFactor, loadingBarHeight * m_scaleFactor});
+    m_loadingActivityVisual.Size(loadingActivitySize * m_scaleFactor);
+    const float loadingActivityVerticalOffset = ((loadingBarHeight - (loadingActivitySize * 2)) * m_scaleFactor) / 2;
+
+    m_loadingActivityVisual.Offset(
+        {loadingActivityHorizontalOffset * m_scaleFactor, loadingActivityVerticalOffset, 0.0f});
+  }
 }
 
 float CompositionRootView::ScaleFactor() noexcept {
@@ -179,7 +212,10 @@ float CompositionRootView::ScaleFactor() noexcept {
 }
 
 void CompositionRootView::ScaleFactor(float value) noexcept {
-  m_scaleFactor = value;
+  if (m_scaleFactor != value) {
+    m_scaleFactor = value;
+    UpdateRootVisualSize();
+  }
 }
 
 winrt::Microsoft::ReactNative::Composition::Theme CompositionRootView::Theme() noexcept {
@@ -397,6 +433,7 @@ void CompositionRootView::ClearLoadingUI() noexcept {
   RootVisual().Remove(m_loadingVisual);
 
   m_loadingVisual = nullptr;
+  m_loadingActivityVisual = nullptr;
 }
 
 void CompositionRootView::EnsureLoadingUI() noexcept {}
@@ -425,6 +462,63 @@ void CompositionRootView::ShowInstanceError() noexcept {
   ClearLoadingUI();
 }
 
+Composition::IDrawingSurfaceBrush CompositionRootView::CreateLoadingVisualBrush() noexcept {
+  auto compContext =
+      winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
+          m_context.Properties().Handle());
+
+  winrt::Windows::Foundation::Size surfaceSize = {
+      m_size.Width * m_scaleFactor, std::min(m_size.Height, loadingBarHeight) * m_scaleFactor};
+  auto drawingSurface = compContext.CreateDrawingSurfaceBrush(
+      surfaceSize,
+      winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+      winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
+
+  POINT offset;
+  {
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, &offset);
+    if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
+      d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Green));
+
+      facebook::react::LayoutConstraints constraints;
+      constraints.maximumSize.width = std::max(0.0f, m_size.Width - loadingTextHorizontalOffset);
+      constraints.maximumSize.height = std::max(0.0f, m_size.Height - loadingBarHeight);
+
+      auto attributedString = facebook::react::AttributedString{};
+      auto fragment = facebook::react::AttributedString::Fragment{};
+      fragment.string = "Loading";
+      fragment.textAttributes.fontSize = loadingBarFontSize;
+      attributedString.appendFragment(fragment);
+      auto attributedStringBox = facebook::react::AttributedStringBox{attributedString};
+
+      auto textAttributes = facebook::react::TextAttributes{};
+      textAttributes.foregroundColor = facebook::react::whiteColor();
+
+      winrt::com_ptr<::IDWriteTextLayout> textLayout;
+      facebook::react::TextLayoutManager::GetTextLayout(
+          attributedStringBox, {} /*paragraphAttributes*/, constraints, textLayout);
+
+      DWRITE_TEXT_METRICS tm;
+      textLayout->GetMetrics(&tm);
+      const float textVerticalOffsetWithinLoadingBar = ((loadingBarHeight - tm.height) * m_scaleFactor) / 2;
+
+      auto theme = winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(Theme());
+
+      Composition::RenderText(
+          *d2dDeviceContext,
+          *textLayout,
+          attributedStringBox.getValue(),
+          textAttributes,
+          {static_cast<float>(offset.x + (loadingTextHorizontalOffset * m_scaleFactor)),
+           static_cast<float>(offset.y + textVerticalOffsetWithinLoadingBar)},
+          m_scaleFactor,
+          *theme);
+    }
+  }
+
+  return drawingSurface;
+}
+
 void CompositionRootView::ShowInstanceLoading() noexcept {
   if (!Mso::React::ReactOptions::UseDeveloperSupport(m_context.Properties().Handle()))
     return;
@@ -436,19 +530,18 @@ void CompositionRootView::ShowInstanceLoading() noexcept {
       winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
           m_context.Properties().Handle());
 
-  auto brush = compContext.CreateColorBrush({0x80, 0x03, 0x29, 0x29});
+  auto drawingSurface = CreateLoadingVisualBrush();
+
   m_loadingVisual = compContext.CreateSpriteVisual();
-  m_loadingVisual.RelativeSizeWithOffset({0.0f, 50.0f}, {1.0f, 0.0f});
-  m_loadingVisual.Offset({0.0f, -25.0f, 0.0f}, {0.0f, 0.5f, 0.0f});
-  m_loadingVisual.Brush(brush);
+  m_loadingVisual.Brush(drawingSurface);
 
   auto foregroundBrush = compContext.CreateColorBrush({255, 255, 255, 255});
 
-  auto activity = compContext.CreateActivityVisual();
-  activity.Size(15.0f);
-  activity.Brush(foregroundBrush);
-  activity.Offset({-50.0f, 5.0f, 0.0f}, {0.5f, 0.0f, 0.0f});
-  m_loadingVisual.InsertAt(activity, 0);
+  m_loadingActivityVisual = compContext.CreateActivityVisual();
+  m_loadingActivityVisual.Brush(foregroundBrush);
+  m_loadingVisual.InsertAt(m_loadingActivityVisual, 0);
+
+  UpdateLoadingVisualSize();
 
   RootVisual().InsertAt(m_loadingVisual, m_hasRenderedVisual ? 1 : 0);
 }
@@ -523,7 +616,6 @@ winrt::Microsoft::UI::Content::ContentIsland CompositionRootView::Island() noexc
 
   if (!m_island) {
     auto rootVisual = m_compositor.CreateSpriteVisual();
-    rootVisual.RelativeSizeAdjustment({1, 1});
 
     RootVisual(winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::CreateVisual(rootVisual));
     m_island = winrt::Microsoft::UI::Content::ContentIsland::Create(rootVisual);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -127,6 +127,7 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   std::shared_ptr<::Microsoft::ReactNative::CompositionEventHandler> m_CompositionEventHandler;
   winrt::Microsoft::ReactNative::Composition::IVisual m_rootVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_loadingVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::IActivityVisual m_loadingActivityVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme m_theme{nullptr};
   winrt::Microsoft::ReactNative::ReactNotificationSubscription m_themeChangedSubscription{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme::ThemeChanged_revoker m_themeChangedRevoker;
@@ -137,6 +138,9 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   void ShowInstanceLoaded() noexcept;
   void ShowInstanceError() noexcept;
   void ShowInstanceLoading() noexcept;
+  void UpdateRootVisualSize() noexcept;
+  void UpdateLoadingVisualSize() noexcept;
+  Composition::IDrawingSurfaceBrush CreateLoadingVisualBrush() noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -14,6 +14,7 @@
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include "CompositionDynamicAutomationProvider.h"
 #include "CompositionHelpers.h"
+#include "TextDrawing.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
@@ -316,174 +317,22 @@ void ParagraphComponentView::DrawText() noexcept {
       d2dDeviceContext->Clear(
           m_props->backgroundColor ? theme()->D2DColor(*m_props->backgroundColor)
                                    : D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
-      assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-      const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
-      float oldDpiX, oldDpiY;
-      d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-      d2dDeviceContext->SetDpi(dpi, dpi);
-
-      float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
-      float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);
 
       const auto &paragraphProps = *std::static_pointer_cast<const facebook::react::ParagraphProps>(m_props);
 
-      // Create a solid color brush for the text. A more sophisticated application might want
-      // to cache and reuse a brush across all text elements instead, taking care to recreate
-      // it in the event of device removed.
-      winrt::com_ptr<ID2D1SolidColorBrush> brush;
-      if (paragraphProps.textAttributes.foregroundColor) {
-        auto color = theme()->D2DColor(*paragraphProps.textAttributes.foregroundColor);
-        winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(color, brush.put()));
-      } else {
-        winrt::check_hresult(
-            d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black, 1.0f), brush.put()));
-      }
-
-      if (paragraphProps.textAttributes.textDecorationLineType) {
-        DWRITE_TEXT_RANGE range = {0, std::numeric_limits<uint32_t>::max()};
-        if (*(paragraphProps.textAttributes.textDecorationLineType) ==
-                facebook::react::TextDecorationLineType::Underline ||
-            *(paragraphProps.textAttributes.textDecorationLineType) ==
-                facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
-          m_textLayout->SetUnderline(true, range);
-        } else {
-          m_textLayout->SetUnderline(false, range);
-        }
-      }
-
-      if (paragraphProps.textAttributes.textDecorationLineType) {
-        DWRITE_TEXT_RANGE range = {0, std::numeric_limits<uint32_t>::max()};
-        if (*(paragraphProps.textAttributes.textDecorationLineType) ==
-                facebook::react::TextDecorationLineType::Strikethrough ||
-            *(paragraphProps.textAttributes.textDecorationLineType) ==
-                facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
-          m_textLayout->SetStrikethrough(true, range);
-        } else {
-          m_textLayout->SetStrikethrough(false, range);
-        }
-      }
+      RenderText(
+          *d2dDeviceContext,
+          *m_textLayout,
+          m_attributedStringBox.getValue(),
+          paragraphProps.textAttributes,
+          {static_cast<float>(offset.x) + m_layoutMetrics.contentInsets.left,
+           static_cast<float>(offset.y) + m_layoutMetrics.contentInsets.top},
+          m_layoutMetrics.pointScaleFactor,
+          *theme());
 
       if (!isnan(paragraphProps.opacity)) {
         m_visual.Opacity(paragraphProps.opacity);
       }
-
-      // Create color effects for individual text fragments.
-      unsigned int position = 0;
-      unsigned int length = 0;
-      for (auto fragment : m_attributedStringBox.getValue().getFragments()) {
-        length = static_cast<UINT32>(fragment.string.length());
-        DWRITE_TEXT_RANGE range = {position, length};
-        if (fragment.textAttributes.foregroundColor &&
-                (fragment.textAttributes.foregroundColor != paragraphProps.textAttributes.foregroundColor) ||
-            !isnan(fragment.textAttributes.opacity)) {
-          winrt::com_ptr<ID2D1SolidColorBrush> fragmentBrush;
-          if (fragment.textAttributes.foregroundColor) {
-            auto color = theme()->D2DColor(*fragment.textAttributes.foregroundColor);
-            winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(color, fragmentBrush.put()));
-          } else {
-            winrt::check_hresult(
-                d2dDeviceContext->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black, 1.0f), fragmentBrush.put()));
-          }
-
-          if (fragment.textAttributes.textDecorationLineType) {
-            if (*(fragment.textAttributes.textDecorationLineType) ==
-                    facebook::react::TextDecorationLineType::Underline ||
-                *(fragment.textAttributes.textDecorationLineType) ==
-                    facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
-              m_textLayout->SetUnderline(true, range);
-            } else {
-              m_textLayout->SetUnderline(false, range);
-            }
-          }
-
-          if (fragment.textAttributes.textDecorationLineType) {
-            if (*(fragment.textAttributes.textDecorationLineType) ==
-                    facebook::react::TextDecorationLineType::Strikethrough ||
-                *(fragment.textAttributes.textDecorationLineType) ==
-                    facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
-              m_textLayout->SetStrikethrough(true, range);
-            } else {
-              m_textLayout->SetStrikethrough(false, range);
-            }
-          }
-
-          if (!isnan(fragment.textAttributes.opacity)) {
-            fragmentBrush->SetOpacity(fragment.textAttributes.opacity);
-          }
-          m_textLayout->SetDrawingEffect(fragmentBrush.get(), range);
-
-          // DWrite doesn't handle background highlight colors, so we manually draw the background color for ranges
-          if (facebook::react::isColorMeaningful(fragment.textAttributes.backgroundColor)) {
-            UINT32 actualHitTestCount = 0;
-            if (range.length > 0) {
-              m_textLayout->HitTestTextRange(
-                  range.startPosition,
-                  range.length,
-                  0, // x
-                  0, // y
-                  NULL,
-                  0, // metrics count
-                  &actualHitTestCount);
-            }
-
-            // Allocate enough room to return all hit-test metrics.
-            std::vector<DWRITE_HIT_TEST_METRICS> hitTestMetrics(actualHitTestCount);
-            if (range.length > 0) {
-              m_textLayout->HitTestTextRange(
-                  range.startPosition,
-                  range.length,
-                  0, // x
-                  0, // y
-                  &hitTestMetrics[0],
-                  static_cast<UINT32>(hitTestMetrics.size()),
-                  &actualHitTestCount);
-            }
-
-            // Draw the selection ranges behind the text.
-            if (actualHitTestCount > 0) {
-              // Note that an ideal layout will return fractional values,
-              // so you may see slivers between the selection ranges due
-              // to the per-primitive anti-aliasing of the edges unless
-              // it is disabled (better for performance anyway).
-              auto oldAliasMode = d2dDeviceContext->GetAntialiasMode();
-              d2dDeviceContext->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
-
-              winrt::com_ptr<ID2D1SolidColorBrush> textHighlightBrush;
-              winrt::check_hresult(d2dDeviceContext->CreateSolidColorBrush(
-                  theme()->D2DColor(*fragment.textAttributes.backgroundColor), textHighlightBrush.put()));
-
-              for (size_t i = 0; i < actualHitTestCount; ++i) {
-                const DWRITE_HIT_TEST_METRICS &htm = hitTestMetrics[i];
-
-                const D2D1_RECT_F rect = {
-                    std::round(htm.left + offsetX),
-                    std::round(htm.top + offsetY),
-                    std::round(htm.left + htm.width + offsetX),
-                    std::round(htm.top + htm.height + offsetY)};
-
-                d2dDeviceContext->FillRectangle(rect, textHighlightBrush.get());
-              }
-              d2dDeviceContext->SetAntialiasMode(oldAliasMode);
-            }
-          }
-        }
-
-        position += length;
-      }
-
-      // Draw the line of text at the specified offset, which corresponds to the top-left
-      // corner of our drawing surface. Notice we don't call BeginDraw on the D2D device
-      // context; this has already been done for us by the composition API.
-      d2dDeviceContext->DrawTextLayout(
-          D2D1::Point2F(
-              static_cast<FLOAT>((offset.x + m_layoutMetrics.contentInsets.left) / m_layoutMetrics.pointScaleFactor),
-              static_cast<FLOAT>((offset.y + m_layoutMetrics.contentInsets.top) / m_layoutMetrics.pointScaleFactor)),
-          m_textLayout.get(),
-          brush.get(),
-          D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
-
-      // restore dpi to old state
-      d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);
     }
     m_requireRedraw = false;
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.cpp
@@ -1,0 +1,179 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "TextDrawing.h"
+
+#include <AutoDraw.h>
+#include <Utils/ValueUtils.h>
+#include <unicode.h>
+#include <windows.ui.composition.interop.h>
+#include <winrt/Microsoft.ReactNative.Composition.h>
+#include "CompositionHelpers.h"
+
+namespace winrt::Microsoft::ReactNative::Composition {
+
+void RenderText(
+    ID2D1DeviceContext &deviceContext,
+    ::IDWriteTextLayout &textLayout,
+    const facebook::react::AttributedString &attributedString,
+    const facebook::react::TextAttributes &textAttributes,
+    facebook::react::Point offset,
+    float pointScaleFactor,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme &theme) noexcept {
+  float offsetX = offset.x / pointScaleFactor;
+  float offsetY = offset.y / pointScaleFactor;
+
+  assert(deviceContext.GetUnitMode() == D2D1_UNIT_MODE_DIPS);
+  const auto dpi = pointScaleFactor * 96.0f;
+  float oldDpiX, oldDpiY;
+  deviceContext.GetDpi(&oldDpiX, &oldDpiY);
+  deviceContext.SetDpi(dpi, dpi);
+
+  // Create a solid color brush for the text. A more sophisticated application might want
+  // to cache and reuse a brush across all text elements instead, taking care to recreate
+  // it in the event of device removed.
+  winrt::com_ptr<ID2D1SolidColorBrush> brush;
+  if (textAttributes.foregroundColor) {
+    auto color = theme.D2DColor(*textAttributes.foregroundColor);
+    winrt::check_hresult(deviceContext.CreateSolidColorBrush(color, brush.put()));
+  } else {
+    winrt::check_hresult(deviceContext.CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black, 1.0f), brush.put()));
+  }
+
+  if (textAttributes.textDecorationLineType) {
+    DWRITE_TEXT_RANGE range = {0, std::numeric_limits<uint32_t>::max()};
+    if (*(textAttributes.textDecorationLineType) == facebook::react::TextDecorationLineType::Underline ||
+        *(textAttributes.textDecorationLineType) == facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+      textLayout.SetUnderline(true, range);
+    } else {
+      textLayout.SetUnderline(false, range);
+    }
+  }
+
+  if (textAttributes.textDecorationLineType) {
+    DWRITE_TEXT_RANGE range = {0, std::numeric_limits<uint32_t>::max()};
+    if (*(textAttributes.textDecorationLineType) == facebook::react::TextDecorationLineType::Strikethrough ||
+        *(textAttributes.textDecorationLineType) == facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+      textLayout.SetStrikethrough(true, range);
+    } else {
+      textLayout.SetStrikethrough(false, range);
+    }
+  }
+
+  // Create color effects for individual text fragments.
+  unsigned int position = 0;
+  unsigned int length = 0;
+  for (auto fragment : attributedString.getFragments()) {
+    length = static_cast<UINT32>(fragment.string.length());
+    DWRITE_TEXT_RANGE range = {position, length};
+    if (fragment.textAttributes.foregroundColor &&
+            (fragment.textAttributes.foregroundColor != textAttributes.foregroundColor) ||
+        !isnan(fragment.textAttributes.opacity)) {
+      winrt::com_ptr<ID2D1SolidColorBrush> fragmentBrush;
+      if (fragment.textAttributes.foregroundColor) {
+        auto color = theme.D2DColor(*fragment.textAttributes.foregroundColor);
+        winrt::check_hresult(deviceContext.CreateSolidColorBrush(color, fragmentBrush.put()));
+      } else {
+        winrt::check_hresult(
+            deviceContext.CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black, 1.0f), fragmentBrush.put()));
+      }
+
+      if (fragment.textAttributes.textDecorationLineType) {
+        if (*(fragment.textAttributes.textDecorationLineType) == facebook::react::TextDecorationLineType::Underline ||
+            *(fragment.textAttributes.textDecorationLineType) ==
+                facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+          textLayout.SetUnderline(true, range);
+        } else {
+          textLayout.SetUnderline(false, range);
+        }
+      }
+
+      if (fragment.textAttributes.textDecorationLineType) {
+        if (*(fragment.textAttributes.textDecorationLineType) ==
+                facebook::react::TextDecorationLineType::Strikethrough ||
+            *(fragment.textAttributes.textDecorationLineType) ==
+                facebook::react::TextDecorationLineType::UnderlineStrikethrough) {
+          textLayout.SetStrikethrough(true, range);
+        } else {
+          textLayout.SetStrikethrough(false, range);
+        }
+      }
+
+      if (!isnan(fragment.textAttributes.opacity)) {
+        fragmentBrush->SetOpacity(fragment.textAttributes.opacity);
+      }
+      textLayout.SetDrawingEffect(fragmentBrush.get(), range);
+
+      // DWrite doesn't handle background highlight colors, so we manually draw the background color for ranges
+      if (facebook::react::isColorMeaningful(fragment.textAttributes.backgroundColor)) {
+        UINT32 actualHitTestCount = 0;
+        if (range.length > 0) {
+          textLayout.HitTestTextRange(
+              range.startPosition,
+              range.length,
+              0, // x
+              0, // y
+              NULL,
+              0, // metrics count
+              &actualHitTestCount);
+        }
+
+        // Allocate enough room to return all hit-test metrics.
+        std::vector<DWRITE_HIT_TEST_METRICS> hitTestMetrics(actualHitTestCount);
+        if (range.length > 0) {
+          textLayout.HitTestTextRange(
+              range.startPosition,
+              range.length,
+              0, // x
+              0, // y
+              &hitTestMetrics[0],
+              static_cast<UINT32>(hitTestMetrics.size()),
+              &actualHitTestCount);
+        }
+
+        // Draw the selection ranges behind the text.
+        if (actualHitTestCount > 0) {
+          // Note that an ideal layout will return fractional values,
+          // so you may see slivers between the selection ranges due
+          // to the per-primitive anti-aliasing of the edges unless
+          // it is disabled (better for performance anyway).
+          auto oldAliasMode = deviceContext.GetAntialiasMode();
+          deviceContext.SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
+
+          winrt::com_ptr<ID2D1SolidColorBrush> textHighlightBrush;
+          winrt::check_hresult(deviceContext.CreateSolidColorBrush(
+              theme.D2DColor(*fragment.textAttributes.backgroundColor), textHighlightBrush.put()));
+
+          for (size_t i = 0; i < actualHitTestCount; ++i) {
+            const DWRITE_HIT_TEST_METRICS &htm = hitTestMetrics[i];
+
+            const D2D1_RECT_F rect = {
+                std::round(htm.left + offsetX),
+                std::round(htm.top + offsetY),
+                std::round(htm.left + htm.width + offsetX),
+                std::round(htm.top + htm.height + offsetY)};
+
+            deviceContext.FillRectangle(rect, textHighlightBrush.get());
+          }
+          deviceContext.SetAntialiasMode(oldAliasMode);
+        }
+      }
+    }
+
+    position += length;
+  }
+
+  // Draw the line of text at the specified offset, which corresponds to the top-left
+  // corner of our drawing surface. Notice we don't call BeginDraw on the D2D device
+  // context; this has already been done for us by the composition API.
+  deviceContext.DrawTextLayout(
+      D2D1::Point2F(offsetX, offsetY), &textLayout, brush.get(), D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
+
+  // restore dpi to old state
+  deviceContext.SetDpi(oldDpiX, oldDpiY);
+}
+
+} // namespace winrt::Microsoft::ReactNative::Composition

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextDrawing.h
@@ -1,0 +1,25 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <Fabric/Composition/Theme.h>
+#include <d2d1_1.h>
+#include <dwrite.h>
+#include <react/renderer/attributedstring/AttributedString.h>
+#include <winrt/Windows.UI.Composition.h>
+#include "CompositionHelpers.h"
+
+namespace winrt::Microsoft::ReactNative::Composition {
+
+void RenderText(
+    ID2D1DeviceContext &deviceContext,
+    ::IDWriteTextLayout &textLayout,
+    const facebook::react::AttributedString &attributedString,
+    const facebook::react::TextAttributes &textAttributes,
+    facebook::react::Point offset,
+    float pointScaleFactor,
+    winrt::Microsoft::ReactNative::Composition::implementation::Theme &theme) noexcept;
+
+} // namespace winrt::Microsoft::ReactNative::Composition

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -138,6 +138,9 @@
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\TextDrawing.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UiaHelpers.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>


### PR DESCRIPTION
Extract RenderText to a shared function, to allow easier text rendering in places other than ParagraphComponentView.

Fixed up some scaling issues in CompositionRootView's loading UI.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12866)