### PR TITLE
Adds device parameter to InspectorPackagerConnection URL

### DIFF
--- a/change/react-native-windows-d17982cd-2055-44f9-9a72-6990f8f78715.json
+++ b/change/react-native-windows-d17982cd-2055-44f9-9a72-6990f8f78715.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds device parameter to InspectorPackagerConnection URL",
+  "packageName": "react-native-windows",
+  "email": "erozell@outlook.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
+++ b/vnext/Microsoft.ReactNative/ReactHost/ReactInstanceWin.cpp
@@ -611,7 +611,7 @@ void ReactInstanceWin::InitializeBridgeless() noexcept {
 
               if (devSettings->useDirectDebugger) {
                 ::Microsoft::ReactNative::GetSharedDevManager()->EnsureHermesInspector(
-                    devSettings->sourceBundleHost, devSettings->sourceBundlePort);
+                    devSettings->sourceBundleHost, devSettings->sourceBundlePort, DebugBundlePath());
               }
 
               m_jsiRuntimeHolder = std::make_shared<Microsoft::ReactNative::HermesRuntimeHolder>(

--- a/vnext/Shared/DevServerHelper.h
+++ b/vnext/Shared/DevServerHelper.h
@@ -76,12 +76,14 @@ class DevServerHelper {
       const std::string &packagerHost,
       const uint16_t packagerPort,
       const std::string &deviceName,
-      const std::string &packageName) {
+      const std::string &packageName,
+      const std::string &deviceId) {
     return string_format(
         InspectorDeviceUrlFormat,
         GetDeviceLocalHost(packagerHost, packagerPort).c_str(),
         deviceName.c_str(),
-        packageName.c_str());
+        packageName.c_str(),
+        deviceId.c_str());
   }
 
   static constexpr const char DefaultPackagerHost[] = "localhost";
@@ -105,7 +107,7 @@ class DevServerHelper {
   static constexpr const char PackagerConnectionUrlFormat[] = "ws://%s/message";
   static constexpr const char PackagerStatusUrlFormat[] = "http://%s/status";
   static constexpr const char PackagerOpenStackFrameUrlFormat[] = "https://%s/open-stack-frame";
-  static constexpr const char InspectorDeviceUrlFormat[] = "ws://%s/inspector/device?name=%s&app=%s";
+  static constexpr const char InspectorDeviceUrlFormat[] = "ws://%s/inspector/device?name=%s&app=%s&device=%s";
 
   static constexpr const char PackagerOkStatus[] = "packager-status:running";
   const int LongPollFailureDelayMs = 5000;

--- a/vnext/Shared/DevSupportManager.h
+++ b/vnext/Shared/DevSupportManager.h
@@ -49,7 +49,10 @@ class DevSupportManager final : public facebook::react::IDevSupportManager {
       std::function<void()> onChangeCallback) override;
   virtual void StopPollingLiveReload() override;
 
-  virtual void EnsureHermesInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept override;
+  virtual void EnsureHermesInspector(
+      const std::string &packagerHost,
+      const uint16_t packagerPort,
+      const std::string &jsBundleName) noexcept override;
   virtual void UpdateBundleStatus(bool isLastDownloadSuccess, int64_t updateTimestamp) noexcept override;
 
  private:

--- a/vnext/Shared/IDevSupportManager.h
+++ b/vnext/Shared/IDevSupportManager.h
@@ -24,7 +24,10 @@ struct IDevSupportManager {
       std::function<void()> onChangeCallback) = 0;
   virtual void StopPollingLiveReload() = 0;
 
-  virtual void EnsureHermesInspector(const std::string &packagerHost, const uint16_t packagerPort) noexcept = 0;
+  virtual void EnsureHermesInspector(
+      const std::string &packagerHost,
+      const uint16_t packagerPort,
+      const std::string &bundleName) noexcept = 0;
   virtual void UpdateBundleStatus(bool isLastDownloadSuccess, int64_t updateTimestamp) noexcept = 0;
 };
 


### PR DESCRIPTION
## Description

### Type of Change
_Erase all that don't apply._
- New feature (non-breaking change which adds functionality)

### Why
In preparation for unblocking Fusebox in react-native-windows, this change adds a stable device ID, which is a hash of the publisher device ID from Windows APIs and the bundle ID.

## Testing
Code compiles and generates a device stable ID per bundle name.

## Changelog
Should this change be included in the release notes: _no_

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13007)