### PR TITLE
[CodeQL] Unsafe shell command constructed from library input

### DIFF
--- a/packages/@rnw-scripts/beachball-config/package.json
+++ b/packages/@rnw-scripts/beachball-config/package.json
@@ -31,7 +31,8 @@
     "beachball": "^2.20.0",
     "eslint": "^8.19.0",
     "prettier": "2.8.8",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "shell-quote": "^1.8.1"
   },
   "files": [
     "lib-commonjs"

--- a/packages/@rnw-scripts/beachball-config/package.json
+++ b/packages/@rnw-scripts/beachball-config/package.json
@@ -27,6 +27,7 @@
     "@rnw-scripts/just-task": "2.3.29",
     "@rnw-scripts/ts-config": "2.0.5",
     "@types/node": "^18.0.0",
+    "@types/shell-quote": "^1.7.5",
     "beachball": "^2.20.0",
     "eslint": "^8.19.0",
     "prettier": "2.8.8",

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {execSync} from 'child_process';
+import {execFile, execFileSync, execSync} from 'child_process';
 import {findRepoPackageSync} from '@react-native-windows/package-utils';
 
 import type {RepoOptions} from 'beachball/lib/types/BeachballOptions';
@@ -28,7 +28,7 @@ const Options: RepoOptions = {
     postbump: (_packagePath, name, version) => {
       if (name === 'react-native-windows') {
         console.log(`Stamping RNW Version ${version}`);
-        execSync(`yarn stamp-version ${version}`);
+        execFileSync(`yarn stamp-version`, [version]);
       }
     }
   },

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -28,7 +28,7 @@ const Options: RepoOptions = {
     // Stamp versions when we publish a new package
     postbump: (_packagePath, name, version) => {
       if (name === 'react-native-windows') {
-        console.log(`Stamping RNW Version ` + quote([`${version}`]));
+        console.log(`Stamping RNW Version ${version}`);
         execSync(`yarn stamp-version ` + quote([`${version}`]));
       }
     }

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -28,7 +28,7 @@ const Options: RepoOptions = {
     postbump: (_packagePath, name, version) => {
       if (name === 'react-native-windows') {
         console.log(`Stamping RNW Version ${version}`);
-        execFileSync(`yarn stamp-version`, [version]);
+        execFileSync(`yarn`, [`stamp-version`, `${version}`]);
       }
     }
   },

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -5,7 +5,7 @@
  * @format
  */
 
-import {execFile, execFileSync, execSync} from 'child_process';
+import {execFileSync} from 'child_process';
 import {findRepoPackageSync} from '@react-native-windows/package-utils';
 
 import type {RepoOptions} from 'beachball/lib/types/BeachballOptions';

--- a/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
+++ b/packages/@rnw-scripts/beachball-config/src/beachball.config.ts
@@ -5,7 +5,8 @@
  * @format
  */
 
-import {execFileSync} from 'child_process';
+import {execSync} from 'child_process';
+import {quote} from 'shell-quote';
 import {findRepoPackageSync} from '@react-native-windows/package-utils';
 
 import type {RepoOptions} from 'beachball/lib/types/BeachballOptions';
@@ -27,8 +28,8 @@ const Options: RepoOptions = {
     // Stamp versions when we publish a new package
     postbump: (_packagePath, name, version) => {
       if (name === 'react-native-windows') {
-        console.log(`Stamping RNW Version ${version}`);
-        execFileSync(`yarn`, [`stamp-version`, `${version}`]);
+        console.log(`Stamping RNW Version ` + quote([`${version}`]));
+        execSync(`yarn stamp-version ` + quote([`${version}`]));
       }
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,6 +3160,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.7.tgz#326f5fdda70d13580777bcaa1bc6fa772a5aef0e"
   integrity sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==
 
+"@types/shell-quote@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/shell-quote/-/shell-quote-1.7.5.tgz#6db4704742d307cd6d604e124e3ad6cd5ed943f3"
+  integrity sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==
+
 "@types/shelljs@^0.8.8":
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.15.tgz#22c6ab9dfe05cec57d8e6cb1a95ea173aee9fcac"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11379,7 +11379,7 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.6.1, shell-quote@^1.7.3:
+shell-quote@^1.6.1, shell-quote@^1.7.3, shell-quote@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
   integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==


### PR DESCRIPTION
Another CodeQL fix #12704 

`packages/@rnw-scripts/beachball-config/lib-commonjs/beachball.config.js:26:47`

https://codeql.github.com/codeql-query-help/javascript/js-shell-command-constructed-from-input/

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13001)