### PR TITLE
[0.74] Ensure D2D device context is not used outside Begin/End draw

### DIFF
--- a/change/react-native-windows-48f54764-11c8-49c7-bf4a-a4d724d35f20.json
+++ b/change/react-native-windows-48f54764-11c8-49c7-bf4a-a4d724d35f20.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure D2D device context is not used outside Begin/End draw",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
@@ -20,6 +20,7 @@ class AutoDrawDrawingSurface {
 
   ~AutoDrawDrawingSurface() noexcept {
     if (m_d2dDeviceContext) {
+      m_d2dDeviceContext = nullptr;
       m_drawingSurfaceInterop->EndDraw();
     }
   }


### PR DESCRIPTION
## Description
This ensures that drawing code is not able to access the D2D device context outside of a BeginDraw/EndDraw pair.

Office internal code enforces that all references to the device context must be released before EndDraw is called.