### PR TITLE
Move CompositionSwitcher to Experimental namespace

### DIFF
--- a/change/react-native-windows-d75f3dbd-5fae-4d7e-8b71-53b112f5d21a.json
+++ b/change/react-native-windows-d75f3dbd-5fae-4d7e-8b71-53b112f5d21a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Move CompositionSwitcher to Experimental namespace",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
+++ b/packages/e2e-test-app-fabric/windows/RNTesterApp-Fabric/RNTesterApp-Fabric.cpp
@@ -99,11 +99,7 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
   winrt::Microsoft::ReactNative::ReactCoreInjection::SetTopLevelWindowId(
       host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
 
-  // By using the MicrosoftCompositionContextHelper here, React Native Windows will use Lifted Visuals for its
-  // tree.
-  winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
-      host.InstanceSettings().Properties(),
-      winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::CreateContext(compositor));
+  winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(host.InstanceSettings(), compositor);
 
   return host;
 }
@@ -170,8 +166,6 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   bridge.Connect(rootView.Island());
   bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
 
-  auto invScale = 1.0f / scaleFactor;
-  rootView.RootVisual().Scale({invScale, invScale, invScale});
   rootView.ScaleFactor(scaleFactor);
 
   // Set the intialSize of the root view
@@ -380,8 +374,7 @@ winrt::Windows::Data::Json::JsonObject DumpVisualTreeRecurse(
 winrt::Windows::Data::Json::JsonObject DumpVisualTreeHelper(winrt::Windows::Data::Json::JsonObject payloadObj) {
   auto accessibilityId = payloadObj.GetNamedString(L"accessibilityId");
   winrt::Windows::Data::Json::JsonObject visualTree;
-  auto root = winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::InnerVisual(
-      global_rootView->RootVisual());
+  auto root = global_rootView->RootVisual();
   visualTree = DumpVisualTreeRecurse(root, accessibilityId, false);
   return visualTree;
 }

--- a/packages/playground/windows/ExperimentalFeatures.props
+++ b/packages/playground/windows/ExperimentalFeatures.props
@@ -3,7 +3,6 @@
 
   <PropertyGroup Label="Microsoft.ReactNative Experimental Features">
     <UseHermes>true</UseHermes>
-    <UseFabric>true</UseFabric>
     <UseWinUI3>false</UseWinUI3>
     <UseExperimentalWinUI3>false</UseExperimentalWinUI3>
     <EnableSourceLink>true</EnableSourceLink>
@@ -20,6 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="WinUI3 for fabric" Condition="'$(SolutionName)'=='playground-composition'">
+    <UseFabric>true</UseFabric>
     <UseWinUI3>true</UseWinUI3>
   </PropertyGroup>
 

--- a/packages/playground/windows/playground-composition/CustomComponent.cpp
+++ b/packages/playground/windows/playground-composition/CustomComponent.cpp
@@ -100,7 +100,7 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
     base_type::FinalizeUpdates(updateMask);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual CreateVisual() noexcept {
+  winrt::Microsoft::UI::Composition::Visual CreateVisual() noexcept {
 #ifdef USE_EXPERIMENTAL_WINUI3
 
     m_xamlIsland = winrt::Microsoft::UI::Xaml::XamlIsland{};
@@ -109,19 +109,15 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
     m_contentIsland = m_xamlIsland.ContentIsland();
 #endif
 
-    m_visual = CompositionContext().CreateSpriteVisual();
+    m_visual = Compositor().CreateSpriteVisual();
     // m_visual.Brush(CompositionContext().CreateColorBrush({255, 255, 0, 255}));
 #ifdef USE_EXPERIMENTAL_WINUI3
-
-    auto parentSystemVisual =
-        winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::InnerVisual(m_visual)
-            .as<winrt::Windows::UI::Composition::ContainerVisual>();
 
     auto hwnd = reinterpret_cast<HWND>(
         winrt::Microsoft::ReactNative::ReactCoreInjection::GetTopLevelWindowId(ReactContext().Properties()));
 
     m_siteBridge = winrt::Microsoft::UI::Content::SystemVisualSiteBridge::Create(
-        m_contentIsland.Compositor(), parentSystemVisual, winrt::Microsoft::UI::GetWindowIdFromWindow(hwnd));
+        m_contentIsland.Compositor(), m_visual, winrt::Microsoft::UI::GetWindowIdFromWindow(hwnd));
     m_siteBridge.Connect(m_contentIsland);
 
     auto rootXamlVisualSize = m_contentIsland.Root().Size();
@@ -171,7 +167,7 @@ struct CustomComponent : CustomComponentT<CustomComponent> {
   const bool m_nativeLayout;
   winrt::Microsoft::UI::Xaml::Controls::TextBlock m_buttonLabelTextBlock{nullptr};
   winrt::Microsoft::ReactNative::IComponentState m_state;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::UI::Composition::Visual m_visual{nullptr};
 #ifdef USE_EXPERIMENTAL_WINUI3
   winrt::Microsoft::UI::Xaml::XamlIsland m_xamlIsland{nullptr};
   winrt::Microsoft::UI::Content::ContentIsland m_contentIsland{nullptr};

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -299,8 +299,9 @@ struct WindowData {
 
   LRESULT TranslateMessage(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) noexcept {
     if (!m_useLiftedComposition && m_compRootView) {
-      return static_cast<LRESULT>(m_compRootView
-                  .as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>().SendMessage(message, wparam, lparam));
+      return static_cast<LRESULT>(
+          m_compRootView.as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+              .SendMessage(message, wparam, lparam));
     }
     return 0;
   }

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -219,7 +219,9 @@ struct WindowData {
               root.RelativeSizeAdjustment({1.0f, 1.0f});
               root.Offset({0, 0, 0});
               m_target.Root(root);
-              m_compRootView.SetWindow(reinterpret_cast<uint64_t>(hwnd));
+              m_compRootView
+                  .as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+                  .SetWindow(reinterpret_cast<uint64_t>(hwnd));
               m_compRootView
                   .as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
                   .InternalRootVisual(winrt::Microsoft::ReactNative::Composition::Experimental::

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -39,6 +39,8 @@ winrt::Microsoft::UI::Dispatching::DispatcherQueueController g_liftedDispatcherQ
 winrt::Microsoft::UI::Composition::Compositor g_liftedCompositor{nullptr};
 #endif
 
+#undef SendMessage
+
 void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
 
 // Have to use TurboModules to override built in modules.. so the standard attributed package provider doesn't work.

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -16,6 +16,7 @@
 #include <UIAutomation.h>
 #include <windows.ui.composition.interop.h>
 
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Windows.UI.Composition.Desktop.h>
 #include <winrt/Windows.UI.Composition.h>
@@ -176,31 +177,14 @@ struct WindowData {
             }
 
             if (windowData->m_useLiftedComposition) {
-              // By using the MicrosoftCompositionContextHelper here, React Native Windows will use Lifted Visuals for
-              // its tree.
-              winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
-                  InstanceSettings().Properties(),
-                  winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::CreateContext(
-                      g_liftedCompositor));
+              // By setting the compositor here we opt into using the new architecture.
+              winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(
+                  InstanceSettings(), g_liftedCompositor);
 
               auto bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
                   g_liftedCompositor, winrt::Microsoft::UI::GetWindowIdFromWindow(hwnd));
 
               auto appContent = m_compRootView.Island();
-
-              auto invScale = 1.0f / ScaleFactor(hwnd);
-              m_compRootView.RootVisual().Scale({invScale, invScale, invScale});
-
-              /*
-                // Future versions of WinAppSDK will have more capabilities around scale and size
-                auto site = bridge.Site();
-                auto siteWindow = site.Environment();
-                auto displayScale = siteWindow.DisplayScale();
-
-                site.ParentScale(displayScale);
-                site.ActualSize({m_width / displayScale, m_height / displayScale});
-                site.ClientSize({m_width / displayScale, m_height / displayScale});
-              */
 
               bridge.Connect(appContent);
               bridge.Show();
@@ -211,12 +195,16 @@ struct WindowData {
               bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
 
             } else if (!m_target) {
-              // By using the SystemCompositionContextHelper here, React Native Windows will use System Visuals for its
-              // tree.
-              winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
-                  InstanceSettings().Properties(),
-                  winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateContext(
-                      g_compositor));
+              // General users of RNW should never set CompositionContext - this is an advanced usage to inject another
+              // composition implementation. By using the SystemCompositionContextHelper here, React Native Windows will
+              // use System Visuals for its tree.
+              winrt::Microsoft::ReactNative::ReactPropertyBag(InstanceSettings().Properties())
+                  .Set(
+                      winrt::Microsoft::ReactNative::ReactPropertyId<
+                          winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext>{
+                          L"ReactNative.Composition", L"CompositionContext"},
+                      winrt::Microsoft::ReactNative::Composition::Experimental::SystemCompositionContextHelper::
+                          CreateContext(g_compositor));
 
               auto interop = g_compositor.as<ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
               winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{nullptr};
@@ -232,8 +220,10 @@ struct WindowData {
               root.Offset({0, 0, 0});
               m_target.Root(root);
               m_compRootView.SetWindow(reinterpret_cast<uint64_t>(hwnd));
-              m_compRootView.RootVisual(
-                  winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateVisual(root));
+              m_compRootView
+                  .as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+                  .InternalRootVisual(winrt::Microsoft::ReactNative::Composition::Experimental::
+                                          SystemCompositionContextHelper::CreateVisual(root));
               m_compRootView.ScaleFactor(ScaleFactor(hwnd));
               m_compRootView.Size({m_width / ScaleFactor(hwnd), m_height / ScaleFactor(hwnd)});
             }

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -39,8 +39,6 @@ winrt::Microsoft::UI::Dispatching::DispatcherQueueController g_liftedDispatcherQ
 winrt::Microsoft::UI::Composition::Compositor g_liftedCompositor{nullptr};
 #endif
 
-#undef SendMessage
-
 void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
 
 // Have to use TurboModules to override built in modules.. so the standard attributed package provider doesn't work.
@@ -301,7 +299,8 @@ struct WindowData {
 
   LRESULT TranslateMessage(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) noexcept {
     if (!m_useLiftedComposition && m_compRootView) {
-      return static_cast<LRESULT>(m_compRootView.SendMessage(message, wparam, lparam));
+      return static_cast<LRESULT>(m_compRootView
+                  .as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>().SendMessage(message, wparam, lparam));
     }
     return 0;
   }

--- a/vnext/Desktop/React.Windows.Desktop.vcxproj
+++ b/vnext/Desktop/React.Windows.Desktop.vcxproj
@@ -53,6 +53,7 @@
     <V8AppPlatform>win32</V8AppPlatform>
     <HermesCompileRtti>false</HermesCompileRtti>
     <IncludeFabricInterface Condition="'$(IncludeFabricInterface)' == ''">true</IncludeFabricInterface>
+    <UseWinUI3 Condition="'$(UseWinUI3)' == ''">true</UseWinUI3>
   </PropertyGroup>
   <PropertyGroup Label="Permissive">
     <ENABLEPermissive>true</ENABLEPermissive>

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -8,9 +8,9 @@
 void* winrt_make_Microsoft_Internal_TestController();
 void* winrt_make_Microsoft_ReactNative_CompositionRootView();
 #ifdef USE_WINUI3
-void *winrt_make_Microsoft_ReactNative_Composition_MicrosoftCompositionContextHelper();
+void *winrt_make_Microsoft_ReactNative_Composition_Experimental_MicrosoftCompositionContextHelper();
 #endif
-void *winrt_make_Microsoft_ReactNative_Composition_SystemCompositionContextHelper();
+void *winrt_make_Microsoft_ReactNative_Composition_Experimental_SystemCompositionContextHelper();
 void *winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();
 void* winrt_make_Microsoft_ReactNative_JsiRuntime();
 void* winrt_make_Microsoft_ReactNative_ReactCoreInjection();
@@ -50,12 +50,12 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
       return winrt_make_Microsoft_ReactNative_CompositionRootView();
     }
 #ifdef USE_WINUI3
-    if (requal(name, L"Microsoft.ReactNative.Composition.MicrosoftCompositionContextHelper")) {
-      return winrt_make_Microsoft_ReactNative_Composition_MicrosoftCompositionContextHelper();
+    if (requal(name, L"Microsoft.ReactNative.Composition.Experimental.MicrosoftCompositionContextHelper")) {
+      return winrt_make_Microsoft_ReactNative_Composition_Experimental_MicrosoftCompositionContextHelper();
     }
 #endif
-    if (requal(name, L"Microsoft.ReactNative.Composition.SystemCompositionContextHelper")) {
-      return winrt_make_Microsoft_ReactNative_Composition_SystemCompositionContextHelper();
+    if (requal(name, L"Microsoft.ReactNative.Composition.Experimental.SystemCompositionContextHelper")) {
+      return winrt_make_Microsoft_ReactNative_Composition_Experimental_SystemCompositionContextHelper();
     }
     if (requal(name, L"Microsoft.ReactNative.Composition.CompositionUIService")) {
       return winrt_make_Microsoft_ReactNative_Composition_CompositionUIService();

--- a/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
@@ -3,14 +3,14 @@
 
 #include <winrt/Microsoft.ReactNative.Composition.h>
 
-#include <CompositionSwitcher.interop.h>
+#include <CompositionSwitcher.Experimental.interop.h>
 
 namespace Microsoft::ReactNative::Composition {
 
 class AutoDrawDrawingSurface {
  public:
   AutoDrawDrawingSurface(
-      winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush &drawingSurface,
+      winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush &drawingSurface,
       POINT *offset) noexcept {
     drawingSurface.as(m_drawingSurfaceInterop);
     m_drawingSurfaceInterop->BeginDraw(m_d2dDeviceContext.put(), offset);
@@ -31,7 +31,7 @@ class AutoDrawDrawingSurface {
   }
 
  private:
-  winrt::com_ptr<ICompositionDrawingSurfaceInterop> m_drawingSurfaceInterop;
+  winrt::com_ptr<Experimental::ICompositionDrawingSurfaceInterop> m_drawingSurfaceInterop;
   winrt::com_ptr<ID2D1DeviceContext> m_d2dDeviceContext;
 };
 

--- a/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
+++ b/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
@@ -12,7 +12,7 @@
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Windows.Graphics.DirectX.Direct3D11.h>
 
-namespace Microsoft::ReactNative::Composition {
+namespace Microsoft::ReactNative::Composition::Experimental {
 
 struct __declspec(uuid("941FDD90-ED27-49CE-A1CD-86ECB2D4A0FA")) ICompositionDrawingSurfaceInterop : public IUnknown {
   virtual HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, POINT *offset) noexcept = 0;

--- a/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
+++ b/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
@@ -31,4 +31,4 @@ struct __declspec(uuid("4742F122-3EE0-48AA-9EA9-44A00147B55F")) ICompositionCont
   virtual void D2DFactory(ID2D1Factory1 **outD2DFactory) noexcept = 0;
 };
 
-} // namespace Microsoft::ReactNative::Composition
+} // namespace Microsoft::ReactNative::Composition::Experimental

--- a/vnext/Microsoft.ReactNative/CompositionComponentView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionComponentView.idl
@@ -6,6 +6,7 @@ import "Theme.idl";
 import "ViewProps.idl";
 import "Composition.Input.idl";
 import "CompositionSwitcher.idl";
+import "IReactContext.idl";
 
 #include "DocString.h"
 
@@ -28,7 +29,7 @@ namespace Microsoft.ReactNative.Composition
   [experimental]
   [webhosthidden]
   runtimeclass CreateCompositionComponentViewArgs : Microsoft.ReactNative.CreateComponentViewArgs {
-    ICompositionContext CompositionContext { get; };
+    Microsoft.UI.Composition.Compositor Compositor { get; };
     ComponentViewFeatures Features;
   };
 
@@ -37,12 +38,26 @@ namespace Microsoft.ReactNative.Composition
   unsealed runtimeclass ComponentView : Microsoft.ReactNative.ComponentView {
     ComponentView(CreateCompositionComponentViewArgs args);
 
-    ICompositionContext CompositionContext { get; };
+    Microsoft.UI.Composition.Compositor Compositor { get; };
     Theme Theme;
     overridable void OnThemeChanged();
     Boolean CapturePointer(Microsoft.ReactNative.Composition.Input.Pointer pointer);
     void ReleasePointerCapture(Microsoft.ReactNative.Composition.Input.Pointer pointer);
   };
+
+  namespace Experimental {
+    [webhosthidden]
+    [experimental]
+    DOC_STRING("Custom ViewComponents need to implement this interface to be able to provide a custom"
+    " visual using the composition context that allows custom compositors. This is only required for"
+    " custom components that need to support running in RNW instances with custom compositors. Most"
+    " custom components can just override CreateVisual on ViewComponentView."
+    " This will be removed in a future version")
+    interface IInternalCreateVisual
+    {
+      Microsoft.ReactNative.Composition.Experimental.IVisual CreateInternalVisual();
+    }
+  }
 
   [experimental]
   [webhosthidden]
@@ -51,7 +66,7 @@ namespace Microsoft.ReactNative.Composition
 
     Microsoft.ReactNative.ViewProps ViewProps { get; };
 
-    overridable IVisual CreateVisual();
+    overridable Microsoft.UI.Composition.Visual CreateVisual();
   };
 
   [experimental]

--- a/vnext/Microsoft.ReactNative/CompositionContext.idl
+++ b/vnext/Microsoft.ReactNative/CompositionContext.idl
@@ -5,17 +5,17 @@
 #include "DocString.h"
 import "CompositionSwitcher.idl";
 
-namespace Microsoft.ReactNative.Composition
+namespace Microsoft.ReactNative.Composition.Experimental
 {
   [webhosthidden]
   [default_interface]
   [experimental]
-  DOC_STRING("A helper static class for to create a @ICompositionContext based on Windows.Composition Visuals.  And to access the underlying Windows.Composition objects from the abstraction.")
+  DOC_STRING("A helper static class to create a @ICompositionContext based on Windows.Composition Visuals. This is not for general consumption and is expected to be removed in a future release.")
   static runtimeclass SystemCompositionContextHelper
   {
     DOC_STRING(
       "Creates a @ICompositionContext from a Compositor")
-    static ICompositionContext CreateContext(Windows.UI.Composition.Compositor compositor);
+    static Microsoft.ReactNative.Composition.Experimental.ICompositionContext CreateContext(Windows.UI.Composition.Compositor compositor);
 
     DOC_STRING(
       "Creates a @IVisual from a Visual")
@@ -32,12 +32,12 @@ namespace Microsoft.ReactNative.Composition
   [webhosthidden]
   [default_interface]
   [experimental]
-  DOC_STRING("A helper static class for to create a @ICompositionContext based on Microsoft.Composition Visuals.  And to access the underlying Microsoft.Composition objects from the abstraction.")
+  DOC_STRING("A helper static class to create a @ICompositionContext based on Microsoft.Composition Visuals. Generally it should not be required to call this directly. Instead you should call @CompositionUIService.SetCompositor. This is not for general consumption and is expected to be removed in a future release.")
   static runtimeclass MicrosoftCompositionContextHelper
   {
     DOC_STRING(
       "Creates a @ICompositionContext from a Compositor")
-    static ICompositionContext CreateContext(Microsoft.UI.Composition.Compositor compositor);
+    static Microsoft.ReactNative.Composition.Experimental.ICompositionContext CreateContext(Microsoft.UI.Composition.Compositor compositor);
 
     DOC_STRING(
       "Creates a @IVisual from a Visual")

--- a/vnext/Microsoft.ReactNative/CompositionRootView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionRootView.idl
@@ -52,6 +52,12 @@ namespace Microsoft.ReactNative
   {
     DOC_STRING("The RootVisual associated with the @CompositionRootView. It must be set to show any React UI elements.")
     Microsoft.ReactNative.Composition.Experimental.IVisual InternalRootVisual { get; set; };
+    
+    DOC_STRING("Hosting Window that input is coming from. Only required when not using ContentIslands")
+    void SetWindow(UInt64 hwnd);
+
+    DOC_STRING("Forward input to the RootView. Only required when not using ContentIslands")
+    Int64 SendMessage(UInt32 Msg, UInt64 WParam, Int64 LParam);
   }
   }
 
@@ -86,12 +92,6 @@ namespace Microsoft.ReactNative
 
     Windows.Foundation.Size Measure(Windows.Foundation.Size availableSize);
     Windows.Foundation.Size Arrange(Windows.Foundation.Size availableSize);
-
-    DOC_STRING("Hosting Window that input is coming from. Only required when not using ContentIslands")
-    void SetWindow(UInt64 hwnd);
-
-    DOC_STRING("Forward input to the RootView. Only required when not using ContentIslands")
-    Int64 SendMessage(UInt32 Msg, UInt64 WParam, Int64 LParam);
 
     Object GetUiaProvider();
 

--- a/vnext/Microsoft.ReactNative/CompositionRootView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionRootView.idl
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import "CompositionContext.idl";
 import "IJSValueWriter.idl";
 import "ReactCoreInjection.idl";
 import "ReactNativeHost.idl";
@@ -41,6 +40,21 @@ namespace Microsoft.ReactNative
     Boolean WasFocusMoved {get;};
   };
 
+  namespace Composition.Experimental {
+  [webhosthidden]
+  [experimental]
+  DOC_STRING("Custom ViewComponents need to implement this interface to be able to provide a custom"
+  " visual using the composition context that allows custom compositors.  This is only required for"
+  " custom components that need to support running in RNW instances with custom compositors.  Most"
+  " custom components can just override CreateVisual on ViewComponentView. This interface will be removed"
+  " in future versions")
+  interface IInternalCompositionRootView
+  {
+    DOC_STRING("The RootVisual associated with the @CompositionRootView. It must be set to show any React UI elements.")
+    Microsoft.ReactNative.Composition.Experimental.IVisual InternalRootVisual { get; set; };
+  }
+  }
+
   [default_interface]
   [webhosthidden]
   [experimental]
@@ -60,7 +74,7 @@ namespace Microsoft.ReactNative
     IReactViewHost ReactViewHost { get; set; };
 
     DOC_STRING("The RootVisual associated with the @CompositionRootView. It must be set to show any React UI elements.")
-    Microsoft.ReactNative.Composition.IVisual RootVisual { get; set; };
+    Microsoft.UI.Composition.Visual RootVisual { get; };
 
     Windows.Foundation.Size Size {get; set; };
 

--- a/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
+++ b/vnext/Microsoft.ReactNative/CompositionSwitcher.idl
@@ -4,7 +4,7 @@
 #include "NamespaceRedirect.h"
 #include "DocString.h"
 
-namespace Microsoft.ReactNative.Composition
+namespace Microsoft.ReactNative.Composition.Experimental
 {
   enum CompositionStretch
   {
@@ -161,4 +161,4 @@ namespace Microsoft.ReactNative.Composition
     // event Windows.Foundation.EventHandler<RenderingDeviceReplacedArgs> RenderingDeviceReplaced;
   }
 
-} // namespace Microsoft.ReactNative.Composition
+} // namespace Microsoft.ReactNative.Composition.Experimental

--- a/vnext/Microsoft.ReactNative/CompositionUIService.idl
+++ b/vnext/Microsoft.ReactNative/CompositionUIService.idl
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import "IReactContext.idl";
-import "IReactPropertyBag.idl";
-import "CompositionContext.idl";
+import "ReactInstanceSettings.idl";
 
-#include "NamespaceRedirect.h"
 #include "DocString.h"
 
 namespace Microsoft.ReactNative.Composition
@@ -18,7 +15,12 @@ namespace Microsoft.ReactNative.Composition
   runtimeclass CompositionUIService
   {
     DOC_STRING(
-      "Sets the CompositionContext for this react instance.  This can be created using @CompositionContextHelper.CreateContext")
-    static void SetCompositionContext(Microsoft.ReactNative.IReactPropertyBag properties, ICompositionContext compositionContext);
+      "Configures the react instance to use the provided Compositor. Setting this will opt into using the new architecture")
+    static void SetCompositor(Microsoft.ReactNative.ReactInstanceSettings settings, Microsoft.UI.Composition.Compositor compositor);
+
+    DOC_STRING(
+      "Gets the Compositor used by this ReactNative instance.")
+    static Microsoft.UI.Composition.Compositor GetCompositor(Microsoft.ReactNative.IReactPropertyBag properties);
+
   }
 } // namespace Microsoft.ReactNative.Composition

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
@@ -51,11 +51,13 @@ winrt::Windows::UI::Color Color::AsWindowsColor(
     const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept {
   return winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Color(*m_color);
 }
+#ifdef USE_WINUI3
 winrt::Microsoft::UI::Composition::CompositionBrush Color::AsBrush(
     const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept {
   return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerBrush(
       winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Brush(*m_color));
 }
+#endif
 winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Color::AsInternalBrush(
     const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept {
   return winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Brush(*m_color);

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.cpp
@@ -51,7 +51,12 @@ winrt::Windows::UI::Color Color::AsWindowsColor(
     const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept {
   return winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Color(*m_color);
 }
-winrt::Microsoft::ReactNative::Composition::IBrush Color::AsBrush(
+winrt::Microsoft::UI::Composition::CompositionBrush Color::AsBrush(
+    const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept {
+  return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerBrush(
+      winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Brush(*m_color));
+}
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Color::AsInternalBrush(
     const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept {
   return winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(theme)->Brush(*m_color);
 }

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
@@ -7,6 +7,7 @@
 #include "ViewProps.g.h"
 
 #include <react/renderer/components/view/ViewProps.h>
+#include "winrt/Microsoft.ReactNative.Composition.Experimental.h"
 #include "winrt/Microsoft.ReactNative.h"
 
 namespace Microsoft::ReactNative {
@@ -35,11 +36,13 @@ class AbiViewProps final : public facebook::react::ViewProps {
 
 namespace winrt::Microsoft::ReactNative::implementation {
 
-struct Color : ColorT<Color> {
+struct Color : ColorT<Color, Composition::Experimental::IInternalColor> {
   Color(facebook::react::SharedColor color);
 
   winrt::Windows::UI::Color AsWindowsColor(const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
-  winrt::Microsoft::ReactNative::Composition::IBrush AsBrush(
+  winrt::Microsoft::UI::Composition::CompositionBrush AsBrush(
+      const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush AsInternalBrush(
       const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept;
 
   static winrt::Microsoft::ReactNative::Color ReadValue(

--- a/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
+++ b/vnext/Microsoft.ReactNative/Fabric/AbiViewProps.h
@@ -40,8 +40,10 @@ struct Color : ColorT<Color, Composition::Experimental::IInternalColor> {
   Color(facebook::react::SharedColor color);
 
   winrt::Windows::UI::Color AsWindowsColor(const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
+#ifdef USE_WINUI3
   winrt::Microsoft::UI::Composition::CompositionBrush AsBrush(
       const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept;
+#endif
   winrt::Microsoft::ReactNative::Composition::Experimental::IBrush AsInternalBrush(
       const winrt::Microsoft::ReactNative::Composition::Theme theme) noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.cpp
@@ -14,14 +14,14 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 winrt::Microsoft::ReactNative::ComponentView ActivityIndicatorComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<ActivityIndicatorComponentView>(compContext, tag, reactContext);
 }
 
 ActivityIndicatorComponentView::ActivityIndicatorComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(compContext, tag, reactContext, ComponentViewFeatures::Default, false) {
@@ -141,7 +141,8 @@ facebook::react::Tag ActivityIndicatorComponentView::hitTest(
   return -1;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ActivityIndicatorComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ActivityIndicatorComponentView::Visual()
+    const noexcept {
   return m_visual;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ActivityIndicatorComponentView.h
@@ -17,7 +17,7 @@ struct ActivityIndicatorComponentView : ActivityIndicatorComponentViewT<Activity
   using Super = ActivityIndicatorComponentViewT<ActivityIndicatorComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -42,11 +42,11 @@ struct ActivityIndicatorComponentView : ActivityIndicatorComponentViewT<Activity
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   virtual std::string DefaultControlType() const noexcept;
 
   ActivityIndicatorComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -55,8 +55,8 @@ struct ActivityIndicatorComponentView : ActivityIndicatorComponentViewT<Activity
   void updateVisualSize() noexcept;
   void updateProgressColor(const facebook::react::SharedColor &color) noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IActivityVisual m_ActivityIndicatorVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual m_ActivityIndicatorVisual{nullptr};
   facebook::react::SharedViewProps m_props;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.cpp
@@ -42,7 +42,7 @@ void ComponentViewRegistry::Initialize(winrt::Microsoft::ReactNative::ReactConte
 ComponentViewDescriptor const &ComponentViewRegistry::dequeueComponentViewWithComponentHandle(
     facebook::react::ComponentHandle componentHandle,
     facebook::react::Tag tag,
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext) noexcept {
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext) noexcept {
   // TODO implement recycled components like core does
 
   winrt::Microsoft::ReactNative::ComponentView view{nullptr};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ComponentViewRegistry.h
@@ -19,7 +19,8 @@ class ComponentViewRegistry final : public IComponentViewRegistry {
   ComponentViewDescriptor const &dequeueComponentViewWithComponentHandle(
       facebook::react::ComponentHandle componentHandle,
       facebook::react::Tag tag,
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext) noexcept override;
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext) noexcept
+      override;
   ComponentViewDescriptor const &componentViewDescriptorWithTag(facebook::react::Tag tag) const noexcept override;
   winrt::Microsoft::ReactNative::ComponentView findComponentViewWithTag(
       facebook::react::Tag tag) const noexcept override;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1,12 +1,12 @@
 
 #include "pch.h"
 #include "CompositionContextHelper.h"
-#if __has_include("Composition.SystemCompositionContextHelper.g.cpp")
-#include "Composition.SystemCompositionContextHelper.g.cpp"
+#if __has_include("Composition.Experimental.SystemCompositionContextHelper.g.cpp")
+#include "Composition.Experimental.SystemCompositionContextHelper.g.cpp"
 #endif
 #ifdef USE_WINUI3
-#if __has_include("Composition.MicrosoftCompositionContextHelper.g.cpp")
-#include "Composition.MicrosoftCompositionContextHelper.g.cpp"
+#if __has_include("Composition.Experimental.MicrosoftCompositionContextHelper.g.cpp")
+#include "Composition.Experimental.MicrosoftCompositionContextHelper.g.cpp"
 #endif
 #endif
 
@@ -23,7 +23,7 @@
 #include <winrt/Microsoft.UI.Composition.interop.h>
 #endif
 
-namespace Microsoft::ReactNative::Composition {
+namespace Microsoft::ReactNative::Composition::Experimental {
 
 template <typename TSpriteVisual>
 struct CompositionTypeTraits {};
@@ -91,7 +91,8 @@ struct CompositionTypeTraits<WindowsTypeTag> {
   using IInnerCompositionVisual = IWindowsCompositionVisual;
   using IInnerCompositionBrush = IWindowsCompositionBrush;
   using IInnerCompositionDrawingSurface = IWindowsCompositionDrawingSurfaceInner;
-  using CompositionContextHelper = winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper;
+  using CompositionContextHelper =
+      winrt::Microsoft::ReactNative::Composition::Experimental::SystemCompositionContextHelper;
 };
 using WindowsTypeRedirects = CompositionTypeTraits<WindowsTypeTag>;
 
@@ -159,7 +160,8 @@ struct CompositionTypeTraits<MicrosoftTypeTag> {
   using IInnerCompositionVisual = IMicrosoftCompositionVisual;
   using IInnerCompositionBrush = IMicrosoftCompositionBrush;
   using IInnerCompositionDrawingSurface = IMicrosoftCompositionDrawingSurfaceInner;
-  using CompositionContextHelper = winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper;
+  using CompositionContextHelper =
+      winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper;
 };
 using MicrosoftTypeRedirects = CompositionTypeTraits<MicrosoftTypeTag>;
 #endif
@@ -188,7 +190,7 @@ struct GeometrySource : public winrt::implements<
 template <typename TTypeRedirects>
 struct CompDropShadow : public winrt::implements<
                             CompDropShadow<TTypeRedirects>,
-                            winrt::Microsoft::ReactNative::Composition::IDropShadow,
+                            winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow,
                             typename TTypeRedirects::IInnerCompositionDropShadow> {
   CompDropShadow(typename TTypeRedirects::DropShadow const &shadow) : m_shadow(shadow) {}
 
@@ -223,7 +225,7 @@ using MicrosoftCompDropShadow = CompDropShadow<MicrosoftTypeRedirects>;
 template <typename TTypeRedirects>
 struct CompBrush : public winrt::implements<
                        CompBrush<TTypeRedirects>,
-                       winrt::Microsoft::ReactNative::Composition::IBrush,
+                       winrt::Microsoft::ReactNative::Composition::Experimental::IBrush,
                        typename TTypeRedirects::IInnerCompositionBrush> {
   CompBrush(typename TTypeRedirects::CompositionBrush const &brush) : m_brush(brush) {}
 
@@ -242,8 +244,8 @@ using MicrosoftCompBrush = CompBrush<MicrosoftTypeRedirects>;
 template <typename TTypeRedirects>
 struct CompDrawingSurfaceBrush : public winrt::implements<
                                      CompDrawingSurfaceBrush<TTypeRedirects>,
-                                     winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush,
-                                     winrt::Microsoft::ReactNative::Composition::IBrush,
+                                     winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush,
+                                     winrt::Microsoft::ReactNative::Composition::Experimental::IBrush,
                                      typename TTypeRedirects::IInnerCompositionBrush,
                                      ICompositionDrawingSurfaceInterop,
                                      typename TTypeRedirects::IInnerCompositionDrawingSurface> {
@@ -284,23 +286,23 @@ struct CompDrawingSurfaceBrush : public winrt::implements<
     m_brush.VerticalAlignmentRatio(ratio);
   }
 
-  void Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch mode) noexcept {
+  void Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch mode) noexcept {
     static_assert(
-        static_cast<winrt::Microsoft::ReactNative::Composition::CompositionStretch>(
+        static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch>(
             TTypeRedirects::CompositionStretch::None) ==
-        winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+        winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     static_assert(
-        static_cast<winrt::Microsoft::ReactNative::Composition::CompositionStretch>(
+        static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch>(
             TTypeRedirects::CompositionStretch::Fill) ==
-        winrt::Microsoft::ReactNative::Composition::CompositionStretch::Fill);
+        winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::Fill);
     static_assert(
-        static_cast<winrt::Microsoft::ReactNative::Composition::CompositionStretch>(
+        static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch>(
             TTypeRedirects::CompositionStretch::Uniform) ==
-        winrt::Microsoft::ReactNative::Composition::CompositionStretch::Uniform);
+        winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::Uniform);
     static_assert(
-        static_cast<winrt::Microsoft::ReactNative::Composition::CompositionStretch>(
+        static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch>(
             TTypeRedirects::CompositionStretch::UniformToFill) ==
-        winrt::Microsoft::ReactNative::Composition::CompositionStretch::UniformToFill);
+        winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::UniformToFill);
 
     m_brush.Stretch(static_cast<typename TTypeRedirects::CompositionStretch>(mode));
   }
@@ -316,19 +318,19 @@ using MicrosoftCompDrawingSurfaceBrush = CompDrawingSurfaceBrush<MicrosoftTypeRe
 
 template <typename TTypeRedirects>
 void SetAnimationClass(
-    winrt::Microsoft::ReactNative::Composition::AnimationClass value,
+    winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value,
     typename const TTypeRedirects::Visual &visual) {
   constexpr int64_t ScrollBarExpandBeginTime = 400; // ms
   constexpr int64_t ScrollBarExpandDuration = 167; // ms
   constexpr int64_t SwitchDuration = 167; // ms
 
   switch (value) {
-    case winrt::Microsoft::ReactNative::Composition::AnimationClass::None: {
+    case winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::None: {
       visual.ImplicitAnimations(nullptr);
       break;
     }
 
-    case winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb: {
+    case winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::SwitchThumb: {
       auto compositor = visual.Compositor();
       auto offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
       offsetAnimation.InsertExpressionKeyFrame(
@@ -344,7 +346,7 @@ void SetAnimationClass(
       break;
     }
 
-    case winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar: {
+    case winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBar: {
       auto compositor = visual.Compositor();
 
       auto opacityAnimation = compositor.CreateScalarKeyFrameAnimation();
@@ -360,15 +362,15 @@ void SetAnimationClass(
       break;
     }
 
-    case winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical:
-    case winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal: {
+    case winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbVertical:
+    case winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbHorizontal: {
       auto compositor = visual.Compositor();
       auto offsetAnimation = compositor.CreateVector3KeyFrameAnimation();
       // We cannot just use a DelayTime, since we want changes to the offset in the scrolling dirction to happen
       // immediately, and only delay the offset changes used when hiding/showing the scrollbar
       float delayStartFrameOffset =
           static_cast<float>(ScrollBarExpandBeginTime) / (ScrollBarExpandBeginTime + ScrollBarExpandDuration);
-      if (value == winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical) {
+      if (value == winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbVertical) {
         offsetAnimation.InsertExpressionKeyFrame(
             0.0f, L"vector3(this.CurrentValue.X, this.FinalValue.Y, this.FinalValue.Z)");
         offsetAnimation.InsertExpressionKeyFrame(
@@ -407,7 +409,9 @@ struct CompVisualImpl {
     return m_visual;
   }
 
-  void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
+  void InsertAt(
+      const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual,
+      uint32_t index) noexcept {
     auto containerChildren = InnerVisual().as<typename TTypeRedirects::ContainerVisual>().Children();
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     if (index == 0) {
@@ -420,13 +424,13 @@ struct CompVisualImpl {
     containerChildren.InsertAbove(compVisual, insertAfter.Current());
   }
 
-  void Remove(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept {
+  void Remove(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept {
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     auto containerChildren = InnerVisual().as<typename TTypeRedirects::ContainerVisual>().Children();
     containerChildren.Remove(compVisual);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual GetAt(uint32_t index) noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual GetAt(uint32_t index) noexcept {
     auto containerChildren = m_visual.as<typename TTypeRedirects::ContainerVisual>().Children();
     auto it = containerChildren.First();
     for (uint32_t i = 0; i < index; i++)
@@ -488,11 +492,12 @@ struct CompVisualImpl {
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
   }
 
-  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() const noexcept {
-    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility BackfaceVisibility() const noexcept {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility>(
+        m_visual.BackfaceVisibility());
   }
 
-  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) noexcept {
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility value) noexcept {
     m_visual.BackfaceVisibility(static_cast<typename TTypeRedirects::CompositionBackfaceVisibility>(value));
   }
 
@@ -504,7 +509,7 @@ struct CompVisualImpl {
     m_visual.Comment(value);
   }
 
-  void AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass value) noexcept {
+  void AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value) noexcept {
     SetAnimationClass<TTypeRedirects>(value, m_visual);
   }
 
@@ -515,7 +520,7 @@ struct CompVisualImpl {
 template <typename TTypeRedirects>
 struct CompVisual : public winrt::implements<
                         CompVisual<TTypeRedirects>,
-                        winrt::Microsoft::ReactNative::Composition::IVisual,
+                        winrt::Microsoft::ReactNative::Composition::Experimental::IVisual,
                         typename TTypeRedirects::IInnerCompositionVisual,
                         IVisualInterop>,
                     CompVisualImpl<TTypeRedirects> {
@@ -540,8 +545,8 @@ using MicrosoftCompVisual = CompVisual<MicrosoftTypeRedirects>;
 template <typename TTypeRedirects>
 struct CompSpriteVisual : winrt::implements<
                               CompSpriteVisual<TTypeRedirects>,
-                              winrt::Microsoft::ReactNative::Composition::ISpriteVisual,
-                              winrt::Microsoft::ReactNative::Composition::IVisual,
+                              winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual,
+                              winrt::Microsoft::ReactNative::Composition::Experimental::IVisual,
                               typename TTypeRedirects::IInnerCompositionVisual,
                               IVisualInterop>,
                           CompVisualImpl<TTypeRedirects, typename TTypeRedirects::SpriteVisual> {
@@ -558,11 +563,11 @@ struct CompSpriteVisual : winrt::implements<
     Super::SetClippingPath(clippingPath);
   }
 
-  void Brush(const winrt::Microsoft::ReactNative::Composition::IBrush &brush) noexcept {
+  void Brush(const winrt::Microsoft::ReactNative::Composition::Experimental::IBrush &brush) noexcept {
     Super::m_visual.Brush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
-  void Shadow(const winrt::Microsoft::ReactNative::Composition::IDropShadow &shadow) noexcept {
+  void Shadow(const winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow &shadow) noexcept {
     Super::m_visual.Shadow(TTypeRedirects::CompositionContextHelper::InnerDropShadow(shadow));
   }
 };
@@ -572,13 +577,14 @@ using MicrosoftCompSpriteVisual = CompSpriteVisual<MicrosoftTypeRedirects>;
 #endif
 
 template <typename TTypeRedirects>
-struct CompRoundedRectangleVisual : winrt::implements<
-                                        CompRoundedRectangleVisual<TTypeRedirects>,
-                                        winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual,
-                                        winrt::Microsoft::ReactNative::Composition::IVisual,
-                                        typename TTypeRedirects::IInnerCompositionVisual,
-                                        IVisualInterop>,
-                                    CompVisualImpl<TTypeRedirects> {
+struct CompRoundedRectangleVisual
+    : winrt::implements<
+          CompRoundedRectangleVisual<TTypeRedirects>,
+          winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual,
+          winrt::Microsoft::ReactNative::Composition::Experimental::IVisual,
+          typename TTypeRedirects::IInnerCompositionVisual,
+          IVisualInterop>,
+      CompVisualImpl<TTypeRedirects> {
   using Super = CompVisualImpl<TTypeRedirects>;
   CompRoundedRectangleVisual(typename TTypeRedirects::ShapeVisual const &visual) : Super(visual) {
     auto compositor = visual.Compositor();
@@ -622,7 +628,7 @@ struct CompRoundedRectangleVisual : winrt::implements<
     Super::m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
   }
 
-  void Brush(const winrt::Microsoft::ReactNative::Composition::IBrush &brush) noexcept {
+  void Brush(const winrt::Microsoft::ReactNative::Composition::Experimental::IBrush &brush) noexcept {
     m_spriteShape.FillBrush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
@@ -631,7 +637,7 @@ struct CompRoundedRectangleVisual : winrt::implements<
     updateGeometry();
   }
 
-  void StrokeBrush(const winrt::Microsoft::ReactNative::Composition::IBrush &brush) noexcept {
+  void StrokeBrush(const winrt::Microsoft::ReactNative::Composition::Experimental::IBrush &brush) noexcept {
     m_spriteShape.StrokeBrush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
@@ -653,9 +659,10 @@ using WindowsCompRoundedRectangleVisual = CompRoundedRectangleVisual<WindowsType
 using MicrosoftCompRoundedRectangleVisual = CompRoundedRectangleVisual<MicrosoftTypeRedirects>;
 #endif
 
-struct CompScrollPositionChangedArgs : winrt::implements<
-                                           CompScrollPositionChangedArgs,
-                                           winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs> {
+struct CompScrollPositionChangedArgs
+    : winrt::implements<
+          CompScrollPositionChangedArgs,
+          winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs> {
   CompScrollPositionChangedArgs(winrt::Windows::Foundation::Numerics::float2 position) : m_position(position) {}
 
   winrt::Windows::Foundation::Numerics::float2 Position() const noexcept {
@@ -669,8 +676,8 @@ struct CompScrollPositionChangedArgs : winrt::implements<
 template <typename TTypeRedirects>
 struct CompScrollerVisual : winrt::implements<
                                 CompScrollerVisual<TTypeRedirects>,
-                                winrt::Microsoft::ReactNative::Composition::IScrollVisual,
-                                winrt::Microsoft::ReactNative::Composition::IVisual,
+                                winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual,
+                                winrt::Microsoft::ReactNative::Composition::Experimental::IVisual,
                                 typename TTypeRedirects::IInnerCompositionVisual,
                                 IVisualInterop> {
   struct ScrollInteractionTrackerOwner
@@ -749,7 +756,9 @@ struct CompScrollerVisual : winrt::implements<
     return m_visual;
   }
 
-  void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
+  void InsertAt(
+      const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual,
+      uint32_t index) noexcept {
     auto containerChildren = m_contentVisual.Children();
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     if (index == 0) {
@@ -762,13 +771,13 @@ struct CompScrollerVisual : winrt::implements<
     containerChildren.InsertAbove(compVisual, insertAfter.Current());
   }
 
-  void Remove(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept {
+  void Remove(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept {
     auto compVisual = TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     auto containerChildren = m_contentVisual.Children();
     containerChildren.Remove(compVisual);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual GetAt(uint32_t index) noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual GetAt(uint32_t index) noexcept {
     auto containerChildren = m_visual.as<typename TTypeRedirects::ContainerVisual>().Children();
     auto it = containerChildren.First();
     for (uint32_t i = 0; i < index; i++)
@@ -776,7 +785,7 @@ struct CompScrollerVisual : winrt::implements<
     return TTypeRedirects::CompositionContextHelper::CreateVisual(it.Current());
   }
 
-  void Brush(const winrt::Microsoft::ReactNative::Composition::IBrush &brush) noexcept {
+  void Brush(const winrt::Microsoft::ReactNative::Composition::Experimental::IBrush &brush) noexcept {
     m_visual.Brush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
@@ -824,11 +833,12 @@ struct CompScrollerVisual : winrt::implements<
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
   }
 
-  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() {
-    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility BackfaceVisibility() {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility>(
+        m_visual.BackfaceVisibility());
   }
 
-  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) {
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility value) {
     m_visual.BackfaceVisibility(static_cast<typename TTypeRedirects::CompositionBackfaceVisibility>(value));
   }
 
@@ -852,13 +862,14 @@ struct CompScrollerVisual : winrt::implements<
     m_visual.Clip(clip);
   }
 
-  void Shadow(const winrt::Microsoft::ReactNative::Composition::IDropShadow &shadow) noexcept {
+  void Shadow(const winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow &shadow) noexcept {
     m_visual.Shadow(TTypeRedirects::CompositionContextHelper::InnerDropShadow(shadow));
   }
 
   winrt::event_token ScrollPositionChanged(
       winrt::Windows::Foundation::EventHandler<
-          winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs> const &handler) noexcept {
+          winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs> const
+          &handler) noexcept {
     return m_scrollPositionChangedEvent.add(handler);
   }
 
@@ -927,7 +938,7 @@ struct CompScrollerVisual : winrt::implements<
     }
   }
 
-  void AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass value) noexcept {
+  void AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value) noexcept {
     SetAnimationClass<TTypeRedirects>(value, m_visual);
   }
 
@@ -949,8 +960,8 @@ struct CompScrollerVisual : winrt::implements<
   winrt::Windows::Foundation::Numerics::float3 m_currentPosition;
   winrt::Windows::Foundation::Numerics::float2 m_contentSize{0};
   winrt::Windows::Foundation::Numerics::float2 m_visualSize{0};
-  winrt::event<
-      winrt::Windows::Foundation::EventHandler<winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs>>
+  winrt::event<winrt::Windows::Foundation::EventHandler<
+      winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs>>
       m_scrollPositionChangedEvent;
   typename TTypeRedirects::SpriteVisual m_visual{nullptr};
   typename TTypeRedirects::SpriteVisual m_contentVisual{nullptr};
@@ -965,8 +976,8 @@ using MicrosoftCompScrollerVisual = CompScrollerVisual<MicrosoftTypeRedirects>;
 template <typename TTypeRedirects>
 struct CompActivityVisual : winrt::implements<
                                 CompActivityVisual<TTypeRedirects>,
-                                winrt::Microsoft::ReactNative::Composition::IActivityVisual,
-                                winrt::Microsoft::ReactNative::Composition::IVisual,
+                                winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual,
+                                winrt::Microsoft::ReactNative::Composition::Experimental::IVisual,
                                 typename TTypeRedirects::IInnerCompositionVisual,
                                 IVisualInterop> {
   /************************************************************************************
@@ -1311,7 +1322,7 @@ struct CompActivityVisual : winrt::implements<
     _root.StartAnimation(L"Progress", progressAnimation);
   }
 
-  void Brush(winrt::Microsoft::ReactNative::Composition::IBrush brush) noexcept {
+  void Brush(winrt::Microsoft::ReactNative::Composition::Experimental::IBrush brush) noexcept {
     auto innerBrush = TTypeRedirects::CompositionContextHelper::InnerBrush(brush);
     if (brush) {
       _themeProperties.InsertVector4(
@@ -1330,7 +1341,9 @@ struct CompActivityVisual : winrt::implements<
     return m_visual;
   }
 
-  void InsertAt(const winrt::Microsoft::ReactNative::Composition::IVisual &visual, uint32_t index) noexcept {
+  void InsertAt(
+      const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual,
+      uint32_t index) noexcept {
     auto containerChildren = m_contentVisual.Children();
     auto compVisual = typename TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     if (index == 0) {
@@ -1343,13 +1356,13 @@ struct CompActivityVisual : winrt::implements<
     containerChildren.InsertAbove(compVisual, insertAfter.Current());
   }
 
-  void Remove(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept {
+  void Remove(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept {
     auto compVisual = typename TTypeRedirects::CompositionContextHelper::InnerVisual(visual);
     auto containerChildren = m_contentVisual.Children();
     containerChildren.Remove(compVisual);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual GetAt(uint32_t index) noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual GetAt(uint32_t index) noexcept {
     auto containerChildren = m_visual.as<typename TTypeRedirects::ContainerVisual>().Children();
     auto it = containerChildren.First();
     for (uint32_t i = 0; i < index; i++)
@@ -1399,11 +1412,12 @@ struct CompActivityVisual : winrt::implements<
     m_visual.RelativeSizeAdjustment(relativeSizeAdjustment);
   }
 
-  winrt::Microsoft::ReactNative::Composition::BackfaceVisibility BackfaceVisibility() const noexcept {
-    return static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(m_visual.BackfaceVisibility());
+  winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility BackfaceVisibility() const noexcept {
+    return static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility>(
+        m_visual.BackfaceVisibility());
   }
 
-  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::BackfaceVisibility value) noexcept {
+  void BackfaceVisibility(winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility value) noexcept {
     m_visual.BackfaceVisibility(static_cast<typename TTypeRedirects::CompositionBackfaceVisibility>(value));
   }
 
@@ -1427,7 +1441,7 @@ struct CompActivityVisual : winrt::implements<
     m_visual.Clip(clip);
   }
 
-  void AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass value) noexcept {
+  void AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value) noexcept {
     SetAnimationClass<TTypeRedirects>(value, m_visual);
   }
 
@@ -1441,8 +1455,9 @@ using MicrosoftCompActivityVisual = CompActivityVisual<MicrosoftTypeRedirects>;
 #endif
 
 template <typename TTypeRedirects>
-struct CompCaretVisual
-    : winrt::implements<CompCaretVisual<TTypeRedirects>, winrt::Microsoft::ReactNative::Composition::ICaretVisual> {
+struct CompCaretVisual : winrt::implements<
+                             CompCaretVisual<TTypeRedirects>,
+                             winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual> {
   CompCaretVisual(typename TTypeRedirects::Compositor const &compositor)
       : m_compositor(compositor),
         m_compVisual(compositor.CreateSpriteVisual()),
@@ -1468,13 +1483,13 @@ struct CompCaretVisual
     m_opacityAnimation.IterationCount(500);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual CreateVisual() const noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual CreateVisual() const noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IVisual InnerVisual() const noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual InnerVisual() const noexcept {
     return m_visual;
   }
 
-  void Brush(winrt::Microsoft::ReactNative::Composition::IBrush brush) noexcept {
+  void Brush(winrt::Microsoft::ReactNative::Composition::Experimental::IBrush brush) noexcept {
     m_compVisual.Brush(TTypeRedirects::CompositionContextHelper::InnerBrush(brush));
   }
 
@@ -1502,35 +1517,36 @@ struct CompCaretVisual
     }
   }
 
-  void AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass value) noexcept {
+  void AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value) noexcept {
     SetAnimationClass(value, m_compVisual);
   }
 
  private:
   bool m_isVisible{true};
   typename TTypeRedirects::SpriteVisual m_compVisual;
-  winrt::Microsoft::ReactNative::Composition::IVisual m_visual;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_visual;
   typename TTypeRedirects::ScalarKeyFrameAnimation m_opacityAnimation;
   typename TTypeRedirects::Compositor m_compositor{nullptr};
 };
 
-winrt::Microsoft::ReactNative::Composition::IVisual CompCaretVisual<WindowsTypeRedirects>::CreateVisual()
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual CompCaretVisual<WindowsTypeRedirects>::CreateVisual()
     const noexcept {
-  return winrt::make<Composition::WindowsCompSpriteVisual>(m_compVisual);
+  return winrt::make<Composition::Experimental::WindowsCompSpriteVisual>(m_compVisual);
 }
 using WindowsCompCaretVisual = CompCaretVisual<WindowsTypeRedirects>;
 
 #ifdef USE_WINUI3
-winrt::Microsoft::ReactNative::Composition::IVisual CompCaretVisual<MicrosoftTypeRedirects>::CreateVisual()
-    const noexcept {
-  return winrt::make<Composition::MicrosoftCompSpriteVisual>(m_compVisual);
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual
+CompCaretVisual<MicrosoftTypeRedirects>::CreateVisual() const noexcept {
+  return winrt::make<Composition::Experimental::MicrosoftCompSpriteVisual>(m_compVisual);
 }
 using MicrosoftCompCaretVisual = CompCaretVisual<MicrosoftTypeRedirects>;
 #endif
 
 template <typename TTypeRedirects>
-struct CompFocusVisual
-    : winrt::implements<CompFocusVisual<TTypeRedirects>, winrt::Microsoft::ReactNative::Composition::IFocusVisual> {
+struct CompFocusVisual : winrt::implements<
+                             CompFocusVisual<TTypeRedirects>,
+                             winrt::Microsoft::ReactNative::Composition::Experimental::IFocusVisual> {
   CompFocusVisual(typename TTypeRedirects::Compositor const &compositor)
       : m_compVisual(compositor.CreateSpriteVisual()), m_brush(compositor.CreateNineGridBrush()) {
     m_visual = CreateVisual();
@@ -1542,9 +1558,9 @@ struct CompFocusVisual
     m_brush.IsCenterHollow(true);
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual CreateVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual CreateVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IVisual InnerVisual() const noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual InnerVisual() const noexcept {
     return m_visual;
   }
 
@@ -1573,7 +1589,7 @@ struct CompFocusVisual
     m_brush.SetInsets(inset, inset, inset, inset);
   }
 
-  void AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass value) noexcept {
+  void AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass value) noexcept {
     SetAnimationClass(value, m_compVisual);
   }
 
@@ -1581,17 +1597,19 @@ struct CompFocusVisual
   float m_scaleFactor{0};
   typename TTypeRedirects::CompositionNineGridBrush m_brush;
   typename TTypeRedirects::SpriteVisual m_compVisual;
-  winrt::Microsoft::ReactNative::Composition::IVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_visual{nullptr};
 };
 
-winrt::Microsoft::ReactNative::Composition::IVisual CompFocusVisual<WindowsTypeRedirects>::CreateVisual() noexcept {
-  return winrt::make<Composition::WindowsCompSpriteVisual>(m_compVisual);
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual
+CompFocusVisual<WindowsTypeRedirects>::CreateVisual() noexcept {
+  return winrt::make<Composition::Experimental::WindowsCompSpriteVisual>(m_compVisual);
 }
 using WindowsCompFocusVisual = CompFocusVisual<WindowsTypeRedirects>;
 
 #ifdef USE_WINUI3
-winrt::Microsoft::ReactNative::Composition::IVisual CompFocusVisual<MicrosoftTypeRedirects>::CreateVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompSpriteVisual>(m_compVisual);
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual
+CompFocusVisual<MicrosoftTypeRedirects>::CreateVisual() noexcept {
+  return winrt::make<Composition::Experimental::MicrosoftCompSpriteVisual>(m_compVisual);
 }
 using MicrosoftCompFocusVisual = CompFocusVisual<MicrosoftTypeRedirects>;
 #endif
@@ -1599,7 +1617,7 @@ using MicrosoftCompFocusVisual = CompFocusVisual<MicrosoftTypeRedirects>;
 template <typename TTypeRedirects>
 struct CompContext : winrt::implements<
                          CompContext<TTypeRedirects>,
-                         winrt::Microsoft::ReactNative::Composition::ICompositionContext,
+                         winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext,
                          typename TTypeRedirects::IInnerCompositionCompositor,
                          ICompositionContextInterop> {
   CompContext(typename TTypeRedirects::Compositor const &compositor) : m_compositor(compositor) {}
@@ -1673,26 +1691,28 @@ struct CompContext : winrt::implements<
     return m_d2dDevice;
   }
 
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual CreateSpriteVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual CreateSpriteVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual CreateRoundedRectangleVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual
+  CreateRoundedRectangleVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IScrollVisual CreateScrollerVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual CreateScrollerVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IActivityVisual CreateActivityVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual CreateActivityVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IDropShadow CreateDropShadow() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow CreateDropShadow() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IBrush CreateColorBrush(winrt::Windows::UI::Color color) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush CreateColorBrush(
+      winrt::Windows::UI::Color color) noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush CreateDrawingSurfaceBrush(
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush CreateDrawingSurfaceBrush(
       winrt::Windows::Foundation::Size surfaceSize,
       winrt::Windows::Graphics::DirectX::DirectXPixelFormat pixelFormat,
       winrt::Windows::Graphics::DirectX::DirectXAlphaMode alphaMode) noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::ICaretVisual CreateCaretVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual CreateCaretVisual() noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::IFocusVisual CreateFocusVisual() noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IFocusVisual CreateFocusVisual() noexcept;
 
   typename TTypeRedirects::CompositionGraphicsDevice CompositionGraphicsDevice() noexcept;
 
@@ -1709,52 +1729,53 @@ struct CompContext : winrt::implements<
   winrt::com_ptr<ID3D11DeviceContext> m_d3dDeviceContext;
 };
 
-winrt::Microsoft::ReactNative::Composition::ISpriteVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual
 CompContext<WindowsTypeRedirects>::CreateSpriteVisual() noexcept {
-  return winrt::make<Composition::WindowsCompSpriteVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::WindowsCompSpriteVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IScrollVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual
 CompContext<WindowsTypeRedirects>::CreateScrollerVisual() noexcept {
-  return winrt::make<Composition::WindowsCompScrollerVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::WindowsCompScrollerVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual
 CompContext<WindowsTypeRedirects>::CreateRoundedRectangleVisual() noexcept {
-  return winrt::make<Composition::WindowsCompRoundedRectangleVisual>(m_compositor.CreateShapeVisual());
+  return winrt::make<Composition::Experimental::WindowsCompRoundedRectangleVisual>(m_compositor.CreateShapeVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IActivityVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual
 CompContext<WindowsTypeRedirects>::CreateActivityVisual() noexcept {
-  return winrt::make<Composition::WindowsCompActivityVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::WindowsCompActivityVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IDropShadow CompContext<WindowsTypeRedirects>::CreateDropShadow() noexcept {
-  return winrt::make<Composition::WindowsCompDropShadow>(m_compositor.CreateDropShadow());
+winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow
+CompContext<WindowsTypeRedirects>::CreateDropShadow() noexcept {
+  return winrt::make<Composition::Experimental::WindowsCompDropShadow>(m_compositor.CreateDropShadow());
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush CompContext<WindowsTypeRedirects>::CreateColorBrush(
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush CompContext<WindowsTypeRedirects>::CreateColorBrush(
     winrt::Windows::UI::Color color) noexcept {
-  return winrt::make<Composition::WindowsCompBrush>(m_compositor.CreateColorBrush(color));
+  return winrt::make<Composition::Experimental::WindowsCompBrush>(m_compositor.CreateColorBrush(color));
 }
 
-winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush
+winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush
 CompContext<WindowsTypeRedirects>::CreateDrawingSurfaceBrush(
     winrt::Windows::Foundation::Size surfaceSize,
     winrt::Windows::Graphics::DirectX::DirectXPixelFormat pixelFormat,
     winrt::Windows::Graphics::DirectX::DirectXAlphaMode alphaMode) noexcept {
-  return winrt::make<Composition::WindowsCompDrawingSurfaceBrush>(
+  return winrt::make<Composition::Experimental::WindowsCompDrawingSurfaceBrush>(
       m_compositor, CompositionGraphicsDevice().CreateDrawingSurface(surfaceSize, pixelFormat, alphaMode));
 }
 
-winrt::Microsoft::ReactNative::Composition::ICaretVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual
 CompContext<WindowsTypeRedirects>::CreateCaretVisual() noexcept {
-  return winrt::make<Composition::WindowsCompCaretVisual>(m_compositor);
+  return winrt::make<Composition::Experimental::WindowsCompCaretVisual>(m_compositor);
 }
 
-winrt::Microsoft::ReactNative::Composition::IFocusVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IFocusVisual
 CompContext<WindowsTypeRedirects>::CreateFocusVisual() noexcept {
-  return winrt::make<Composition::WindowsCompFocusVisual>(m_compositor);
+  return winrt::make<Composition::Experimental::WindowsCompFocusVisual>(m_compositor);
 }
 
 template <>
@@ -1779,42 +1800,42 @@ CompContext<WindowsTypeRedirects>::CompositionGraphicsDevice() noexcept {
 using WindowsCompContext = CompContext<WindowsTypeRedirects>;
 
 #ifdef USE_WINUI3
-winrt::Microsoft::ReactNative::Composition::ISpriteVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual
 CompContext<MicrosoftTypeRedirects>::CreateSpriteVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompSpriteVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::MicrosoftCompSpriteVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IScrollVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual
 CompContext<MicrosoftTypeRedirects>::CreateScrollerVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompScrollerVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::MicrosoftCompScrollerVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual
 CompContext<MicrosoftTypeRedirects>::CreateRoundedRectangleVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompRoundedRectangleVisual>(m_compositor.CreateShapeVisual());
+  return winrt::make<Composition::Experimental::MicrosoftCompRoundedRectangleVisual>(m_compositor.CreateShapeVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IActivityVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual
 CompContext<MicrosoftTypeRedirects>::CreateActivityVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompActivityVisual>(m_compositor.CreateSpriteVisual());
+  return winrt::make<Composition::Experimental::MicrosoftCompActivityVisual>(m_compositor.CreateSpriteVisual());
 }
 
-winrt::Microsoft::ReactNative::Composition::IDropShadow
+winrt::Microsoft::ReactNative::Composition::Experimental::IDropShadow
 CompContext<MicrosoftTypeRedirects>::CreateDropShadow() noexcept {
-  return winrt::make<Composition::MicrosoftCompDropShadow>(m_compositor.CreateDropShadow());
+  return winrt::make<Composition::Experimental::MicrosoftCompDropShadow>(m_compositor.CreateDropShadow());
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush CompContext<MicrosoftTypeRedirects>::CreateColorBrush(
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush CompContext<MicrosoftTypeRedirects>::CreateColorBrush(
     winrt::Windows::UI::Color color) noexcept {
-  return winrt::make<Composition::MicrosoftCompBrush>(m_compositor.CreateColorBrush(color));
+  return winrt::make<Composition::Experimental::MicrosoftCompBrush>(m_compositor.CreateColorBrush(color));
 }
 
-winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush
+winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush
 CompContext<MicrosoftTypeRedirects>::CreateDrawingSurfaceBrush(
     winrt::Windows::Foundation::Size surfaceSize,
     winrt::Windows::Graphics::DirectX::DirectXPixelFormat pixelFormat,
     winrt::Windows::Graphics::DirectX::DirectXAlphaMode alphaMode) noexcept {
-  return winrt::make<Composition::MicrosoftCompDrawingSurfaceBrush>(
+  return winrt::make<Composition::Experimental::MicrosoftCompDrawingSurfaceBrush>(
       m_compositor,
       CompositionGraphicsDevice().CreateDrawingSurface(
           surfaceSize,
@@ -1822,14 +1843,14 @@ CompContext<MicrosoftTypeRedirects>::CreateDrawingSurfaceBrush(
           static_cast<winrt::Microsoft::Graphics::DirectX::DirectXAlphaMode>(alphaMode)));
 }
 
-winrt::Microsoft::ReactNative::Composition::ICaretVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual
 CompContext<MicrosoftTypeRedirects>::CreateCaretVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompCaretVisual>(m_compositor);
+  return winrt::make<Composition::Experimental::MicrosoftCompCaretVisual>(m_compositor);
 }
 
-winrt::Microsoft::ReactNative::Composition::IFocusVisual
+winrt::Microsoft::ReactNative::Composition::Experimental::IFocusVisual
 CompContext<MicrosoftTypeRedirects>::CreateFocusVisual() noexcept {
-  return winrt::make<Composition::MicrosoftCompFocusVisual>(m_compositor);
+  return winrt::make<Composition::Experimental::MicrosoftCompFocusVisual>(m_compositor);
 }
 
 template <>
@@ -1845,19 +1866,19 @@ CompContext<MicrosoftTypeRedirects>::CompositionGraphicsDevice() noexcept {
 using MicrosoftCompContext = CompContext<MicrosoftTypeRedirects>;
 #endif
 
-} // namespace Microsoft::ReactNative::Composition
+} // namespace Microsoft::ReactNative::Composition::Experimental
 
-namespace winrt::Microsoft::ReactNative::Composition::implementation {
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation {
 
 ICompositionContext SystemCompositionContextHelper::CreateContext(
     winrt::Windows::UI::Composition::Compositor const &compositor) noexcept {
-  return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompContext>(compositor);
+  return winrt::make<::Microsoft::ReactNative::Composition::Experimental::WindowsCompContext>(compositor);
 }
 
 IVisual SystemCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &visual) noexcept {
   if (auto spriteVisual = visual.try_as<winrt::Windows::UI::Composition::SpriteVisual>())
-    return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompSpriteVisual>(spriteVisual);
-  return winrt::make<::Microsoft::ReactNative::Composition::WindowsCompVisual>(visual);
+    return winrt::make<::Microsoft::ReactNative::Composition::Experimental::WindowsCompSpriteVisual>(spriteVisual);
+  return winrt::make<::Microsoft::ReactNative::Composition::Experimental::WindowsCompVisual>(visual);
 }
 
 winrt::Windows::UI::Composition::Compositor SystemCompositionContextHelper::InnerCompositor(
@@ -1896,14 +1917,14 @@ winrt::Windows::UI::Composition::ICompositionSurface SystemCompositionContextHel
 #ifdef USE_WINUI3
 ICompositionContext MicrosoftCompositionContextHelper::CreateContext(
     winrt::Microsoft::UI::Composition::Compositor const &compositor) noexcept {
-  return winrt::make<::Microsoft::ReactNative::Composition::MicrosoftCompContext>(compositor);
+  return winrt::make<::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompContext>(compositor);
 }
 
 IVisual MicrosoftCompositionContextHelper::CreateVisual(
     winrt::Microsoft::UI::Composition::Visual const &visual) noexcept {
   if (auto spriteVisual = visual.try_as<winrt::Microsoft::UI::Composition::SpriteVisual>())
-    return winrt::make<::Microsoft::ReactNative::Composition::MicrosoftCompSpriteVisual>(spriteVisual);
-  return winrt::make<::Microsoft::ReactNative::Composition::MicrosoftCompVisual>(visual);
+    return winrt::make<::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompSpriteVisual>(spriteVisual);
+  return winrt::make<::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompVisual>(visual);
 }
 
 winrt::Microsoft::UI::Composition::Compositor MicrosoftCompositionContextHelper::InnerCompositor(
@@ -1941,4 +1962,4 @@ winrt::Microsoft::UI::Composition::ICompositionSurface MicrosoftCompositionConte
 }
 #endif
 
-} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
@@ -3,24 +3,24 @@
 #pragma once
 
 #ifdef USE_WINUI3
-#include "Composition.MicrosoftCompositionContextHelper.g.h"
+#include "Composition.Experimental.MicrosoftCompositionContextHelper.g.h"
 #endif
-#include "Composition.SystemCompositionContextHelper.g.h"
+#include "Composition.Experimental.SystemCompositionContextHelper.g.h"
 
 #include <d2d1_1.h>
 #include <windows.ui.composition.interop.h>
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionHelpers.h"
 
-namespace winrt::Microsoft::ReactNative::Composition {
+namespace winrt::Microsoft::ReactNative::Composition::Experimental {
 #ifdef USE_WINUI3
 using CompositionContextHelper = MicrosoftCompositionContextHelper;
 #else
 using CompositionContextHelper = SystemCompositionContextHelper;
 #endif
-} // namespace winrt::Microsoft::ReactNative::Composition
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental
 
-namespace winrt::Microsoft::ReactNative::Composition::implementation {
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation {
 
 struct SystemCompositionContextHelper : SystemCompositionContextHelperT<SystemCompositionContextHelper> {
   SystemCompositionContextHelper() = default;
@@ -48,9 +48,9 @@ struct MicrosoftCompositionContextHelper : MicrosoftCompositionContextHelperT<Mi
 };
 #endif
 
-} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation
 
-namespace winrt::Microsoft::ReactNative::Composition::factory_implementation {
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::factory_implementation {
 
 struct SystemCompositionContextHelper
     : SystemCompositionContextHelperT<SystemCompositionContextHelper, implementation::SystemCompositionContextHelper> {
@@ -62,4 +62,4 @@ struct MicrosoftCompositionContextHelper : MicrosoftCompositionContextHelperT<
                                                implementation::MicrosoftCompositionContextHelper> {};
 #endif
 
-} // namespace winrt::Microsoft::ReactNative::Composition::factory_implementation
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::factory_implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -45,32 +45,32 @@ winrt::Windows::UI::Composition::ICompositionSurface SystemCompositionContextHel
 
 #ifdef USE_WINUI3
 ICompositionContext MicrosoftCompositionContextHelper::CreateContext(
-    winrt::Windows::UI::Composition::Compositor const &) noexcept {
+    winrt::Microsoft::UI::Composition::Compositor const &) noexcept {
   return nullptr;
 }
 
-IVisual MicrosoftCompositionContextHelper::CreateVisual(winrt::Windows::UI::Composition::Visual const &) noexcept {
+IVisual MicrosoftCompositionContextHelper::CreateVisual(winrt::Microsoft::UI::Composition::Visual const &) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::Compositor MicrosoftCompositionContextHelper::InnerCompositor(
+winrt::Microsoft::UI::Composition::Compositor MicrosoftCompositionContextHelper::InnerCompositor(
     ICompositionContext) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::Visual MicrosoftCompositionContextHelper::InnerVisual(IVisual) noexcept {
+winrt::Microsoft::UI::Composition::Visual MicrosoftCompositionContextHelper::InnerVisual(IVisual) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::DropShadow MicrosoftCompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
+winrt::Microsoft::UI::Composition::DropShadow MicrosoftCompositionContextHelper::InnerDropShadow(IDropShadow) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::CompositionBrush MicrosoftCompositionContextHelper::InnerBrush(IBrush) noexcept {
+winrt::Microsoft::UI::Composition::CompositionBrush MicrosoftCompositionContextHelper::InnerBrush(IBrush) noexcept {
   return nullptr;
 }
 
-winrt::Windows::UI::Composition::ICompositionSurface MicrosoftCompositionContextHelper::InnerSurface(
+winrt::Microsoft::UI::Composition::ICompositionSurface MicrosoftCompositionContextHelper::InnerSurface(
     IDrawingSurfaceBrush) noexcept {
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper_emptyimpl.cpp
@@ -1,16 +1,16 @@
 
 #include "pch.h"
 #include "CompositionContextHelper.h"
-#if __has_include("Composition.SystemCompositionContextHelper.g.cpp")
-#include "Composition.SystemCompositionContextHelper.g.cpp"
+#if __has_include("Composition.Experimental.SystemCompositionContextHelper.g.cpp")
+#include "Composition.Experimental.SystemCompositionContextHelper.g.cpp"
 #endif
 #ifdef USE_WINUI3
-#if __has_include("Composition.MicrosoftCompositionContextHelper.g.cpp")
-#include "Composition.MicrosoftCompositionContextHelper.g.cpp"
+#if __has_include("Composition.Experimental.MicrosoftCompositionContextHelper.g.cpp")
+#include "Composition.Experimental.MicrosoftCompositionContextHelper.g.cpp"
 #endif
 #endif
 
-namespace winrt::Microsoft::ReactNative::Composition::implementation {
+namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation {
 
 ICompositionContext SystemCompositionContextHelper::CreateContext(
     winrt::Windows::UI::Composition::Compositor const &) noexcept {
@@ -76,4 +76,4 @@ winrt::Windows::UI::Composition::ICompositionSurface MicrosoftCompositionContext
 }
 #endif
 
-} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+} // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHelpers.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <CompositionSwitcher.interop.h>
+#include <CompositionSwitcher.Experimental.interop.h>
 #include <guid/msoGuid.h>
 #include <winrt/Windows.UI.Composition.h>
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -14,6 +14,7 @@
 #include "CompositionContextHelper.h"
 #include "ReactNativeHost.h"
 
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include "CompositionRootAutomationProvider.h"
 #include "CompositionRootView.h"
 
@@ -35,8 +36,9 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
       winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
           ReactViewHost().ReactNativeHost().InstanceSettings().Properties());
 #if USE_WINUI3
-  if (auto liftedCompositor = winrt::Microsoft::ReactNative::Composition::implementation::
-          MicrosoftCompositionContextHelper::InnerCompositor(compositionContext)) {
+  if (auto liftedCompositor =
+          winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
+              compositionContext)) {
     m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView(liftedCompositor);
     m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
 
@@ -44,9 +46,6 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
         liftedCompositor, winrt::Microsoft::UI::GetWindowIdFromWindow(m_hwnd));
 
     auto island = m_compRootView.Island();
-
-    auto invScale = 1.0f / ScaleFactor();
-    m_compRootView.RootVisual().Scale({invScale, invScale, invScale});
 
     bridge.Connect(island);
     bridge.Show();
@@ -59,7 +58,7 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
 
 #endif
     auto compositor =
-        winrt::Microsoft::ReactNative::Composition::implementation::SystemCompositionContextHelper::InnerCompositor(
+        winrt::Microsoft::ReactNative::Composition::Experimental::SystemCompositionContextHelper::InnerCompositor(
             compositionContext);
     auto interop = compositor.as<ABI::Windows::UI::Composition::Desktop::ICompositorDesktopInterop>();
     winrt::Windows::UI::Composition::Desktop::DesktopWindowTarget target{nullptr};
@@ -74,8 +73,10 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
     root.Comment(L"Root Visual");
     target.Root(root);
 
-    m_compRootView.RootVisual(
-        winrt::Microsoft::ReactNative::Composition::SystemCompositionContextHelper::CreateVisual(target.Root()));
+    m_compRootView.as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+        .InternalRootVisual(
+            winrt::Microsoft::ReactNative::Composition::Experimental::SystemCompositionContextHelper::CreateVisual(
+                target.Root()));
 
 #if USE_WINUI3
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionHwndHost.cpp
@@ -40,7 +40,6 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
           winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
               compositionContext)) {
     m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView(liftedCompositor);
-    m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
 
     auto bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
         liftedCompositor, winrt::Microsoft::UI::GetWindowIdFromWindow(m_hwnd));
@@ -54,7 +53,8 @@ void CompositionHwndHost::Initialize(uint64_t hwnd) noexcept {
     bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
   } else {
     m_compRootView = winrt::Microsoft::ReactNative::CompositionRootView();
-    m_compRootView.SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
+    m_compRootView.as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+        .SetWindow(reinterpret_cast<uint64_t>(m_hwnd));
 
 #endif
     auto compositor =
@@ -123,7 +123,9 @@ LRESULT CompositionHwndHost::TranslateMessage(int msg, uint64_t wParam, int64_t 
 #if USE_WINUI3
     if (!m_compRootView.Island()) // When using Island hosting we dont need to forward window messages
 #endif
-      return static_cast<LRESULT>(m_compRootView.SendMessage(msg, wParam, lParam));
+      return static_cast<LRESULT>(
+          m_compRootView.as<winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCompositionRootView>()
+              .SendMessage(msg, wParam, lParam));
   }
   return 0;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -126,7 +126,7 @@ inline Mso::Future<void> CompositionReactViewInstance::PostInUIQueue(TAction &&a
 CompositionRootView::CompositionRootView() noexcept {}
 
 #ifdef USE_WINUI3
-CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor& compositor) noexcept
+CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept
     : m_compositor(compositor) {}
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -126,7 +126,7 @@ inline Mso::Future<void> CompositionReactViewInstance::PostInUIQueue(TAction &&a
 CompositionRootView::CompositionRootView() noexcept {}
 
 #ifdef USE_WINUI3
-CompositionRootView::CompositionRootView(winrt::Microsoft::UI::Composition::Compositor compositor) noexcept
+CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor& compositor) noexcept
     : m_compositor(compositor) {}
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -47,7 +47,7 @@ struct CompositionRootView
   CompositionRootView() noexcept;
 
 #ifdef USE_WINUI3
-  CompositionRootView(winrt::Microsoft::UI::Composition::Compositor compositor) noexcept;
+  CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor& compositor) noexcept;
   winrt::Microsoft::UI::Content::ContentIsland Island() noexcept;
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -47,7 +47,7 @@ struct CompositionRootView
   CompositionRootView() noexcept;
 
 #ifdef USE_WINUI3
-  CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor& compositor) noexcept;
+  CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept;
   winrt::Microsoft::UI::Content::ContentIsland Island() noexcept;
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -7,6 +7,7 @@
 #include <FocusNavigationResult.g.h>
 
 #include <ReactContext.h>
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.ReactNative.h>
 #include "CompositionEventHandler.h"
 #include "ReactHost/React.h"
@@ -40,7 +41,9 @@ struct FocusNavigationResult : FocusNavigationResultT<FocusNavigationResult> {
   const bool m_wasFocusMoved;
 };
 
-struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Microsoft::ReactNative::ICompositionRootView {
+struct CompositionRootView
+    : CompositionRootViewT<CompositionRootView, Composition::Experimental::IInternalCompositionRootView>,
+      ::Microsoft::ReactNative::ICompositionRootView {
   CompositionRootView() noexcept;
 
 #ifdef USE_WINUI3
@@ -52,9 +55,11 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   ReactNative::IReactViewHost ReactViewHost() noexcept;
   void ReactViewHost(ReactNative::IReactViewHost const &value) noexcept;
 
+  winrt::Microsoft::UI::Composition::Visual RootVisual() noexcept;
+
   // property RootVisual
-  winrt::Microsoft::ReactNative::Composition::IVisual RootVisual() noexcept;
-  void RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &value) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual InternalRootVisual() noexcept;
+  void InternalRootVisual(winrt::Microsoft::ReactNative::Composition::Experimental::IVisual const &value) noexcept;
 
   // property Size
   winrt::Windows::Foundation::Size Size() noexcept;
@@ -64,8 +69,8 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   float ScaleFactor() noexcept;
   void ScaleFactor(float value) noexcept;
 
-  void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept;
-  void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::IVisual &visual) noexcept;
+  void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept;
+  void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept;
 
   winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;
@@ -125,9 +130,9 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   winrt::Microsoft::ReactNative::IReactViewHost m_reactViewHost;
   winrt::Microsoft::ReactNative::ReactViewOptions m_reactViewOptions;
   std::shared_ptr<::Microsoft::ReactNative::CompositionEventHandler> m_CompositionEventHandler;
-  winrt::Microsoft::ReactNative::Composition::IVisual m_rootVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_loadingVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IActivityVisual m_loadingActivityVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_rootVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_loadingVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual m_loadingActivityVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme m_theme{nullptr};
   winrt::Microsoft::ReactNative::ReactNotificationSubscription m_themeChangedSubscription{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme::ThemeChanged_revoker m_themeChangedRevoker;
@@ -140,7 +145,7 @@ struct CompositionRootView : CompositionRootViewT<CompositionRootView>, ::Micros
   void ShowInstanceLoading() noexcept;
   void UpdateRootVisualSize() noexcept;
   void UpdateLoadingVisualSize() noexcept;
-  Composition::IDrawingSurfaceBrush CreateLoadingVisualBrush() noexcept;
+  Composition::Experimental::IDrawingSurfaceBrush CreateLoadingVisualBrush() noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -29,6 +29,8 @@ struct CompositionReactViewInstance
 
 CompositionRootView::CompositionRootView() noexcept {}
 
+CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept {}
+
 ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
   return nullptr;
 }
@@ -36,6 +38,17 @@ ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
 void CompositionRootView::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &) noexcept {}
 
 winrt::Microsoft::UI::Composition::Visual CompositionRootView::RootVisual() noexcept {
+  return nullptr;
+}
+
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual CompositionRootView::InternalRootVisual() noexcept {
+  return nullptr;
+}
+
+void CompositionRootView::InternalRootVisual(
+    const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &) noexcept {}
+
+winrt::Microsoft::UI::Content::ContentIsland CompositionRootView::Island() noexcept {
   return nullptr;
 }
 
@@ -104,11 +117,11 @@ void CompositionRootView::ShowInstanceError() noexcept {}
 
 void CompositionRootView::ShowInstanceLoading() noexcept {}
 
-Windows::Foundation::Size CompositionRootView::Measure(Windows::Foundation::Size const &) const {
+winrt::Windows::Foundation::Size CompositionRootView::Measure(winrt::Windows::Foundation::Size const &) const {
   return {};
 }
 
-Windows::Foundation::Size CompositionRootView::Arrange(Windows::Foundation::Size) const {
+winrt::Windows::Foundation::Size CompositionRootView::Arrange(winrt::Windows::Foundation::Size) const {
   return {};
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -35,11 +35,9 @@ ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
 
 void CompositionRootView::ReactViewHost(winrt::Microsoft::ReactNative::IReactViewHost const &) noexcept {}
 
-winrt::Microsoft::ReactNative::Composition::IVisual CompositionRootView::RootVisual() noexcept {
+winrt::Microsoft::UI::Composition::Visual CompositionRootView::RootVisual() noexcept {
   return nullptr;
 }
-
-void CompositionRootView::RootVisual(winrt::Microsoft::ReactNative::Composition::IVisual const &) noexcept {}
 
 winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
   return {};

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.cpp
@@ -10,21 +10,32 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-static const ReactPropertyId<ICompositionContext> &CompositionContextPropertyId() noexcept {
-  static const ReactPropertyId<ICompositionContext> prop{L"ReactNative.Composition", L"CompositionContext"};
+static const ReactPropertyId<Experimental::ICompositionContext> &CompositionContextPropertyId() noexcept {
+  static const ReactPropertyId<Experimental::ICompositionContext> prop{
+      L"ReactNative.Composition", L"CompositionContext"};
   return prop;
 }
 
-void CompositionUIService::SetCompositionContext(
-    IReactPropertyBag const &properties,
-    ICompositionContext const &compositionContext) noexcept {
-  ReactPropertyBag(properties).Set(CompositionContextPropertyId(), compositionContext);
+void CompositionUIService::SetCompositor(
+    const winrt::Microsoft::ReactNative::ReactInstanceSettings &settings,
+    const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept {
+  ReactPropertyBag properties(settings.Properties());
+  properties.Set(
+      CompositionContextPropertyId(),
+      winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::CreateContext(
+          compositor));
   // Default to using Bridgeless mode when using fabric
-  winrt::Microsoft::ReactNative::implementation::QuirkSettings::SetIsBridgeless(
-      ReactPropertyBag(properties), !!compositionContext);
+  winrt::Microsoft::ReactNative::implementation::QuirkSettings::SetIsBridgeless(properties, !!compositor);
 }
 
-ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &properties) noexcept {
+winrt::Microsoft::UI::Composition::Compositor CompositionUIService::GetCompositor(
+    const IReactPropertyBag &properties) noexcept {
+  return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
+      GetCompositionContext(properties));
+}
+
+Experimental::ICompositionContext CompositionUIService::GetCompositionContext(
+    const IReactPropertyBag &properties) noexcept {
   return ReactPropertyBag(properties).Get(CompositionContextPropertyId());
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService.h
@@ -3,17 +3,19 @@
 
 #pragma once
 #include "Composition.CompositionUIService.g.h"
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 struct CompositionUIService : CompositionUIServiceT<CompositionUIService> {
   CompositionUIService() = default;
 
-  static void SetCompositionContext(
-      const IReactPropertyBag &properties,
-      const ICompositionContext &compositionContext) noexcept;
+  static void SetCompositor(
+      const winrt::Microsoft::ReactNative::ReactInstanceSettings &settings,
+      const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept;
+  static winrt::Microsoft::UI::Composition::Compositor GetCompositor(const IReactPropertyBag &properties) noexcept;
 
-  static ICompositionContext GetCompositionContext(const IReactPropertyBag &properties) noexcept;
+  static Experimental::ICompositionContext GetCompositionContext(const IReactPropertyBag &properties) noexcept;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
@@ -6,16 +6,15 @@
 #include "CompositionUIService.h"
 
 #include "Composition.CompositionUIService.g.cpp"
+#include <winrt/Microsoft.UI.Composition.h>
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-void CompositionUIService::SetCompositionContext(IReactPropertyBag const &, ICompositionContext const &) noexcept {}
+void CompositionUIService::SetCompositor(
+    ReactInstanceSettings const &,
+    winrt::Microsoft::UI::Composition::Compositor const &) noexcept {}
 
-winrt::Microsoft::UI::Compositor CompositionUIService::GetCompositor(const IReactPropertyBag &) noexcept {
-  return nullptr;
-}
-
-void CompositionUIService::SetCompositor(const winrt::Microsoft::UI::Compositor &) noexcept {
+winrt::Microsoft::UI::Composition::Compositor CompositionUIService::GetCompositor(const IReactPropertyBag &) noexcept {
   return nullptr;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionUIService_emptyimpl.cpp
@@ -11,7 +11,11 @@ namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 void CompositionUIService::SetCompositionContext(IReactPropertyBag const &, ICompositionContext const &) noexcept {}
 
-ICompositionContext CompositionUIService::GetCompositionContext(const IReactPropertyBag &) noexcept {
+winrt::Microsoft::UI::Compositor CompositionUIService::GetCompositor(const IReactPropertyBag &) noexcept {
+  return nullptr;
+}
+
+void CompositionUIService::SetCompositor(const winrt::Microsoft::UI::Compositor &) noexcept {
   return nullptr;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -14,6 +14,7 @@
 #include <Utils/KeyboardUtils.h>
 #include <Utils/ValueUtils.h>
 #include <Views/FrameworkElementTransferProperties.h>
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionContextHelper.h"
 #include "CompositionDynamicAutomationProvider.h"
@@ -31,11 +32,15 @@ namespace winrt::Microsoft::ReactNative::Composition::implementation {
 CreateCompositionComponentViewArgs::CreateCompositionComponentViewArgs(
     const winrt::Microsoft::ReactNative::IReactContext &reactContext,
     facebook::react::Tag tag,
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compositionContext)
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compositionContext)
     : base_type(reactContext, tag), m_compositionContext(compositionContext){};
 
-winrt::Microsoft::ReactNative::Composition::ICompositionContext CreateCompositionComponentViewArgs::CompositionContext()
-    const noexcept {
+winrt::Microsoft::UI::Composition::Compositor CreateCompositionComponentViewArgs::Compositor() const noexcept {
+  return winrt::Microsoft::ReactNative::Composition::CompositionUIService::GetCompositor(ReactContext().Properties());
+}
+
+winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
+CreateCompositionComponentViewArgs::CompositionContext() const noexcept {
   return m_compositionContext;
 }
 
@@ -48,10 +53,17 @@ void CreateCompositionComponentViewArgs::Features(ComponentViewFeatures value) n
 }
 
 ComponentView::ComponentView(const winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs &args)
-    : ComponentView(args.CompositionContext(), args.Tag(), args.ReactContext(), args.Features(), true) {}
+    : ComponentView(
+          winrt::get_self<
+              winrt::Microsoft::ReactNative::Composition::implementation::CreateCompositionComponentViewArgs>(args)
+              ->CompositionContext(),
+          args.Tag(),
+          args.ReactContext(),
+          args.Features(),
+          true) {}
 
 ComponentView::ComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext,
     ComponentViewFeatures flags,
@@ -74,9 +86,9 @@ facebook::react::Props::Shared ComponentView::props() noexcept {
 void ComponentView::onThemeChanged() noexcept {
   if ((m_flags & ComponentViewFeatures::Background) == ComponentViewFeatures::Background) {
     if (viewProps()->backgroundColor) {
-      Visual().as<ISpriteVisual>().Brush(theme()->Brush(*viewProps()->backgroundColor));
+      Visual().as<Experimental::ISpriteVisual>().Brush(theme()->Brush(*viewProps()->backgroundColor));
     } else {
-      Visual().as<ISpriteVisual>().Brush(nullptr);
+      Visual().as<Experimental::ISpriteVisual>().Brush(nullptr);
     }
   }
 
@@ -108,7 +120,13 @@ winrt::Microsoft::ReactNative::Composition::Theme ComponentView::Theme() const n
   return theme()->get_strong().as<winrt::Microsoft::ReactNative::Composition::Theme>();
 }
 
-winrt::Microsoft::ReactNative::Composition::ICompositionContext ComponentView::CompositionContext() const noexcept {
+winrt::Microsoft::UI::Composition::Compositor ComponentView::Compositor() const noexcept {
+  return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
+      m_compContext);
+}
+
+winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext ComponentView::CompositionContext()
+    const noexcept {
   return m_compContext;
 }
 
@@ -121,9 +139,9 @@ void ComponentView::updateProps(
   if ((m_flags & ComponentViewFeatures::Background) == ComponentViewFeatures::Background) {
     if (oldViewProps.backgroundColor != newViewProps.backgroundColor) {
       if (newViewProps.backgroundColor) {
-        Visual().as<ISpriteVisual>().Brush(theme()->Brush(*newViewProps.backgroundColor));
+        Visual().as<Experimental::ISpriteVisual>().Brush(theme()->Brush(*newViewProps.backgroundColor));
       } else {
-        Visual().as<ISpriteVisual>().Brush(nullptr);
+        Visual().as<Experimental::ISpriteVisual>().Brush(nullptr);
       }
     }
   }
@@ -295,15 +313,17 @@ const facebook::react::SharedViewEventEmitter &ComponentView::GetEventEmitter() 
   return m_eventEmitter;
 }
 
-std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, ComponentView::SpecialBorderLayerCount>
+std::array<
+    winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual,
+    ComponentView::SpecialBorderLayerCount>
 ComponentView::FindSpecialBorderLayers() const noexcept {
-  std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> layers{
+  std::array<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual, SpecialBorderLayerCount> layers{
       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 
   if (m_numBorderVisuals) {
     for (uint8_t i = 0; i < m_numBorderVisuals; i++) {
       auto visual = Visual().GetAt(i);
-      layers[i] = visual.as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>();
+      layers[i] = visual.as<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual>();
     }
   }
 
@@ -328,12 +348,13 @@ struct RoundedPathParameters {
  * right, bottom right, bottom left). "rectPathGeometry" defines the bounding box of the generated shape.
  */
 static winrt::com_ptr<ID2D1PathGeometry> GenerateRoundedRectPathGeometry(
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     const RoundedPathParameters &params,
     const facebook::react::RectangleEdges<float> &rectPathGeometry) noexcept {
   winrt::com_ptr<ID2D1PathGeometry> pathGeometry;
   winrt::com_ptr<ID2D1Factory1> spD2dFactory;
-  compContext.as<::Microsoft::ReactNative::Composition::ICompositionContextInterop>()->D2DFactory(spD2dFactory.put());
+  compContext.as<::Microsoft::ReactNative::Composition::Experimental::ICompositionContextInterop>()->D2DFactory(
+      spD2dFactory.put());
 
   // Create a path geometry.
   HRESULT hr = spD2dFactory->CreatePathGeometry(pathGeometry.put());
@@ -513,7 +534,7 @@ RoundedPathParameters GenerateRoundedPathParameters(
 }
 
 static winrt::com_ptr<ID2D1PathGeometry> GenerateRoundedRectPathGeometry(
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     const facebook::react::RectangleCorners<float> &baseRadius,
     const facebook::react::RectangleEdges<float> &inset,
     const facebook::react::RectangleEdges<float> &rectPathGeometry) noexcept {
@@ -548,7 +569,8 @@ void DrawShape(
 }
 
 struct AutoDrawHelper {
-  AutoDrawHelper(winrt::com_ptr<::Microsoft::ReactNative::Composition::ICompositionDrawingSurfaceInterop> &surface) {
+  AutoDrawHelper(
+      winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop> &surface) {
     m_surface = surface;
     m_surface->BeginDraw(m_pRT.put(), &m_offset);
   }
@@ -567,7 +589,7 @@ struct AutoDrawHelper {
   }
 
  private:
-  winrt::com_ptr<::Microsoft::ReactNative::Composition::ICompositionDrawingSurfaceInterop> m_surface;
+  winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop> m_surface;
   POINT m_offset;
   winrt::com_ptr<ID2D1DeviceContext> m_pRT;
 };
@@ -575,10 +597,11 @@ struct AutoDrawHelper {
 template <typename TShape>
 void SetBorderLayerPropertiesCommon(
     winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
-    winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual &layer,
     TShape &shape,
-    winrt::com_ptr<::Microsoft::ReactNative::Composition::ICompositionDrawingSurfaceInterop> &borderTexture,
+    winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop>
+        &borderTexture,
     const D2D1_RECT_F &textureRect,
     facebook::react::Point anchorPoint,
     facebook::react::Point anchorOffset,
@@ -665,10 +688,11 @@ void SetBorderLayerPropertiesCommon(
 template <typename TShape>
 void SetBorderLayerProperties(
     winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
-    winrt::Microsoft::ReactNative::Composition::ISpriteVisual &layer,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual &layer,
     TShape &shape,
-    winrt::com_ptr<::Microsoft::ReactNative::Composition::ICompositionDrawingSurfaceInterop> &borderTexture,
+    winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop>
+        &borderTexture,
     const D2D1_RECT_F &textureRect,
     facebook::react::Point anchorPoint,
     facebook::react::Point anchorOffset,
@@ -701,7 +725,7 @@ void SetBorderLayerProperties(
       layer.Brush(theme->Brush(*borderColor));
 
       winrt::com_ptr<ID2D1Factory1> spD2dFactory;
-      compContext.as<::Microsoft::ReactNative::Composition::ICompositionContextInterop>()->D2DFactory(
+      compContext.as<::Microsoft::ReactNative::Composition::Experimental::ICompositionContextInterop>()->D2DFactory(
           spD2dFactory.put());
 
       winrt::com_ptr<ID2D1TransformedGeometry> transformedShape;
@@ -709,7 +733,8 @@ void SetBorderLayerProperties(
       winrt::check_hresult(
           spD2dFactory->CreateTransformedGeometry(&shape, &translationTransform, transformedShape.put()));
 
-      layer.as<::Microsoft::ReactNative::Composition::IVisualInterop>()->SetClippingPath(transformedShape.get());
+      layer.as<::Microsoft::ReactNative::Composition::Experimental::IVisualInterop>()->SetClippingPath(
+          transformedShape.get());
     }
     /*
                 else
@@ -732,9 +757,10 @@ const float Bottom = 1.0;
 template <typename TShape>
 void DrawAllBorderLayers(
     winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
-    std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, ComponentView::SpecialBorderLayerCount>
-        &spBorderLayers,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
+    std::array<
+        winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual,
+        ComponentView::SpecialBorderLayerCount> &spBorderLayers,
     TShape &shape,
     const facebook::react::BorderWidths &borderWidths,
     const facebook::react::BorderRadii &borderRadii,
@@ -743,7 +769,7 @@ void DrawAllBorderLayers(
     const facebook::react::BorderColors &borderColors,
     facebook::react::BorderStyle borderStyle) {
   // Now that we've drawn our nice border in one layer, split it into its component layers
-  winrt::com_ptr<::Microsoft::ReactNative::Composition::ICompositionDrawingSurfaceInterop>
+  winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop>
       spTextures[ComponentView::SpecialBorderLayerCount];
 
   // Set component border properties
@@ -904,7 +930,7 @@ void DrawAllBorderLayers(
 }
 
 winrt::com_ptr<ID2D1GeometryGroup> GetGeometryForRoundedBorder(
-    winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     const facebook::react::RectangleCorners<float> &radius,
     const facebook::react::RectangleEdges<float> &inset,
     const facebook::react::RectangleEdges<float> &thickness,
@@ -957,7 +983,8 @@ winrt::com_ptr<ID2D1GeometryGroup> GetGeometryForRoundedBorder(
 
   ID2D1Geometry *ppGeometries[] = {outerPathGeometry.get(), innerPathGeometry.get()};
   winrt::com_ptr<ID2D1Factory1> spD2dFactory;
-  compContext.as<::Microsoft::ReactNative::Composition::ICompositionContextInterop>()->D2DFactory(spD2dFactory.put());
+  compContext.as<::Microsoft::ReactNative::Composition::Experimental::ICompositionContextInterop>()->D2DFactory(
+      spD2dFactory.put());
 
   winrt::com_ptr<ID2D1GeometryGroup> geometryGroup = nullptr;
   // Create a geometry group.
@@ -1037,7 +1064,8 @@ facebook::react::BorderMetrics resolveAndAlignBorderMetrics(
 
 bool ComponentView::TryUpdateSpecialBorderLayers(
     winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
-    std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
+    std::array<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual, SpecialBorderLayerCount>
+        &spBorderVisuals,
     facebook::react::LayoutMetrics const &layoutMetrics,
     const facebook::react::ViewProps &viewProps) noexcept {
   auto borderMetrics = resolveAndAlignBorderMetrics(layoutMetrics, viewProps);
@@ -1151,13 +1179,13 @@ void ComponentView::finalizeBorderUpdates(
   if (!TryUpdateSpecialBorderLayers(theme(), spBorderLayers, layoutMetrics, viewProps)) {
     for (auto &spBorderLayer : spBorderLayers) {
       if (spBorderLayer) {
-        spBorderLayer.as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>().Brush(nullptr);
+        spBorderLayer.as<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual>().Brush(nullptr);
       }
     }
   }
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ComponentView::OuterVisual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ComponentView::OuterVisual() const noexcept {
   return m_outerVisual ? m_outerVisual : Visual();
 }
 
@@ -1204,29 +1232,29 @@ void ComponentView::applyShadowProps(const facebook::react::ViewProps &viewProps
   shadow.BlurRadius(viewProps.shadowRadius);
   if (viewProps.shadowColor)
     shadow.Color(theme()->Color(*viewProps.shadowColor));
-  Visual().as<winrt::Microsoft::ReactNative::Composition::ISpriteVisual>().Shadow(shadow);
+  Visual().as<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual>().Shadow(shadow);
 }
 
 void ComponentView::updateTransformProps(
     const facebook::react::ViewProps &oldViewProps,
     const facebook::react::ViewProps &newViewProps,
-    winrt::Microsoft::ReactNative::Composition::IVisual visual) noexcept {
+    winrt::Microsoft::ReactNative::Composition::Experimental::IVisual visual) noexcept {
   // check for backfaceVisibility prop
   if (oldViewProps.backfaceVisibility != newViewProps.backfaceVisibility) {
     static_assert(
         static_cast<facebook::react::BackfaceVisibility>(
-            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Inherit) ==
+            winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility::Inherit) ==
         facebook::react::BackfaceVisibility::Auto);
     static_assert(
         static_cast<facebook::react::BackfaceVisibility>(
-            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Visible) ==
+            winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility::Visible) ==
         facebook::react::BackfaceVisibility::Visible);
     static_assert(
         static_cast<facebook::react::BackfaceVisibility>(
-            winrt::Microsoft::ReactNative::Composition::BackfaceVisibility::Hidden) ==
+            winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility::Hidden) ==
         facebook::react::BackfaceVisibility::Hidden);
-    visual.BackfaceVisibility(
-        static_cast<winrt::Microsoft::ReactNative::Composition::BackfaceVisibility>(newViewProps.backfaceVisibility));
+    visual.BackfaceVisibility(static_cast<winrt::Microsoft::ReactNative::Composition::Experimental::BackfaceVisibility>(
+        newViewProps.backfaceVisibility));
   }
 
   // Transform - TODO doesn't handle multiple of the same kind of transform -- Doesn't handle hittesting updates
@@ -1317,7 +1345,7 @@ void ComponentView::updateBorderLayoutMetrics(
 
   if (borderMetrics.borderRadii.topLeft == 0 && borderMetrics.borderRadii.topRight == 0 &&
       borderMetrics.borderRadii.bottomLeft == 0 && borderMetrics.borderRadii.bottomRight == 0) {
-    Visual().as<::Microsoft::ReactNative::Composition::IVisualInterop>()->SetClippingPath(nullptr);
+    Visual().as<::Microsoft::ReactNative::Composition::Experimental::IVisualInterop>()->SetClippingPath(nullptr);
   } else {
     winrt::com_ptr<ID2D1PathGeometry> pathGeometry = GenerateRoundedRectPathGeometry(
         m_compContext,
@@ -1328,7 +1356,8 @@ void ComponentView::updateBorderLayoutMetrics(
          layoutMetrics.frame.size.width * layoutMetrics.pointScaleFactor,
          layoutMetrics.frame.size.height * layoutMetrics.pointScaleFactor});
 
-    Visual().as<::Microsoft::ReactNative::Composition::IVisualInterop>()->SetClippingPath(pathGeometry.get());
+    Visual().as<::Microsoft::ReactNative::Composition::Experimental::IVisualInterop>()->SetClippingPath(
+        pathGeometry.get());
   }
 
   if (m_layoutMetrics != layoutMetrics) {
@@ -1360,7 +1389,8 @@ ComponentView::supplementalComponentDescriptorProviders() noexcept {
 comp::CompositionPropertySet ComponentView::EnsureCenterPointPropertySet() noexcept {
   if (m_centerPropSet == nullptr) {
     if (auto compositor =
-            winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerCompositor(m_compContext)) {
+            winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerCompositor(
+                m_compContext)) {
       m_centerPropSet = compositor.CreatePropertySet();
       UpdateCenterPropertySet();
       m_centerPropSet.InsertMatrix4x4(L"transform", winrt::Windows::Foundation::Numerics::float4x4::identity());
@@ -1405,12 +1435,13 @@ void ComponentView::EnsureTransformMatrixFacade() noexcept {
 
   auto centerPointPropSet = EnsureCenterPointPropertySet();
   if (auto compositor =
-          winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerCompositor(m_compContext)) {
+          winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerCompositor(
+              m_compContext)) {
     // TODO cache expression instead of creating new ones all the time
     auto expression = compositor.CreateExpressionAnimation(
         L"Matrix4x4.CreateFromScale(PS.dpiScale3Inv) * Matrix4x4.CreateFromTranslation(PS.translation) * PS.transform * Matrix4x4.CreateFromScale(PS.dpiScale3)");
     expression.SetReferenceParameter(L"PS", centerPointPropSet);
-    winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerVisual(OuterVisual())
+    winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(OuterVisual())
         .StartAnimation(L"TransformMatrix", expression);
   }
 }
@@ -1455,10 +1486,17 @@ std::string ComponentView::DefaultHelpText() const noexcept {
 
 ViewComponentView::ViewComponentView(
     const winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs &args)
-    : ViewComponentView(args.CompositionContext(), args.Tag(), args.ReactContext(), args.Features(), true) {}
+    : ViewComponentView(
+          winrt::get_self<
+              winrt::Microsoft::ReactNative::Composition::implementation::CreateCompositionComponentViewArgs>(args)
+              ->CompositionContext(),
+          args.Tag(),
+          args.ReactContext(),
+          args.Features(),
+          true) {}
 
 ViewComponentView::ViewComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext,
     ComponentViewFeatures flags,
@@ -1468,8 +1506,13 @@ ViewComponentView::ViewComponentView(
   m_props = defaultProps;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ViewComponentView::CreateVisual() noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ViewComponentView::createVisual() noexcept {
   return m_compContext.CreateSpriteVisual();
+}
+
+winrt::Microsoft::UI::Composition::Visual ViewComponentView::CreateVisual() noexcept {
+  return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerVisual(
+      createVisual());
 }
 
 void ViewComponentView::ensureVisual() noexcept {
@@ -1477,16 +1520,23 @@ void ViewComponentView::ensureVisual() noexcept {
     if (m_customComponent) {
       // Review is it expected that I need this cast to call overridden methods?
       winrt::Microsoft::ReactNative::Composition::ViewComponentView outer(*this);
-      m_visual = outer.CreateVisual();
+      winrt::Microsoft::ReactNative::Composition::Experimental::IInternalCreateVisual internalCreateVisual{nullptr};
+      if (outer.try_as(internalCreateVisual)) {
+        m_visual = internalCreateVisual.CreateInternalVisual();
+      } else {
+        m_visual =
+            winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::CreateVisual(
+                outer.CreateVisual());
+      }
     } else {
-      m_visual = CreateVisual();
+      m_visual = createVisual();
     }
     OuterVisual().InsertAt(m_visual, 0);
   }
 }
 
 winrt::Microsoft::ReactNative::ComponentView ViewComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<ViewComponentView>(compContext, tag, reactContext, ComponentViewFeatures::Default, false);
@@ -1680,7 +1730,7 @@ winrt::Microsoft::ReactNative::ViewProps ViewComponentView::ViewProps() noexcept
   return winrt::make<winrt::Microsoft::ReactNative::implementation::ViewProps>(m_props);
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ViewComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ViewComponentView::Visual() const noexcept {
   assert(m_visual);
   return m_visual;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.h
@@ -27,16 +27,18 @@ struct CreateCompositionComponentViewArgs
   CreateCompositionComponentViewArgs(
       const winrt::Microsoft::ReactNative::IReactContext &reactContext,
       facebook::react::Tag tag,
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compositionContext);
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compositionContext);
 
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext CompositionContext() const noexcept;
+  winrt::Microsoft::UI::Composition::Compositor Compositor() const noexcept;
+
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext CompositionContext() const noexcept;
 
   ComponentViewFeatures Features() const noexcept;
   void Features(ComponentViewFeatures value) noexcept;
 
  private:
   ComponentViewFeatures m_features{ComponentViewFeatures::Default};
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compositionContext;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compositionContext;
 };
 
 struct ComponentView
@@ -45,17 +47,17 @@ struct ComponentView
 
   ComponentView(winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs const &args);
   ComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext,
       ComponentViewFeatures flags,
       bool customControl);
 
-  virtual winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept {
+  virtual winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept {
     return nullptr;
   };
   // Visual that should be parented to this ComponentView's parent
-  virtual winrt::Microsoft::ReactNative::Composition::IVisual OuterVisual() const noexcept;
+  virtual winrt::Microsoft::ReactNative::Composition::Experimental::IVisual OuterVisual() const noexcept;
   void updateEventEmitter(facebook::react::EventEmitter::Shared const &eventEmitter) noexcept override;
   const facebook::react::SharedViewEventEmitter &GetEventEmitter() const noexcept;
   void HandleCommand(winrt::hstring commandName, const winrt::Microsoft::ReactNative::IJSValueReader &args) noexcept
@@ -94,7 +96,7 @@ struct ComponentView
   void updateTransformProps(
       const facebook::react::ViewProps &oldViewProps,
       const facebook::react::ViewProps &newViewProps,
-      winrt::Microsoft::ReactNative::Composition::IVisual m_visual) noexcept;
+      winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_visual) noexcept;
   void updateAccessibilityProps(
       const facebook::react::ViewProps &oldView,
       const facebook::react::ViewProps &newViewProps) noexcept;
@@ -116,7 +118,8 @@ struct ComponentView
   virtual std::string DefaultAccessibleName() const noexcept;
   virtual std::string DefaultHelpText() const noexcept;
 
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext CompositionContext() const noexcept;
+  winrt::Microsoft::UI::Composition::Compositor Compositor() const noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext CompositionContext() const noexcept;
 
   // Publicaly overridable APIs
   void FinalizeUpdates(winrt::Microsoft::ReactNative::ComponentViewUpdateMask updateMask) noexcept override;
@@ -129,7 +132,7 @@ struct ComponentView
       facebook::react::Point &localPt) const noexcept;
 
   winrt::IInspectable m_uiaProvider{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compContext;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compContext;
   comp::CompositionPropertySet m_centerPropSet{nullptr};
   facebook::react::SharedViewEventEmitter m_eventEmitter;
   facebook::react::LayoutMetrics m_layoutMetrics;
@@ -150,23 +153,24 @@ struct ComponentView
       const facebook::react::ViewProps &viewProps) noexcept;
   bool TryUpdateSpecialBorderLayers(
       winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
-      std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount> &spBorderVisuals,
+      std::array<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual, SpecialBorderLayerCount>
+          &spBorderVisuals,
       facebook::react::LayoutMetrics const &layoutMetrics,
       const facebook::react::ViewProps &viewProps) noexcept;
-  std::array<winrt::Microsoft::ReactNative::Composition::ISpriteVisual, SpecialBorderLayerCount>
+  std::array<winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual, SpecialBorderLayerCount>
   FindSpecialBorderLayers() const noexcept;
   void UpdateCenterPropertySet() noexcept;
 
   ComponentViewFeatures m_flags;
   void showFocusVisual(bool show) noexcept;
-  winrt::Microsoft::ReactNative::Composition::IFocusVisual m_focusVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IVisual m_outerVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IFocusVisual m_focusVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_outerVisual{nullptr};
 };
 
 struct ViewComponentView : public ViewComponentViewT<ViewComponentView, ComponentView> {
   ViewComponentView(winrt::Microsoft::ReactNative::Composition::CreateCompositionComponentViewArgs const &args);
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -200,23 +204,25 @@ struct ViewComponentView : public ViewComponentViewT<ViewComponentView, Componen
       bool ignorePointerEvents = false) const noexcept override;
   const winrt::Microsoft::ReactNative::IComponentProps userProps(
       facebook::react::Props::Shared const &props) noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   void ensureVisual() noexcept;
 
   ViewComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext,
       ComponentViewFeatures flags,
       bool customComponent);
 
-  // Publicaly overridable APIs
-  virtual winrt::Microsoft::ReactNative::Composition::IVisual CreateVisual() noexcept;
+  virtual winrt::Microsoft::ReactNative::Composition::Experimental::IVisual createVisual() noexcept;
+
+  // Publicly overridable APIs
+  virtual winrt::Microsoft::UI::Composition::Visual CreateVisual() noexcept;
   virtual void UpdateLayoutMetrics(const LayoutMetrics &metrics, const LayoutMetrics &oldMetrics) noexcept;
 
  private:
   facebook::react::SharedViewProps m_props;
-  winrt::Microsoft::ReactNative::Composition::IVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_visual{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.cpp
@@ -11,7 +11,7 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 DebuggingOverlayComponentView::DebuggingOverlayComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : base_type(
@@ -38,7 +38,7 @@ void DebuggingOverlayComponentView::UnmountChildComponentView(
 }
 
 winrt::Microsoft::ReactNative::ComponentView DebuggingOverlayComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<DebuggingOverlayComponentView>(compContext, tag, reactContext);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/DebuggingOverlayComponentView.h
@@ -13,7 +13,7 @@ namespace winrt::Microsoft::ReactNative::Composition::implementation {
 struct DebuggingOverlayComponentView
     : DebuggingOverlayComponentViewT<DebuggingOverlayComponentView, ViewComponentView> {
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -25,7 +25,7 @@ struct DebuggingOverlayComponentView
       uint32_t index) noexcept override;
 
   DebuggingOverlayComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -49,7 +49,7 @@ void ImageComponentView::WindowsImageResponseObserver::didReceiveFailure() const
 }
 
 ImageComponentView::ImageComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(
@@ -244,13 +244,14 @@ void ImageComponentView::ensureDrawingSurface() noexcept {
 
     switch (imageProps->resizeMode) {
       case facebook::react::ImageResizeMode::Stretch:
-        m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::Fill);
+        m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::Fill);
         break;
       case facebook::react::ImageResizeMode::Cover:
-        m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::UniformToFill);
+        m_drawingSurface.Stretch(
+            winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::UniformToFill);
         break;
       case facebook::react::ImageResizeMode::Contain:
-        m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::Uniform);
+        m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::Uniform);
         break;
       case facebook::react::ImageResizeMode::Repeat:
         // TODO - set AlignmentRatio back to 0.5f when switching between resizeModes once we no longer recreate the
@@ -262,8 +263,8 @@ void ImageComponentView::ensureDrawingSurface() noexcept {
       case facebook::react::ImageResizeMode::Center: {
         m_drawingSurface.Stretch(
             (height < frame.height && width < frame.width)
-                ? winrt::Microsoft::ReactNative::Composition::CompositionStretch::None
-                : winrt::Microsoft::ReactNative::Composition::CompositionStretch::Uniform);
+                ? winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None
+                : winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::Uniform);
         break;
       }
       default:
@@ -416,7 +417,7 @@ void ImageComponentView::ensureVisual() noexcept {
   }
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ImageComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ImageComponentView::Visual() const noexcept {
   return m_visual;
 }
 
@@ -429,7 +430,7 @@ std::string ImageComponentView::DefaultControlType() const noexcept {
 }
 
 winrt::Microsoft::ReactNative::ComponentView ImageComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<ImageComponentView>(compContext, tag, reactContext);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -32,7 +32,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
   using Super = ImageComponentViewT<ImageComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -56,12 +56,12 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   bool focusable() const noexcept override;
   virtual std::string DefaultControlType() const noexcept;
 
   ImageComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -91,8 +91,8 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
 
   std::shared_ptr<const facebook::react::ImageProps> m_props;
 
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_drawingSurface;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface;
   winrt::com_ptr<IWICBitmap> m_wicbmp;
   std::shared_ptr<WindowsImageResponseObserver> m_imageResponseObserver;
   facebook::react::ImageShadowNode::ConcreteState::Shared m_state;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -19,7 +19,7 @@
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 WindowsModalHostComponentView::WindowsModalHostComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(
@@ -34,7 +34,7 @@ WindowsModalHostComponentView::WindowsModalHostComponentView(
 }
 
 winrt::Microsoft::ReactNative::ComponentView WindowsModalHostComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<WindowsModalHostComponentView>(compContext, tag, reactContext);
@@ -240,7 +240,7 @@ void WindowsModalHostComponentView::updateLayoutMetrics(
 
     drawingSurface.HorizontalAlignmentRatio(0.f);
     drawingSurface.VerticalAlignmentRatio(0.f);
-    drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+    drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     m_visual.Brush(drawingSurface);
     m_visual.Size(surfaceSize);
     m_visual.Offset({
@@ -307,11 +307,13 @@ facebook::react::SharedViewProps WindowsModalHostComponentView::viewProps() noex
   return m_props;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual WindowsModalHostComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual WindowsModalHostComponentView::Visual()
+    const noexcept {
   return m_visual;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual WindowsModalHostComponentView::OuterVisual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual WindowsModalHostComponentView::OuterVisual()
+    const noexcept {
   return m_visual;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.h
@@ -17,7 +17,7 @@ struct WindowsModalHostComponentView : WindowsModalHostComponentViewT<WindowsMod
   using Super = WindowsModalHostComponentViewT<WindowsModalHostComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -42,12 +42,12 @@ struct WindowsModalHostComponentView : WindowsModalHostComponentViewT<WindowsMod
   bool focusable() const noexcept override;
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual OuterVisual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual OuterVisual() const noexcept override;
   virtual std::string DefaultControlType() const noexcept;
 
   WindowsModalHostComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -59,7 +59,7 @@ struct WindowsModalHostComponentView : WindowsModalHostComponentViewT<WindowsMod
 
  private:
   std::shared_ptr<facebook::react::ModalHostViewProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
   HWND m_hwnd{nullptr};
   winrt::Microsoft::ReactNative::ReactContext m_context;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -19,7 +19,7 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 ParagraphComponentView::ParagraphComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(
@@ -285,7 +285,7 @@ void ParagraphComponentView::updateVisualBrush() noexcept {
     if (m_drawingSurface) {
       m_drawingSurface.HorizontalAlignmentRatio(horizAlignment);
       m_drawingSurface.VerticalAlignmentRatio(0.f);
-      m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+      m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     }
     m_visual.Brush(m_drawingSurface);
   }
@@ -346,12 +346,12 @@ std::string ParagraphComponentView::DefaultAccessibleName() const noexcept {
   return m_attributedStringBox.getValue().getString();
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ParagraphComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ParagraphComponentView::Visual() const noexcept {
   return m_visual;
 }
 
 winrt::Microsoft::ReactNative::ComponentView ParagraphComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<ParagraphComponentView>(compContext, tag, reactContext);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.h
@@ -21,7 +21,7 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   using Super = ParagraphComponentViewT<ParagraphComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -48,12 +48,12 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   void onThemeChanged() noexcept override;
   facebook::react::SharedViewEventEmitter eventEmitterAtPoint(facebook::react::Point pt) noexcept override;
 
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   virtual std::string DefaultControlType() const noexcept override;
   virtual std::string DefaultAccessibleName() const noexcept override;
 
   ParagraphComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -64,13 +64,13 @@ struct ParagraphComponentView : ParagraphComponentViewT<ParagraphComponentView, 
   void updateTextAlignment(const std::optional<facebook::react::TextAlignment> &fbAlignment) noexcept;
 
   std::shared_ptr<facebook::react::ParagraphProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
   winrt::com_ptr<::IDWriteTextLayout> m_textLayout;
   facebook::react::AttributedStringBox m_attributedStringBox;
   facebook::react::ParagraphAttributes m_paragraphAttributes;
 
   bool m_requireRedraw{true};
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_drawingSurface;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface;
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.cpp
@@ -96,7 +96,7 @@ void ReactCompositionViewComponentBuilder::SetLayoutHandler(
 winrt::Microsoft::ReactNative::ComponentView ReactCompositionViewComponentBuilder::CreateView(
     const IReactContext &reactContext,
     int32_t tag,
-    const ICompositionContext &context) noexcept {
+    const Experimental::ICompositionContext &context) noexcept {
   if (m_createView) {
     auto args = winrt::make<implementation::CreateCompositionComponentViewArgs>(reactContext, tag, context);
     return m_createView(args);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ReactCompositionViewComponentBuilder.h
@@ -3,6 +3,7 @@
 // Licensed under the MIT License.
 
 #include <react/renderer/core/ReactPrimitives.h>
+#include "winrt/Microsoft.ReactNative.Composition.Experimental.h"
 #include "winrt/Microsoft.ReactNative.Composition.h"
 #include "winrt/Microsoft.ReactNative.h"
 
@@ -40,8 +41,10 @@ struct ReactCompositionViewComponentBuilder : winrt::implements<
   LayoutHandler LayoutHandler() const noexcept;
   bool IsViewComponent() const noexcept;
 
-  winrt::Microsoft::ReactNative::ComponentView
-  CreateView(const IReactContext &reactContext, facebook::react::Tag tag, const ICompositionContext &context) noexcept;
+  winrt::Microsoft::ReactNative::ComponentView CreateView(
+      const IReactContext &reactContext,
+      facebook::react::Tag tag,
+      const Experimental::ICompositionContext &context) noexcept;
 
  private:
   ViewPropsFactory m_propsFactory;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -14,7 +14,7 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 RootComponentView::RootComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : base_type(
@@ -34,7 +34,7 @@ RootComponentView::~RootComponentView() {
 }
 
 winrt::Microsoft::ReactNative::ComponentView RootComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<RootComponentView>(compContext, tag, reactContext);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.h
@@ -21,7 +21,7 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
   using Super = RootComponentViewT<RootComponentView, ViewComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -45,7 +45,7 @@ struct RootComponentView : RootComponentViewT<RootComponentView, ViewComponentVi
   winrt::IInspectable UiaProviderFromPoint(const POINT &ptPixels) noexcept;
 
   RootComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -39,7 +39,7 @@ enum class ScrollbarHitRegion : int {
 struct ScrollBarComponent {
   ScrollBarComponent(
       const winrt::Microsoft::ReactNative::Composition::ScrollViewComponentView &outer,
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext,
       bool vertical)
       : m_outer(outer), m_compContext(compContext), m_reactContext(reactContext), m_vertical(vertical) {
@@ -54,12 +54,14 @@ struct ScrollBarComponent {
     m_rootVisual.InsertAt(m_arrowVisualLast, 2);
     m_rootVisual.InsertAt(m_thumbVisual, 3);
 
-    m_trackVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
-    m_arrowVisualFirst.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
-    m_arrowVisualLast.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBar);
+    m_trackVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBar);
+    m_arrowVisualFirst.AnimationClass(
+        winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBar);
+    m_arrowVisualLast.AnimationClass(
+        winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBar);
     m_thumbVisual.AnimationClass(
-        vertical ? winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical
-                 : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
+        vertical ? winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbVertical
+                 : winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbHorizontal);
 
     updateShy(true);
     onScaleChanged();
@@ -70,7 +72,9 @@ struct ScrollBarComponent {
     updateHighlight(ScrollbarHitRegion::ArrowFirst);
     updateHighlight(ScrollbarHitRegion::ArrowLast);
     updateHighlight(ScrollbarHitRegion::Thumb);
-    m_trackVisual.Brush(m_outer.Theme().PlatformBrush(L"ScrollBarTrackFill"));
+    m_trackVisual.Brush(
+        winrt::get_self<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_outer.Theme())
+            ->InternalPlatformBrush(L"ScrollBarTrackFill"));
   }
 
   void ContentSize(winrt::Windows::Foundation::Size contentSize) noexcept {
@@ -283,7 +287,7 @@ struct ScrollBarComponent {
     }
   }
 
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept {
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept {
     return m_rootVisual;
   }
 
@@ -307,8 +311,9 @@ struct ScrollBarComponent {
   void stopTrackingThumb() noexcept {
     m_nTrackInputOffset = -1;
     m_thumbVisual.AnimationClass(
-        m_vertical ? winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbVertical
-                   : winrt::Microsoft::ReactNative::Composition::AnimationClass::ScrollBarThumbHorizontal);
+        m_vertical
+            ? winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbVertical
+            : winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::ScrollBarThumbHorizontal);
   }
 
   void handleMoveThumb(const winrt::Microsoft::ReactNative::Composition::Input::PointerRoutedEventArgs &args) {
@@ -365,7 +370,7 @@ struct ScrollBarComponent {
         case ScrollbarHitRegion::Thumb: {
           m_outer.CapturePointer(args.Pointer());
           m_nTrackInputOffset = static_cast<int>((m_vertical ? pos.Y : pos.X) * m_scaleFactor) - m_thumbPos;
-          m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::None);
+          m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::None);
           handleMoveThumb(args);
         }
       }
@@ -510,7 +515,7 @@ struct ScrollBarComponent {
     if (drawingSurface) {
       drawingSurface.HorizontalAlignmentRatio(0.0f);
       drawingSurface.VerticalAlignmentRatio(0.0f);
-      drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+      drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     }
 
     auto &arrowVisual = (region == ScrollbarHitRegion::ArrowFirst) ? m_arrowVisualFirst : m_arrowVisualLast;
@@ -530,11 +535,13 @@ struct ScrollBarComponent {
         if (!std::static_pointer_cast<const facebook::react::ScrollViewProps>(
                  winrt::get_self<ScrollViewComponentView>(m_outer)->viewProps())
                  ->scrollEnabled) {
-          m_thumbVisual.Brush(m_outer.Theme().PlatformBrush(L"ScrollBarThumbFillDisabled"));
+          m_thumbVisual.Brush(
+              winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillDisabled"));
         } else if (m_highlightedRegion == region) {
-          m_thumbVisual.Brush(m_outer.Theme().PlatformBrush(L"ScrollBarThumbFillPointerOver"));
+          m_thumbVisual.Brush(
+              winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFillPointerOver"));
         } else {
-          m_thumbVisual.Brush(m_outer.Theme().PlatformBrush(L"ScrollBarThumbFill"));
+          m_thumbVisual.Brush(winrt::get_self<Theme>(m_outer.Theme())->InternalPlatformBrush(L"ScrollBarThumbFill"));
         }
       }
     }
@@ -542,7 +549,7 @@ struct ScrollBarComponent {
 
  private:
   winrt::Microsoft::ReactNative::Composition::ScrollViewComponentView m_outer;
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compContext;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compContext;
   winrt::Microsoft::ReactNative::ReactContext m_reactContext;
   const bool m_vertical;
   bool m_visible{false};
@@ -562,24 +569,24 @@ struct ScrollBarComponent {
   winrt::Windows::Foundation::Numerics::float3 m_offset{0};
   winrt::Windows::Foundation::Size m_contentSize{0, 0};
   winrt::Windows::Foundation::Size m_size{0, 0};
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_rootVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_thumbVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_arrowVisualFirst{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_arrowVisualLast{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_arrowFirstDrawingSurface{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_arrowLastDrawingSurface{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_trackVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_rootVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual m_thumbVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_arrowVisualFirst{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_arrowVisualLast{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_arrowFirstDrawingSurface{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_arrowLastDrawingSurface{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual m_trackVisual{nullptr};
 };
 
 winrt::Microsoft::ReactNative::ComponentView ScrollViewComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<ScrollViewComponentView>(compContext, tag, reactContext);
 }
 
 ScrollViewComponentView::ScrollViewComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(
@@ -1143,7 +1150,7 @@ void ScrollViewComponentView::ensureVisual() noexcept {
         winrt::auto_revoke,
         [this](
             winrt::IInspectable const & /*sender*/,
-            winrt::Microsoft::ReactNative::Composition::IScrollPositionChangedArgs const &args) {
+            winrt::Microsoft::ReactNative::Composition::Experimental::IScrollPositionChangedArgs const &args) {
           updateStateWithContentOffset();
           auto eventEmitter = GetEventEmitter();
           if (eventEmitter) {
@@ -1207,7 +1214,7 @@ facebook::react::Point ScrollViewComponentView::getClientOffset() const noexcept
           parentOffset.y};
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual ScrollViewComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual ScrollViewComponentView::Visual() const noexcept {
   return m_visual;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.h
@@ -54,7 +54,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   using Super = ScrollViewComponentViewT<ScrollViewComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -82,7 +82,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
   facebook::react::Point getClientOffset() const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
 
   void onThemeChanged() noexcept override;
   void OnPointerReleased(
@@ -101,7 +101,7 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void scrollTo(winrt::Windows::Foundation::Numerics::float3 offset, bool animate) noexcept;
 
   ScrollViewComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -125,11 +125,11 @@ struct ScrollInteractionTrackerOwner : public winrt::implements<
   void updateStateWithContentOffset() noexcept;
 
   facebook::react::Size m_contentSize;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IScrollVisual m_scrollVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual m_scrollVisual{nullptr};
   std::shared_ptr<ScrollBarComponent> m_horizontalScrollbarComponent{nullptr};
   std::shared_ptr<ScrollBarComponent> m_verticalScrollbarComponent{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IScrollVisual::ScrollPositionChanged_revoker
+  winrt::Microsoft::ReactNative::Composition::Experimental::IScrollVisual::ScrollPositionChanged_revoker
       m_scrollPositionChangedRevoker{};
 
   facebook::react::SharedViewProps m_props;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.cpp
@@ -25,7 +25,7 @@ constexpr float trackStrokeThickness = 1.0f;
 } // namespace SwitchConstants
 
 SwitchComponentView::SwitchComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : base_type(
@@ -38,7 +38,7 @@ SwitchComponentView::SwitchComponentView(
 }
 
 winrt::Microsoft::ReactNative::ComponentView SwitchComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<SwitchComponentView>(compContext, tag, reactContext);
@@ -137,9 +137,9 @@ void SwitchComponentView::handleScaleChange() noexcept {
 void SwitchComponentView::updateVisuals() noexcept {
   const auto switchProps = std::static_pointer_cast<const facebook::react::SwitchProps>(m_props);
   auto &theme = *this->theme();
-  winrt::Microsoft::ReactNative::Composition::IBrush defaultColor;
-  winrt::Microsoft::ReactNative::Composition::IBrush fillColor;
-  winrt::Microsoft::ReactNative::Composition::IBrush thumbFill;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush defaultColor;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush fillColor;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush thumbFill;
 
   auto thumbWidth = SwitchConstants::thumbWidth;
   auto thumbHeight = SwitchConstants::thumbWidth;
@@ -217,7 +217,7 @@ void SwitchComponentView::updateVisuals() noexcept {
   float offsetY = ((SwitchConstants::trackHeight - thumbHeight) * m_layoutMetrics.pointScaleFactor) / 2.0f;
 
   if (m_supressAnimationForNextFrame) {
-    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::None);
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::None);
   }
 
   if (switchProps->value) {
@@ -235,7 +235,7 @@ void SwitchComponentView::updateVisuals() noexcept {
   m_thumbVisual.Brush(thumbFill);
 
   if (m_supressAnimationForNextFrame) {
-    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb);
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::SwitchThumb);
     m_supressAnimationForNextFrame = false;
   }
 }
@@ -264,7 +264,7 @@ void SwitchComponentView::ensureVisual() noexcept {
     m_visual.InsertAt(m_trackVisual, 0);
 
     m_thumbVisual = m_compContext.CreateRoundedRectangleVisual();
-    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::AnimationClass::SwitchThumb);
+    m_thumbVisual.AnimationClass(winrt::Microsoft::ReactNative::Composition::Experimental::AnimationClass::SwitchThumb);
     m_trackVisual.InsertAt(m_thumbVisual, 0);
 
     handleScaleChange();
@@ -288,7 +288,7 @@ facebook::react::Tag SwitchComponentView::hitTest(
   return -1;
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual SwitchComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual SwitchComponentView::Visual() const noexcept {
   return m_visual;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/SwitchComponentView.h
@@ -17,7 +17,7 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, Component
   using Super = SwitchComponentViewT<SwitchComponentView, ComponentView>;
 
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -55,11 +55,11 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, Component
 
   facebook::react::Tag hitTest(facebook::react::Point pt, facebook::react::Point &localPt, bool ignorePointerEvents)
       const noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   std::string DefaultControlType() const noexcept override;
 
   SwitchComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -74,9 +74,9 @@ struct SwitchComponentView : SwitchComponentViewT<SwitchComponentView, Component
   bool m_supressAnimationForNextFrame{false};
   bool m_visualUpdateRequired{true};
   facebook::react::Size m_contentSize;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_trackVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IRoundedRectangleVisual m_thumbVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual m_trackVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IRoundedRectangleVisual m_thumbVisual{nullptr};
   facebook::react::SharedViewProps m_props;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -482,7 +482,7 @@ facebook::react::AttributedString WindowsTextInputComponentView::getAttributedSt
 }
 
 WindowsTextInputComponentView::WindowsTextInputComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : Super(
@@ -1371,7 +1371,7 @@ void WindowsTextInputComponentView::ensureDrawingSurface() noexcept {
 
     m_drawingSurface.HorizontalAlignmentRatio(0.f);
     m_drawingSurface.VerticalAlignmentRatio(0.f);
-    m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+    m_drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     m_visual.Brush(m_drawingSurface);
   }
 }
@@ -1547,12 +1547,13 @@ void WindowsTextInputComponentView::onThemeChanged() noexcept {
   base_type::onThemeChanged();
 }
 
-winrt::Microsoft::ReactNative::Composition::IVisual WindowsTextInputComponentView::Visual() const noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IVisual WindowsTextInputComponentView::Visual()
+    const noexcept {
   return m_visual;
 }
 
 winrt::Microsoft::ReactNative::ComponentView WindowsTextInputComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<WindowsTextInputComponentView>(compContext, tag, reactContext);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.h
@@ -25,7 +25,7 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
 
   using Super = WindowsTextInputComponentViewT<WindowsTextInputComponentView, ComponentView>;
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -52,7 +52,7 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
       facebook::react::Point &localPt,
       bool ignorePointerEvents = false) const noexcept override;
   void OnRenderingDeviceLost() noexcept override;
-  winrt::Microsoft::ReactNative::Composition::IVisual Visual() const noexcept override;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IVisual Visual() const noexcept override;
   void onFocusLost() noexcept override;
   void onFocusGained() noexcept override;
   bool focusable() const noexcept override;
@@ -83,7 +83,7 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
   bool getAcccessiblityIsReadOnly() noexcept override;
 
   WindowsTextInputComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
@@ -114,9 +114,9 @@ struct WindowsTextInputComponentView : WindowsTextInputComponentViewT<WindowsTex
       const winrt::Microsoft::ReactNative::Composition::Input::CharacterReceivedRoutedEventArgs &args) noexcept;
 
   winrt::Windows::UI::Composition::CompositionSurfaceBrush m_brush{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_visual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::ICaretVisual m_caretVisual{nullptr};
-  winrt::Microsoft::ReactNative::Composition::IDrawingSurfaceBrush m_drawingSurface{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICaretVisual m_caretVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface{nullptr};
 
   // Used by ITextHost impl
   CHARFORMAT2W m_cf;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
@@ -450,10 +450,12 @@ winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::Internal
   return PlatformBrush(winrt::to_string(platformColor));
 }
 
+#ifdef USE_WINUI3
 winrt::Microsoft::UI::Composition::CompositionBrush Theme::PlatformBrush(winrt::hstring platformColor) noexcept {
   return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerBrush(
       PlatformBrush(winrt::to_string(platformColor)));
 }
+#endif
 
 winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::PlatformBrush(
     const std::string &platformColor) noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.cpp
@@ -445,11 +445,18 @@ winrt::Windows::UI::Color Theme::PlatformColor(const std::string &platformColor)
   return {0, 0, 0, 0}; // Transparent
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(winrt::hstring platformColor) noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::InternalPlatformBrush(
+    winrt::hstring platformColor) noexcept {
   return PlatformBrush(winrt::to_string(platformColor));
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(const std::string &platformColor) noexcept {
+winrt::Microsoft::UI::Composition::CompositionBrush Theme::PlatformBrush(winrt::hstring platformColor) noexcept {
+  return winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerBrush(
+      PlatformBrush(winrt::to_string(platformColor)));
+}
+
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::PlatformBrush(
+    const std::string &platformColor) noexcept {
   if (m_emptyTheme)
     return nullptr;
 
@@ -465,7 +472,8 @@ winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(const st
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::Brush(const facebook::react::Color &color) noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::Brush(
+    const facebook::react::Color &color) noexcept {
   if (m_emptyTheme)
     return nullptr;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
@@ -7,18 +7,19 @@
 #include "Composition.Theme.g.h"
 #include <Microsoft.ReactNative.Cxx/ReactContext.h>
 #include <react/renderer/graphics/Color.h>
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
 #include <winrt/Microsoft.ReactNative.Composition.h>
 #include <winrt/Windows.UI.ViewManagement.h>
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-struct Theme : ThemeT<Theme> {
+struct Theme : ThemeT<Theme, Experimental::IInternalTheme> {
   Theme(
       const winrt::Microsoft::ReactNative::ReactContext &reactContext,
       const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &customResourceLoader) noexcept;
 
   // Public APIs
-  winrt::Microsoft::ReactNative::Composition::IBrush PlatformBrush(winrt::hstring platformColor) noexcept;
+  winrt::Microsoft::UI::Composition::CompositionBrush PlatformBrush(winrt::hstring platformColor) noexcept;
   bool TryGetPlatformColor(winrt::hstring platformColor, winrt::Windows::UI::Color &color) noexcept;
   bool IsEmpty() const noexcept;
 
@@ -29,9 +30,13 @@ struct Theme : ThemeT<Theme> {
   // Internal APIs
   Theme() noexcept;
 
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush InternalPlatformBrush(
+      winrt::hstring platformColor) noexcept;
+
   winrt::Windows::UI::Color PlatformColor(const std::string &platformColor) noexcept;
-  winrt::Microsoft::ReactNative::Composition::IBrush PlatformBrush(const std::string &platformColor) noexcept;
-  winrt::Microsoft::ReactNative::Composition::IBrush Brush(const facebook::react::Color &color) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush PlatformBrush(
+      const std::string &platformColor) noexcept;
+  winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Brush(const facebook::react::Color &color) noexcept;
   winrt::Windows::UI::Color Color(const facebook::react::Color &color) noexcept;
 
   D2D1::ColorF D2DColor(const facebook::react::Color &color) noexcept;
@@ -59,9 +64,10 @@ struct Theme : ThemeT<Theme> {
   std::unordered_map<std::string, std::pair<bool, winrt::Windows::UI::Color>> m_colorCache;
   winrt::Windows::UI::ViewManagement::UISettings m_uisettings;
   winrt::Windows::UI::ViewManagement::UISettings::ColorValuesChanged_revoker m_colorValuesChangedRevoker;
-  std::unordered_map<std::string, winrt::Microsoft::ReactNative::Composition::IBrush> m_platformColorBrushCache;
-  std::unordered_map<DWORD, winrt::Microsoft::ReactNative::Composition::IBrush> m_colorBrushCache;
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compositionContext;
+  std::unordered_map<std::string, winrt::Microsoft::ReactNative::Composition::Experimental::IBrush>
+      m_platformColorBrushCache;
+  std::unordered_map<DWORD, winrt::Microsoft::ReactNative::Composition::Experimental::IBrush> m_colorBrushCache;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compositionContext;
   winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader m_customResourceLoader;
   winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader::ResourcesChanged_revoker m_resourceChangedRevoker;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
@@ -18,8 +18,10 @@ struct Theme : ThemeT<Theme, Experimental::IInternalTheme> {
       const winrt::Microsoft::ReactNative::ReactContext &reactContext,
       const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &customResourceLoader) noexcept;
 
-  // Public APIs
+// Public APIs
+#ifdef USE_WINUI3
   winrt::Microsoft::UI::Composition::CompositionBrush PlatformBrush(winrt::hstring platformColor) noexcept;
+#endif
   bool TryGetPlatformColor(winrt::hstring platformColor, winrt::Windows::UI::Color &color) noexcept;
   bool IsEmpty() const noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
@@ -35,7 +35,7 @@ winrt::Windows::UI::Color Theme::PlatformColor(const std::string &) noexcept {
   return {};
 }
 
-winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::PlatformBrush(winrt::hstring) noexcept {
+winrt::Microsoft::UI::Composition::CompositionBrush Theme::PlatformBrush(winrt::hstring) noexcept {
   return nullptr;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
@@ -35,15 +35,15 @@ winrt::Windows::UI::Color Theme::PlatformColor(const std::string &) noexcept {
   return {};
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(winrt::hstring) noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::PlatformBrush(winrt::hstring) noexcept {
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::PlatformBrush(const std::string &) noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::PlatformBrush(const std::string &) noexcept {
   return nullptr;
 }
 
-winrt::Microsoft::ReactNative::Composition::IBrush Theme::Brush(const facebook::react::Color &) noexcept {
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush Theme::Brush(const facebook::react::Color &) noexcept {
   return nullptr;
 }
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -14,7 +14,7 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 UnimplementedNativeViewComponentView::UnimplementedNativeViewComponentView(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext)
     : base_type(
@@ -30,7 +30,7 @@ UnimplementedNativeViewComponentView::UnimplementedNativeViewComponentView(
 }
 
 winrt::Microsoft::ReactNative::ComponentView UnimplementedNativeViewComponentView::Create(
-    const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+    const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
     facebook::react::Tag tag,
     winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept {
   return winrt::make<UnimplementedNativeViewComponentView>(compContext, tag, reactContext);
@@ -65,7 +65,7 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
 
     drawingSurface.HorizontalAlignmentRatio(0.f);
     drawingSurface.VerticalAlignmentRatio(0.f);
-    drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::CompositionStretch::None);
+    drawingSurface.Stretch(winrt::Microsoft::ReactNative::Composition::Experimental::CompositionStretch::None);
     m_labelVisual.Brush(drawingSurface);
     m_labelVisual.Size(surfaceSize);
     m_labelVisual.Offset({

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.h
@@ -17,7 +17,7 @@ namespace winrt::Microsoft::ReactNative::Composition::implementation {
 struct UnimplementedNativeViewComponentView
     : public UnimplementedNativeViewComponentViewT<UnimplementedNativeViewComponentView, ViewComponentView> {
   [[nodiscard]] static winrt::Microsoft::ReactNative::ComponentView Create(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext) noexcept;
 
@@ -29,13 +29,13 @@ struct UnimplementedNativeViewComponentView
       override;
 
   UnimplementedNativeViewComponentView(
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext,
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext,
       facebook::react::Tag tag,
       winrt::Microsoft::ReactNative::ReactContext const &reactContext);
 
  private:
   std::shared_ptr<facebook::react::UnimplementedNativeViewProps const> m_props;
-  winrt::Microsoft::ReactNative::Composition::ISpriteVisual m_labelVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_labelVisual{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
+++ b/vnext/Microsoft.ReactNative/Fabric/FabricUIManagerModule.h
@@ -63,7 +63,7 @@ struct FabricUIManager final : public std::enable_shared_from_this<FabricUIManag
   void didMountComponentsWithRootTag(facebook::react::SurfaceId surfaceId) noexcept;
 
   winrt::Microsoft::ReactNative::ReactContext m_context;
-  winrt::Microsoft::ReactNative::Composition::ICompositionContext m_compContext;
+  winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext m_compContext;
   std::shared_ptr<facebook::react::Scheduler> m_scheduler;
   std::shared_ptr<facebook::react::SurfaceManager> m_surfaceManager;
   std::mutex m_schedulerMutex; // Protect m_scheduler

--- a/vnext/Microsoft.ReactNative/Fabric/IComponentViewRegistry.h
+++ b/vnext/Microsoft.ReactNative/Fabric/IComponentViewRegistry.h
@@ -22,7 +22,7 @@ struct IComponentViewRegistry {
   virtual ComponentViewDescriptor const &dequeueComponentViewWithComponentHandle(
       facebook::react::ComponentHandle componentHandle,
       facebook::react::Tag tag,
-      const winrt::Microsoft::ReactNative::Composition::ICompositionContext &compContext) noexcept = 0;
+      const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext &compContext) noexcept = 0;
   virtual ComponentViewDescriptor const &componentViewDescriptorWithTag(facebook::react::Tag tag) const noexcept = 0;
   virtual winrt::Microsoft::ReactNative::ComponentView findComponentViewWithTag(
       facebook::react::Tag tag) const noexcept = 0;

--- a/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/NativeAnimatedNodeManager.cpp
@@ -46,7 +46,8 @@ comp::Compositor NativeAnimatedNodeManager::Compositor() const noexcept {
       winrt::Microsoft::ReactNative::Composition::implementation::CompositionUIService::GetCompositionContext(
           m_context.Properties().Handle());
   if (compositionContext) {
-    return winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerCompositor(compositionContext);
+    return winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerCompositor(
+        compositionContext);
   }
 #endif
 #ifndef CORE_ABI

--- a/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
+++ b/vnext/Microsoft.ReactNative/Modules/Animated/PropsAnimatedNode.cpp
@@ -181,9 +181,11 @@ void PropsAnimatedNode::StartAnimations() {
             view.m_element.RotationAxis(m_rotationAxis);
 #ifdef USE_FABRIC
           } else {
-            auto visual = winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerVisual(
-                view.m_componentView.as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()
-                    ->Visual());
+            auto visual =
+                winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(
+                    view.m_componentView
+                        .as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>()
+                        ->Visual());
             visual.RotationAxis(m_rotationAxis);
 #endif
           }
@@ -395,8 +397,8 @@ void PropsAnimatedNode::StartAnimation(
   } else if (view.m_componentView) {
     auto baseComponentView =
         view.m_componentView.as<winrt::Microsoft::ReactNative::Composition::implementation::ComponentView>();
-    auto visual =
-        winrt::Microsoft::ReactNative::Composition::CompositionContextHelper::InnerVisual(baseComponentView->Visual());
+    auto visual = winrt::Microsoft::ReactNative::Composition::Experimental::CompositionContextHelper::InnerVisual(
+        baseComponentView->Visual());
     if (visual) {
       auto targetProp = animation.Target();
       if (targetProp == L"Rotation") {

--- a/vnext/Microsoft.ReactNative/Theme.idl
+++ b/vnext/Microsoft.ReactNative/Theme.idl
@@ -37,12 +37,21 @@ namespace Microsoft.ReactNative.Composition
     event Windows.Foundation.EventHandler<Object> ResourcesChanged;
   };
 
+  namespace Experimental {
+    [webhosthidden]
+    [experimental]
+    interface IInternalTheme {
+      Microsoft.ReactNative.Composition.Experimental.IBrush InternalPlatformBrush(String platformColor);
+    }
+  }
+
   [webhosthidden]
   [experimental]
   runtimeclass Theme {
     Theme(Microsoft.ReactNative.IReactContext reactContext, ICustomResourceLoader resourceLoader);
 
-    Microsoft.ReactNative.Composition.IBrush PlatformBrush(String platformColor);
+    Microsoft.UI.Composition.CompositionBrush PlatformBrush(String platformColor);
+
     Boolean TryGetPlatformColor(String platformColor, out Windows.UI.Color color);
     DOC_STRING("An empty theme is used when the final theme is not yet known.  It will generally return transparent colors.")
     Boolean IsEmpty { get; };

--- a/vnext/Microsoft.ReactNative/Theme.idl
+++ b/vnext/Microsoft.ReactNative/Theme.idl
@@ -50,7 +50,9 @@ namespace Microsoft.ReactNative.Composition
   runtimeclass Theme {
     Theme(Microsoft.ReactNative.IReactContext reactContext, ICustomResourceLoader resourceLoader);
 
+#ifdef USE_WINUI3
     Microsoft.UI.Composition.CompositionBrush PlatformBrush(String platformColor);
+#endif
 
     Boolean TryGetPlatformColor(String platformColor, out Windows.UI.Color color);
     DOC_STRING("An empty theme is used when the final theme is not yet known.  It will generally return transparent colors.")

--- a/vnext/Microsoft.ReactNative/ViewProps.idl
+++ b/vnext/Microsoft.ReactNative/ViewProps.idl
@@ -8,11 +8,19 @@ import "Theme.idl";
 
 namespace Microsoft.ReactNative {
 
+  namespace Composition.Experimental {
+    [webhosthidden]
+    [experimental]
+    interface IInternalColor {
+      Microsoft.ReactNative.Composition.Experimental.IBrush AsInternalBrush(Microsoft.ReactNative.Composition.Theme theme);
+    }
+  }
+
   [webhosthidden]
   [experimental]
   runtimeclass Color {
     Windows.UI.Color AsWindowsColor(Microsoft.ReactNative.Composition.Theme theme);
-    Microsoft.ReactNative.Composition.IBrush AsBrush(Microsoft.ReactNative.Composition.Theme theme);
+    Microsoft.UI.Composition.CompositionBrush AsBrush(Microsoft.ReactNative.Composition.Theme theme);
 
     static Color Black();
     static Color Transparent();

--- a/vnext/Microsoft.ReactNative/ViewProps.idl
+++ b/vnext/Microsoft.ReactNative/ViewProps.idl
@@ -20,7 +20,9 @@ namespace Microsoft.ReactNative {
   [experimental]
   runtimeclass Color {
     Windows.UI.Color AsWindowsColor(Microsoft.ReactNative.Composition.Theme theme);
+#ifdef USE_WINUI3
     Microsoft.UI.Composition.CompositionBrush AsBrush(Microsoft.ReactNative.Composition.Theme theme);
+#endif
 
     static Color Black();
     static Color Transparent();

--- a/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
+++ b/vnext/templates/cpp-app/windows/MyApp/MyApp.cpp
@@ -74,11 +74,8 @@ winrt::Microsoft::ReactNative::ReactNativeHost CreateReactNativeHost(
   winrt::Microsoft::ReactNative::ReactCoreInjection::SetTopLevelWindowId(
       host.InstanceSettings().Properties(), reinterpret_cast<uint64_t>(hwnd));
 
-  // By using the MicrosoftCompositionContextHelper here, React Native Windows will use Lifted Visuals for its
-  // tree.
-  winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
-      host.InstanceSettings().Properties(),
-      winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::CreateContext(compositor));
+  winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(
+      host.InstanceSettings(), compositor);
 
   return host;
 }
@@ -144,8 +141,6 @@ _Use_decl_annotations_ int CALLBACK WinMain(HINSTANCE instance, HINSTANCE, PSTR 
   bridge.Connect(rootView.Island());
   bridge.ResizePolicy(winrt::Microsoft::UI::Content::ContentSizePolicy::ResizeContentToParentWindow);
 
-  auto invScale = 1.0f / scaleFactor;
-  rootView.RootVisual().Scale({invScale, invScale, invScale});
   rootView.ScaleFactor(scaleFactor);
 
   // Set the intialSize of the root view


### PR DESCRIPTION
This moves all the objects related to the composition switcher into an Experimental namespace.

On public objects that used to expose objects from the switcher we now directly expose Microsoft.UI.Composition objects.  There are experimental interfaces that can be used to set composition switcher objects instead.

This should limit the effect of the switcher on the public interface.  We still use the switcher internally to allow Office to be able to continue to inject a custom composition interface.  But now when we remove this ability APIs outside of the experimental namespace should not need to change.

Example:

Before:
```cpp
winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositionContext(
    InstanceSettings().Properties(),
    winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::CreateContext(
        g_liftedCompositor));

// Have to use MicrosoftCompositionContextHelper to access actual Microsoft.UI.Composition visual.
auto rootVisual = winrt::Microsoft::ReactNative::Composition::MicrosoftCompositionContextHelper::InnerVisual(compositionRootView.RootVisual());
```

After:
```cpp
winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(
    InstanceSettings(), g_liftedCompositor);

// CompositionRootView.RootVisual now directly returns a Microsoft.UI.Composition visual.
auto rootVisual = compositionRootView.RootVisual();
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12960)