### PR TITLE
Fixed Microsoft.ReactNative.IntegrationTests and Mso.UnitTests to run with Fabric

### DIFF
--- a/.ado/jobs/universal.yml
+++ b/.ado/jobs/universal.yml
@@ -30,11 +30,19 @@
               BuildConfiguration: Debug
               BuildPlatform: x64
               UseFabric: true
+            - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
+              BuildConfiguration: Release
+              BuildPlatform: x86
+              UseFabric: true
         - BuildEnvironment: SecurePullRequest
           Matrix:
             - Name: X64DebugFabric
               BuildConfiguration: Debug
               BuildPlatform: x64
+              UseFabric: true
+            - Name: X86ReleaseFabric # Specifically built so binskim / tests get run on fabric
+              BuildConfiguration: Release
+              BuildPlatform: x86
               UseFabric: true
         - BuildEnvironment: Continuous
           Matrix:

--- a/change/react-native-windows-4d8d825f-a8b0-4648-8616-b8e262062143.json
+++ b/change/react-native-windows-4d8d825f-a8b0-4648-8616-b8e262062143.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix Microsoft.ReactNative.IntegrationTests to run with Fabric",
+  "packageName": "react-native-windows",
+  "email": "jthysell@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -10,6 +10,15 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
+  <!-- Because the test exe is unpackaged, it needs the self contained WinAppSDK stuff below when testing against fabric -->
+  <PropertyGroup Label="FromWinUI3_VSIX" Condition="'$(UseWinUI3)'=='true'">
+    <AppContainerApplication>false</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -171,7 +171,7 @@
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">
-      <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="TestBundle.targets" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/Microsoft.ReactNative.IntegrationTests.vcxproj
@@ -54,6 +54,9 @@
     <Import Project="PropertySheet.props" />
     -->
   </ImportGroup>
+  <ImportGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">
+    <Import Project="..\PropertySheets\WinUI.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
@@ -166,6 +169,9 @@
     <PackageReference Include="Microsoft.VCRTForwarders.140" Version="1.0.6" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
     <PackageReference Include="$(V8PackageName)" Version="$(V8Version)" Condition="'$(UseV8)' == 'true'" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">
+      <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="TestBundle.targets" />

--- a/vnext/Microsoft.ReactNative.IntegrationTests/ReactInstanceSettingsTests.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/ReactInstanceSettingsTests.cpp
@@ -4,11 +4,21 @@
 #include "pch.h"
 
 #include <winrt/Microsoft.ReactNative.h>
+
+#ifdef USE_WINUI3
+#include <winrt/Microsoft.UI.Dispatching.h>
+#else
 #include <winrt/Windows.System.h>
+#endif
 
 using namespace winrt;
 using namespace Microsoft::ReactNative;
+
+#ifdef USE_WINUI3
+using namespace Microsoft::UI::Dispatching;
+#else
 using namespace Windows::System;
+#endif
 
 namespace ReactNativeIntegrationTests {
 

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.cpp
@@ -9,7 +9,6 @@
 namespace ReactNativeIntegrationTests {
 
 using namespace winrt;
-using namespace Windows::System;
 
 // Work around crash in DeviceInfo when running outside of XAML environment
 REACT_MODULE(DeviceInfo)
@@ -51,7 +50,11 @@ TestReactNativeHostHolder::TestReactNativeHostHolder(
     Mso::Functor<void(winrt::Microsoft::ReactNative::ReactNativeHost const &)> &&hostInitializer,
     Options &&options) noexcept {
   m_host = winrt::Microsoft::ReactNative::ReactNativeHost{};
-  m_queueController = DispatcherQueueController::CreateOnDedicatedThread();
+#ifdef USE_WINUI3
+  m_queueController = winrt::Microsoft::UI::Dispatching::DispatcherQueueController::CreateOnDedicatedThread();
+#else
+  m_queueController = winrt::Windows::System::DispatcherQueueController::CreateOnDedicatedThread();
+#endif
   m_queueController.DispatcherQueue().TryEnqueue([this,
                                                   jsBundle = std::wstring{jsBundle},
                                                   hostInitializer = std::move(hostInitializer),

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
@@ -8,9 +8,9 @@
 #include <string_view>
 
 #ifdef USE_WINUI3
-  #include <winrt/Microsoft.UI.Dispatching.h>
+#include <winrt/Microsoft.UI.Dispatching.h>
 #else
-  #include <winrt/Windows.System.h>
+#include <winrt/Windows.System.h>
 #endif
 
 namespace ReactNativeIntegrationTests {

--- a/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
+++ b/vnext/Microsoft.ReactNative.IntegrationTests/TestReactNativeHostHolder.h
@@ -5,8 +5,13 @@
 
 #include <functional/functor.h>
 #include <winrt/Microsoft.ReactNative.h>
-#include <winrt/Windows.System.h>
 #include <string_view>
+
+#ifdef USE_WINUI3
+  #include <winrt/Microsoft.UI.Dispatching.h>
+#else
+  #include <winrt/Windows.System.h>
+#endif
 
 namespace ReactNativeIntegrationTests {
 
@@ -25,7 +30,11 @@ struct TestReactNativeHostHolder {
 
  private:
   winrt::Microsoft::ReactNative::ReactNativeHost m_host{nullptr};
+#ifdef USE_WINUI3
+  winrt::Microsoft::UI::Dispatching::DispatcherQueueController m_queueController{nullptr};
+#else
   winrt::Windows::System::DispatcherQueueController m_queueController{nullptr};
+#endif
 };
 
 } // namespace ReactNativeIntegrationTests

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -53,6 +53,9 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="PropertySheet.props" />
   </ImportGroup>
+  <ImportGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">
+    <Import Project="..\PropertySheets\WinUI.props" />
+  </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <ItemDefinitionGroup>
     <ClCompile>
@@ -146,6 +149,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn" Version="1.8.1" />
     <PackageReference Include="Microsoft.Windows.CppWinRT" Version="$(CppWinRTVersion)" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(UseFabric)' == 'true' AND '$(UseWinUI3)' == 'true' ">
+    <PackageReference Include="$(WinUIPackageName)" Version="$(WinUIPackageVersion)" Condition="'$(OverrideWinUIPackage)'!='true'" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -12,6 +12,15 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(ReactNativeWindowsDir)PropertySheets\React.Cpp.props" />
+  <!-- Because the test exe is unpackaged, it needs the self contained WinAppSDK stuff below when testing against fabric -->
+  <PropertyGroup Label="FromWinUI3_VSIX" Condition="'$(UseWinUI3)'=='true'">
+    <AppContainerApplication>false</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <WindowsPackageType>None</WindowsPackageType>
+  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>

--- a/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
+++ b/vnext/Mso.UnitTests/Mso.UnitTests.vcxproj
@@ -74,6 +74,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <PreprocessorDefinitions>_CONSOLE;MS_TARGET_WINDOWS;MSO_MOTIFCPP;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/await %(AdditionalOptions) /bigobj</AdditionalOptions>
       <ConformanceMode>true</ConformanceMode>
       <CallingConvention>Cdecl</CallingConvention>


### PR DESCRIPTION
## Description

This PR makes Microsoft.ReactNative.IntegrationTests aware of Fabric requirements to use the WinAppSDK `DispatchQueueController`. This PR also fixes both that project and Mso.UnitTests to be able to consume self-contained WinAppSDK so they can run (the tests had code but were technically never exercising it).

Finally this PR also enables a fabric config in PR to make sure we catch test failures like this in the future.

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
See above.

Resolves #12923 

### What
See above.

## Screenshots
N/A

## Testing
Ran Microsoft.ReactNative.Integration tests locally.

## Changelog
Should this change be included in the release notes: _yes_

Fixed Microsoft.ReactNative.IntegrationTests and Mso.UnitTests to run with Fabric
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12924)