### PR TITLE
Rework EventPhase type to avoid using TS enum

### DIFF
--- a/change/react-native-windows-34318f60-875e-4332-8268-b27e579969ca.json
+++ b/change/react-native-windows-34318f60-875e-4332-8268-b27e579969ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rework EventPhase type to avoid using TS enum",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src-win/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/vnext/src-win/Libraries/Components/View/ViewPropTypes.d.ts
@@ -167,16 +167,16 @@ export interface ViewPropsAndroid {
 
 // [Windows
 
-export enum EventPhase {
-  None = 0,
-  Capturing,
-  AtTarget,
-  Bubbling,
+export namespace EventPhase {
+  export const None = 0;
+  export const Capturing = 1;
+  export const AtTarget = 2;
+  export const Bubbling = 3;
 }
 
-export enum HandledEventPhase {
-  Capturing = EventPhase.Capturing,
-  Bubbling = EventPhase.Bubbling,
+export namespace HandledEventPhase {
+  const Capturing = EventPhase.Capturing;
+  const Bubbling = EventPhase.Bubbling;
 }
 
 export interface INativeKeyboardEvent {
@@ -186,7 +186,11 @@ export interface INativeKeyboardEvent {
   shiftKey: boolean;
   key: string;
   code: string;
-  eventPhase: EventPhase;
+  eventPhase:
+    | EventPhase.None
+    | EventPhase.Capturing
+    | EventPhase.AtTarget
+    | EventPhase.Bubbling;
 }
 
 export interface IHandledKeyboardEvent {
@@ -195,7 +199,7 @@ export interface IHandledKeyboardEvent {
   metaKey?: boolean;
   shiftKey?: boolean;
   code: string;
-  handledEventPhase?: HandledEventPhase;
+  handledEventPhase?: EventPhase.Capturing | EventPhase.Bubbling;
 }
 
 export type IKeyboardEvent = NativeSyntheticEvent<INativeKeyboardEvent>;


### PR DESCRIPTION
## Description
We should not be using TS enums to describe the types of RN.  TS enums are not a type-level extension of JavaScript.

This export aligns how we are exporting EventPhase on windows with how we are doing it on win32
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12908)