### PR TITLE
Release render target before calling enddraw

### DIFF
--- a/change/react-native-windows-08dee799-0260-4d56-bdca-ad1deebab3bb.json
+++ b/change/react-native-windows-08dee799-0260-4d56-bdca-ad1deebab3bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Release render target before calling enddraw",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -554,6 +554,7 @@ struct AutoDrawHelper {
   }
 
   ~AutoDrawHelper() {
+    m_pRT = nullptr;
     m_surface->EndDraw();
   }
 


### PR DESCRIPTION
## Description
Office's implementation of DrawingSurface has some validation that all references to the RenderTarget are released before EndDraw is called to ensure that no-one draws to the surface outside of the draw.  The AutoDrawHelper should release its ref for similar reasons.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12881)