### PR TITLE
[Fabric] Fix hang on shutdown when JS instance failed to start

### DIFF
--- a/change/react-native-windows-ded8504d-7e64-46ef-9c94-474b8b0b7c61.json
+++ b/change/react-native-windows-ded8504d-7e64-46ef-9c94-474b8b0b7c61.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[Fabric] Fix hang on shutdown when JS instance failed to start",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -363,7 +363,7 @@ struct AutoMRE {
   ~AutoMRE() {
     mre->Set();
   }
-  std::shared_ptr<Mso::ManualResetEvent> mre;
+  Mso::ManualResetEvent mre;
 };
 
 void CompositionRootView::UninitRootView() noexcept {
@@ -384,9 +384,9 @@ void CompositionRootView::UninitRootView() noexcept {
     // method should return a Promise, which should be resolved when the JS logic is complete.
     // The task will auto set the event on destruction to ensure that the event is set if the JS Queue has already been
     // shutdown
-    auto mre = std::make_shared<Mso::ManualResetEvent>();
+    Mso::ManualResetEvent mre;
     m_context.JSDispatcher().Post([autoMRE = std::make_shared<AutoMRE>(AutoMRE{mre})]() {});
-    mre->Wait();
+    mre.Wait();
 
     // Paper version gives the JS thread time to finish executing - Is this needed?
     // m_jsMessageThread.Load()->runOnQueueSync([]() {});

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -385,7 +385,7 @@ void CompositionRootView::UninitRootView() noexcept {
     // The task will auto set the event on destruction to ensure that the event is set if the JS Queue has already been
     // shutdown
     Mso::ManualResetEvent mre;
-    m_context.JSDispatcher().Post([autoMRE = std::make_shared<AutoMRE>(AutoMRE{mre})]() {});
+    m_context.JSDispatcher().Post([autoMRE = std::make_unique<AutoMRE>(AutoMRE{mre})]() {});
     mre.Wait();
 
     // Paper version gives the JS thread time to finish executing - Is this needed?

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -361,7 +361,7 @@ void CompositionRootView::UpdateRootViewInternal() noexcept {
 
 struct AutoMRE {
   ~AutoMRE() {
-    mre->Set();
+    mre.Set();
   }
   Mso::ManualResetEvent mre;
 };


### PR DESCRIPTION
`CompositionRootView::UninitRootView` will currently deadlock if the JS Queue has already been shut down as it requires a task on the JS queue to run before it will continue.

This change modifies the task to set the event being waited on when the task is destroyed.  This means that if the JS queue has already been shut down, the task will be released and `UninitRootView` will continue to run.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12867)