### PR TITLE
[cpp-lib] Fix typo in metro.config.js

### DIFF
--- a/change/react-native-windows-4bf9ae6c-4aa1-4e1e-a65e-29aa30067d1a.json
+++ b/change/react-native-windows-4bf9ae6c-4aa1-4e1e-a65e-29aa30067d1a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "[cpp-lib] Fix typo in metro.config.js",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/vnext/templates/cpp-lib/example/metro.config.js
+++ b/vnext/templates/cpp-lib/example/metro.config.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const escape = require('escape-string-regexp');
 const exclusionList = require('metro-config/src/defaults/exclusionList');
-const pak = require('../package.json');
+const pack = require('../package.json');
 
 const root = path.resolve(__dirname, '..');
 const modules = Object.keys({ ...pack.peerDependencies });

--- a/vnext/templates/cpp-lib/example/metro.config.js
+++ b/vnext/templates/cpp-lib/example/metro.config.js
@@ -6,7 +6,7 @@ const exclusionList = require('metro-config/src/defaults/exclusionList');
 const pak = require('../package.json');
 
 const root = path.resolve(__dirname, '..');
-const modules = Object.keys({ ...pak.peerDependencies });
+const modules = Object.keys({ ...pack.peerDependencies });
 
 const rnwPath = fs.realpathSync(
   path.resolve(require.resolve('react-native-windows/package.json'), '..'),


### PR DESCRIPTION
## Description
There's a typo in the metro.config.js file of the cpp-lib template

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13179)