### PR TITLE
[0.74] Fix reference cycle between CompositionRootView and CompositionEventHandler

### DIFF
--- a/change/react-native-windows-55134846-d638-4b46-8190-55b23cf11c3d.json
+++ b/change/react-native-windows-55134846-d638-4b46-8190-55b23cf11c3d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rework custom resources API",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/react-native-windows-55134846-d638-4b46-8190-55b23cf11c3d.json
+++ b/change/react-native-windows-55134846-d638-4b46-8190-55b23cf11c3d.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Rework custom resources API",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",

--- a/change/react-native-windows-73af8adf-3550-45d3-baed-c5e49c135395.json
+++ b/change/react-native-windows-73af8adf-3550-45d3-baed-c5e49c135395.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Fix a reference cycle between CompositionRootView and CompositionEventHandler",
   "packageName": "react-native-windows",
   "email": "30809111+acoates-ms@users.noreply.github.com",

--- a/change/react-native-windows-73af8adf-3550-45d3-baed-c5e49c135395.json
+++ b/change/react-native-windows-73af8adf-3550-45d3-baed-c5e49c135395.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix a reference cycle between CompositionRootView and CompositionEventHandler",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/Microsoft.ReactNative/CompositionRootView.idl
+++ b/vnext/Microsoft.ReactNative/CompositionRootView.idl
@@ -95,8 +95,10 @@ namespace Microsoft.ReactNative
 
     Object GetUiaProvider();
 
-    DOC_STRING("Theme used for Platform colors within this RootView")
-    Microsoft.ReactNative.Composition.Theme Theme;
+    DOC_STRING("Provides resources used for Platform colors within this RootView")
+    Microsoft.ReactNative.Composition.ICustomResourceLoader Resources;
+
+    Microsoft.ReactNative.Composition.Theme Theme { get; };
 
 #ifdef USE_WINUI3
     Microsoft.UI.Content.ContentIsland Island { get; };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.cpp
@@ -152,67 +152,78 @@ struct CompositionInputKeyboardSource : winrt::implements<
 CompositionEventHandler::CompositionEventHandler(
     const winrt::Microsoft::ReactNative::ReactContext &context,
     const winrt::Microsoft::ReactNative::CompositionRootView &CompositionRootView)
-    : m_context(context) {
-  m_compRootView = CompositionRootView;
-
+    : m_context(context), m_wkRootView(CompositionRootView) {
 #ifdef USE_WINUI3
-  if (auto island = m_compRootView.Island()) {
+  if (auto island = CompositionRootView.Island()) {
     auto pointerSource = winrt::Microsoft::UI::Input::InputPointerSource::GetForIsland(island);
 
     m_pointerPressedToken =
         pointerSource.PointerPressed([this](
                                          winrt::Microsoft::UI::Input::InputPointerSource const &,
                                          winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (SurfaceId() == -1)
-            return;
+          if (auto strongRootView = m_wkRootView.get()) {
+            if (SurfaceId() == -1)
+              return;
 
-          auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-              args.CurrentPoint(), m_compRootView.ScaleFactor());
-          onPointerPressed(pp, args.KeyModifiers());
+            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                args.CurrentPoint(), strongRootView.ScaleFactor());
+            onPointerPressed(pp, args.KeyModifiers());
+          }
         });
 
     m_pointerReleasedToken =
         pointerSource.PointerReleased([this](
                                           winrt::Microsoft::UI::Input::InputPointerSource const &,
                                           winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (SurfaceId() == -1)
-            return;
+          if (auto strongRootView = m_wkRootView.get()) {
+            if (SurfaceId() == -1)
+              return;
 
-          auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-              args.CurrentPoint(), m_compRootView.ScaleFactor());
-          onPointerReleased(pp, args.KeyModifiers());
+            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                args.CurrentPoint(), strongRootView.ScaleFactor());
+            onPointerReleased(pp, args.KeyModifiers());
+          }
         });
 
     m_pointerMovedToken = pointerSource.PointerMoved([this](
                                                          winrt::Microsoft::UI::Input::InputPointerSource const &,
                                                          winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          args.CurrentPoint(), m_compRootView.ScaleFactor());
-      onPointerMoved(pp, args.KeyModifiers());
+      if (auto strongRootView = m_wkRootView.get()) {
+        if (SurfaceId() == -1)
+          return;
+
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            args.CurrentPoint(), strongRootView.ScaleFactor());
+        onPointerMoved(pp, args.KeyModifiers());
+      }
     });
 
     m_pointerCaptureLostToken =
         pointerSource.PointerCaptureLost([this](
                                              winrt::Microsoft::UI::Input::InputPointerSource const &,
                                              winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (SurfaceId() == -1)
-            return;
+          if (auto strongRootView = m_wkRootView.get()) {
+            if (SurfaceId() == -1)
+              return;
 
-          auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-              args.CurrentPoint(), m_compRootView.ScaleFactor());
-          onPointerCaptureLost(pp, args.KeyModifiers());
+            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                args.CurrentPoint(), strongRootView.ScaleFactor());
+            onPointerCaptureLost(pp, args.KeyModifiers());
+          }
         });
 
     m_pointerWheelChangedToken =
         pointerSource.PointerWheelChanged([this](
                                               winrt::Microsoft::UI::Input::InputPointerSource const &,
                                               winrt::Microsoft::UI::Input::PointerEventArgs const &args) {
-          if (SurfaceId() == -1)
-            return;
+          if (auto strongRootView = m_wkRootView.get()) {
+            if (SurfaceId() == -1)
+              return;
 
-          auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-              args.CurrentPoint(), m_compRootView.ScaleFactor());
-          onPointerWheelChanged(pp, args.KeyModifiers());
+            auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+                args.CurrentPoint(), strongRootView.ScaleFactor());
+            onPointerWheelChanged(pp, args.KeyModifiers());
+          }
         });
 
     auto keyboardSource = winrt::Microsoft::UI::Input::InputKeyboardSource::GetForIsland(island);
@@ -220,61 +231,71 @@ CompositionEventHandler::CompositionEventHandler(
     m_keyDownToken = keyboardSource.KeyDown([this](
                                                 winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                                 winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
-      if (SurfaceId() == -1)
-        return;
+      if (auto strongRootView = m_wkRootView.get()) {
+        if (SurfaceId() == -1)
+          return;
 
-      auto focusedComponent = RootComponentView().GetFocusedComponent();
-      auto keyArgs = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
-          focusedComponent
-              ? focusedComponent.Tag()
-              : static_cast<facebook::react::Tag>(
-                    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(m_compRootView)
-                        ->GetTag()),
-          args);
-      auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-      onKeyDown(keyboardSource, keyArgs);
-      winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+        auto focusedComponent = RootComponentView().GetFocusedComponent();
+        auto keyArgs =
+            winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
+                focusedComponent
+                    ? focusedComponent.Tag()
+                    : static_cast<facebook::react::Tag>(
+                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
+                              strongRootView)
+                              ->GetTag()),
+                args);
+        auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+        onKeyDown(keyboardSource, keyArgs);
+        winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+      }
     });
 
     m_keyUpToken = keyboardSource.KeyUp([this](
                                             winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                             winrt::Microsoft::UI::Input::KeyEventArgs const &args) {
-      if (SurfaceId() == -1)
-        return;
+      if (auto strongRootView = m_wkRootView.get()) {
+        if (SurfaceId() == -1)
+          return;
 
-      auto focusedComponent = RootComponentView().GetFocusedComponent();
-      auto keyArgs = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
-          focusedComponent
-              ? focusedComponent.Tag()
-              : static_cast<facebook::react::Tag>(
-                    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(m_compRootView)
-                        ->GetTag()),
-          args);
-      auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-      onKeyUp(keyboardSource, keyArgs);
-      winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+        auto focusedComponent = RootComponentView().GetFocusedComponent();
+        auto keyArgs =
+            winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
+                focusedComponent
+                    ? focusedComponent.Tag()
+                    : static_cast<facebook::react::Tag>(
+                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
+                              strongRootView)
+                              ->GetTag()),
+                args);
+        auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+        onKeyUp(keyboardSource, keyArgs);
+        winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+      }
     });
 
     m_characterReceivedToken =
         keyboardSource.CharacterReceived([this](
                                              winrt::Microsoft::UI::Input::InputKeyboardSource const &source,
                                              winrt::Microsoft::UI::Input::CharacterReceivedEventArgs const &args) {
-          if (SurfaceId() == -1)
-            return;
+          if (auto strongRootView = m_wkRootView.get()) {
+            if (SurfaceId() == -1)
+              return;
 
-          auto focusedComponent = RootComponentView().GetFocusedComponent();
-          auto charArgs = winrt::make<
-              winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
-              focusedComponent
-                  ? focusedComponent.Tag()
-                  : static_cast<facebook::react::Tag>(
-                        winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
-                            m_compRootView)
-                            ->GetTag()),
-              args);
-          auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
-          onCharacterReceived(keyboardSource, charArgs);
-          winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+            auto focusedComponent = RootComponentView().GetFocusedComponent();
+            auto charArgs = winrt::make<
+                winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
+                focusedComponent
+                    ? focusedComponent.Tag()
+                    : static_cast<facebook::react::Tag>(
+                          winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
+                              strongRootView)
+                              ->GetTag()),
+                args);
+            auto keyboardSource = winrt::make<CompositionInputKeyboardSource>(source);
+            onCharacterReceived(keyboardSource, charArgs);
+            winrt::get_self<CompositionInputKeyboardSource>(keyboardSource)->Disconnect();
+          }
         });
   }
 #endif
@@ -282,24 +303,29 @@ CompositionEventHandler::CompositionEventHandler(
 
 CompositionEventHandler::~CompositionEventHandler() {
 #ifdef USE_WINUI3
-  if (auto island = m_compRootView.Island()) {
-    auto pointerSource = winrt::Microsoft::UI::Input::InputPointerSource::GetForIsland(island);
-    pointerSource.PointerPressed(m_pointerPressedToken);
-    pointerSource.PointerReleased(m_pointerReleasedToken);
-    pointerSource.PointerMoved(m_pointerMovedToken);
-    pointerSource.PointerCaptureLost(m_pointerCaptureLostToken);
-    pointerSource.PointerWheelChanged(m_pointerWheelChangedToken);
-    auto keyboardSource = winrt::Microsoft::UI::Input::InputKeyboardSource::GetForIsland(island);
-    keyboardSource.KeyDown(m_keyDownToken);
-    keyboardSource.KeyUp(m_keyUpToken);
-    keyboardSource.CharacterReceived(m_characterReceivedToken);
+  if (auto strongRootView = m_wkRootView.get()) {
+    if (auto island = strongRootView.Island()) {
+      auto pointerSource = winrt::Microsoft::UI::Input::InputPointerSource::GetForIsland(island);
+      pointerSource.PointerPressed(m_pointerPressedToken);
+      pointerSource.PointerReleased(m_pointerReleasedToken);
+      pointerSource.PointerMoved(m_pointerMovedToken);
+      pointerSource.PointerCaptureLost(m_pointerCaptureLostToken);
+      pointerSource.PointerWheelChanged(m_pointerWheelChangedToken);
+      auto keyboardSource = winrt::Microsoft::UI::Input::InputKeyboardSource::GetForIsland(island);
+      keyboardSource.KeyDown(m_keyDownToken);
+      keyboardSource.KeyUp(m_keyUpToken);
+      keyboardSource.CharacterReceived(m_characterReceivedToken);
+    }
   }
 #endif
 }
 
 facebook::react::SurfaceId CompositionEventHandler::SurfaceId() const noexcept {
-  return static_cast<facebook::react::SurfaceId>(
-      winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(m_compRootView)->GetTag());
+  if (auto strongRootView = m_wkRootView.get()) {
+    return static_cast<facebook::react::SurfaceId>(
+        winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(strongRootView)->GetTag());
+  }
+  return -1;
 }
 
 winrt::Microsoft::ReactNative::Composition::implementation::RootComponentView &
@@ -369,86 +395,104 @@ winrt::Windows::System::VirtualKeyModifiers GetKeyModifiers(uint64_t wParam) {
 int64_t CompositionEventHandler::SendMessage(HWND hwnd, uint32_t msg, uint64_t wParam, int64_t lParam) noexcept {
   switch (msg) {
     case WM_LBUTTONDOWN: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerPressed(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerPressed(pp, GetKeyModifiers(wParam));
+      }
       return 0;
     }
     case WM_POINTERDOWN: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerPressed(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerPressed(pp, GetKeyModifiers(wParam));
+      }
       return 0;
     }
     case WM_LBUTTONUP: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerReleased(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerReleased(pp, GetKeyModifiers(wParam));
+      }
       return 0;
     }
     case WM_POINTERUP: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerReleased(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerReleased(pp, GetKeyModifiers(wParam));
+      }
       return 0;
     }
     case WM_MOUSEMOVE: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerMoved(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerMoved(pp, GetKeyModifiers(wParam));
+      }
       return 0;
     }
     case WM_CAPTURECHANGED: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerCaptureLost(pp, winrt::Windows::System::VirtualKeyModifiers::None);
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerCaptureLost(pp, winrt::Windows::System::VirtualKeyModifiers::None);
+      }
       return 0;
     }
     case WM_MOUSEWHEEL: {
-      auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
-          hwnd, msg, wParam, lParam, m_compRootView.ScaleFactor());
-      onPointerWheelChanged(pp, GetKeyModifiers(wParam));
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto pp = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::PointerPoint>(
+            hwnd, msg, wParam, lParam, strongRootView.ScaleFactor());
+        onPointerWheelChanged(pp, GetKeyModifiers(wParam));
+      }
       break;
     }
     case WM_CHAR:
     case WM_SYSCHAR: {
-      auto focusedComponent = RootComponentView().GetFocusedComponent();
-      auto args = winrt::make<
-          winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
-          focusedComponent
-              ? focusedComponent.Tag()
-              : static_cast<facebook::react::Tag>(
-                    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(m_compRootView)
-                        ->GetTag()),
-          msg,
-          wParam,
-          lParam);
-      auto keyboardSource = winrt::make<CompositionKeyboardSource>(this);
-      onCharacterReceived(keyboardSource, args);
-      winrt::get_self<CompositionKeyboardSource>(keyboardSource)->Disconnect();
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto focusedComponent = RootComponentView().GetFocusedComponent();
+        auto args = winrt::make<
+            winrt::Microsoft::ReactNative::Composition::Input::implementation::CharacterReceivedRoutedEventArgs>(
+            focusedComponent ? focusedComponent.Tag()
+                             : static_cast<facebook::react::Tag>(
+                                   winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
+                                       strongRootView)
+                                       ->GetTag()),
+            msg,
+            wParam,
+            lParam);
+        auto keyboardSource = winrt::make<CompositionKeyboardSource>(this);
+        onCharacterReceived(keyboardSource, args);
+        winrt::get_self<CompositionKeyboardSource>(keyboardSource)->Disconnect();
+      }
       break;
     }
     case WM_KEYDOWN:
     case WM_KEYUP:
     case WM_SYSKEYDOWN:
     case WM_SYSKEYUP: {
-      auto focusedComponent = RootComponentView().GetFocusedComponent();
-      auto args = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
-          focusedComponent
-              ? focusedComponent.Tag()
-              : static_cast<facebook::react::Tag>(
-                    winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(m_compRootView)
-                        ->GetTag()),
-          msg,
-          wParam,
-          lParam);
-      auto keyboardSource = winrt::make<CompositionKeyboardSource>(this);
-      if (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) {
-        onKeyDown(keyboardSource, args);
-      } else {
-        onKeyUp(keyboardSource, args);
+      if (auto strongRootView = m_wkRootView.get()) {
+        auto focusedComponent = RootComponentView().GetFocusedComponent();
+        auto args = winrt::make<winrt::Microsoft::ReactNative::Composition::Input::implementation::KeyRoutedEventArgs>(
+            focusedComponent ? focusedComponent.Tag()
+                             : static_cast<facebook::react::Tag>(
+                                   winrt::get_self<winrt::Microsoft::ReactNative::implementation::CompositionRootView>(
+                                       strongRootView)
+                                       ->GetTag()),
+            msg,
+            wParam,
+            lParam);
+        auto keyboardSource = winrt::make<CompositionKeyboardSource>(this);
+        if (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) {
+          onKeyDown(keyboardSource, args);
+        } else {
+          onKeyUp(keyboardSource, args);
+        }
+        winrt::get_self<CompositionKeyboardSource>(keyboardSource)->Disconnect();
       }
-      winrt::get_self<CompositionKeyboardSource>(keyboardSource)->Disconnect();
       break;
     }
   }
@@ -571,9 +615,9 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
 
   // We only want to emit events to JS if there is a view that is currently listening to said event
   // so we only send those event to the JS side if the element which has been entered is itself listening,
-  // or if one of its parents is listening in case those listeners care about the capturing phase. Adding the ability
-  // for native to distinguish between capturing listeners and not could be an optimization to further reduce the
-  // number of events we send to JS
+  // or if one of its parents is listening in case those listeners care about the capturing phase. Adding the
+  // ability for native to distinguish between capturing listeners and not could be an optimization to further
+  // reduce the number of events we send to JS
   bool hasParentEnterListener = false;
   bool emittedNativeEnteredEvent = false;
 
@@ -673,7 +717,8 @@ void CompositionEventHandler::HandleIncomingPointerEvent(
   }
 
   for (auto itComponentView = viewsToEmitJSLeaveEventsTo.rbegin(); itComponentView != viewsToEmitJSLeaveEventsTo.rend();
-       itComponentView++) { //  for (UIView *componentView in [viewsToEmitJSLeaveEventsTo reverseObjectEnumerator]) {
+       itComponentView++) { //  for (UIView *componentView in [viewsToEmitJSLeaveEventsTo
+                            //  reverseObjectEnumerator]) {
     auto componentView = *itComponentView;
 
     const auto eventEmitter =
@@ -769,8 +814,10 @@ void CompositionEventHandler::getTargetPointerArgs(
     auto targetComponentView = fabricuiManager->GetViewRegistry().componentViewDescriptorWithTag(tag).view;
     auto clientRect = winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(targetComponentView)
                           ->getClientRect();
-    ptLocal.x = ptScaled.x - (clientRect.left / m_compRootView.ScaleFactor());
-    ptLocal.y = ptScaled.y - (clientRect.top / m_compRootView.ScaleFactor());
+    if (auto strongRootView = m_wkRootView.get()) {
+      ptLocal.x = ptScaled.x - (clientRect.left / strongRootView.ScaleFactor());
+      ptLocal.y = ptScaled.y - (clientRect.top / strongRootView.ScaleFactor());
+    }
   } else {
     tag = RootComponentView().hitTest(ptScaled, ptLocal);
   }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionEventHandler.h
@@ -154,7 +154,7 @@ class CompositionEventHandler {
   PointerId m_touchId = 0;
 
   std::map<PointerId, std::vector<ReactTaggedView>> m_currentlyHoveredViewsPerPointer;
-  winrt::Microsoft::ReactNative::CompositionRootView m_compRootView{nullptr};
+  winrt::weak_ref<winrt::Microsoft::ReactNative::CompositionRootView> m_wkRootView;
   winrt::Microsoft::ReactNative::ReactContext m_context;
 
   facebook::react::Tag m_pointerCapturingComponentTag{-1}; // Component that has captured input

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -383,12 +383,9 @@ void CompositionRootView::InitRootView(
 
   m_context = winrt::Microsoft::ReactNative::ReactContext(std::move(context));
 
-  winrt::Microsoft::ReactNative::CompositionRootView compositionRootView;
-  get_strong().as(compositionRootView);
-
   m_reactViewOptions = std::move(viewOptions);
   m_CompositionEventHandler =
-      std::make_shared<::Microsoft::ReactNative::CompositionEventHandler>(m_context, compositionRootView);
+      std::make_shared<::Microsoft::ReactNative::CompositionEventHandler>(m_context, *this);
 
   UpdateRootViewInternal();
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -131,6 +131,13 @@ CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition
     : m_compositor(compositor) {}
 #endif
 
+CompositionRootView::~CompositionRootView() noexcept {
+  if (m_uiDispatcher) {
+    assert(m_uiDispatcher.HasThreadAccess());
+    UninitRootView();
+  }
+}
+
 ReactNative::IReactViewHost CompositionRootView::ReactViewHost() noexcept {
   return m_reactViewHost;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.cpp
@@ -240,29 +240,32 @@ void CompositionRootView::ScaleFactor(float value) noexcept {
   }
 }
 
+winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader CompositionRootView::Resources() noexcept {
+  return m_resources;
+}
+
+void CompositionRootView::Resources(
+    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &resources) noexcept {
+  m_resources = resources;
+
+  if (m_context && m_theme) {
+    Theme(winrt::make<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_context, m_resources));
+  }
+}
+
 winrt::Microsoft::ReactNative::Composition::Theme CompositionRootView::Theme() noexcept {
   if (!m_theme) {
-    Theme(winrt::Microsoft::ReactNative::Composition::Theme::GetDefaultTheme(m_context.Handle()));
-    m_themeChangedSubscription = m_context.Notifications().Subscribe(
-        winrt::Microsoft::ReactNative::ReactNotificationId<void>(
-            winrt::Microsoft::ReactNative::Composition::Theme::ThemeChangedEventName()),
-        m_context.UIDispatcher(),
-        [wkThis = get_weak()](
-            IInspectable const & /*sender*/,
-            winrt::Microsoft::ReactNative::ReactNotificationArgs<void> const & /*args*/) {
-          auto pThis = wkThis.get();
-          pThis->Theme(winrt::Microsoft::ReactNative::Composition::Theme::GetDefaultTheme(pThis->m_context.Handle()));
-        });
+    assert(m_context);
+    if (m_resources) {
+      Theme(winrt::make<winrt::Microsoft::ReactNative::Composition::implementation::Theme>(m_context, m_resources));
+    } else {
+      Theme(winrt::Microsoft::ReactNative::Composition::Theme::GetDefaultTheme(m_context.Handle()));
+    }
   }
   return m_theme;
 }
 
 void CompositionRootView::Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept {
-  if (m_themeChangedSubscription) {
-    m_themeChangedSubscription.Unsubscribe();
-    m_themeChangedSubscription = nullptr;
-  }
-
   if (value == m_theme)
     return;
 
@@ -270,20 +273,22 @@ void CompositionRootView::Theme(const winrt::Microsoft::ReactNative::Composition
 
   m_themeChangedRevoker = m_theme.ThemeChanged(
       winrt::auto_revoke,
-      [this](
+      [wkThis = get_weak()](
           const winrt::Windows::Foundation::IInspectable & /*sender*/,
           const winrt::Windows::Foundation::IInspectable & /*args*/) {
-        if (auto rootView = GetComponentView()) {
-          Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
-              [](const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
-                winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(view)->onThemeChanged();
-                return false;
-              };
+        if (auto strongThis = wkThis.get()) {
+          if (auto rootView = strongThis->GetComponentView()) {
+            Mso::Functor<bool(const winrt::Microsoft::ReactNative::ComponentView &)> fn =
+                [](const winrt::Microsoft::ReactNative::ComponentView &view) noexcept {
+                  winrt::get_self<winrt::Microsoft::ReactNative::implementation::ComponentView>(view)->onThemeChanged();
+                  return false;
+                };
 
-          winrt::Microsoft::ReactNative::ComponentView view{nullptr};
-          winrt::check_hresult(rootView->QueryInterface(
-              winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(view)));
-          walkTree(view, true, fn);
+            winrt::Microsoft::ReactNative::ComponentView view{nullptr};
+            winrt::check_hresult(rootView->QueryInterface(
+                winrt::guid_of<winrt::Microsoft::ReactNative::ComponentView>(), winrt::put_abi(view)));
+            walkTree(view, true, fn);
+          }
         }
       });
 
@@ -382,10 +387,8 @@ void CompositionRootView::InitRootView(
   }
 
   m_context = winrt::Microsoft::ReactNative::ReactContext(std::move(context));
-
   m_reactViewOptions = std::move(viewOptions);
-  m_CompositionEventHandler =
-      std::make_shared<::Microsoft::ReactNative::CompositionEventHandler>(m_context, *this);
+  m_CompositionEventHandler = std::make_shared<::Microsoft::ReactNative::CompositionEventHandler>(m_context, *this);
 
   UpdateRootViewInternal();
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -73,6 +73,9 @@ struct CompositionRootView
   void RemoveRenderedVisual(const winrt::Microsoft::ReactNative::Composition::Experimental::IVisual &visual) noexcept;
   bool TrySetFocus() noexcept;
 
+  winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader Resources() noexcept;
+  void Resources(const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &resources) noexcept;
+
   winrt::Microsoft::ReactNative::Composition::Theme Theme() noexcept;
   void Theme(const winrt::Microsoft::ReactNative::Composition::Theme &value) noexcept;
 
@@ -134,8 +137,8 @@ struct CompositionRootView
   winrt::Microsoft::ReactNative::Composition::Experimental::IVisual m_rootVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_loadingVisual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::IActivityVisual m_loadingActivityVisual{nullptr};
+  winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader m_resources{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme m_theme{nullptr};
-  winrt::Microsoft::ReactNative::ReactNotificationSubscription m_themeChangedSubscription{nullptr};
   winrt::Microsoft::ReactNative::Composition::Theme::ThemeChanged_revoker m_themeChangedRevoker;
 
   void UpdateRootViewInternal() noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView.h
@@ -45,6 +45,7 @@ struct CompositionRootView
     : CompositionRootViewT<CompositionRootView, Composition::Experimental::IInternalCompositionRootView>,
       ::Microsoft::ReactNative::ICompositionRootView {
   CompositionRootView() noexcept;
+  ~CompositionRootView() noexcept;
 
 #ifdef USE_WINUI3
   CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -69,6 +69,12 @@ winrt::Microsoft::ReactNative::Composition::Theme CompositionRootView::Theme() n
 }
 void CompositionRootView::Theme(const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {}
 
+winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader CompositionRootView::Resources() noexcept {
+  return nullptr;
+}
+void CompositionRootView::Resources(const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept {}
+
+
 winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
   return nullptr;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -72,8 +72,8 @@ void CompositionRootView::Theme(const winrt::Microsoft::ReactNative::Composition
 winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader CompositionRootView::Resources() noexcept {
   return nullptr;
 }
-void CompositionRootView::Resources(const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept {}
-
+void CompositionRootView::Resources(
+    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept {}
 
 winrt::IInspectable CompositionRootView::GetUiaProvider() noexcept {
   return nullptr;

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionRootView_emptyimpl.cpp
@@ -28,6 +28,7 @@ struct CompositionReactViewInstance
 //===========================================================================
 
 CompositionRootView::CompositionRootView() noexcept {}
+CompositionRootView::~CompositionRootView() noexcept {}
 
 CompositionRootView::CompositionRootView(const winrt::Microsoft::UI::Composition::Compositor &compositor) noexcept {}
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme.h
@@ -50,12 +50,13 @@ struct Theme : ThemeT<Theme, Experimental::IInternalTheme> {
 
   static winrt::Microsoft::ReactNative::Composition::Theme GetDefaultTheme(
       const winrt::Microsoft::ReactNative::IReactContext &context) noexcept;
-  static void SetDefaultTheme(
+  static void SetDefaultResources(
       const winrt::Microsoft::ReactNative::ReactInstanceSettings &settings,
-      const winrt::Microsoft::ReactNative::Composition::Theme &theme) noexcept;
-  static winrt::Microsoft::ReactNative::IReactPropertyName ThemeChangedEventName() noexcept;
+      const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &resources) noexcept;
 
  private:
+  void UpdateCustomResources(
+      const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &resources) noexcept;
   bool TryGetPlatformColor(const std::string &platformColor, winrt::Windows::UI::Color &color) noexcept;
   void ClearCacheAndRaiseChangedEvent() noexcept;
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/Theme_emptyimpl.cpp
@@ -74,12 +74,8 @@ winrt::Microsoft::ReactNative::Composition::Theme Theme::EmptyTheme() noexcept {
   return nullptr;
 }
 
-/*static*/ void Theme::SetDefaultTheme(
+/*static*/ void Theme::SetDefaultResources(
     const winrt::Microsoft::ReactNative::ReactInstanceSettings &,
-    const winrt::Microsoft::ReactNative::Composition::Theme &) noexcept {}
-
-/*static*/ IReactPropertyName Theme::ThemeChangedEventName() noexcept {
-  return nullptr;
-}
+    const winrt::Microsoft::ReactNative::Composition::ICustomResourceLoader &) noexcept {}
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Theme.idl
+++ b/vnext/Microsoft.ReactNative/Theme.idl
@@ -61,8 +61,7 @@ namespace Microsoft.ReactNative.Composition
     event Windows.Foundation.EventHandler<Object> ThemeChanged;
 
     static Theme GetDefaultTheme(Microsoft.ReactNative.IReactContext context);
-    static void SetDefaultTheme(Microsoft.ReactNative.ReactInstanceSettings settings, Theme theme);
-    static Microsoft.ReactNative.IReactPropertyName ThemeChangedEventName { get; };
+    static void SetDefaultResources(Microsoft.ReactNative.ReactInstanceSettings settings, ICustomResourceLoader theme);
   };
 
 } // namespace Microsoft.ReactNative


### PR DESCRIPTION
Port #13013 and #13163 to 0.74
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13171)