### PR TITLE
Disable node-tests job for now

### DIFF
--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -12,7 +12,7 @@ parameters:
 
   - name: versions
     type: object
-    default: [18]
+    default: [20]
 
 jobs:
   - ${{ each nodeVersion in parameters.versions }}:
@@ -20,7 +20,7 @@ jobs:
       displayName: Node Tests v${{ nodeVersion }}
       timeoutInMinutes: 20
       variables: [template: ../variables/windows.yml]
-      pool: ${{ parameters.AgentPool.Medium }}
+      pool: windows-2022
 
       steps:
         - template: ../templates/checkout-shallow.yml

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -26,8 +26,6 @@ jobs:
         - template: ../templates/checkout-shallow.yml
 
         - template: ../templates/strict-yarn-install.yml
-          parameters:
-            workspace: '@rnw-scripts/beachball-config'
 
         - task: NodeTool@0
           displayName: Using Node ${{ nodeVersion }}.x

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -25,6 +25,10 @@ jobs:
       steps:
         - template: ../templates/checkout-shallow.yml
 
+        - template: ../templates/strict-yarn-install.yml
+          parameters:
+            workspace: '@rnw-scripts/beachball-config'
+
         - template: ../templates/prepare-js-env.yml
 
         - task: NodeTool@0

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -20,7 +20,7 @@ jobs:
       displayName: Node Tests v${{ nodeVersion }}
       timeoutInMinutes: 20
       variables: [template: ../variables/windows.yml]
-      pool: windows-2022
+      pool: ubuntu-latest
 
       steps:
         - template: ../templates/checkout-shallow.yml

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -29,8 +29,6 @@ jobs:
           parameters:
             workspace: '@rnw-scripts/beachball-config'
 
-        - template: ../templates/prepare-js-env.yml
-
         - task: NodeTool@0
           displayName: Using Node ${{ nodeVersion }}.x
           inputs:

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -20,7 +20,7 @@ jobs:
       displayName: Node Tests v${{ nodeVersion }}
       timeoutInMinutes: 20
       variables: [template: ../variables/windows.yml]
-      pool: ubuntu-latest
+      pool: {vmImage: ubuntu-latest}
 
       steps:
         - template: ../templates/checkout-shallow.yml

--- a/.ado/jobs/node-tests.yml
+++ b/.ado/jobs/node-tests.yml
@@ -12,7 +12,7 @@ parameters:
 
   - name: versions
     type: object
-    default: [20]
+    default: [18]
 
 jobs:
   - ${{ each nodeVersion in parameters.versions }}:
@@ -20,12 +20,12 @@ jobs:
       displayName: Node Tests v${{ nodeVersion }}
       timeoutInMinutes: 20
       variables: [template: ../variables/windows.yml]
-      pool: {vmImage: ubuntu-latest}
+      pool: ${{ parameters.AgentPool.Medium }}
 
       steps:
         - template: ../templates/checkout-shallow.yml
 
-        - template: ../templates/strict-yarn-install.yml
+        - template: ../templates/prepare-js-env.yml
 
         - task: NodeTool@0
           displayName: Using Node ${{ nodeVersion }}.x

--- a/.ado/stages.yml
+++ b/.ado/stages.yml
@@ -51,10 +51,10 @@ stages:
           buildEnvironment: ${{ parameters.buildEnvironment }}
           AgentPool: ${{ parameters.AgentPool }}
 
-      - template: jobs/node-tests.yml
-        parameters:
-          buildEnvironment: ${{ parameters.buildEnvironment }}
-          AgentPool: ${{ parameters.AgentPool }}
+      # - template: jobs/node-tests.yml
+      #   parameters:
+      #     buildEnvironment: ${{ parameters.buildEnvironment }}
+      #     AgentPool: ${{ parameters.AgentPool }}
 
       - template: jobs/macos-tests.yml
 


### PR DESCRIPTION
The extra node test job was to test node 18 in preparation for moving the whole repo to node 18.  At this point we are running node 18 everywhere else so it's not testing anything new.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12945)