### PR TITLE
Disable broken "Enable integration test web application (#12714)" in CI

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -23,7 +23,7 @@ parameters:
             BuildConfiguration: Release
             BuildPlatform: x64
             UseFabric: false
-          - Name: X86Debug
+          - Name: X86Release # Specifically built so binskim / tests get run
             BuildConfiguration: Debug
             BuildPlatform: x86
             UseFabric: false
@@ -48,7 +48,7 @@ parameters:
           - Name: X86Debug
             BuildConfiguration: Debug
             BuildPlatform: x86
-          - Name: X86Release
+          - Name: X86Release  # Specifically built so binskim / tests get run
             BuildConfiguration: Release
             BuildPlatform: x86
           - Name: Arm64Debug
@@ -64,7 +64,7 @@ parameters:
           - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
             BuildConfiguration: Release
             BuildPlatform: x86
-            UseFabric: true
+            UseFabric: true            
 
 jobs:
   - ${{ each config in parameters.buildMatrix }}:
@@ -82,14 +82,11 @@ jobs:
 
             #5059 - Disable failing or intermittent tests (IntegrationTestHarness,WebSocket,Logging).
             #10732 -  WebSocketIntegrationTest::SendReceiveSsl fails on Windows Server 2022.
-            #12714 -  Disable for first deployment of test website.
-            #         RNTesterIntegrationTests::WebSocket
-            #         RNTesterIntegrationTests::WebSocketBlob
             - name: Desktop.IntegrationTests.Filter
               value: >
+                (FullyQualifiedName!=RNTesterIntegrationTests::Blob)&
                 (FullyQualifiedName!=RNTesterIntegrationTests::IntegrationTestHarness)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::WebSocket)&
-                (FullyQualifiedName!=RNTesterIntegrationTests::WebSocketBlob)&
+                (FullyQualifiedName!=WebSocketResourcePerformanceTest::ProcessThreadsPerResource)&
                 (FullyQualifiedName!=WebSocketIntegrationTest::SendReceiveSsl)&
                 (FullyQualifiedName!=Microsoft::React::Test::HttpOriginPolicyIntegrationTest)
             #6799 -
@@ -107,31 +104,6 @@ jobs:
           cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
           steps:
-            # Set up IIS tests {
-            - pwsh: |
-                Install-WindowsFeature -Name Web-Server, Web-Scripting-Tools
-              displayName: Install IIS
-
-            - pwsh: |
-                Invoke-WebRequest `
-                  -Uri 'https://download.visualstudio.microsoft.com/download/pr/20598243-c38f-4538-b2aa-af33bc232f80/ea9b2ca232f59a6fdc84b7a31da88464/dotnet-hosting-8.0.3-win.exe' `
-                  -OutFile dotnet-hosting-8.0.3-win.exe
-
-                Write-Host 'Installing .NET hosting bundle'
-                Start-Process -Wait -FilePath .\dotnet-hosting-8.0.3-win.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
-                Write-Host 'Installed .NET hosting bundle'
-
-                Invoke-WebRequest `
-                  -Uri 'https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/dotnet-sdk-7.0.407-win-x64.exe' `
-                  -OutFile dotnet-sdk-7.0.407-win-x64.exe
-
-                Write-Host 'Installing .NET 7 SDK'
-                Start-Process -Wait -FilePath .\dotnet-sdk-7.0.407-win-x64.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
-                Write-Host 'Installed .NET 7 SDK'
-              displayName: Install the .NET Core Hosting Bundle
-
-            # } Set up IIS tests
-
             - template: ../templates/checkout-shallow.yml
 
             - template: ../templates/prepare-js-env.yml
@@ -200,89 +172,11 @@ jobs:
                   filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tfs\Start-TestServers.ps1
                   arguments: -SourcesDirectory $(Build.SourcesDirectory)\vnext -Preload -SleepSeconds 120
 
-              - task: DotNetCoreCLI@2
-                displayName: Publish Test Website
-                inputs:
-                  command: publish
-                  publishWebProjects: false
-                  zipAfterPublish: false
-                  projects: $(Build.SourcesDirectory)\vnext\TestWebsite\Microsoft.ReactNative.Test.Website.csproj
-                  arguments: --configuration ${{ matrix.BuildConfiguration }}
-
-              - pwsh: |
-                  # Create and make available to IIS
-                  $cert = New-SelfSignedCertificate `
-                    -Type SSLServerAuthentication `
-                    -KeyExportPolicy Exportable `
-                    -Subject 'CN=localhost' `
-                    -NotAfter ([DateTime]::Now).AddHours(2) `
-                    -CertStoreLocation Cert:\LocalMachine\My\
-
-                  $certPath = "${env:TEMP}\localhost.pfx"
-                  $certPass = -join ('a'..'z' | Get-Random -Count 32) | ConvertTo-SecureString -AsPlainText -Force
-                  $certHash = $cert.Thumbprint
-                  Write-Host "##vso[task.setvariable variable=TestWebsiteCertificateThumbprint]$certHash"
-
-                  # Export PFX
-                  $cert | Export-PfxCertificate -FilePath $certPath -Password $certPass
-
-                  # Trust globally
-                  Import-PfxCertificate `
-                    -Exportable `
-                    -FilePath $certPath `
-                    -Password $certPass `
-                    -CertStoreLocation Cert:\LocalMachine\Root\
-                displayName: Install SSL Certificate
-
-              - task: IISWebAppManagementOnMachineGroup@0
-                displayName: Create Test Website
-                inputs:
-                  EnableIIS: false
-                  IISDeploymentType: IISWebsite
-                  ActionIISWebsite: CreateOrUpdateWebsite
-                  SSLCertThumbPrint: $(TestWebsiteCertificateThumbprint)
-                  # IIS Website
-                  WebsiteName: RNW Test Website
-                  WebsitePhysicalPath: $(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
-                  WebsitePhysicalPathAuth: WebsiteUserPassThrough
-                  CreateOrUpdateAppPoolForWebsite: false
-                  ConfigureAuthenticationForWebsite: false
-                  # IIS Application pool
-                  AppPoolNameForWebsite: DefaultAppPool
-                  # IIS Bindings
-                  # See https://stackoverflow.com/questions/60089756
-                  AddBinding: true
-                  Bindings: |
-                    {
-                      bindings: [
-                        {
-                          "protocol": "http",
-                          "ipAddress": "*",
-                          "port": "5555",
-                          "sslThumbprint": "",
-                          "sniFlag": false
-                        },
-                        {
-                          "protocol": "https",
-                          "ipAddress": "*",
-                          "port": "5543",
-                          "sslThumbprint": "$(TestWebsiteCertificateThumbprint)",
-                          "sniFlag": false
-                        }
-                      ]
-                    }
-
               - task: PowerShell@2
-                displayName: Ensure servers readiness
+                displayName: Check the metro bundle server
                 inputs:
                   targetType: 'inline'
-                  script: |
-                    # Test website
-                    Invoke-WebRequest -Uri 'http://localhost:5555'
-                    Invoke-WebRequest -Uri 'https://localhost:5543'
-
-                    # Bundler
-                    Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windows&dev=true"
+                  script: Invoke-WebRequest -UseBasicParsing -Uri "http://localhost:8081/IntegrationTests/IntegrationTestsApp.bundle?platform=windows&dev=true"
 
               - task: VSTest@2
                 displayName: Run Desktop Integration Tests


### PR DESCRIPTION
This paritally reverts commit a09af289ffd3662a0e23e1b980401697c78d36b4 which was checked in but not tested (CI only runs new tests on X86 Release, PR only ran X86 debug, doesn't work).

## Description

### Type of Change
_Erase all that don't apply._
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Why
What is the motivation for this change? Add a few sentences describing the context and overall goals of the pull request's commits.

Resolves [Add Relevant Issue Here]

### What
What changes were made to the codebase to solve the bug, add the functionality, etc. that you specified above.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios.

_Optional_: Describe the tests that you ran locally to verify your changes.

## Changelog
Should this change be included in the release notes: _indicate yes or no_

Add a brief summary of the change to use in the release notes for the next release.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12910)