### PR TITLE
Add timeout to Fabric e2etest task instead of entire job

### DIFF
--- a/.ado/jobs/e2e-test.yml
+++ b/.ado/jobs/e2e-test.yml
@@ -158,7 +158,7 @@ jobs:
 
             variables: [template: ../variables/windows.yml]
             pool: ${{ parameters.AgentPool.Medium }}
-            timeoutInMinutes: 35 # how long to run the job before automatically cancelling
+            timeoutInMinutes: 60 # how long to run the job before automatically cancelling
             cancelTimeoutInMinutes: 5 # how much time to give 'run always even if cancelled tasks' before killing them
 
             steps:
@@ -199,6 +199,7 @@ jobs:
                   yarn e2etest
                 displayName: yarn e2etest
                 workingDirectory: packages/e2e-test-app-fabric
+                timeoutInMinutes: 10 # Time to wait for this task to complete before the server kills it.
 
               - script: npx jest --clearCache
                 displayName: clear jest cache


### PR DESCRIPTION
## Description
#12984 changed the Fabric e2etest job timeout from 60min to 35min to allow for faster re-runs when the e2etask got in a bad state that took up the entire 60 min. 35min is fine if the e2etest task succeeds, but if it fails for a legitimate reason, then the job doesn't have enough time to upload the new snapshots.

This change moves the timeout from the job to the task. 

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13166)