### PR TITLE
Use std:: coroutines for compatibility with C++20 and Clang 17

### DIFF
--- a/change/react-native-windows-7a71f7ee-8200-414f-a2a3-21c273419000.json
+++ b/change/react-native-windows-7a71f7ee-8200-414f-a2a3-21c273419000.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Use std:: coroutines for compatibility with C++20 and Clang 17",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -64,10 +64,8 @@ auto resume_in_queue(const Mso::DispatchQueue &queue) noexcept {
 
     void await_resume() const noexcept {}
 
-    void await_suspend(std::experimental::coroutine_handle<> resume) noexcept {
-      m_callback = [context = resume.address()]() noexcept {
-        std::experimental::coroutine_handle<>::from_address(context)();
-      };
+    void await_suspend(winrt::impl::coroutine_handle<> resume) noexcept {
+      m_callback = [context = resume.address()]() noexcept { winrt::impl::coroutine_handle<>::from_address(context)(); };
       m_queue.Post(std::move(m_callback));
     }
 

--- a/vnext/Shared/Networking/WinRTWebSocketResource.cpp
+++ b/vnext/Shared/Networking/WinRTWebSocketResource.cpp
@@ -65,7 +65,9 @@ auto resume_in_queue(const Mso::DispatchQueue &queue) noexcept {
     void await_resume() const noexcept {}
 
     void await_suspend(winrt::impl::coroutine_handle<> resume) noexcept {
-      m_callback = [context = resume.address()]() noexcept { winrt::impl::coroutine_handle<>::from_address(context)(); };
+      m_callback = [context = resume.address()]() noexcept {
+        winrt::impl::coroutine_handle<>::from_address(context)();
+      };
       m_queue.Post(std::move(m_callback));
     }
 

--- a/vnext/Shared/Utils/CppWinrtLessExceptions.h
+++ b/vnext/Shared/Utils/CppWinrtLessExceptions.h
@@ -35,7 +35,7 @@ struct lessthrow_await_adapter {
     return async.Status() == winrt::Windows::Foundation::AsyncStatus::Completed;
   }
 
-  void await_suspend(std::experimental::coroutine_handle<> handle) const {
+  void await_suspend(winrt::impl::coroutine_handle<> handle) const {
     auto context = winrt::capture<winrt::impl::IContextCallback>(WINRT_IMPL_CoGetObjectContext);
 
     async.Completed([handle, context = std::move(context)](auto const &, winrt::Windows::Foundation::AsyncStatus) {
@@ -43,7 +43,7 @@ struct lessthrow_await_adapter {
       args.data = handle.address();
 
       auto callback = [](winrt::impl::com_callback_args *args) noexcept -> int32_t {
-        std::experimental::coroutine_handle<>::from_address(args->data)();
+        winrt::impl::coroutine_handle<>::from_address(args->data)();
         return S_OK;
       };
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
Newer versions of Clang do not support mixing C++20 and std::experimental coroutines. In such cases, we should prefer the coroutine types declared in the std:: namespace.

## Testing
Wait for CI tests.

## Changelog
Should this change be included in the release notes: _no_
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12887)