### PR TITLE
Fix bad version bump

### DIFF
--- a/change/@office-iss-react-native-win32-5b95bb7e-63c7-4bba-b73a-93217e0a4f27.json
+++ b/change/@office-iss-react-native-win32-5b95bb7e-63c7-4bba-b73a-93217e0a4f27.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 3/7",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-71302ad5-da23-44ce-821c-2568811a9e0f.json
+++ b/change/@react-native-windows-automation-71302ad5-da23-44ce-821c-2568811a9e0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/automation",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-automation-channel-2673052a-80e8-42ac-b3c5-6fd027bcf092.json
+++ b/change/@react-native-windows-automation-channel-2673052a-80e8-42ac-b3c5-6fd027bcf092.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate 3/7",
+  "packageName": "@react-native-windows/automation-channel",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-cli-75da1e11-fec9-40e3-aa84-86eb9af01952.json
+++ b/change/@react-native-windows-cli-75da1e11-fec9-40e3-aa84-86eb9af01952.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/cli",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-codegen-83a4c02c-a292-4cf5-8537-9fc789f2674d.json
+++ b/change/@react-native-windows-codegen-83a4c02c-a292-4cf5-8537-9fc789f2674d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/codegen",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-find-repo-root-d11f4ae1-2978-4614-ad33-12f7cc884ba5.json
+++ b/change/@react-native-windows-find-repo-root-d11f4ae1-2978-4614-ad33-12f7cc884ba5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/find-repo-root",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-fs-5eeab5fd-493f-407c-a915-ba7d6527be6b.json
+++ b/change/@react-native-windows-fs-5eeab5fd-493f-407c-a915-ba7d6527be6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/fs",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-package-utils-cf65128f-3cb9-4781-b6b7-1ae3b8f7840c.json
+++ b/change/@react-native-windows-package-utils-cf65128f-3cb9-4781-b6b7-1ae3b8f7840c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/package-utils",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@react-native-windows-telemetry-443cc76e-6acf-4458-92db-4880584581d8.json
+++ b/change/@react-native-windows-telemetry-443cc76e-6acf-4458-92db-4880584581d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bad version bump",
+  "packageName": "@react-native-windows/telemetry",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-create-github-releases-b7f89eb0-d02e-4b22-aa7d-59036963a78a.json
+++ b/change/@rnw-scripts-create-github-releases-b7f89eb0-d02e-4b22-aa7d-59036963a78a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/create-github-releases",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-doxysaurus-03ed2d50-506f-4fc7-967d-c83688abfef6.json
+++ b/change/@rnw-scripts-doxysaurus-03ed2d50-506f-4fc7-967d-c83688abfef6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/doxysaurus",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-eslint-config-aa6d9f22-496a-4e9d-a8cc-22258b1385af.json
+++ b/change/@rnw-scripts-eslint-config-aa6d9f22-496a-4e9d-a8cc-22258b1385af.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Integrate 3/7",
+  "packageName": "@rnw-scripts/eslint-config",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-format-files-34ecb6ba-2a4f-479c-b15e-e763568fb290.json
+++ b/change/@rnw-scripts-format-files-34ecb6ba-2a4f-479c-b15e-e763568fb290.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/format-files",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-integrate-rn-5793b999-322d-4020-89e0-d0e1c79a304a.json
+++ b/change/@rnw-scripts-integrate-rn-5793b999-322d-4020-89e0-d0e1c79a304a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-promote-release-1a61367f-c506-460f-ac50-7dcdf043765b.json
+++ b/change/@rnw-scripts-promote-release-1a61367f-c506-460f-ac50-7dcdf043765b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/promote-release",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@rnw-scripts-take-screenshot-bac99b31-bba1-47d2-b3e9-66d6da469613.json
+++ b/change/@rnw-scripts-take-screenshot-bac99b31-bba1-47d2-b3e9-66d6da469613.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "@rnw-scripts/take-screenshot",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-platform-override-278ef4d4-e0be-4d7d-bb43-8262c0dd689c.json
+++ b/change/react-native-platform-override-278ef4d4-e0be-4d7d-bb43-8262c0dd689c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "react-native-platform-override",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-91e4571c-cdb6-4c4e-b7f6-d720a005abd1.json
+++ b/change/react-native-windows-91e4571c-cdb6-4c4e-b7f6-d720a005abd1.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Handle dpi during drawing more consistently",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-a2eec9ff-521f-4bd0-a670-317f4ff4de0b.json
+++ b/change/react-native-windows-a2eec9ff-521f-4bd0-a670-317f4ff4de0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Integrate 3/7",
+  "packageName": "react-native-windows",
+  "email": "yajurgrover24@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-init-90435126-9923-4261-b011-7da3202acf5a.json
+++ b/change/react-native-windows-init-90435126-9923-4261-b011-7da3202acf5a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bad version bump",
+  "packageName": "react-native-windows-init",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32-tester/package.json
+++ b/packages/@office-iss/react-native-win32-tester/package.json
@@ -17,12 +17,12 @@
     "flow-enums-runtime": "^0.0.5"
   },
   "peerDependencies": {
-    "@office-iss/react-native-win32": "^0.0.1-0",
+    "@office-iss/react-native-win32": "^0.0.0-canary.240",
     "react": "18.0.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e"
   },
   "devDependencies": {
-    "@office-iss/react-native-win32": "^0.0.1-0",
+    "@office-iss/react-native-win32": "^0.0.0-canary.240",
     "@rnw-scripts/babel-react-native-config": "0.0.0",
     "@rnw-scripts/eslint-config": "1.2.12",
     "@rnw-scripts/just-task": "2.3.28",

--- a/packages/@office-iss/react-native-win32/CHANGELOG.json
+++ b/packages/@office-iss/react-native-win32/CHANGELOG.json
@@ -2,47 +2,6 @@
   "name": "@office-iss/react-native-win32",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:13 GMT",
-      "version": "0.0.1-0",
-      "tag": "@office-iss/react-native-win32_v0.0.1-0",
-      "comments": {
-        "prerelease": [
-          {
-            "author": "yajurgrover24@gmail.com",
-            "package": "@office-iss/react-native-win32",
-            "commit": "2b8821b81ab7ec1e8cc483dcbd9573455b4d5d24",
-            "comment": "Integrate 3/7"
-          }
-        ],
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@office-iss/react-native-win32",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@office-iss/react-native-win32",
-            "comment": "Bump @rnw-scripts/jest-out-of-tree-snapshot-resolver to v1.1.16",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@office-iss/react-native-win32",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@office-iss/react-native-win32",
-            "comment": "Bump react-native-platform-override to v1.9.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:18 GMT",
       "version": "0.0.0-canary.240",
       "tag": "@office-iss/react-native-win32_v0.0.0-canary.240",

--- a/packages/@office-iss/react-native-win32/CHANGELOG.md
+++ b/packages/@office-iss/react-native-win32/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @office-iss/react-native-win32
 
-This log was last generated on Thu, 25 Apr 2024 05:19:13 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:18 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.0.1-0
-
-Thu, 25 Apr 2024 05:19:13 GMT
-
-### Changes
-
-- Integrate 3/7 (yajurgrover24@gmail.com)
 
 ## 0.0.0-canary.240
 

--- a/packages/@office-iss/react-native-win32/package.json
+++ b/packages/@office-iss/react-native-win32/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-iss/react-native-win32",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.240",
   "description": "Implementation of react native on top of Office's Win32 platform.",
   "repository": {
     "type": "git",
@@ -98,7 +98,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/automation-channel/CHANGELOG.json
+++ b/packages/@react-native-windows/automation-channel/CHANGELOG.json
@@ -2,39 +2,6 @@
   "name": "@react-native-windows/automation-channel",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:13 GMT",
-      "version": "0.12.144",
-      "tag": "@react-native-windows/automation-channel_v0.12.144",
-      "comments": {
-        "patch": [
-          {
-            "author": "yajurgrover24@gmail.com",
-            "package": "@react-native-windows/automation-channel",
-            "commit": "2b8821b81ab7ec1e8cc483dcbd9573455b4d5d24",
-            "comment": "Integrate 3/7"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-channel",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-channel",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-channel",
-            "comment": "Bump react-native-windows to v0.0.1-0",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 24 Apr 2024 05:15:13 GMT",
       "version": "0.12.143",
       "tag": "@react-native-windows/automation-channel_v0.12.143",

--- a/packages/@react-native-windows/automation-channel/CHANGELOG.md
+++ b/packages/@react-native-windows/automation-channel/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Change Log - @react-native-windows/automation-channel
 
-This log was last generated on Thu, 25 Apr 2024 05:19:13 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Apr 2024 05:15:13 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.12.144
-
-Thu, 25 Apr 2024 05:19:13 GMT
-
-### Patches
-
-- Integrate 3/7 (yajurgrover24@gmail.com)
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
-- Bump react-native-windows to v0.0.1-0
 
 ## 0.12.143
 

--- a/packages/@react-native-windows/automation-channel/package.json
+++ b/packages/@react-native-windows/automation-channel/package.json
@@ -32,7 +32,7 @@
     "prettier": "2.8.8",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0",
+    "react-native-windows": "^0.0.0-canary.804",
     "typescript": "5.0.4"
   },
   "files": [

--- a/packages/@react-native-windows/automation-commands/CHANGELOG.json
+++ b/packages/@react-native-windows/automation-commands/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@react-native-windows/automation-commands",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.1.246",
-      "tag": "@react-native-windows/automation-commands_v0.1.246",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-commands",
-            "comment": "Bump @react-native-windows/automation-channel to v0.12.144",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-commands",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation-commands",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 24 Apr 2024 05:15:13 GMT",
       "version": "0.1.245",
       "tag": "@react-native-windows/automation-commands_v0.1.245",

--- a/packages/@react-native-windows/automation-commands/CHANGELOG.md
+++ b/packages/@react-native-windows/automation-commands/CHANGELOG.md
@@ -1,18 +1,8 @@
 # Change Log - @react-native-windows/automation-commands
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Apr 2024 05:15:13 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.1.246
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/automation-channel to v0.12.144
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 0.1.245
 

--- a/packages/@react-native-windows/automation/CHANGELOG.json
+++ b/packages/@react-native-windows/automation/CHANGELOG.json
@@ -2,39 +2,6 @@
   "name": "@react-native-windows/automation",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.3.226",
-      "tag": "@react-native-windows/automation_v0.3.226",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation",
-            "comment": "Bump @react-native-windows/automation-channel to v0.12.144",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/automation",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 24 Apr 2024 05:15:13 GMT",
       "version": "0.3.225",
       "tag": "@react-native-windows/automation_v0.3.225",

--- a/packages/@react-native-windows/automation/CHANGELOG.md
+++ b/packages/@react-native-windows/automation/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Change Log - @react-native-windows/automation
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Apr 2024 05:15:13 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.3.226
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/automation-channel to v0.12.144
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 0.3.225
 

--- a/packages/@react-native-windows/automation/package.json
+++ b/packages/@react-native-windows/automation/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@react-native-windows/automation-channel": "^0.12.144",
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.2",

--- a/packages/@react-native-windows/cli/CHANGELOG.json
+++ b/packages/@react-native-windows/cli/CHANGELOG.json
@@ -2,51 +2,6 @@
   "name": "@react-native-windows/cli",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/cli_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @react-native-windows/codegen to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @react-native-windows/package-utils to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @react-native-windows/telemetry to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/cli",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:18 GMT",
       "version": "0.0.0-canary.208",
       "tag": "@react-native-windows/cli_v0.0.0-canary.208",

--- a/packages/@react-native-windows/cli/package.json
+++ b/packages/@react-native-windows/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/cli",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.208",
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "repository": {
@@ -17,10 +17,10 @@
     "watch": "rnw-scripts watch"
   },
   "dependencies": {
-    "@react-native-windows/codegen": "0.0.1-0",
-    "@react-native-windows/fs": "^0.0.1-0",
-    "@react-native-windows/package-utils": "^0.0.1-0",
-    "@react-native-windows/telemetry": "^0.0.1-0",
+    "@react-native-windows/codegen": "0.0.0-canary.83",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
+    "@react-native-windows/package-utils": "^0.0.0-canary.66",
+    "@react-native-windows/telemetry": "^0.0.0-canary.91",
     "@xmldom/xmldom": "^0.7.7",
     "chalk": "^4.1.0",
     "cli-spinners": "^2.2.0",
@@ -78,7 +78,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/codegen/CHANGELOG.json
+++ b/packages/@react-native-windows/codegen/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@react-native-windows/codegen",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/codegen_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/codegen",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/codegen",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/codegen",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.0.0-canary.83",
       "tag": "@react-native-windows/codegen_v0.0.0-canary.83",

--- a/packages/@react-native-windows/codegen/package.json
+++ b/packages/@react-native-windows/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/codegen",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.83",
   "description": "Generators for react-native-codegen targeting react-native-windows",
   "main": "lib-commonjs/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "react-native-windows-codegen": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "chalk": "^4.1.0",
     "globby": "^11.0.4",
     "mustache": "^4.0.1",
@@ -61,7 +61,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/find-repo-root/CHANGELOG.json
+++ b/packages/@react-native-windows/find-repo-root/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@react-native-windows/find-repo-root",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/find-repo-root_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/find-repo-root",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/find-repo-root",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/find-repo-root",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.0.0-canary.69",
       "tag": "@react-native-windows/find-repo-root_v0.0.0-canary.69",

--- a/packages/@react-native-windows/find-repo-root/package.json
+++ b/packages/@react-native-windows/find-repo-root/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/find-repo-root",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.69",
   "license": "MIT",
   "scripts": {
     "build": "rnw-scripts build",
@@ -16,7 +16,7 @@
     "directory": "packages/@react-native-windows/find-repo-root"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "find-up": "^4.1.0"
   },
   "devDependencies": {
@@ -36,7 +36,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/fs/CHANGELOG.json
+++ b/packages/@react-native-windows/fs/CHANGELOG.json
@@ -2,27 +2,6 @@
   "name": "@react-native-windows/fs",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/fs_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/fs",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/fs",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.0.0-canary.40",
       "tag": "@react-native-windows/fs_v0.0.0-canary.40",

--- a/packages/@react-native-windows/fs/package.json
+++ b/packages/@react-native-windows/fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-native-windows/fs",
   "description": "A minimal-dependency drop-in replacement to `fs` with changes for resiliency, promises, and convenience.",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.40",
   "license": "MIT",
   "scripts": {
     "build": "rnw-scripts build",
@@ -40,7 +40,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true

--- a/packages/@react-native-windows/package-utils/CHANGELOG.json
+++ b/packages/@react-native-windows/package-utils/CHANGELOG.json
@@ -2,39 +2,6 @@
   "name": "@react-native-windows/package-utils",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/package-utils_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/package-utils",
-            "comment": "Bump @react-native-windows/find-repo-root to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/package-utils",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/package-utils",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/package-utils",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.0.0-canary.66",
       "tag": "@react-native-windows/package-utils_v0.0.0-canary.66",

--- a/packages/@react-native-windows/package-utils/package.json
+++ b/packages/@react-native-windows/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/package-utils",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.66",
   "license": "MIT",
   "scripts": {
     "build": "rnw-scripts build",
@@ -16,8 +16,8 @@
     "directory": "packages/@react-native-windows/package-utils"
   },
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.1-0",
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/find-repo-root": "^0.0.0-canary.69",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "get-monorepo-packages": "^1.2.0",
     "lodash": "^4.17.15"
   },
@@ -38,7 +38,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/telemetry/CHANGELOG.json
+++ b/packages/@react-native-windows/telemetry/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@react-native-windows/telemetry",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.0.1-0",
-      "tag": "@react-native-windows/telemetry_v0.0.1-0",
-      "comments": {
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/telemetry",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/telemetry",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@react-native-windows/telemetry",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.0.0-canary.91",
       "tag": "@react-native-windows/telemetry_v0.0.0-canary.91",

--- a/packages/@react-native-windows/telemetry/package.json
+++ b/packages/@react-native-windows/telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-windows/telemetry",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.91",
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "typings": "lib-commonjs/index.d.ts",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@azure/core-auth": "1.5.0",
-    "@react-native-windows/fs": "0.0.1-0",
+    "@react-native-windows/fs": "0.0.0-canary.40",
     "@xmldom/xmldom": "^0.7.7",
     "applicationinsights": "2.9.1",
     "ci-info": "^3.2.0",
@@ -55,7 +55,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "promoteRelease": true,

--- a/packages/@react-native-windows/tester/package.json
+++ b/packages/@react-native-windows/tester/package.json
@@ -19,7 +19,7 @@
     "@react-native-picker/picker": "2.4.10",
     "react": "18.0.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0",
+    "react-native-windows": "^0.0.0-canary.804",
     "react-native-xaml": "^0.0.78"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "just-scripts": "^1.3.3",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
     "react-native-platform-override": "^1.9.28",
-    "react-native-windows": "^0.0.1-0",
+    "react-native-windows": "^0.0.0-canary.804",
     "typescript": "5.0.4"
   },
   "engines": {

--- a/packages/@rnw-scripts/beachball-config/package.json
+++ b/packages/@rnw-scripts/beachball-config/package.json
@@ -17,7 +17,7 @@
     "directory": "packages/@rnw-scripts/beachball-config"
   },
   "dependencies": {
-    "@react-native-windows/package-utils": "0.0.1-0",
+    "@react-native-windows/package-utils": "0.0.0-canary.66",
     "@rnw-scripts/stamp-version": "0.0.0",
     "find-up": "^4.1.0"
   },

--- a/packages/@rnw-scripts/create-github-releases/CHANGELOG.json
+++ b/packages/@rnw-scripts/create-github-releases/CHANGELOG.json
@@ -2,39 +2,6 @@
   "name": "@rnw-scripts/create-github-releases",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.4.36",
-      "tag": "@rnw-scripts/create-github-releases_v1.4.36",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/create-github-releases",
-            "comment": "Bump @react-native-windows/find-repo-root to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/create-github-releases",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/create-github-releases",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/create-github-releases",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.4.35",
       "tag": "@rnw-scripts/create-github-releases_v1.4.35",

--- a/packages/@rnw-scripts/create-github-releases/CHANGELOG.md
+++ b/packages/@rnw-scripts/create-github-releases/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Change Log - @rnw-scripts/create-github-releases
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.4.36
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/find-repo-root to v0.0.1-0
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.4.35
 

--- a/packages/@rnw-scripts/create-github-releases/package.json
+++ b/packages/@rnw-scripts/create-github-releases/package.json
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@octokit/rest": "^18.5.3",
-    "@react-native-windows/find-repo-root": "^0.0.1-0",
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/find-repo-root": "^0.0.0-canary.69",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.0",

--- a/packages/@rnw-scripts/doxysaurus/CHANGELOG.json
+++ b/packages/@rnw-scripts/doxysaurus/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@rnw-scripts/doxysaurus",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "0.4.29",
-      "tag": "@rnw-scripts/doxysaurus_v0.4.29",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/doxysaurus",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/doxysaurus",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/doxysaurus",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "0.4.28",
       "tag": "@rnw-scripts/doxysaurus_v0.4.28",

--- a/packages/@rnw-scripts/doxysaurus/CHANGELOG.md
+++ b/packages/@rnw-scripts/doxysaurus/CHANGELOG.md
@@ -1,18 +1,8 @@
 # Change Log - @rnw-scripts/doxysaurus
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.4.29
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 0.4.28
 

--- a/packages/@rnw-scripts/doxysaurus/package.json
+++ b/packages/@rnw-scripts/doxysaurus/package.json
@@ -19,7 +19,7 @@
     "doxysaurus": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.0",

--- a/packages/@rnw-scripts/eslint-config/CHANGELOG.json
+++ b/packages/@rnw-scripts/eslint-config/CHANGELOG.json
@@ -2,21 +2,6 @@
   "name": "@rnw-scripts/eslint-config",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:13 GMT",
-      "version": "1.2.12",
-      "tag": "@rnw-scripts/eslint-config_v1.2.12",
-      "comments": {
-        "patch": [
-          {
-            "author": "yajurgrover24@gmail.com",
-            "package": "@rnw-scripts/eslint-config",
-            "commit": "2b8821b81ab7ec1e8cc483dcbd9573455b4d5d24",
-            "comment": "Integrate 3/7"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.2.11",
       "tag": "@rnw-scripts/eslint-config_v1.2.11",

--- a/packages/@rnw-scripts/eslint-config/CHANGELOG.md
+++ b/packages/@rnw-scripts/eslint-config/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @rnw-scripts/eslint-config
 
-This log was last generated on Thu, 25 Apr 2024 05:19:13 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.2.12
-
-Thu, 25 Apr 2024 05:19:13 GMT
-
-### Patches
-
-- Integrate 3/7 (yajurgrover24@gmail.com)
 
 ## 1.2.11
 

--- a/packages/@rnw-scripts/format-files/CHANGELOG.json
+++ b/packages/@rnw-scripts/format-files/CHANGELOG.json
@@ -2,27 +2,6 @@
   "name": "@rnw-scripts/format-files",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.1.31",
-      "tag": "@rnw-scripts/format-files_v1.1.31",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/format-files",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/format-files",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.1.30",
       "tag": "@rnw-scripts/format-files_v1.1.30",

--- a/packages/@rnw-scripts/format-files/CHANGELOG.md
+++ b/packages/@rnw-scripts/format-files/CHANGELOG.md
@@ -1,17 +1,8 @@
 # Change Log - @rnw-scripts/format-files
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.1.31
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.1.30
 

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rnw-scripts/format-files",
-  "version": "1.1.31",
+  "version": "1.1.30",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@rnw-scripts/format-files/package.json
+++ b/packages/@rnw-scripts/format-files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rnw-scripts/format-files",
-  "version": "1.1.30",
+  "version": "1.1.31",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/@rnw-scripts/integrate-rn/CHANGELOG.json
+++ b/packages/@rnw-scripts/integrate-rn/CHANGELOG.json
@@ -2,51 +2,6 @@
   "name": "@rnw-scripts/integrate-rn",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.4.29",
-      "tag": "@rnw-scripts/integrate-rn_v1.4.29",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump @react-native-windows/find-repo-root to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump @react-native-windows/package-utils to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump react-native-platform-override to v1.9.28",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/integrate-rn",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.4.28",
       "tag": "@rnw-scripts/integrate-rn_v1.4.28",

--- a/packages/@rnw-scripts/integrate-rn/CHANGELOG.md
+++ b/packages/@rnw-scripts/integrate-rn/CHANGELOG.md
@@ -1,21 +1,8 @@
 # Change Log - @rnw-scripts/integrate-rn
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.4.29
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/find-repo-root to v0.0.1-0
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @react-native-windows/package-utils to v0.0.1-0
-- Bump react-native-platform-override to v1.9.28
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.4.28
 

--- a/packages/@rnw-scripts/integrate-rn/package.json
+++ b/packages/@rnw-scripts/integrate-rn/package.json
@@ -19,9 +19,9 @@
     "integrate-rn": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.1-0",
-    "@react-native-windows/fs": "^0.0.1-0",
-    "@react-native-windows/package-utils": "^0.0.1-0",
+    "@react-native-windows/find-repo-root": "^0.0.0-canary.69",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
+    "@react-native-windows/package-utils": "^0.0.0-canary.66",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "async": "^3.2.3",

--- a/packages/@rnw-scripts/jest-out-of-snapshot-resolver/CHANGELOG.json
+++ b/packages/@rnw-scripts/jest-out-of-snapshot-resolver/CHANGELOG.json
@@ -2,21 +2,6 @@
   "name": "@rnw-scripts/jest-out-of-tree-snapshot-resolver",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.1.16",
-      "tag": "@rnw-scripts/jest-out-of-tree-snapshot-resolver_v1.1.16",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/jest-out-of-tree-snapshot-resolver",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.1.15",
       "tag": "@rnw-scripts/jest-out-of-tree-snapshot-resolver_v1.1.15",

--- a/packages/@rnw-scripts/jest-out-of-snapshot-resolver/CHANGELOG.md
+++ b/packages/@rnw-scripts/jest-out-of-snapshot-resolver/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @rnw-scripts/jest-out-of-tree-snapshot-resolver
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.1.16
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @rnw-scripts/eslint-config to v1.2.12
 
 ## 1.1.15
 

--- a/packages/@rnw-scripts/jest-out-of-tree-resolver/CHANGELOG.json
+++ b/packages/@rnw-scripts/jest-out-of-tree-resolver/CHANGELOG.json
@@ -2,21 +2,6 @@
   "name": "@rnw-scripts/jest-out-of-tree-resolver",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.1.15",
-      "tag": "@rnw-scripts/jest-out-of-tree-resolver_v1.1.15",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/jest-out-of-tree-resolver",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.1.14",
       "tag": "@rnw-scripts/jest-out-of-tree-resolver_v1.1.14",

--- a/packages/@rnw-scripts/jest-out-of-tree-resolver/CHANGELOG.md
+++ b/packages/@rnw-scripts/jest-out-of-tree-resolver/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @rnw-scripts/jest-out-of-tree-resolver
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.1.15
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @rnw-scripts/eslint-config to v1.2.12
 
 ## 1.1.14
 

--- a/packages/@rnw-scripts/just-task/CHANGELOG.json
+++ b/packages/@rnw-scripts/just-task/CHANGELOG.json
@@ -2,21 +2,6 @@
   "name": "@rnw-scripts/just-task",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "2.3.28",
-      "tag": "@rnw-scripts/just-task_v2.3.28",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/just-task",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "2.3.27",
       "tag": "@rnw-scripts/just-task_v2.3.27",

--- a/packages/@rnw-scripts/just-task/CHANGELOG.md
+++ b/packages/@rnw-scripts/just-task/CHANGELOG.md
@@ -1,16 +1,8 @@
 # Change Log - @rnw-scripts/just-task
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 2.3.28
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @rnw-scripts/eslint-config to v1.2.12
 
 ## 2.3.27
 

--- a/packages/@rnw-scripts/promote-release/CHANGELOG.json
+++ b/packages/@rnw-scripts/promote-release/CHANGELOG.json
@@ -2,45 +2,6 @@
   "name": "@rnw-scripts/promote-release",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "2.1.35",
-      "tag": "@rnw-scripts/promote-release_v2.1.35",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/promote-release",
-            "comment": "Bump @react-native-windows/find-repo-root to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/promote-release",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/promote-release",
-            "comment": "Bump @react-native-windows/package-utils to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/promote-release",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/promote-release",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "2.1.34",
       "tag": "@rnw-scripts/promote-release_v2.1.34",

--- a/packages/@rnw-scripts/promote-release/CHANGELOG.md
+++ b/packages/@rnw-scripts/promote-release/CHANGELOG.md
@@ -1,20 +1,8 @@
 # Change Log - @rnw-scripts/promote-release
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 2.1.35
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/find-repo-root to v0.0.1-0
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @react-native-windows/package-utils to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 2.1.34
 

--- a/packages/@rnw-scripts/promote-release/package.json
+++ b/packages/@rnw-scripts/promote-release/package.json
@@ -18,9 +18,9 @@
     "promote-release": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/find-repo-root": "^0.0.1-0",
-    "@react-native-windows/fs": "^0.0.1-0",
-    "@react-native-windows/package-utils": "^0.0.1-0",
+    "@react-native-windows/find-repo-root": "^0.0.0-canary.69",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
+    "@react-native-windows/package-utils": "^0.0.0-canary.66",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.0",

--- a/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
+++ b/packages/@rnw-scripts/promote-release/src/promoteRelease.ts
@@ -155,7 +155,14 @@ async function updatePackageBeachballConfig(
       return pkg.mergeProps({
         beachball: {
           defaultNpmTag: distTag(release, version),
-          disallowedChangeTypes: ['major', 'minor', 'patch'],
+          disallowedChangeTypes: [
+            'major',
+            'minor',
+            'patch',
+            'premajor',
+            'preminor',
+            'prepatch',
+          ],
         },
       });
 
@@ -163,7 +170,14 @@ async function updatePackageBeachballConfig(
       return pkg.mergeProps({
         beachball: {
           defaultNpmTag: distTag(release, version),
-          disallowedChangeTypes: ['major', 'minor', 'prerelease'],
+          disallowedChangeTypes: [
+            'major',
+            'minor',
+            'prerelease',
+            'premajor',
+            'preminor',
+            'prepatch',
+          ],
         },
       });
 
@@ -171,7 +185,14 @@ async function updatePackageBeachballConfig(
       return pkg.mergeProps({
         beachball: {
           defaultNpmTag: distTag(release, version),
-          disallowedChangeTypes: ['major', 'minor', 'prerelease'],
+          disallowedChangeTypes: [
+            'major',
+            'minor',
+            'prerelease',
+            'premajor',
+            'preminor',
+            'prepatch',
+          ],
         },
       });
   }

--- a/packages/@rnw-scripts/stamp-version/package.json
+++ b/packages/@rnw-scripts/stamp-version/package.json
@@ -15,8 +15,8 @@
     "stamp-version": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
-    "@react-native-windows/package-utils": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
+    "@react-native-windows/package-utils": "^0.0.0-canary.66",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "mustache": "^4.0.1",

--- a/packages/@rnw-scripts/take-screenshot/CHANGELOG.json
+++ b/packages/@rnw-scripts/take-screenshot/CHANGELOG.json
@@ -2,33 +2,6 @@
   "name": "@rnw-scripts/take-screenshot",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.1.35",
-      "tag": "@rnw-scripts/take-screenshot_v1.1.35",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/take-screenshot",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/take-screenshot",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "@rnw-scripts/take-screenshot",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.1.34",
       "tag": "@rnw-scripts/take-screenshot_v1.1.34",

--- a/packages/@rnw-scripts/take-screenshot/CHANGELOG.md
+++ b/packages/@rnw-scripts/take-screenshot/CHANGELOG.md
@@ -1,18 +1,8 @@
 # Change Log - @rnw-scripts/take-screenshot
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.1.35
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.1.34
 

--- a/packages/@rnw-scripts/take-screenshot/package.json
+++ b/packages/@rnw-scripts/take-screenshot/package.json
@@ -18,7 +18,7 @@
     "take-screenshot": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "screenshot-desktop": "^1.12.2",
@@ -37,7 +37,10 @@
   },
   "beachball": {
     "disallowedChangeTypes": [
-      "major"
+      "major",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   },
   "files": [

--- a/packages/debug-test/package.json
+++ b/packages/debug-test/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@react-native-windows/automation": "^0.3.226",
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@rnw-scripts/eslint-config": "1.2.12",
     "@rnw-scripts/ts-config": "2.0.5",
     "@types/jest": "^29.2.2",

--- a/packages/e2e-test-app-fabric/package.json
+++ b/packages/e2e-test-app-fabric/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0"
+    "react-native-windows": "^0.0.0-canary.804"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/e2e-test-app/package.json
+++ b/packages/e2e-test-app/package.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0",
+    "react-native-windows": "^0.0.0-canary.804",
     "react-native-xaml": "^0.0.78"
   },
   "devDependencies": {

--- a/packages/integration-test-app/package.json
+++ b/packages/integration-test-app/package.json
@@ -11,13 +11,13 @@
   },
   "dependencies": {
     "@react-native-windows/automation-channel": "^0.12.144",
-    "@react-native-windows/fs": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
     "@typescript-eslint/eslint-plugin": "^5.21.0",
     "@typescript-eslint/parser": "^5.21.0",
     "chai": "^4.2.0",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0"
+    "react-native-windows": "^0.0.0-canary.804"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -16,7 +16,7 @@
     "@typescript-eslint/parser": "^5.21.0",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0"
+    "react-native-windows": "^0.0.0-canary.804"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/packages/react-native-platform-override/CHANGELOG.json
+++ b/packages/react-native-platform-override/CHANGELOG.json
@@ -2,39 +2,6 @@
   "name": "react-native-platform-override",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.9.28",
-      "tag": "react-native-platform-override_v1.9.28",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "react-native-platform-override",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-platform-override",
-            "comment": "Bump @react-native-windows/package-utils to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-platform-override",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-platform-override",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.9.27",
       "tag": "react-native-platform-override_v1.9.27",

--- a/packages/react-native-platform-override/CHANGELOG.md
+++ b/packages/react-native-platform-override/CHANGELOG.md
@@ -1,19 +1,8 @@
 # Change Log - react-native-platform-override
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.9.28
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @react-native-windows/package-utils to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.9.27
 

--- a/packages/react-native-platform-override/package.json
+++ b/packages/react-native-platform-override/package.json
@@ -22,8 +22,8 @@
     "react-native-platform-override": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "^0.0.1-0",
-    "@react-native-windows/package-utils": "^0.0.1-0",
+    "@react-native-windows/fs": "^0.0.0-canary.40",
+    "@react-native-windows/package-utils": "^0.0.0-canary.66",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "async": "^3.2.3",

--- a/packages/react-native-windows-init/CHANGELOG.json
+++ b/packages/react-native-windows-init/CHANGELOG.json
@@ -2,45 +2,6 @@
   "name": "react-native-windows-init",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:14 GMT",
-      "version": "1.4.12",
-      "tag": "react-native-windows-init_v1.4.12",
-      "comments": {
-        "patch": [
-          {
-            "author": "beachball",
-            "package": "react-native-windows-init",
-            "comment": "Bump @react-native-windows/fs to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows-init",
-            "comment": "Bump @react-native-windows/telemetry to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows-init",
-            "comment": "Bump @react-native-windows/cli to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows-init",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows-init",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 10 Apr 2024 05:18:19 GMT",
       "version": "1.4.11",
       "tag": "react-native-windows-init_v1.4.11",

--- a/packages/react-native-windows-init/CHANGELOG.md
+++ b/packages/react-native-windows-init/CHANGELOG.md
@@ -1,20 +1,8 @@
 # Change Log - react-native-windows-init
 
-This log was last generated on Thu, 25 Apr 2024 05:19:14 GMT and should not be manually modified.
+This log was last generated on Wed, 10 Apr 2024 05:18:19 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 1.4.12
-
-Thu, 25 Apr 2024 05:19:14 GMT
-
-### Patches
-
-- Bump @react-native-windows/fs to v0.0.1-0
-- Bump @react-native-windows/telemetry to v0.0.1-0
-- Bump @react-native-windows/cli to v0.0.1-0
-- Bump @rnw-scripts/eslint-config to v1.2.12
-- Bump @rnw-scripts/just-task to v2.3.28
 
 ## 1.4.11
 

--- a/packages/react-native-windows-init/package.json
+++ b/packages/react-native-windows-init/package.json
@@ -22,8 +22,8 @@
     "react-native-windows-init": "./bin.js"
   },
   "dependencies": {
-    "@react-native-windows/fs": "0.0.1-0",
-    "@react-native-windows/telemetry": "0.0.1-0",
+    "@react-native-windows/fs": "0.0.0-canary.40",
+    "@react-native-windows/telemetry": "0.0.0-canary.91",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.57.1",
     "chalk": "^4.1.0",
@@ -37,7 +37,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@react-native-windows/cli": "0.0.1-0",
+    "@react-native-windows/cli": "0.0.0-canary.208",
     "@rnw-scripts/eslint-config": "1.2.12",
     "@rnw-scripts/jest-unittest-config": "1.5.8",
     "@rnw-scripts/just-task": "2.3.28",
@@ -63,7 +63,10 @@
   ],
   "beachball": {
     "disallowedChangeTypes": [
-      "prerelease"
+      "prerelease",
+      "premajor",
+      "preminor",
+      "prepatch"
     ]
   }
 }

--- a/packages/sample-apps/package.json
+++ b/packages/sample-apps/package.json
@@ -16,14 +16,14 @@
     "@typescript-eslint/parser": "^5.57.1",
     "react": "18.2.0",
     "react-native": "0.75.0-nightly-20240307-ff03b149e",
-    "react-native-windows": "^0.0.1-0"
+    "react-native-windows": "^0.0.0-canary.804"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/eslint-parser": "^7.20.0",
     "@babel/runtime": "^7.20.0",
-    "@react-native-windows/cli": "0.0.1-0",
-    "@react-native-windows/codegen": "0.0.1-0",
+    "@react-native-windows/cli": "0.0.0-canary.208",
+    "@react-native-windows/codegen": "0.0.0-canary.83",
     "@react-native/metro-config": "0.75.0-nightly-20240307-ff03b149e",
     "@rnw-scripts/babel-react-native-config": "0.0.0",
     "@rnw-scripts/eslint-config": "1.2.12",

--- a/vnext/CHANGELOG.json
+++ b/vnext/CHANGELOG.json
@@ -2,65 +2,6 @@
   "name": "react-native-windows",
   "entries": [
     {
-      "date": "Thu, 25 Apr 2024 05:19:13 GMT",
-      "version": "0.0.1-0",
-      "tag": "react-native-windows_v0.0.1-0",
-      "comments": {
-        "prerelease": [
-          {
-            "author": "30809111+acoates-ms@users.noreply.github.com",
-            "package": "react-native-windows",
-            "commit": "89538936b34ea592412c5fd7fde812320941d2f5",
-            "comment": "Handle dpi during drawing more consistently"
-          },
-          {
-            "author": "yajurgrover24@gmail.com",
-            "package": "react-native-windows",
-            "commit": "2b8821b81ab7ec1e8cc483dcbd9573455b4d5d24",
-            "comment": "Integrate 3/7"
-          }
-        ],
-        "prepatch": [
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump @react-native-windows/cli to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump @react-native-windows/codegen to v0.0.1-0",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump @rnw-scripts/eslint-config to v1.2.12",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump @rnw-scripts/jest-out-of-tree-snapshot-resolver to v1.1.16",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump @rnw-scripts/just-task to v2.3.28",
-            "commit": "not available"
-          },
-          {
-            "author": "beachball",
-            "package": "react-native-windows",
-            "comment": "Bump react-native-platform-override to v1.9.28",
-            "commit": "not available"
-          }
-        ]
-      }
-    },
-    {
       "date": "Wed, 24 Apr 2024 05:15:12 GMT",
       "version": "0.0.0-canary.804",
       "tag": "react-native-windows_v0.0.0-canary.804",

--- a/vnext/CHANGELOG.md
+++ b/vnext/CHANGELOG.md
@@ -1,17 +1,8 @@
 # Change Log - react-native-windows
 
-This log was last generated on Thu, 25 Apr 2024 05:19:13 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Apr 2024 05:15:12 GMT and should not be manually modified.
 
 <!-- Start content -->
-
-## 0.0.1-0
-
-Thu, 25 Apr 2024 05:19:13 GMT
-
-### Changes
-
-- Handle dpi during drawing more consistently (30809111+acoates-ms@users.noreply.github.com)
-- Integrate 3/7 (yajurgrover24@gmail.com)
 
 ## 0.0.0-canary.804
 

--- a/vnext/PropertySheets/Generated/PackageVersion.g.props
+++ b/vnext/PropertySheets/Generated/PackageVersion.g.props
@@ -10,11 +10,11 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ReactNativeWindowsVersion>0.0.1-0</ReactNativeWindowsVersion>
+    <ReactNativeWindowsVersion>0.0.0-canary.804</ReactNativeWindowsVersion>
     <ReactNativeWindowsMajor>0</ReactNativeWindowsMajor>
     <ReactNativeWindowsMinor>0</ReactNativeWindowsMinor>
-    <ReactNativeWindowsPatch>1</ReactNativeWindowsPatch>
-    <ReactNativeWindowsCanary>false</ReactNativeWindowsCanary>
-    <ReactNativeWindowsCommitId>89538936b34ea592412c5fd7fde812320941d2f5</ReactNativeWindowsCommitId>
+    <ReactNativeWindowsPatch>0</ReactNativeWindowsPatch>
+    <ReactNativeWindowsCanary>true</ReactNativeWindowsCanary>
+    <ReactNativeWindowsCommitId>347922f9c9e3fdde0468e15e4c17c8a0f057954d</ReactNativeWindowsCommitId>
   </PropertyGroup>
 </Project>

--- a/vnext/package.json
+++ b/vnext/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-windows",
-  "version": "0.0.1-0",
+  "version": "0.0.0-canary.804",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@react-native-community/cli": "13.6.1",
     "@react-native-community/cli-platform-android": "13.6.1",
     "@react-native-community/cli-platform-ios": "13.6.1",
-    "@react-native-windows/cli": "0.0.1-0",
+    "@react-native-windows/cli": "0.0.0-canary.208",
     "@react-native/assets": "1.0.0",
     "@react-native/assets-registry": "0.75.0-nightly-20240307-ff03b149e",
     "@react-native/codegen": "0.75.0-nightly-20240307-ff03b149e",
@@ -64,7 +64,7 @@
     "yargs": "^17.6.2"
   },
   "devDependencies": {
-    "@react-native-windows/codegen": "0.0.1-0",
+    "@react-native-windows/codegen": "0.0.0-canary.83",
     "@react-native/metro-config": "0.75.0-nightly-20240307-ff03b149e",
     "@rnw-scripts/babel-react-native-config": "0.0.0",
     "@rnw-scripts/eslint-config": "1.2.12",
@@ -95,7 +95,10 @@
     "disallowedChangeTypes": [
       "major",
       "minor",
-      "patch"
+      "patch",
+      "premajor",
+      "preminor",
+      "prepatch"
     ],
     "gitTags": true
   },


### PR DESCRIPTION
A new version of beachball has some additional change types, which caused our prerelease package versions to get bumped in an unexpected way.

This adds the new change types to the lists of disallowedChangeTypes, and reverts the versions of packages with a prerelease version so that they are back as expected.


I tested running `npx beachball bump` locally to verify that the versions got bumped as expected.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12980)