### PR TITLE
Partial implementation of TextLayoutManager::measureLines

### DIFF
--- a/change/react-native-windows-6ffd41f8-bf53-4629-9917-3c2349d77112.json
+++ b/change/react-native-windows-6ffd41f8-bf53-4629-9917-3c2349d77112.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Partial implementation of TextLayoutManager::measureLines",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -17,11 +17,10 @@
 namespace facebook::react {
 
 void TextLayoutManager::GetTextLayout(
-    const AttributedString& attributedString,
-    const ParagraphAttributes& paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     Size size,
     winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept {
-
   auto fragments = attributedString.getFragments();
   auto outerFragment = fragments[0];
 
@@ -127,13 +126,11 @@ void TextLayoutManager::GetTextLayout(
   }
 }
 
-
 void TextLayoutManager::GetTextLayout(
-    const AttributedStringBox& attributedStringBox,
-    const ParagraphAttributes& paragraphAttributes,
+    const AttributedStringBox &attributedStringBox,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints,
     winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept {
-
   if (attributedStringBox.getValue().isEmpty())
     return;
 
@@ -141,8 +138,8 @@ void TextLayoutManager::GetTextLayout(
 }
 
 TextMeasurement TextLayoutManager::measure(
-    const AttributedStringBox& attributedStringBox,
-    const ParagraphAttributes& paragraphAttributes,
+    const AttributedStringBox &attributedStringBox,
+    const ParagraphAttributes &paragraphAttributes,
     const TextLayoutContext &layoutContext,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void> /* hostTextStorage */) const {
@@ -196,7 +193,7 @@ TextMeasurement TextLayoutManager::measure(
  */
 TextMeasurement TextLayoutManager::measureCachedSpannableById(
     int64_t cacheId,
-    const ParagraphAttributes& paragraphAttributes,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   assert(false);
   return {};
@@ -222,10 +219,9 @@ Microsoft::ReactNative::TextTransform ConvertTextTransform(std::optional<TextTra
 }
 
 LinesMeasurements TextLayoutManager::measureLines(
-    const AttributedString& attributedString,
-    const ParagraphAttributes& paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     Size size) const {
-
   LinesMeasurements lineMeasurements{};
 
   winrt::com_ptr<IDWriteTextLayout> spTextLayout;
@@ -233,61 +229,61 @@ LinesMeasurements TextLayoutManager::measureLines(
   GetTextLayout(attributedString, paragraphAttributes, size, spTextLayout);
 
   if (spTextLayout) {
-      std::vector<DWRITE_LINE_METRICS> lineMetrics;
-      uint32_t actualLineCount;
-      spTextLayout->GetLineMetrics(nullptr, 0, &actualLineCount);
-      lineMetrics.resize(static_cast<size_t>(actualLineCount));
-      winrt::check_hresult(spTextLayout->GetLineMetrics(lineMetrics.data(), actualLineCount, &actualLineCount));
-      uint32_t startRange = 0;
-      const auto count = (paragraphAttributes.maximumNumberOfLines > 0)
-          ? std::min(static_cast<uint32_t>(paragraphAttributes.maximumNumberOfLines), actualLineCount)
-          : actualLineCount;
-      for (uint32_t i = 0; i < count; ++i) {
-        UINT32 actualHitTestCount = 0;
-        spTextLayout->HitTestTextRange(
-            startRange,
-            lineMetrics[i].length,
-            0, // x
-            0, // y
-            NULL,
-            0, // metrics count
-            &actualHitTestCount);
+    std::vector<DWRITE_LINE_METRICS> lineMetrics;
+    uint32_t actualLineCount;
+    spTextLayout->GetLineMetrics(nullptr, 0, &actualLineCount);
+    lineMetrics.resize(static_cast<size_t>(actualLineCount));
+    winrt::check_hresult(spTextLayout->GetLineMetrics(lineMetrics.data(), actualLineCount, &actualLineCount));
+    uint32_t startRange = 0;
+    const auto count = (paragraphAttributes.maximumNumberOfLines > 0)
+        ? std::min(static_cast<uint32_t>(paragraphAttributes.maximumNumberOfLines), actualLineCount)
+        : actualLineCount;
+    for (uint32_t i = 0; i < count; ++i) {
+      UINT32 actualHitTestCount = 0;
+      spTextLayout->HitTestTextRange(
+          startRange,
+          lineMetrics[i].length,
+          0, // x
+          0, // y
+          NULL,
+          0, // metrics count
+          &actualHitTestCount);
 
-        // Allocate enough room to return all hit-test metrics.
-        std::vector<DWRITE_HIT_TEST_METRICS> hitTestMetrics(actualHitTestCount);
-        spTextLayout->HitTestTextRange(
-            startRange,
-            lineMetrics[i].length,
-            0, // x
-            0, // y
-            &hitTestMetrics[0],
-            static_cast<UINT32>(hitTestMetrics.size()),
-            &actualHitTestCount);
+      // Allocate enough room to return all hit-test metrics.
+      std::vector<DWRITE_HIT_TEST_METRICS> hitTestMetrics(actualHitTestCount);
+      spTextLayout->HitTestTextRange(
+          startRange,
+          lineMetrics[i].length,
+          0, // x
+          0, // y
+          &hitTestMetrics[0],
+          static_cast<UINT32>(hitTestMetrics.size()),
+          &actualHitTestCount);
 
-        float width = 0;
-        for (auto tm : hitTestMetrics) {
-          width += tm.width;
-        }
+      float width = 0;
+      for (auto tm : hitTestMetrics) {
+        width += tm.width;
+      }
 
-        std::string str;
-        for (const auto &fragment : attributedString.getFragments()) {
-          str = str +
-              winrt::to_string(Microsoft::ReactNative::TransformableText::TransformText(
-                  winrt::hstring{Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string)},
-                  ConvertTextTransform(fragment.textAttributes.textTransform)));
-        }
+      std::string str;
+      for (const auto &fragment : attributedString.getFragments()) {
+        str = str +
+            winrt::to_string(Microsoft::ReactNative::TransformableText::TransformText(
+                winrt::hstring{Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string)},
+                ConvertTextTransform(fragment.textAttributes.textTransform)));
+      }
 
-        lineMeasurements.emplace_back(LineMeasurement(
-            str.substr(startRange, lineMetrics[i].length),
-            {{hitTestMetrics[0].left, hitTestMetrics[0].top}, // origin
-             {width, lineMetrics[i].height}},
-            0.0f, // TODO descender
-            0.0f, // TODO: capHeight
-            0.0f, // TODO ascender
-            0.0f // TODO: xHeight
-            ));
+      lineMeasurements.emplace_back(LineMeasurement(
+          str.substr(startRange, lineMetrics[i].length),
+          {{hitTestMetrics[0].left, hitTestMetrics[0].top}, // origin
+           {width, lineMetrics[i].height}},
+          0.0f, // TODO descender
+          0.0f, // TODO: capHeight
+          0.0f, // TODO ascender
+          0.0f // TODO: xHeight
+          ));
 
-        startRange += lineMetrics[i].length;
+      startRange += lineMetrics[i].length;
     }
   }
 
@@ -295,8 +291,8 @@ LinesMeasurements TextLayoutManager::measureLines(
 }
 
 std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
-    const AttributedString& attributedString,
-    const ParagraphAttributes& paragraphAttributes,
+    const AttributedString &attributedString,
+    const ParagraphAttributes &paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   return nullptr;
 }
@@ -305,7 +301,7 @@ void *TextLayoutManager::getNativeTextLayoutManager() const {
   return (void *)this;
 }
 
-winrt::hstring TextLayoutManager::GetTransformedText(const AttributedString& attributedString) {
+winrt::hstring TextLayoutManager::GetTransformedText(const AttributedString &attributedString) {
   winrt::hstring result{};
   for (const auto &fragment : attributedString.getFragments()) {
     result = result +

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -17,14 +17,12 @@
 namespace facebook::react {
 
 void TextLayoutManager::GetTextLayout(
-    AttributedStringBox attributedStringBox,
-    ParagraphAttributes paragraphAttributes,
-    LayoutConstraints layoutConstraints,
+    const AttributedString& attributedString,
+    const ParagraphAttributes& paragraphAttributes,
+    Size size,
     winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept {
-  if (attributedStringBox.getValue().isEmpty())
-    return;
 
-  auto fragments = attributedStringBox.getValue().getFragments();
+  auto fragments = attributedString.getFragments();
   auto outerFragment = fragments[0];
 
   DWRITE_FONT_STYLE style = DWRITE_FONT_STYLE_NORMAL;
@@ -86,14 +84,14 @@ void TextLayoutManager::GetTextLayout(
   }
   winrt::check_hresult(spTextFormat->SetTextAlignment(alignment));
 
-  auto str = GetTransformedText(attributedStringBox);
+  auto str = GetTransformedText(attributedString);
 
   winrt::check_hresult(Microsoft::ReactNative::DWriteFactory()->CreateTextLayout(
       str.c_str(), // The string to be laid out and formatted.
       static_cast<UINT32>(str.size()), // The length of the string.
       spTextFormat.get(), // The text format to apply to the string (contains font information, etc).
-      layoutConstraints.maximumSize.width, // The width of the layout box.
-      layoutConstraints.maximumSize.height, // The height of the layout box.
+      size.width, // The width of the layout box.
+      size.height, // The height of the layout box.
       spTextLayout.put() // The IDWriteTextLayout interface pointer.
       ));
 
@@ -129,9 +127,22 @@ void TextLayoutManager::GetTextLayout(
   }
 }
 
+
+void TextLayoutManager::GetTextLayout(
+    const AttributedStringBox& attributedStringBox,
+    const ParagraphAttributes& paragraphAttributes,
+    LayoutConstraints layoutConstraints,
+    winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept {
+
+  if (attributedStringBox.getValue().isEmpty())
+    return;
+
+  GetTextLayout(attributedStringBox.getValue(), paragraphAttributes, layoutConstraints.maximumSize, spTextLayout);
+}
+
 TextMeasurement TextLayoutManager::measure(
-    AttributedStringBox attributedStringBox,
-    ParagraphAttributes paragraphAttributes,
+    const AttributedStringBox& attributedStringBox,
+    const ParagraphAttributes& paragraphAttributes,
     const TextLayoutContext &layoutContext,
     LayoutConstraints layoutConstraints,
     std::shared_ptr<void> /* hostTextStorage */) const {
@@ -185,29 +196,10 @@ TextMeasurement TextLayoutManager::measure(
  */
 TextMeasurement TextLayoutManager::measureCachedSpannableById(
     int64_t cacheId,
-    ParagraphAttributes const &paragraphAttributes,
+    const ParagraphAttributes& paragraphAttributes,
     LayoutConstraints layoutConstraints) const {
   assert(false);
   return {};
-}
-
-LinesMeasurements TextLayoutManager::measureLines(
-    AttributedString attributedString,
-    ParagraphAttributes paragraphAttributes,
-    Size size) const {
-  assert(false);
-  return {};
-}
-
-std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
-    AttributedString attributedString,
-    ParagraphAttributes paragraphAttributes,
-    LayoutConstraints layoutConstraints) const {
-  return nullptr;
-}
-
-void *TextLayoutManager::getNativeTextLayoutManager() const {
-  return (void *)this;
 }
 
 Microsoft::ReactNative::TextTransform ConvertTextTransform(std::optional<TextTransform> const &transform) {
@@ -229,9 +221,93 @@ Microsoft::ReactNative::TextTransform ConvertTextTransform(std::optional<TextTra
   return Microsoft::ReactNative::TextTransform::Undefined;
 }
 
-winrt::hstring TextLayoutManager::GetTransformedText(AttributedStringBox const &attributedStringBox) {
+LinesMeasurements TextLayoutManager::measureLines(
+    const AttributedString& attributedString,
+    const ParagraphAttributes& paragraphAttributes,
+    Size size) const {
+
+  LinesMeasurements lineMeasurements{};
+
+  winrt::com_ptr<IDWriteTextLayout> spTextLayout;
+
+  GetTextLayout(attributedString, paragraphAttributes, size, spTextLayout);
+
+  if (spTextLayout) {
+      std::vector<DWRITE_LINE_METRICS> lineMetrics;
+      uint32_t actualLineCount;
+      spTextLayout->GetLineMetrics(nullptr, 0, &actualLineCount);
+      lineMetrics.resize(static_cast<size_t>(actualLineCount));
+      winrt::check_hresult(spTextLayout->GetLineMetrics(lineMetrics.data(), actualLineCount, &actualLineCount));
+      uint32_t startRange = 0;
+      const auto count = (paragraphAttributes.maximumNumberOfLines > 0)
+          ? std::min(static_cast<uint32_t>(paragraphAttributes.maximumNumberOfLines), actualLineCount)
+          : actualLineCount;
+      for (uint32_t i = 0; i < count; ++i) {
+        UINT32 actualHitTestCount = 0;
+        spTextLayout->HitTestTextRange(
+            startRange,
+            lineMetrics[i].length,
+            0, // x
+            0, // y
+            NULL,
+            0, // metrics count
+            &actualHitTestCount);
+
+        // Allocate enough room to return all hit-test metrics.
+        std::vector<DWRITE_HIT_TEST_METRICS> hitTestMetrics(actualHitTestCount);
+        spTextLayout->HitTestTextRange(
+            startRange,
+            lineMetrics[i].length,
+            0, // x
+            0, // y
+            &hitTestMetrics[0],
+            static_cast<UINT32>(hitTestMetrics.size()),
+            &actualHitTestCount);
+
+        float width = 0;
+        for (auto tm : hitTestMetrics) {
+          width += tm.width;
+        }
+
+        std::string str;
+        for (const auto &fragment : attributedString.getFragments()) {
+          str = str +
+              winrt::to_string(Microsoft::ReactNative::TransformableText::TransformText(
+                  winrt::hstring{Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string)},
+                  ConvertTextTransform(fragment.textAttributes.textTransform)));
+        }
+
+        lineMeasurements.emplace_back(LineMeasurement(
+            str.substr(startRange, lineMetrics[i].length),
+            {{hitTestMetrics[0].left, hitTestMetrics[0].top}, // origin
+             {width, lineMetrics[i].height}},
+            0.0f, // TODO descender
+            0.0f, // TODO: capHeight
+            0.0f, // TODO ascender
+            0.0f // TODO: xHeight
+            ));
+
+        startRange += lineMetrics[i].length;
+    }
+  }
+
+  return lineMeasurements;
+}
+
+std::shared_ptr<void> TextLayoutManager::getHostTextStorage(
+    const AttributedString& attributedString,
+    const ParagraphAttributes& paragraphAttributes,
+    LayoutConstraints layoutConstraints) const {
+  return nullptr;
+}
+
+void *TextLayoutManager::getNativeTextLayoutManager() const {
+  return (void *)this;
+}
+
+winrt::hstring TextLayoutManager::GetTransformedText(const AttributedString& attributedString) {
   winrt::hstring result{};
-  for (const auto &fragment : attributedStringBox.getValue().getFragments()) {
+  for (const auto &fragment : attributedString.getFragments()) {
     result = result +
         Microsoft::ReactNative::TransformableText::TransformText(
                  winrt::hstring{Microsoft::Common::Unicode::Utf8ToUtf16(fragment.string)},

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -35,8 +35,8 @@ class TextLayoutManager {
    * Measures `attributedStringBox` using native text rendering infrastructure.
    */
   TextMeasurement measure(
-      AttributedStringBox attributedStringBox,
-      ParagraphAttributes paragraphAttributes,
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
       const TextLayoutContext &layoutContext,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void> /* hostTextStorage */) const;
@@ -45,12 +45,12 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(AttributedString attributedString, ParagraphAttributes paragraphAttributes, Size size)
+  LinesMeasurements measureLines(const AttributedString& attributedString, const ParagraphAttributes& paragraphAttributes, Size size)
       const;
 
   std::shared_ptr<void> getHostTextStorage(
-      AttributedString attributedString,
-      ParagraphAttributes paragraphAttributes,
+      const AttributedString& attributedString,
+      const ParagraphAttributes& paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   /**
@@ -59,7 +59,7 @@ class TextLayoutManager {
    */
   TextMeasurement measureCachedSpannableById(
       int64_t cacheId,
-      ParagraphAttributes const &paragraphAttributes,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   /*
@@ -69,15 +69,21 @@ class TextLayoutManager {
   void *getNativeTextLayoutManager() const;
 
   static void GetTextLayout(
-      AttributedStringBox attributedStringBox,
-      ParagraphAttributes paragraphAttributes,
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
       LayoutConstraints layoutConstraints,
       winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept;
 
 #pragma endregion
 
  private:
-  static winrt::hstring GetTransformedText(AttributedStringBox const &attributedStringBox);
+  static winrt::hstring GetTransformedText(const AttributedString& attributedString);
+  static void GetTextLayout(
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
+      Size size,
+      winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept;
+
 
   ContextContainer::Shared m_contextContainer;
 #pragma warning(push)

--- a/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/platform/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -35,8 +35,8 @@ class TextLayoutManager {
    * Measures `attributedStringBox` using native text rendering infrastructure.
    */
   TextMeasurement measure(
-      const AttributedStringBox& attributedStringBox,
-      const ParagraphAttributes& paragraphAttributes,
+      const AttributedStringBox &attributedStringBox,
+      const ParagraphAttributes &paragraphAttributes,
       const TextLayoutContext &layoutContext,
       LayoutConstraints layoutConstraints,
       std::shared_ptr<void> /* hostTextStorage */) const;
@@ -45,12 +45,14 @@ class TextLayoutManager {
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  LinesMeasurements measureLines(const AttributedString& attributedString, const ParagraphAttributes& paragraphAttributes, Size size)
-      const;
+  LinesMeasurements measureLines(
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
+      Size size) const;
 
   std::shared_ptr<void> getHostTextStorage(
-      const AttributedString& attributedString,
-      const ParagraphAttributes& paragraphAttributes,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints) const;
 
   /**
@@ -69,21 +71,20 @@ class TextLayoutManager {
   void *getNativeTextLayoutManager() const;
 
   static void GetTextLayout(
-      const AttributedStringBox& attributedStringBox,
-      const ParagraphAttributes& paragraphAttributes,
+      const AttributedStringBox &attributedStringBox,
+      const ParagraphAttributes &paragraphAttributes,
       LayoutConstraints layoutConstraints,
       winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept;
 
 #pragma endregion
 
  private:
-  static winrt::hstring GetTransformedText(const AttributedString& attributedString);
+  static winrt::hstring GetTransformedText(const AttributedString &attributedString);
   static void GetTextLayout(
       const AttributedString &attributedString,
       const ParagraphAttributes &paragraphAttributes,
       Size size,
       winrt::com_ptr<IDWriteTextLayout> &spTextLayout) noexcept;
-
 
   ContextContainer::Shared m_contextContainer;
 #pragma warning(push)


### PR DESCRIPTION
## Description
Recent integrations started calling TextLayoutManager::measureLines, which causes the basic Text example page to assert.

This is not a complete implementation, #12929 files as additional work needed.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12930)