### PR TITLE
Ensure D2D device context is not used outside Begin/End draw

### DIFF
--- a/change/react-native-windows-b9725ce8-aa24-4cc7-bb58-901190465ffc.json
+++ b/change/react-native-windows-b9725ce8-aa24-4cc7-bb58-901190465ffc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Ensure D2D device context is not used outside Begin/End draw",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
+++ b/vnext/Microsoft.ReactNative.Cxx/AutoDraw.h
@@ -20,6 +20,7 @@ class AutoDrawDrawingSurface {
 
   ~AutoDrawDrawingSurface() noexcept {
     if (m_d2dDeviceContext) {
+      m_d2dDeviceContext = nullptr;
       m_drawingSurfaceInterop->EndDraw();
     }
   }


### PR DESCRIPTION
This ensures that drawing code is not able to access the D2D device context outside of a BeginDraw/EndDraw pair.

Office internal code enforces that all references to the device context must be released before EndDraw is called.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13011)