### PR TITLE
Dont use CoreWindow to determine key state

### DIFF
--- a/change/@office-iss-react-native-win32-6b1b9c92-50ad-4985-89ba-4f2505aa825c.json
+++ b/change/@office-iss-react-native-win32-6b1b9c92-50ad-4985-89ba-4f2505aa825c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix PaperUIManager (port from windows)",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-3701d914-c1cc-48f7-b2ad-e84229318968.json
+++ b/change/react-native-windows-3701d914-c1cc-48f7-b2ad-e84229318968.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Dont use CoreWindow to determine key state",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src-win/Libraries/ReactNative/PaperUIManager.win32.js
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/ReactNative/PaperUIManager.win32.js
@@ -98,7 +98,9 @@ const UIManagerJS: UIManagerJSInterface = {
 };
 
 // [Windows The spread operator doesn't work on JSI turbomodules, so use this instead
-for (const propName of Object.getOwnPropertyNames(NativeUIManager)) {
+for (const propName of Object.getOwnPropertyNames(
+  Object.getPrototypeOf(NativeUIManager),
+)) {
   // $FlowFixMe
   UIManagerJS[propName] = NativeUIManager[propName];
 }

--- a/vnext/Desktop.DLL/react-native-win32.x64.def
+++ b/vnext/Desktop.DLL/react-native-win32.x64.def
@@ -80,6 +80,7 @@ YGConfigGetUseWebDefaults
 YGConfigIsExperimentalFeatureEnabled
 YGConfigNew
 YGConfigSetContext
+YGConfigSetErrata
 YGConfigSetExperimentalFeatureEnabled
 YGConfigSetLogger
 YGConfigSetPointScaleFactor

--- a/vnext/Desktop.DLL/react-native-win32.x86.def
+++ b/vnext/Desktop.DLL/react-native-win32.x86.def
@@ -80,6 +80,7 @@ _YGConfigGetUseWebDefaults@4
 _YGConfigIsExperimentalFeatureEnabled@8
 _YGConfigNew@0
 _YGConfigSetContext@8
+_YGConfigSetErrata@8
 _YGConfigSetExperimentalFeatureEnabled@12
 _YGConfigSetLogger@8
 _YGConfigSetPointScaleFactor@8

--- a/vnext/Desktop/module.g.cpp
+++ b/vnext/Desktop/module.g.cpp
@@ -21,6 +21,7 @@ void* winrt_make_Microsoft_ReactNative_ReactNotificationServiceHelper();
 void* winrt_make_Microsoft_ReactNative_ReactPropertyBagHelper();
 void* winrt_make_Microsoft_ReactNative_ReactViewOptions();
 void* winrt_make_Microsoft_ReactNative_RedBoxHelper();
+void* winrt_make_Microsoft_ReactNative_QuirkSettings();
 void* winrt_make_facebook_react_NativeLogEventSource();
 void* winrt_make_facebook_react_NativeTraceEventSource();
 
@@ -103,6 +104,11 @@ void* __stdcall winrt_get_activation_factory([[maybe_unused]] std::wstring_view 
     if (requal(name, L"Microsoft.ReactNative.RedBoxHelper"))
     {
         return winrt_make_Microsoft_ReactNative_RedBoxHelper();
+    }
+
+    if (requal(name, L"Microsoft.ReactNative.QuirkSettings"))
+    {
+        return winrt_make_Microsoft_ReactNative_QuirkSettings();
     }
 
     if (requal(name, L"facebook.react.NativeLogEventSource"))

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1593,7 +1593,7 @@ inline winrt::Windows::System::VirtualKey GetLeftOrRightModifiedKey(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     winrt::Windows::System::VirtualKey leftKey,
     winrt::Windows::System::VirtualKey rightKey) {
-  return (source.GetKeyState(leftKey) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ? leftKey : rightKey;
+  return (source.GetKeyState(leftKey) == winrt::Windows::UI::Core::CoreVirtualKeyStates::Down) ? leftKey : rightKey;
 }
 
 std::string CodeFromVirtualKey(
@@ -1619,13 +1619,13 @@ std::string CodeFromVirtualKey(
     }
   }
 
-  return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
+  return ::Microsoft::ReactNative::GetOrUnidentifiedCode(virtualKey);
 }
 
 void ViewComponentView::OnKeyDown(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
-  auto eventCode = ::Microsoft::ReactNative::CodeFromVirtualKey(source, args.Key());
+  auto eventCode = CodeFromVirtualKey(source, args.Key());
   bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) !=
       winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
   bool fAlt = source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) !=
@@ -1664,7 +1664,7 @@ void ViewComponentView::OnKeyDown(
 void ViewComponentView::OnKeyUp(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     const winrt::Microsoft::ReactNative::Composition::Input::KeyRoutedEventArgs &args) noexcept {
-  auto eventCode = ::Microsoft::ReactNative::CodeFromVirtualKey(source, args.Key());
+  auto eventCode = CodeFromVirtualKey(source, args.Key());
   bool fShift = source.GetKeyState(winrt::Windows::System::VirtualKey::Shift) !=
       winrt::Windows::UI::Core::CoreVirtualKeyStates::None;
   bool fAlt = source.GetKeyState(winrt::Windows::System::VirtualKey::Menu) !=

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionViewComponentView.cpp
@@ -1593,10 +1593,12 @@ inline winrt::Windows::System::VirtualKey GetLeftOrRightModifiedKey(
     const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
     winrt::Windows::System::VirtualKey leftKey,
     winrt::Windows::System::VirtualKey rightKey) {
-  return (source.GetKeyState(leftKey) == winrt::Microsoft::UI::Input::VirtualKeyStates::KeyDown) ? leftKey : rightKey;
+  return (source.GetKeyState(leftKey) == winrt::Microsoft::UI::Input::VirtualKeyStates::Down) ? leftKey : rightKey;
 }
 
-std::string CodeFromVirtualKey(const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source, winrt::Windows::System::VirtualKey virtualKey) {
+std::string CodeFromVirtualKey(
+    const winrt::Microsoft::ReactNative::Composition::Input::KeyboardSource &source,
+    winrt::Windows::System::VirtualKey virtualKey) {
   int key = static_cast<int>(virtualKey);
 
   if (isdigit(key)) {
@@ -1607,9 +1609,7 @@ std::string CodeFromVirtualKey(const winrt::Microsoft::ReactNative::Composition:
     // Override the virtual key if it's modified key of Control, Shift or Menu
     if (virtualKey == winrt::Windows::System::VirtualKey::Control) {
       virtualKey = GetLeftOrRightModifiedKey(
-          source,
-          winrt::Windows::System::VirtualKey::LeftControl,
-          winrt::Windows::System::VirtualKey::RightControl);
+          source, winrt::Windows::System::VirtualKey::LeftControl, winrt::Windows::System::VirtualKey::RightControl);
     } else if (virtualKey == winrt::Windows::System::VirtualKey::Shift) {
       virtualKey = GetLeftOrRightModifiedKey(
           source, winrt::Windows::System::VirtualKey::LeftShift, winrt::Windows::System::VirtualKey::RightShift);

--- a/vnext/Microsoft.ReactNative/Utils/KeyboardUtils.cpp
+++ b/vnext/Microsoft.ReactNative/Utils/KeyboardUtils.cpp
@@ -348,6 +348,14 @@ static const std::string GetOrUnidentified(
   return "Unidentified";
 }
 
+const std::string GetOrUnidentifiedCode(winrt::Windows::System::VirtualKey virtualKey) {
+  return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
+}
+
+const std::string GetOrUnidentifiedKey(winrt::Windows::System::VirtualKey virtualKey) {
+  return GetOrUnidentified(virtualKey, g_virtualKeyToKey);
+}
+
 std::string FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool fShift, bool fCaps) {
   int vk = static_cast<int>(virtualKey);
 
@@ -362,7 +370,7 @@ std::string FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool f
     return std::string{c};
   }
 
-  return GetOrUnidentified(virtualKey, g_virtualKeyToKey);
+  return GetOrUnidentifiedKey(virtualKey);
 }
 
 bool IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::System::VirtualKey virtualKey) {
@@ -410,7 +418,7 @@ std::string CodeFromVirtualKey(winrt::Windows::System::VirtualKey virtualKey) {
     }
   }
 
-  return GetOrUnidentified(virtualKey, g_virtualKeyToCode);
+  return GetOrUnidentifiedCode(virtualKey);
 }
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/Utils/KeyboardUtils.h
+++ b/vnext/Microsoft.ReactNative/Utils/KeyboardUtils.h
@@ -12,4 +12,7 @@ bool IsModifiedKeyPressed(winrt::CoreWindow const &coreWindow, winrt::Windows::S
 std::string FromVirtualKey(winrt::Windows::System::VirtualKey virtualKey, bool fShift, bool fCaps);
 std::string CodeFromVirtualKey(winrt::Windows::System::VirtualKey virtualKey);
 
+const std::string GetOrUnidentifiedCode(winrt::Windows::System::VirtualKey virtualKey);
+const std::string GetOrUnidentifiedKey(winrt::Windows::System::VirtualKey virtualKey);
+
 } // namespace Microsoft::ReactNative


### PR DESCRIPTION
## Description
- Some of the key handling code was using CoreWindow to determine the key state of left control vs right control.  Rework to use the Islands KeybaordInputSource.
- Fix Win32's PaperUIManger
- Export YGConfigSetErrata method from react-native-win32.dll
- Export QuirkSettings activation factory from react-native-win32.dll

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/12998)