### PR TITLE
[0.73] Rework EventPhase type to avoid using TS enum

### DIFF
--- a/change/react-native-windows-ee9ce75f-9d70-4967-b60c-2d355f0c9d8e.json
+++ b/change/react-native-windows-ee9ce75f-9d70-4967-b60c-2d355f0c9d8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Rework EventPhase type to avoid using TS enum",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/vnext/src/Libraries/Components/View/ViewPropTypes.d.ts
@@ -172,16 +172,16 @@ export interface ViewPropsAndroid {
 
 // [Windows
 
-export enum EventPhase {
-  None = 0,
-  Capturing,
-  AtTarget,
-  Bubbling,
+export namespace EventPhase {
+  export const None = 0;
+  export const Capturing = 1;
+  export const AtTarget = 2;
+  export const Bubbling = 3;
 }
 
-export enum HandledEventPhase {
-  Capturing = EventPhase.Capturing,
-  Bubbling = EventPhase.Bubbling,
+export namespace HandledEventPhase {
+  const Capturing = EventPhase.Capturing;
+  const Bubbling = EventPhase.Bubbling;
 }
 
 export interface INativeKeyboardEvent {
@@ -191,7 +191,11 @@ export interface INativeKeyboardEvent {
   shiftKey: boolean;
   key: string;
   code: string;
-  eventPhase: EventPhase;
+  eventPhase:
+    | EventPhase.None
+    | EventPhase.Capturing
+    | EventPhase.AtTarget
+    | EventPhase.Bubbling;
 }
 
 export interface IHandledKeyboardEvent {
@@ -200,7 +204,7 @@ export interface IHandledKeyboardEvent {
   metaKey?: boolean;
   shiftKey?: boolean;
   code: string;
-  handledEventPhase?: HandledEventPhase;
+  handledEventPhase?: EventPhase.Capturing | EventPhase.Bubbling;
 }
 
 export type IKeyboardEvent = NativeSyntheticEvent<INativeKeyboardEvent>;


### PR DESCRIPTION
Port #12908 to 0.73
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12909)