### PR TITLE
Enable test website on x86

### DIFF
--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -15,10 +15,6 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
-            #TODO: Remove before merging
-          - Name: X86Release
-            BuildConfiguration: Release
-            BuildPlatform: x86
           - Name: X64Debug
             BuildConfiguration: Debug
             BuildPlatform: x64
@@ -35,6 +31,10 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x64
             UseFabric: true
+            #TODO: Remove before merging
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
       - BuildEnvironment: SecurePullRequest
         Matrix:
           - Name: X64DebugFabric
@@ -125,22 +125,12 @@ jobs:
                 Start-Process -Wait -FilePath .\dotnet-hosting-8.0.3-win.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET hosting bundle'
 
-                #if ('x64' -eq "${{ matrix.BuildPlatform }}") {
-                  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x64.exe'
-                  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/$dotnetSdkOutFile"
-                #}
-                #elseif ('x86' -eq "${{ matrix.BuildPlatform }}") {
-                #  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
-                #  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
-                #} else {
-                #  Write-Error 'Unsupported platform for test website'
-                #}
                 Invoke-WebRequest `
-                  -Uri $dotnetSdkUrl `
-                  -OutFile $dotnetSdkOutFile
+                  -Uri 'https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/dotnet-sdk-7.0.407-win-x64.exe' `
+                  -OutFile dotnet-sdk-7.0.407-win-x64.exe
 
                 Write-Host 'Installing .NET 7 SDK'
-                Start-Process -Wait -FilePath $dotnetSdkOutFile -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
+                Start-Process -Wait -FilePath .\dotnet-sdk-7.0.407-win-x64.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET 7 SDK'
               displayName: Install the .NET Core Hosting Bundle
 
@@ -214,8 +204,6 @@ jobs:
                   filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tfs\Start-TestServers.ps1
                   arguments: -SourcesDirectory $(Build.SourcesDirectory)\vnext -Preload -SleepSeconds 120
 
-              - task: NuGetAuthenticate@1
-
               - task: DotNetCoreCLI@2
                 displayName: Publish Test Website
                 inputs:
@@ -226,8 +214,6 @@ jobs:
                   arguments: --configuration ${{ matrix.BuildConfiguration }}
 
               - pwsh: |
-                  ls vnext\target\x64\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
-
                   # Create and make available to IIS
                   $cert = New-SelfSignedCertificate `
                     -Type SSLServerAuthentication `
@@ -261,6 +247,8 @@ jobs:
                   SSLCertThumbPrint: $(TestWebsiteCertificateThumbprint)
                   # IIS Website
                   WebsiteName: RNW Test Website
+                  # Hard-coding x64 for publish path.
+                  # Our MSBuild customizations cause dotnet commans to assume the default PlatformTarget
                   WebsitePhysicalPath: $(Build.SourcesDirectory)\vnext\target\x64\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
                   WebsitePhysicalPathAuth: WebsiteUserPassThrough
                   CreateOrUpdateAppPoolForWebsite: false

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -109,6 +109,12 @@ jobs:
           steps:
             # Set up IIS tests {
             - pwsh: |
+                #TODO: Remove before merging
+                Write-Host "'$env:BuildPlatform' => [$env:BuildPlatform]"
+                Write-Host "'$env:BUILDPLATFORM' => [$env:BUILDPLATFORM]"
+                Write-Host "'$(BuildPlatform)' => [$(BuildPlatform)]"
+                Write-Host "'${{ matrix.BuildPlatform }}' => [${{ matrix.BuildPlatform }}]"
+
                 Install-WindowsFeature -Name Web-Server, Web-Scripting-Tools
               displayName: Install IIS
 
@@ -215,7 +221,7 @@ jobs:
                   publishWebProjects: false
                   zipAfterPublish: false
                   projects: $(Build.SourcesDirectory)\vnext\TestWebsite\Microsoft.ReactNative.Test.Website.csproj
-                  arguments: --configuration ${{ matrix.BuildConfiguration }}
+                  arguments: --configuration ${{ matrix.BuildConfiguration }} --arch ${{ matrix.BuildPlatform }}
 
               - pwsh: |
                   # Create and make available to IIS

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -121,12 +121,20 @@ jobs:
                 Start-Process -Wait -FilePath .\dotnet-hosting-8.0.3-win.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET hosting bundle'
 
+                if ('x64' -eq "$env:BuildPlatform") {
+                  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x64.exe'
+                  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/$dotnetSdkOutFile"
+                }
+                elseif ('x86' -eq "$env:BuildPlatform") {
+                  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
+                  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
+                }
                 Invoke-WebRequest `
-                  -Uri 'https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/dotnet-sdk-7.0.407-win-x64.exe' `
-                  -OutFile dotnet-sdk-7.0.407-win-x64.exe
+                  -Uri $dotnetSdkUrl `
+                  -OutFile $dotnetSdkOutFile
 
                 Write-Host 'Installing .NET 7 SDK'
-                Start-Process -Wait -FilePath .\dotnet-sdk-7.0.407-win-x64.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
+                Start-Process -Wait -FilePath $dotnetSdkOutFile -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET 7 SDK'
               displayName: Install the .NET Core Hosting Bundle
 

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -113,12 +113,6 @@ jobs:
           steps:
             # Set up IIS tests {
             - pwsh: |
-                #TODO: Remove before merging
-                Write-Host "env:BuildPlatform => [$env:BuildPlatform]"
-                Write-Host "env:BUILDPLATFORM => [$env:BUILDPLATFORM]"
-                #Write-Host "(BuildPlatform) => [$(BuildPlatform)]"
-                Write-Host "{{ matrix.BuildPlatform }} => [${{ matrix.BuildPlatform }}]"
-
                 Install-WindowsFeature -Name Web-Server, Web-Scripting-Tools
               displayName: Install IIS
 
@@ -229,7 +223,7 @@ jobs:
                   publishWebProjects: false
                   zipAfterPublish: false
                   projects: $(Build.SourcesDirectory)\vnext\TestWebsite\Microsoft.ReactNative.Test.Website.csproj
-                  arguments: --configuration ${{ matrix.BuildConfiguration }} --arch ${{ matrix.BuildPlatform }} -p:PlatformTarget=${{ matrix.BuildPlatform }}
+                  arguments: --configuration ${{ matrix.BuildConfiguration }}
 
               - pwsh: |
                   ls vnext\target\x64\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -265,7 +265,7 @@ jobs:
                   SSLCertThumbPrint: $(TestWebsiteCertificateThumbprint)
                   # IIS Website
                   WebsiteName: RNW Test Website
-                  WebsitePhysicalPath: $(Build.SourcesDirectory)\vnext\target\${{ matrix.BuildPlatform }}\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
+                  WebsitePhysicalPath: $(Build.SourcesDirectory)\vnext\target\x64\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
                   WebsitePhysicalPathAuth: WebsiteUserPassThrough
                   CreateOrUpdateAppPoolForWebsite: false
                   ConfigureAuthenticationForWebsite: false

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -15,6 +15,10 @@ parameters:
     default:
       - BuildEnvironment: PullRequest
         Matrix:
+            #TODO: Remove before merging
+          - Name: X86Release
+            BuildConfiguration: Release
+            BuildPlatform: x86
           - Name: X64Debug
             BuildConfiguration: Debug
             BuildPlatform: x64
@@ -112,7 +116,7 @@ jobs:
                 #TODO: Remove before merging
                 Write-Host "'$env:BuildPlatform' => [$env:BuildPlatform]"
                 Write-Host "'$env:BUILDPLATFORM' => [$env:BUILDPLATFORM]"
-                Write-Host "'$(BuildPlatform)' => [$(BuildPlatform)]"
+                #Write-Host "'$(BuildPlatform)' => [$(BuildPlatform)]"
                 Write-Host "'${{ matrix.BuildPlatform }}' => [${{ matrix.BuildPlatform }}]"
 
                 Install-WindowsFeature -Name Web-Server, Web-Scripting-Tools

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -131,16 +131,16 @@ jobs:
                 Start-Process -Wait -FilePath .\dotnet-hosting-8.0.3-win.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET hosting bundle'
 
-                if ('x64' -eq "${{ matrix.BuildPlatform }}") {
+                #if ('x64' -eq "${{ matrix.BuildPlatform }}") {
                   $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x64.exe'
                   $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/$dotnetSdkOutFile"
-                }
-                elseif ('x86' -eq "${{ matrix.BuildPlatform }}") {
-                  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
-                  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
-                } else {
-                  Write-Error 'Unsupported platform for test website'
-                }
+                #}
+                #elseif ('x86' -eq "${{ matrix.BuildPlatform }}") {
+                #  $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
+                #  $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
+                #} else {
+                #  Write-Error 'Unsupported platform for test website'
+                #}
                 Invoke-WebRequest `
                   -Uri $dotnetSdkUrl `
                   -OutFile $dotnetSdkOutFile
@@ -232,6 +232,8 @@ jobs:
                   arguments: --configuration ${{ matrix.BuildConfiguration }} --arch ${{ matrix.BuildPlatform }} -p:PlatformTarget=${{ matrix.BuildPlatform }}
 
               - pwsh: |
+                  ls vnext\target\x64\${{ matrix.BuildConfiguration }}\Microsoft.ReactNative.Test.Website\Publish
+
                   # Create and make available to IIS
                   $cert = New-SelfSignedCertificate `
                     -Type SSLServerAuthentication `

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -229,7 +229,7 @@ jobs:
                   publishWebProjects: false
                   zipAfterPublish: false
                   projects: $(Build.SourcesDirectory)\vnext\TestWebsite\Microsoft.ReactNative.Test.Website.csproj
-                  arguments: --configuration ${{ matrix.BuildConfiguration }} --arch ${{ matrix.BuildPlatform }}
+                  arguments: --configuration ${{ matrix.BuildConfiguration }} --arch ${{ matrix.BuildPlatform }} -p:PlatformTarget=${{ matrix.BuildPlatform }}
 
               - pwsh: |
                   # Create and make available to IIS

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -134,6 +134,8 @@ jobs:
                 elseif ('x86' -eq "$env:BuildPlatform") {
                   $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
                   $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
+                } else {
+                  Write-Error 'Unsupported platform for test website'
                 }
                 Invoke-WebRequest `
                   -Uri $dotnetSdkUrl `

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -220,6 +220,8 @@ jobs:
                   filePath: $(Build.SourcesDirectory)\vnext\Scripts\Tfs\Start-TestServers.ps1
                   arguments: -SourcesDirectory $(Build.SourcesDirectory)\vnext -Preload -SleepSeconds 120
 
+              - task: NuGetAuthenticate@1
+
               - task: DotNetCoreCLI@2
                 displayName: Publish Test Website
                 inputs:

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -114,10 +114,10 @@ jobs:
             # Set up IIS tests {
             - pwsh: |
                 #TODO: Remove before merging
-                Write-Host "'$env:BuildPlatform' => [$env:BuildPlatform]"
-                Write-Host "'$env:BUILDPLATFORM' => [$env:BUILDPLATFORM]"
-                #Write-Host "'$(BuildPlatform)' => [$(BuildPlatform)]"
-                Write-Host "'${{ matrix.BuildPlatform }}' => [${{ matrix.BuildPlatform }}]"
+                Write-Host "env:BuildPlatform => [$env:BuildPlatform]"
+                Write-Host "env:BUILDPLATFORM => [$env:BUILDPLATFORM]"
+                #Write-Host "(BuildPlatform) => [$(BuildPlatform)]"
+                Write-Host "{{ matrix.BuildPlatform }} => [${{ matrix.BuildPlatform }}]"
 
                 Install-WindowsFeature -Name Web-Server, Web-Scripting-Tools
               displayName: Install IIS
@@ -131,11 +131,11 @@ jobs:
                 Start-Process -Wait -FilePath .\dotnet-hosting-8.0.3-win.exe -ArgumentList '/INSTALL', '/QUIET', '/NORESTART'
                 Write-Host 'Installed .NET hosting bundle'
 
-                if ('x64' -eq "$env:BuildPlatform") {
+                if ('x64' -eq "${{ matrix.BuildPlatform }}") {
                   $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x64.exe'
                   $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f2ec926e-0d98-4a8b-8c70-722ccc2ca0e5/b59941b0c60f16421679baafdb7e9338/$dotnetSdkOutFile"
                 }
-                elseif ('x86' -eq "$env:BuildPlatform") {
+                elseif ('x86' -eq "${{ matrix.BuildPlatform }}") {
                   $dotnetSdkOutFile = 'dotnet-sdk-7.0.407-win-x86.exe'
                   $dotnetSdkUrl = "https://download.visualstudio.microsoft.com/download/pr/f7f831c9-ee1e-4501-bfc8-d3750aeb0e76/8a7dce2defcd92c77e147603fce87528/$dotnetSdkOutFile"
                 } else {

--- a/.ado/jobs/desktop.yml
+++ b/.ado/jobs/desktop.yml
@@ -31,10 +31,6 @@ parameters:
             BuildConfiguration: Debug
             BuildPlatform: x64
             UseFabric: true
-            #TODO: Remove before merging
-          - Name: X86Release
-            BuildConfiguration: Release
-            BuildPlatform: x86
       - BuildEnvironment: SecurePullRequest
         Matrix:
           - Name: X64DebugFabric


### PR DESCRIPTION
## Description
Enable deploying the test website on x86 CI environments.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
Custom MSBuild logic causes `PlatformTarget` to yield the value `x64` for `dotnet` commands even when the solution was built for `x86`.

This causes IIS not finding the website location at `vnext\target\$(BuildPlatform)\$(BuildConfiguration)...` when `BuildPlatform` is not equal to `x64` and returning HTTP `40x` status errors.

### What
Make IIS use a fixed value for the `BuildPlatform` in the website's location.

## Testing
Temporarily enabled `x86|Release` in the pull request matrix to ensure the website works as expected.
Disabled before merging.
See https://dev.azure.com/ms/react-native-windows/_build/results?buildId=560987&view=logs&jobId=9424bcb6-bf6e-5e05-97df-1709db307089&j=9424bcb6-bf6e-5e05-97df-1709db307089&t=06e5a27c-ef2d-5a24-8119-31e1f439c522

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12913)