### PR TITLE
Remove previous SizeChanged event listener when reloading the app

### DIFF
--- a/change/react-native-windows-5b3a6677-59a2-42c3-bd99-e6867b16abb8.json
+++ b/change/react-native-windows-5b3a6677-59a2-42c3-bd99-e6867b16abb8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove previous SizeChanged event listener when reloading the app",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.cpp
@@ -234,15 +234,18 @@ void NativeUIManager::AddRootView(ShadowNode &shadowNode, facebook::react::IReac
   Microsoft::ReactNative::SetTag(element, rootTag);
 
   // Add listener to size change so we can redo the layout when that happens
-  m_sizeChangedVector.push_back(view.as<xaml::FrameworkElement>().SizeChanged(
-      winrt::auto_revoke, [this, rootTag](auto &&, xaml::SizeChangedEventArgs const &args) {
-        ApplyLayout(rootTag, args.NewSize().Width, args.NewSize().Height);
-      }));
+  m_sizeChangedMap.insert(
+      {rootTag,
+       view.as<xaml::FrameworkElement>().SizeChanged(
+           winrt::auto_revoke, [this, rootTag](auto &&, xaml::SizeChangedEventArgs const &args) {
+             ApplyLayout(rootTag, args.NewSize().Width, args.NewSize().Height);
+           })});
 }
 
 void NativeUIManager::removeRootView(Microsoft::ReactNative::ShadowNode &shadow) {
   SystraceSection s("NativeUIManager::removeRootView");
   m_tagsToXamlReactControl.erase(shadow.m_tag);
+  m_sizeChangedMap.erase(shadow.m_tag);
   RemoveView(shadow, true);
 }
 

--- a/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
+++ b/vnext/Microsoft.ReactNative/Modules/NativeUIManager.h
@@ -118,7 +118,7 @@ class NativeUIManager final : public INativeUIManager {
 
   std::unordered_map<int64_t, YogaNodePtr> m_tagsToYogaNodes;
   std::unordered_map<int64_t, std::unique_ptr<YogaContext>> m_tagsToYogaContext;
-  std::vector<xaml::FrameworkElement::SizeChanged_revoker> m_sizeChangedVector;
+  std::unordered_map<int64_t, xaml::FrameworkElement::SizeChanged_revoker> m_sizeChangedMap;
   std::vector<std::function<void()>> m_batchCompletedCallbacks;
   std::vector<int64_t> m_extraLayoutNodes;
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
After a dev reload, the ReactRootView is assigned a new root tag. We never evicted the old auto revoker from the m_sizeChangedVector when this occurred, and could lead to attempts to do layout on a stale root tag. This fixes the issue, moving the SizeChanged event revoker data structure to a map, and evicting the listener for the root tag when it is removed.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12888)