### PR TITLE
Add builds and nugets for MS.RN Fabric

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -19,10 +19,6 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x64
             UseFabric: false
-          - Name: X64DebugFabric
-            BuildConfiguration: Debug
-            BuildPlatform: x64
-            UseFabric: true
           - Name: X64Release
             BuildConfiguration: Release
             BuildPlatform: x64
@@ -31,6 +27,10 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x86
             UseFabric: false
+          - Name: X64DebugFabric
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            UseFabric: true
       - BuildEnvironment: SecurePullRequest
         Matrix:
           - Name: X64DebugFabric
@@ -48,16 +48,20 @@ parameters:
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
           - Name: Arm64Debug
             BuildConfiguration: Debug
             BuildPlatform: ARM64
           - Name: Arm64Release
             BuildConfiguration: Release
             BuildPlatform: ARM64
-          - Name: X86Release
-            BuildConfiguration: Release
-            BuildPlatform: x86
-          - X86ReleaseFabric:
+          - Name: X64DebugFabric
+            BuildConfiguration: Debug
+            BuildPlatform: x64
+            UseFabric: true
+          - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
             BuildConfiguration: Release
             BuildPlatform: x86
             UseFabric: true

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -107,7 +107,10 @@
                 - template: ../templates/msbuild-sln.yml
                   parameters:
                     solutionDir: vnext
-                    solutionName: Microsoft.ReactNative.sln
+                    ${{ if eq(matrix.UseFabric, true) }}:
+                      solutionName: Microsoft.ReactNative.CppOnly.slnf
+                    ${{ else }}:
+                      solutionName: Microsoft.ReactNative.sln
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
 
@@ -271,7 +274,7 @@
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
                     failOnMinTestsNotRun: true
-                  condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')))
+                  condition: and(succeeded(), not(eq('${{ matrix.BuildPlatform }}', 'ARM64')), eq('${{ matrix.UseFabric }}', 'false'))
 
                 - task: VSTest@2
                   displayName: Run Universal Unit Tests (NetCore)
@@ -289,4 +292,4 @@
                     collectDumpOn: onAbortOnly
                     vsTestVersion: latest
                     failOnMinTestsNotRun: true
-                  condition: and(succeeded(), eq('${{ matrix.BuildPlatform }}', 'x64'))
+                  condition: and(succeeded(), eq('${{ matrix.BuildPlatform }}', 'x64'), eq('${{ matrix.UseFabric }}', 'false'))

--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -13,40 +13,70 @@
       default:
         - BuildEnvironment: PullRequest
           Matrix:
-            - Name: X64Release
-              BuildConfiguration: Release
-              BuildPlatform: x64
-            - Name: X86Debug
-              BuildConfiguration: Debug
-              BuildPlatform: x86
-              CreateApiDocs: true
-        - BuildEnvironment: Continuous
-          Matrix:
-            - Name: Arm64Debug
-              BuildConfiguration: Debug
-              BuildPlatform: ARM64
-            - Name: Arm64Release
-              BuildConfiguration: Release
-              BuildPlatform: ARM64
             - Name: X64Debug
               BuildConfiguration: Debug
               BuildPlatform: x64
+              UseFabric: false
             - Name: X64Release
               BuildConfiguration: Release
               BuildPlatform: x64
+              UseFabric: false
             - Name: X86Debug
               BuildConfiguration: Debug
               BuildPlatform: x86
+              UseFabric: false
+              CreateApiDocs: true
+            - Name: X64DebugFabric
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              UseFabric: true
+        - BuildEnvironment: SecurePullRequest
+          Matrix:
+            - Name: X64DebugFabric
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              UseFabric: true
+        - BuildEnvironment: Continuous
+          Matrix:
+            - Name: X64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              UseFabric: false
+            - Name: X64Release
+              BuildConfiguration: Release
+              BuildPlatform: x64
+              UseFabric: false
+            - Name: X86Debug
+              BuildConfiguration: Debug
+              BuildPlatform: x86
+              UseFabric: false
               CreateApiDocs: true
             - Name: X86Release
               BuildConfiguration: Release
               BuildPlatform: x86
+              UseFabric: false
+            - Name: Arm64Debug
+              BuildConfiguration: Debug
+              BuildPlatform: ARM64
+              UseFabric: false
+            - Name: Arm64Release
+              BuildConfiguration: Release
+              BuildPlatform: ARM64
+              UseFabric: false
+            - Name: X64DebugFabric
+              BuildConfiguration: Debug
+              BuildPlatform: x64
+              UseFabric: true
+            - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
+              BuildConfiguration: Release
+              BuildPlatform: x86
+              UseFabric: true
 
   jobs:
     - ${{ each config in parameters.buildMatrix }}:
       - ${{ if eq(config.BuildEnvironment, parameters.buildEnvironment) }}:
         - ${{ each matrix in config.Matrix }}:
-            - job: UniversalBuild${{ matrix.BuildPlatform }}${{ matrix.BuildConfiguration }}
+            - job: UniversalBuild${{ matrix.Name }}
               variables:
                 - template: ../variables/windows.yml
                 # Some tasks run on a different user (VssAdministrator) instead of the default user (AzDevOps).
@@ -70,6 +100,9 @@
                     buildEnvironment: ${{ config.BuildEnvironment }}
 
                 - template: ../templates/apply-published-version-vars.yml
+
+                - ${{ if eq(matrix.UseFabric, true) }}:
+                  - template: ../templates/enable-fabric-experimental-feature.yml
 
                 - template: ../templates/msbuild-sln.yml
                   parameters:
@@ -102,7 +135,10 @@
 
                 - template: ../templates/publish-build-artifacts.yml
                   parameters:
-                    artifactName: ReactWindows
+                    ${{ if eq(matrix.UseFabric, true) }}:
+                      artifactName: ReactWindowsFabric
+                    ${{ else }}:
+                      artifactName: ReactWindows
                     buildPlatform: ${{ matrix.BuildPlatform }}
                     buildConfiguration: ${{ matrix.BuildConfiguration }}
                     contents: |

--- a/.ado/publish.yml
+++ b/.ado/publish.yml
@@ -275,21 +275,51 @@ extends:
               X64Release:
                 BuildConfiguration: Release
                 BuildPlatform: x64
+                UseFabric: false
               X86Release:
                 BuildConfiguration: Release
                 BuildPlatform: x86
+                UseFabric: false
               Arm64Release:
                 BuildConfiguration: Release
                 BuildPlatform: ARM64
+                UseFabric: false
               X64Debug:
                 BuildConfiguration: Debug
                 BuildPlatform: x64
+                UseFabric: false
               X86Debug:
                 BuildConfiguration: Debug
                 BuildPlatform: x86
+                UseFabric: false
               Arm64Debug:
                 BuildConfiguration: Debug
-                BuildPlatform: ARM64          
+                BuildPlatform: ARM64Debug
+                UseFabric: false
+              X64ReleaseFabric:
+                BuildConfiguration: Release
+                BuildPlatform: x64
+                UseFabric: true
+              X86ReleaseFabric:
+                BuildConfiguration: Release
+                BuildPlatform: x86
+                UseFabric: true
+              Arm64ReleaseFabric:
+                BuildConfiguration: Release
+                BuildPlatform: ARM64
+                UseFabric: true
+              X64DebugFabric:
+                BuildConfiguration: Debug
+                BuildPlatform: x64
+                UseFabric: true
+              X86DebugFabric:
+                BuildConfiguration: Debug
+                BuildPlatform: x86
+                UseFabric: true
+              Arm64DebugFabric:
+                BuildConfiguration: Debug
+                BuildPlatform: ARM64
+                UseFabric: true
           pool: ${{ parameters.AgentPool.Large }}
           timeoutInMinutes: 360 # CodeQL requires 3x usual build timeout
 
@@ -303,6 +333,9 @@ extends:
               buildEnvironment: Publish
 
           - template: .ado/templates/apply-published-version-vars.yml@self
+
+          - ${{ if eq(matrix.UseFabric, true) }}:
+            - template: .ado/templates/enable-fabric-experimental-feature.yml@self
 
           - template: .ado/templates/msbuild-sln.yml@self
             parameters:
@@ -321,7 +354,10 @@ extends:
           - template: .ado/templates/publish-build-artifacts.yml@self
             parameters:
               oneESMode: true ## Files are only copied to staging, not published
-              artifactName: ReactWindows
+              ${{ if eq(matrix.UseFabric, true) }}:
+                artifactName: ReactWindowsFabric
+              ${{ if eq(matrix.UseFabric, false) }}:
+                artifactName: ReactWindows
               buildPlatform: $(BuildPlatform)
               buildConfiguration: $(BuildConfiguration)
               contents: |
@@ -354,9 +390,14 @@ extends:
               targetPath: '$(CrashDumpRootPath)'
               artifactName: Crash dumps - $(Agent.JobName)-$(System.JobAttempt)
             - output: pipelineArtifact
-              displayName: 'Publish Artifact: ReactWindows.$(BuildPlatform).$(BuildConfiguration)'
-              artifactName: ReactWindows.$(BuildPlatform).$(BuildConfiguration)
-              targetPath: $(Build.StagingDirectory)/NuGet/ReactWindows/$(BuildPlatform)/$(BuildConfiguration)
+              ${{ if eq(matrix.UseFabric, true) }}:
+                displayName: 'Publish Artifact: ReactWindowsFabric.$(BuildPlatform).$(BuildConfiguration)'
+                artifactName: ReactWindowsFabric.$(BuildPlatform).$(BuildConfiguration)
+                targetPath: $(Build.StagingDirectory)/NuGet/ReactWindowsFabric/$(BuildPlatform)/$(BuildConfiguration)
+              ${{ if eq(matrix.UseFabric, false) }}:
+                displayName: 'Publish Artifact: ReactWindows.$(BuildPlatform).$(BuildConfiguration)'
+                artifactName: ReactWindows.$(BuildPlatform).$(BuildConfiguration)
+                targetPath: $(Build.StagingDirectory)/NuGet/ReactWindows/$(BuildPlatform)/$(BuildConfiguration)
 
         - job: RNWNuget
           dependsOn:
@@ -390,6 +431,32 @@ extends:
               packMicrosoftReactNativeCxx: true
               packMicrosoftReactNativeManaged: true
               packMicrosoftReactNativeManagedCodeGen: true
+              ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
+                signMicrosoft: true
+              slices:
+                - platform: x64
+                  configuration: Release
+                - platform: x86
+                  configuration: Release
+                - platform: ARM64
+                  configuration: Release  
+                - platform: x64
+                  configuration: Debug
+                - platform: x86
+                  configuration: Debug
+                - platform: ARM64
+                  configuration: Debug
+
+          - template: .ado/templates/prep-and-pack-nuget.yml@self
+            parameters:
+              artifactName: ReactWindowsFabric
+              publishCommitId: $(publishCommitId)
+              npmVersion: $(npmVersion)-Fabric
+              nugetroot: $(System.DefaultWorkingDirectory)\ReactWindows
+              packMicrosoftReactNative: true
+              packMicrosoftReactNativeCxx: true
+              # packMicrosoftReactNativeManaged: true
+              # packMicrosoftReactNativeManagedCodeGen: true
               ${{ if or(eq(variables['EnableCodesign'], 'true'), endsWith(variables['Build.SourceBranchName'], '-stable')) }}: # Sign if EnableCodeSign or on *-stable release builds
                 signMicrosoft: true
               slices:

--- a/change/react-native-windows-2054f9f3-4bfb-45c2-8c07-b7ac052b1922.json
+++ b/change/react-native-windows-2054f9f3-4bfb-45c2-8c07-b7ac052b1922.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove explicit WinUI3 Microsoft.WinUI Package Reference from Managed",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-2054f9f3-4bfb-45c2-8c07-b7ac052b1922.json
+++ b/change/react-native-windows-2054f9f3-4bfb-45c2-8c07-b7ac052b1922.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Remove explicit WinUI3 Microsoft.WinUI Package Reference from Managed",
+  "comment": "Add builds and nugets for MS.RN Fabric",
   "packageName": "react-native-windows",
   "email": "jthysell@microsoft.com",
   "dependentChangeType": "patch"

--- a/vnext/Microsoft.ReactNative.CppOnly.slnf
+++ b/vnext/Microsoft.ReactNative.CppOnly.slnf
@@ -1,0 +1,21 @@
+{
+  "solution": {
+    "path": "Microsoft.ReactNative.sln",
+    "projects": [
+      "Chakra\\Chakra.vcxitems",
+      "Common\\Common.vcxproj",
+      "Folly\\Folly.vcxproj",
+      "Microsoft.ReactNative.ComponentTests\\Microsoft.ReactNative.ComponentTests.vcxproj",
+      "Microsoft.ReactNative.Cxx.UnitTests\\Microsoft.ReactNative.Cxx.UnitTests.vcxproj",
+      "Microsoft.ReactNative.Cxx\\Microsoft.ReactNative.Cxx.vcxitems",
+      "Microsoft.ReactNative.IntegrationTests\\Microsoft.ReactNative.IntegrationTests.vcxproj",
+      "Microsoft.ReactNative\\Microsoft.ReactNative.vcxproj",
+      "Mso.UnitTests\\Mso.UnitTests.vcxproj",
+      "Mso\\Mso.vcxitems",
+      "ReactCommon\\ReactCommon.vcxproj",
+      "Shared\\Shared.vcxitems",
+      "fmt\\fmt.vcxproj",
+      "include\\Include.vcxitems"
+    ]
+  }
+}

--- a/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
+++ b/vnext/Microsoft.ReactNative.Managed/Microsoft.ReactNative.Managed.csproj
@@ -141,24 +141,15 @@
       <Version>$(NETCoreUWPVersion)</Version>
     </PackageReference>
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(EnableSourceLink)' == 'true'">
-      <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-      </ItemGroup>
-    </When>
-  </Choose>
   <!--
     Visual Studio (but not MSBuild) will ignore Conditions applied directly to
     the PackageReference or ItemGroup containing a PackageReference. Both
     respect <Choose> for conditional restoration.
     -->
   <Choose>
-    <When Condition="'$(UseWinUI3)'=='true'">
+    <When Condition="'$(EnableSourceLink)' == 'true'">
       <ItemGroup>
-        <PackageReference Include="Microsoft.WinUI">
-          <Version>$(WinUI3Version)</Version>
-        </PackageReference>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
## Description

This PR adds configurations for Microsoft.ReactNative with Fabric enabled to PR, CI, and Publish builds. This change will enable the publishing of new versions of the Microsoft.ReactNative NuGet with the `-Fabric` suffix to differentiate it from the current Paper NuGet.

This replicates the setup that Desktop has, where we create and publish versions of React Native Win32 nugets with the `-Fabric` suffix to indicate those versions are using Fabric.

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
We want the default new arch, new app / lib experience to *not* build RNW, but instead consume it via NuGets, see #12639. In order to get that started, we'll need the 

### What
Updated CI/PR/Publish configurations.

## Screenshots
N/A

## Testing
Verified new configurations fired off existing tests in PR.

## Changelog
Should this change be included in the release notes: yes

New Microsoft.ReactNative nugets with Fabric enabled
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12900)