### PR TITLE
Unify some DPI drawing logic

### DIFF
--- a/change/react-native-windows-91e4571c-cdb6-4c4e-b7f6-d720a005abd1.json
+++ b/change/react-native-windows-91e4571c-cdb6-4c4e-b7f6-d720a005abd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Handle dpi during drawing more consistently",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
@@ -11,9 +11,11 @@ class AutoDrawDrawingSurface {
  public:
   AutoDrawDrawingSurface(
       winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush &drawingSurface,
+      float scaleFactor,
       POINT *offset) noexcept {
     drawingSurface.as(m_drawingSurfaceInterop);
-    m_drawingSurfaceInterop->BeginDraw(m_d2dDeviceContext.put(), offset);
+    auto dpi = scaleFactor * 96.0f;
+    m_drawingSurfaceInterop->BeginDraw(m_d2dDeviceContext.put(), dpi, dpi, offset);
   }
 
   ~AutoDrawDrawingSurface() noexcept {

--- a/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
+++ b/vnext/Microsoft.ReactNative.Cxx/CompositionSwitcher.Experimental.interop.h
@@ -15,7 +15,7 @@
 namespace Microsoft::ReactNative::Composition::Experimental {
 
 struct __declspec(uuid("941FDD90-ED27-49CE-A1CD-86ECB2D4A0FA")) ICompositionDrawingSurfaceInterop : public IUnknown {
-  virtual HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, POINT *offset) noexcept = 0;
+  virtual HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, float xDpi, float yDpi, POINT *offset) noexcept = 0;
   virtual HRESULT EndDraw() noexcept = 0;
 };
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -256,13 +256,18 @@ struct CompDrawingSurfaceBrush : public winrt::implements<
     drawingSurface.as(m_drawingSurfaceInterop);
   }
 
-  HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, POINT *offset) noexcept {
+  HRESULT BeginDraw(ID2D1DeviceContext **deviceContextOut, float xDpi, float yDpi, POINT *offset) noexcept {
 #ifdef DEBUG
     // Drawing to a zero sized surface is a waste of time
     auto size = m_drawingSurfaceInterop.as<typename TTypeRedirects::CompositionDrawingSurface>().Size();
     assert(size.Width != 0 && size.Height != 0);
 #endif
-    return m_drawingSurfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), (void **)deviceContextOut, offset);
+
+    auto hr = m_drawingSurfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), (void **)deviceContextOut, offset);
+    if (SUCCEEDED(hr)) {
+      (*deviceContextOut)->SetDpi(xDpi, yDpi);
+    }
+    return hr;
   }
 
   HRESULT EndDraw() noexcept {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -263,7 +263,8 @@ struct CompDrawingSurfaceBrush : public winrt::implements<
     assert(size.Width != 0 && size.Height != 0);
 #endif
 
-    auto hr = m_drawingSurfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), (void **)deviceContextOut, offset);
+    auto hr =
+        m_drawingSurfaceInterop->BeginDraw(nullptr, __uuidof(ID2D1DeviceContext), (void **)deviceContextOut, offset);
     if (SUCCEEDED(hr)) {
       (*deviceContextOut)->SetDpi(xDpi, yDpi);
     }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -496,7 +496,7 @@ Composition::Experimental::IDrawingSurfaceBrush CompositionRootView::CreateLoadi
 
   POINT offset;
   {
-    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, &offset);
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_scaleFactor, &offset);
     if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
       d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Green));
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -186,15 +186,13 @@ void CompositionRootView::RemoveRenderedVisual(
 
 bool CompositionRootView::TrySetFocus() noexcept {
 #ifdef USE_WINUI3
-  if (m_island)
-  {
+  if (m_island) {
     auto focusController = winrt::Microsoft::UI::Input::InputFocusController::GetForIsland(m_island);
     return focusController.TrySetFocus();
   }
 #endif
   return false;
 }
-
 
 winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
   return m_size;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -33,6 +33,7 @@
 
 #ifdef USE_WINUI3
 #include <winrt/Microsoft.UI.Content.h>
+#include <winrt/Microsoft.UI.Input.h>
 #endif
 
 namespace winrt::Microsoft::ReactNative::implementation {
@@ -182,6 +183,18 @@ void CompositionRootView::RemoveRenderedVisual(
   InternalRootVisual().Remove(visual);
   m_hasRenderedVisual = false;
 }
+
+bool CompositionRootView::TrySetFocus() noexcept {
+#ifdef USE_WINUI3
+  if (m_island)
+  {
+    auto focusController = winrt::Microsoft::UI::Input::InputFocusController::GetForIsland(m_island);
+    return focusController.TrySetFocus();
+  }
+#endif
+  return false;
+}
+
 
 winrt::Windows::Foundation::Size CompositionRootView::Size() noexcept {
   return m_size;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -71,6 +71,7 @@ struct CompositionRootView
 
   void AddRenderedVisual(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept;
   void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept;
+  bool TrySetFocus() noexcept;
 
   winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -599,14 +599,13 @@ void SetBorderLayerPropertiesCommon(
   layer.Brush(surface);
 
   POINT offset;
-  ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(surface, 1.0f /* We have already done the dpi scaling */, &offset);
-  if (auto pRT = autoDraw.GetRenderTarget())
-  {
+  ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(
+      surface, 1.0f /* We have already done the dpi scaling */, &offset);
+  if (auto pRT = autoDraw.GetRenderTarget()) {
     // Clear with transparency
     pRT->Clear();
 
-    if (!facebook::react::isColorMeaningful(borderColor))
-    {
+    if (!facebook::react::isColorMeaningful(borderColor)) {
       return;
     }
 
@@ -624,28 +623,24 @@ void SetBorderLayerPropertiesCommon(
 
     winrt::com_ptr<ID2D1StrokeStyle> spStrokeStyle;
 
-    enum class BorderStyle
-    {
-      Solid, Dotted, Dashed
-    };
+    enum class BorderStyle { Solid, Dotted, Dashed };
 
-    if (borderStyle == facebook::react::BorderStyle::Dotted || borderStyle == facebook::react::BorderStyle::Dashed)
-    {
+    if (borderStyle == facebook::react::BorderStyle::Dotted || borderStyle == facebook::react::BorderStyle::Dashed) {
       const auto capStyle =
-        borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_CAP_STYLE_FLAT : D2D1_CAP_STYLE_ROUND;
+          borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_CAP_STYLE_FLAT : D2D1_CAP_STYLE_ROUND;
       const auto strokeStyleProps = D2D1::StrokeStyleProperties(
-        capStyle,
-        capStyle,
-        capStyle,
-        D2D1_LINE_JOIN_MITER,
-        10.0f,
-        borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_DASH_STYLE_DASH : D2D1_DASH_STYLE_DOT,
-        0.0f);
+          capStyle,
+          capStyle,
+          capStyle,
+          D2D1_LINE_JOIN_MITER,
+          10.0f,
+          borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_DASH_STYLE_DASH : D2D1_DASH_STYLE_DOT,
+          0.0f);
       spFactory->CreateStrokeStyle(&strokeStyleProps, nullptr, 0, spStrokeStyle.put());
     }
     D2D1::Matrix3x2F originalTransform;
     D2D1::Matrix3x2F translationTransform =
-      D2D1::Matrix3x2F::Translation(-textureRect.left + offset.x, -textureRect.top + offset.y);
+        D2D1::Matrix3x2F::Translation(-textureRect.left + offset.x, -textureRect.top + offset.y);
 
     pRT->GetTransform(&originalTransform);
     translationTransform = originalTransform * translationTransform;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -6,6 +6,7 @@
 
 #include "CompositionViewComponentView.h"
 
+#include <AutoDraw.h>
 #include <Fabric/AbiState.h>
 #include <Fabric/AbiViewProps.h>
 #include <Fabric/Composition/CompositionRootView.h>
@@ -568,32 +569,6 @@ void DrawShape(
   pRT->DrawGeometry(&geometry, brush, strokeWidth, strokeStyle);
 }
 
-struct AutoDrawHelper {
-  AutoDrawHelper(
-      winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop> &surface) {
-    m_surface = surface;
-    m_surface->BeginDraw(m_pRT.put(), &m_offset);
-  }
-
-  ~AutoDrawHelper() {
-    m_pRT = nullptr;
-    m_surface->EndDraw();
-  }
-
-  const winrt::com_ptr<ID2D1DeviceContext> &GetRenderTarget() const noexcept {
-    return m_pRT;
-  }
-
-  POINT Offset() const noexcept {
-    return m_offset;
-  }
-
- private:
-  winrt::com_ptr<::Microsoft::ReactNative::Composition::Experimental::ICompositionDrawingSurfaceInterop> m_surface;
-  POINT m_offset;
-  winrt::com_ptr<ID2D1DeviceContext> m_pRT;
-};
-
 template <typename TShape>
 void SetBorderLayerPropertiesCommon(
     winrt::Microsoft::ReactNative::Composition::implementation::Theme *theme,
@@ -623,41 +598,42 @@ void SetBorderLayerPropertiesCommon(
 
   layer.Brush(surface);
 
-  AutoDrawHelper autoDraw(borderTexture);
+  POINT offset;
+  ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(surface, 1.0f /* We have already done the dpi scaling */, &offset);
+  if (auto pRT = autoDraw.GetRenderTarget())
+  {
+    // Clear with transparency
+    pRT->Clear();
 
-  winrt::com_ptr<ID2D1DeviceContext> pRT{autoDraw.GetRenderTarget()};
+    if (!facebook::react::isColorMeaningful(borderColor))
+    {
+      return;
+    }
 
-  if (!pRT) {
-    return;
-  }
+    winrt::com_ptr<ID2D1Factory> spFactory;
+    pRT->GetFactory(spFactory.put());
+    assert(spFactory);
+    if (spFactory == nullptr)
+      return;
 
-  // Clear with transparency
-  pRT->Clear();
+    winrt::com_ptr<ID2D1SolidColorBrush> spBorderBrush;
+    pRT->CreateSolidColorBrush(theme->D2DColor(*borderColor), spBorderBrush.put());
+    assert(spBorderBrush);
+    if (spBorderBrush == nullptr)
+      return;
 
-  if (!facebook::react::isColorMeaningful(borderColor)) {
-    return;
-  }
+    winrt::com_ptr<ID2D1StrokeStyle> spStrokeStyle;
 
-  winrt::com_ptr<ID2D1Factory> spFactory;
-  pRT->GetFactory(spFactory.put());
-  assert(spFactory);
-  if (spFactory == nullptr)
-    return;
+    enum class BorderStyle
+    {
+      Solid, Dotted, Dashed
+    };
 
-  winrt::com_ptr<ID2D1SolidColorBrush> spBorderBrush;
-  pRT->CreateSolidColorBrush(theme->D2DColor(*borderColor), spBorderBrush.put());
-  assert(spBorderBrush);
-  if (spBorderBrush == nullptr)
-    return;
-
-  winrt::com_ptr<ID2D1StrokeStyle> spStrokeStyle;
-
-  enum class BorderStyle { Solid, Dotted, Dashed };
-
-  if (borderStyle == facebook::react::BorderStyle::Dotted || borderStyle == facebook::react::BorderStyle::Dashed) {
-    const auto capStyle =
+    if (borderStyle == facebook::react::BorderStyle::Dotted || borderStyle == facebook::react::BorderStyle::Dashed)
+    {
+      const auto capStyle =
         borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_CAP_STYLE_FLAT : D2D1_CAP_STYLE_ROUND;
-    const auto strokeStyleProps = D2D1::StrokeStyleProperties(
+      const auto strokeStyleProps = D2D1::StrokeStyleProperties(
         capStyle,
         capStyle,
         capStyle,
@@ -665,24 +641,21 @@ void SetBorderLayerPropertiesCommon(
         10.0f,
         borderStyle == facebook::react::BorderStyle::Dashed ? D2D1_DASH_STYLE_DASH : D2D1_DASH_STYLE_DOT,
         0.0f);
-    spFactory->CreateStrokeStyle(&strokeStyleProps, nullptr, 0, spStrokeStyle.put());
+      spFactory->CreateStrokeStyle(&strokeStyleProps, nullptr, 0, spStrokeStyle.put());
+    }
+    D2D1::Matrix3x2F originalTransform;
+    D2D1::Matrix3x2F translationTransform =
+      D2D1::Matrix3x2F::Translation(-textureRect.left + offset.x, -textureRect.top + offset.y);
+
+    pRT->GetTransform(&originalTransform);
+    translationTransform = originalTransform * translationTransform;
+
+    pRT->SetTransform(translationTransform);
+
+    DrawShape(pRT, shape, spBorderBrush.get(), strokeWidth, spStrokeStyle.get());
+
+    pRT->SetTransform(originalTransform);
   }
-  D2D1::Matrix3x2F originalTransform;
-  D2D1::Matrix3x2F translationTransform =
-      D2D1::Matrix3x2F::Translation(-textureRect.left + autoDraw.Offset().x, -textureRect.top + autoDraw.Offset().y);
-
-  pRT->GetTransform(&originalTransform);
-  translationTransform = originalTransform * translationTransform;
-
-  float oldDpiX, oldDpiY;
-  pRT->SetTransform(translationTransform);
-  pRT->GetDpi(&oldDpiX, &oldDpiY);
-  pRT->SetDpi(96.0f, 96.0f); // We have already done the dpi scaling...
-
-  DrawShape(pRT.get(), shape, spBorderBrush.get(), strokeWidth, spStrokeStyle.get());
-
-  pRT->SetDpi(oldDpiX, oldDpiY);
-  pRT->SetTransform(originalTransform);
 }
 
 template <typename TShape>

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.cpp
@@ -225,7 +225,8 @@ void ImageComponentView::ensureDrawingSurface() noexcept {
     const auto frame{m_layoutMetrics.getContentFrame().size};
 
     if (imageProps->resizeMode == facebook::react::ImageResizeMode::Repeat) {
-      drawingSurfaceSize = {frame.width * m_layoutMetrics.pointScaleFactor, frame.height * m_layoutMetrics.pointScaleFactor };
+      drawingSurfaceSize = {
+          frame.width * m_layoutMetrics.pointScaleFactor, frame.height * m_layoutMetrics.pointScaleFactor};
     } else if (imageProps->blurRadius > 0) {
       // https://learn.microsoft.com/en-us/windows/win32/direct2d/gaussian-blur#output-bitmap
       // The following equation that can be used to compute the output bitmap:

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -251,7 +251,8 @@ void WindowsModalHostComponentView::updateLayoutMetrics(
 
     POINT offset;
     {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
+      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(
+          drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
       if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
         d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Blue, 0.3f));
         assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Modal/WindowsModalHostViewComponentView.cpp
@@ -251,14 +251,10 @@ void WindowsModalHostComponentView::updateLayoutMetrics(
 
     POINT offset;
     {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, &offset);
+      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
       if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
         d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Blue, 0.3f));
         assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-        const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
-        float oldDpiX, oldDpiY;
-        d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-        d2dDeviceContext->SetDpi(dpi, dpi);
 
         float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
         float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -312,7 +312,8 @@ void ParagraphComponentView::DrawText() noexcept {
 
   POINT offset;
   {
-    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(
+        m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
     if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
       d2dDeviceContext->Clear(
           m_props->backgroundColor ? theme()->D2DColor(*m_props->backgroundColor)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ParagraphComponentView.cpp
@@ -312,7 +312,7 @@ void ParagraphComponentView::DrawText() noexcept {
 
   POINT offset;
   {
-    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, &offset);
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
     if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
       d2dDeviceContext->Clear(
           m_props->backgroundColor ? theme()->D2DColor(*m_props->backgroundColor)

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/RootComponentView.cpp
@@ -55,8 +55,12 @@ void RootComponentView::SetFocusedComponent(const winrt::Microsoft::ReactNative:
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(m_focusedComponent)->onFocusLost();
   }
 
-  if (value)
+  if (value) {
+    if (auto rootView = m_wkRootView.get()) {
+      winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(rootView)->TrySetFocus();
+    }
     winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(value)->onFocusGained();
+  }
 
   m_focusedComponent = value;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -866,6 +866,7 @@ void ScrollViewComponentView::OnPointerWheelChanged(
       }
     }
   }
+  Super::OnPointerWheelChanged(args);
 }
 
 void ScrollViewComponentView::OnPointerPressed(

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ScrollViewComponentView.cpp
@@ -465,14 +465,10 @@ struct ScrollBarComponent {
 
     POINT offset;
     {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, &offset);
+      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_scaleFactor, &offset);
       if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
         d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
         assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-        const auto dpi = m_scaleFactor * 96.0f;
-        float oldDpiX, oldDpiY;
-        d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-        d2dDeviceContext->SetDpi(dpi, dpi);
 
         // Create a solid color brush for the text. A more sophisticated application might want
         // to cache and reuse a brush across all text elements instead, taking care to recreate
@@ -507,9 +503,6 @@ struct ScrollBarComponent {
             spTextLayout.get(),
             brush.get(),
             D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
-
-        // restore dpi to old state
-        d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);
       }
     }
     if (drawingSurface) {

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -635,7 +635,9 @@ void WindowsTextInputComponentView::OnPointerPressed(
 
   auto pp = args.GetCurrentPoint(-1); // TODO use local coords?
   auto position = pp.Position();
-  POINT ptContainer = {static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor), static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
+  POINT ptContainer = {
+      static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor),
+      static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
   lParam = static_cast<LPARAM>(POINTTOPOINTS(ptContainer));
 
   if (pp.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
@@ -680,7 +682,9 @@ void WindowsTextInputComponentView::OnPointerReleased(
 
   auto pp = args.GetCurrentPoint(-1);
   auto position = pp.Position();
-  POINT ptContainer = {static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor), static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
+  POINT ptContainer = {
+      static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor),
+      static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
   lParam = static_cast<LPARAM>(POINTTOPOINTS(ptContainer));
 
   if (pp.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
@@ -725,7 +729,9 @@ void WindowsTextInputComponentView::OnPointerMoved(
 
   auto pp = args.GetCurrentPoint(-1);
   auto position = pp.Position();
-  POINT ptContainer = {static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor), static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
+  POINT ptContainer = {
+      static_cast<LONG>(position.X * m_layoutMetrics.pointScaleFactor),
+      static_cast<LONG>(position.Y * m_layoutMetrics.pointScaleFactor)};
   lParam = static_cast<LPARAM>(POINTTOPOINTS(ptContainer));
 
   if (pp.PointerDeviceType() == winrt::Microsoft::ReactNative::Composition::Input::PointerDeviceType::Mouse) {
@@ -1426,7 +1432,8 @@ void WindowsTextInputComponentView::DrawText() noexcept {
 
   m_drawing = true;
   {
-    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(
+        m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
     if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
       d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
       assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputComponentView.cpp
@@ -1421,14 +1421,10 @@ void WindowsTextInputComponentView::DrawText() noexcept {
 
   m_drawing = true;
   {
-    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, &offset);
+    ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(m_drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
     if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
       d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Black, 0.0f));
       assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-      const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
-      float oldDpiX, oldDpiY;
-      d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-      d2dDeviceContext->SetDpi(dpi, dpi);
 
       RECTL rc{
           static_cast<LONG>(offset.x),
@@ -1484,9 +1480,6 @@ void WindowsTextInputComponentView::DrawText() noexcept {
             brush.get(),
             D2D1_DRAW_TEXT_OPTIONS_ENABLE_COLOR_FONT);
       }
-
-      // restore dpi state
-      d2dDeviceContext->SetDpi(oldDpiX, oldDpiY);
     }
   }
   m_drawing = false;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -76,7 +76,8 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
 
     POINT offset;
     {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
+      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(
+          drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
       if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
         d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Red, 0.3f));
         assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UnimplementedNativeViewComponentView.cpp
@@ -76,14 +76,10 @@ void UnimplementedNativeViewComponentView::updateLayoutMetrics(
 
     POINT offset;
     {
-      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, &offset);
+      ::Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingSurface, m_layoutMetrics.pointScaleFactor, &offset);
       if (auto d2dDeviceContext = autoDraw.GetRenderTarget()) {
         d2dDeviceContext->Clear(D2D1::ColorF(D2D1::ColorF::Red, 0.3f));
         assert(d2dDeviceContext->GetUnitMode() == D2D1_UNIT_MODE_DIPS);
-        const auto dpi = m_layoutMetrics.pointScaleFactor * 96.0f;
-        float oldDpiX, oldDpiY;
-        d2dDeviceContext->GetDpi(&oldDpiX, &oldDpiY);
-        d2dDeviceContext->SetDpi(dpi, dpi);
 
         float offsetX = static_cast<float>(offset.x / m_layoutMetrics.pointScaleFactor);
         float offsetY = static_cast<float>(offset.y / m_layoutMetrics.pointScaleFactor);

--- a/vnext/Scripts/OfficeReact.Win32.nuspec
+++ b/vnext/Scripts/OfficeReact.Win32.nuspec
@@ -40,6 +40,7 @@
     <file src="$nugetroot$\inc\runtimeexecutor\ReactCommon\RuntimeExecutor.h" target="inc\ReactCommon"/>
     <file src="$nugetroot$\inc\cxxreact\*" target="inc\cxxreact"/>
     <file src="$nugetroot$\inc\jsi\**\*.*" target="inc\jsi"/>
+    <file src="$nugetroot$\inc\jsinspector-modern\*" target="inc\jsinspector-modern"/>
     <file src="$nugetroot$\inc\Yoga\*.*" target="inc\Yoga"/>
     <file src="$nugetroot$\inc\folly\**\*.*" target="inc" />
     <file src="$nugetroot$\inc\fmt\**\*.*" target="inc\fmt" />
@@ -62,6 +63,7 @@
     <file src="$nugetroot$\inc\Shared\Networking\OriginPolicy.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\RuntimeOptions.h" target="inc"/>
     <file src="$nugetroot$\inc\Shared\Tracing.h" target="inc"/>
+    <file src="$nugetroot$\inc\Shared\JSI\JSExecutorFactoryDelegate.h" target="inc\JSI"/>
 
     <!-- Test DLL -->
     <file src="$nugetroot$\inc\Test\WebSocketServer.h" target="inc\Test" />


### PR DESCRIPTION
- Unify some DPI drawing logic, which also helps integrate with Office's compositor
- Fix issue where you cannot type in TextInput until switching to another window and back
- Fix issue where tiled images would not draw at the correct size
- Using the mouse scroll wheel on an inner ScrollView would not scroll outer ScrollViews once inner ScrollView reached limit
- KeyUp events in a TextInput would trigger KeyDown events
- TextInput maxLength property was not implemented
- Pressing END in a TextInput would scroll an outer scroll view, when it should just move the cursor within the TextInput
