### PR TITLE
Change Fabric e2etest timeout from 60 to 35m

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -158,7 +158,7 @@ jobs:
 
             variables: [template: ../variables/windows.yml]
             pool: ${{ parameters.AgentPool.Medium }}
-            timeoutInMinutes: 30 # how long to run the job before automatically cancelling
+            timeoutInMinutes: 35 # how long to run the job before automatically cancelling
             cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
             steps:

--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -158,7 +158,7 @@ jobs:
 
             variables: [template: ../variables/windows.yml]
             pool: ${{ parameters.AgentPool.Medium }}
-            timeoutInMinutes: 60 # how long to run the job before automatically cancelling
+            timeoutInMinutes: 30 # how long to run the job before automatically cancelling
             cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
             steps:


### PR DESCRIPTION
The Fabric e2e tests are failing intermittently requiring re-runs to unblock PRs. #12983 will track making the job more stable. In the meantime, reducing the timeout to 35 min to expedite re-runs (the job usually takes 20-25min). 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12984)