### PR TITLE
[0.73] [NetUI] Fix issue using Paper UI manager with newer turbomodule

### DIFF
--- a/change/@office-iss-react-native-win32-3df907f2-8166-40fe-840d-a260eed0fd3e.json
+++ b/change/@office-iss-react-native-win32-3df907f2-8166-40fe-840d-a260eed0fd3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "PaperUIManager running as turbomodule fix",
+  "packageName": "@office-iss/react-native-win32",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
+++ b/packages/@office-iss/react-native-win32/src/Libraries/ReactNative/PaperUIManager.win32.js
@@ -80,7 +80,9 @@ function getViewManagerConfig(viewManagerName: string): any {
 const UIManagerJS = {};
 
 // [Windows The spread operator doesn't work on JSI turbomodules, so use this instead
-for (const propName of Object.getOwnPropertyNames(NativeUIManager)) {
+for (const propName of Object.getOwnPropertyNames(
+  Object.getPrototypeOf(NativeUIManager),
+)) {
   // $FlowFixMe
   UIManagerJS[propName] = NativeUIManager[propName];
 }


### PR DESCRIPTION
This is a port of a fix already in 0.74 and main.
The PaperUIManger fails with newer native versions of TurboModule code. - This make some prototype work against newer versions of fabric harder.  This JS change is compatible with both matching and newer native bits.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13009)