### PR TITLE
Clang portable header fix

### DIFF
--- a/change/react-native-windows-05eb8fa4-a08c-474c-8b2d-bdb4f6fc9f6e.json
+++ b/change/react-native-windows-05eb8fa4-a08c-474c-8b2d-bdb4f6fc9f6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Clang portable header fix",
+  "packageName": "react-native-windows",
+  "email": "ericroz@meta.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Base/FollyIncludes.h
+++ b/vnext/Microsoft.ReactNative/Base/FollyIncludes.h
@@ -17,7 +17,7 @@
 
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
-#include <folly/container/detail/F14table.h>
+#include <folly/container/detail/F14Table.h>
 #pragma warning(pop)
 
 #include <folly/Memory.h>


### PR DESCRIPTION

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)

### Why
Clang warns when case sensitivity for header names is not met. This fixes up one of those cases in FollyIncludes.h

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12889)