### PR TITLE
[CodeQL] Resolve "Weak hashes" alert

### DIFF
--- a/change/react-native-platform-override-aa0ae023-d4d6-436c-bb36-9fa78bbed9af.json
+++ b/change/react-native-platform-override-aa0ae023-d4d6-436c-bb36-9fa78bbed9af.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "[CodeQL] Suppress false positive",
+  "packageName": "react-native-platform-override",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/packages/react-native-platform-override/src/Hash.ts
+++ b/packages/react-native-platform-override/src/Hash.ts
@@ -51,7 +51,7 @@ export class Hasher {
   private readonly hashOpts: HashOpts;
 
   constructor(hashOpts?: HashOpts) {
-    this.hash = crypto.createHash('sha1');
+    this.hash = crypto.createHash('sha1'); // CodeQL [js/weak-hashes] Hash is used for file name mapping as a convenience. Decryption does not leave any data vulnerable.
     this.hashOpts = hashOpts || {};
   }
 


### PR DESCRIPTION
## Description
While SHA-1 is a weak hash algorithm, we're not using it in any kind of encryption manner that would leave data vulnerable if decrypted. We use it as a convenience to map file/directory names that have been forked from upstream and get logged in overrides.json files to be used during our manual integration process. 

#12704 

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13161)