### PR TITLE
[Fabric] Add ability to provide custom image uri handlers

### DIFF
--- a/change/react-native-windows-e43ac1c2-0b09-49f0-9509-e8af020af965.json
+++ b/change/react-native-windows-e43ac1c2-0b09-49f0-9509-e8af020af965.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add ability to provide custom image uri handlers",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/playground/windows/playground-composition/Playground-Composition.cpp
+++ b/packages/playground/windows/playground-composition/Playground-Composition.cpp
@@ -23,6 +23,7 @@
 
 #include <DesktopWindowBridge.h>
 #include "App.xaml.h"
+#include "AutoDraw.h"
 #include "NativeModules.h"
 #include "ReactPropertyBag.h"
 
@@ -40,6 +41,61 @@ winrt::Microsoft::UI::Composition::Compositor g_liftedCompositor{nullptr};
 #endif
 
 void RegisterCustomComponent(winrt::Microsoft::ReactNative::IReactPackageBuilder const &packageBuilder) noexcept;
+
+/**
+ * This ImageHandler will accept images with a uri using the ellipse protocol and render an ellipse image
+ *
+ *   <Image
+ *      style={{width: 400, height: 200}}
+ *      source={{uri: 'customimage://test'}}
+ *   />
+ *
+ * This allows applications to provide custom image rendering pipelines.
+ */
+struct EllipseImageHandler : winrt::implements<
+                                 EllipseImageHandler,
+                                 winrt::Microsoft::ReactNative::Composition::Experimental::IUriBrushProvider,
+                                 winrt::Microsoft::ReactNative::Composition::IUriImageProvider> {
+  bool CanLoadImageUri(winrt::Microsoft::ReactNative::IReactContext context, winrt::Windows::Foundation::Uri uri) {
+    return uri.SchemeName() == L"ellipse";
+  }
+
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory>
+  GetSourceAsync(
+      const winrt::Microsoft::ReactNative::IReactContext &context,
+      const winrt::Microsoft::ReactNative::Composition::ImageSource &imageSource) {
+    co_return [uri = imageSource.Uri(), size = imageSource.Size(), scale = imageSource.Scale(), context](
+                  const winrt::Microsoft::ReactNative::IReactContext &reactContext,
+                  const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
+                      &compositionContext) -> winrt::Microsoft::ReactNative::Composition::Experimental::IBrush {
+      auto compositor =
+          winrt::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompositionContextHelper::InnerCompositor(
+              compositionContext);
+      auto drawingBrush = compositionContext.CreateDrawingSurfaceBrush(
+          size,
+          winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized,
+          winrt::Windows::Graphics::DirectX::DirectXAlphaMode::Premultiplied);
+      POINT pt;
+      Microsoft::ReactNative::Composition::AutoDrawDrawingSurface autoDraw(drawingBrush, scale, &pt);
+      auto renderTarget = autoDraw.GetRenderTarget();
+
+      winrt::com_ptr<ID2D1SolidColorBrush> brush;
+      renderTarget->CreateSolidColorBrush({1.0f, 0.0f, 0.0f, 1.0f}, brush.put());
+      renderTarget->DrawEllipse(
+          {{(pt.x + size.Width / 2) / scale, (pt.y + size.Height / 2) / scale},
+           (size.Width / 2) / scale,
+           (size.Height / 2) / scale},
+          brush.get());
+
+      return drawingBrush;
+    };
+  }
+};
+
+void RegisterEllipseUriImageHandler(const winrt::Microsoft::ReactNative::ReactInstanceSettings &settings) noexcept {
+  winrt::Microsoft::ReactNative::Composition::UriImageManager::AddUriImageProvider(
+      settings.Properties(), winrt::make<EllipseImageHandler>());
+}
 
 // Have to use TurboModules to override built in modules.. so the standard attributed package provider doesn't work.
 struct CompReactPackageProvider
@@ -180,6 +236,9 @@ struct WindowData {
               // By setting the compositor here we opt into using the new architecture.
               winrt::Microsoft::ReactNative::Composition::CompositionUIService::SetCompositor(
                   InstanceSettings(), g_liftedCompositor);
+
+              // Register ellipse:// uri hander for images
+              RegisterEllipseUriImageHandler(host.InstanceSettings());
 
               auto bridge = winrt::Microsoft::UI::Content::DesktopChildSiteBridge::Create(
                   g_liftedCompositor, winrt::Microsoft::UI::GetWindowIdFromWindow(hwnd));

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.cpp
@@ -1966,6 +1966,12 @@ winrt::Microsoft::UI::Composition::ICompositionSurface MicrosoftCompositionConte
   surface.try_as(s);
   return s ? s->Inner() : nullptr;
 }
+
+winrt::Microsoft::ReactNative::Composition::Experimental::IBrush MicrosoftCompositionContextHelper::WrapBrush(
+    const winrt::Microsoft::UI::Composition::CompositionBrush &brush) noexcept {
+  return winrt::make<::Microsoft::ReactNative::Composition::Experimental::MicrosoftCompBrush>(brush);
+}
+
 #endif
 
 } // namespace winrt::Microsoft::ReactNative::Composition::Experimental::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/CompositionContextHelper.h
@@ -45,6 +45,8 @@ struct MicrosoftCompositionContextHelper : MicrosoftCompositionContextHelperT<Mi
   static winrt::Microsoft::UI::Composition::DropShadow InnerDropShadow(IDropShadow shadow) noexcept;
   static winrt::Microsoft::UI::Composition::CompositionBrush InnerBrush(IBrush brush) noexcept;
   static winrt::Microsoft::UI::Composition::ICompositionSurface InnerSurface(IDrawingSurfaceBrush surface) noexcept;
+
+  static IBrush WrapBrush(const winrt::Microsoft::UI::Composition::CompositionBrush &brush) noexcept;
 };
 #endif
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageComponentView.h
@@ -14,6 +14,7 @@
 #include <winrt/Windows.UI.Composition.h>
 #include "CompositionHelpers.h"
 #include "CompositionViewComponentView.h"
+#include "ImageResponseImage.h"
 
 #pragma warning(push)
 #pragma warning(disable : 4244 4305)
@@ -83,7 +84,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
 
   void ImageLoadStart() noexcept;
   void ImageLoaded() noexcept;
-  void didReceiveImage(const winrt::com_ptr<IWICBitmap> &wicbmp) noexcept;
+  void didReceiveImage(const std::shared_ptr<ImageResponseImage> &wicbmp) noexcept;
   void didReceiveFailureFromObserver() noexcept;
   void setStateAndResubscribeImageResponseObserver(
       facebook::react::ImageShadowNode::ConcreteState::Shared const &state) noexcept;
@@ -93,7 +94,7 @@ struct ImageComponentView : ImageComponentViewT<ImageComponentView, ComponentVie
 
   winrt::Microsoft::ReactNative::Composition::Experimental::ISpriteVisual m_visual{nullptr};
   winrt::Microsoft::ReactNative::Composition::Experimental::IDrawingSurfaceBrush m_drawingSurface;
-  winrt::com_ptr<IWICBitmap> m_wicbmp;
+  std::shared_ptr<ImageResponseImage> m_imageResponseImage;
   std::shared_ptr<WindowsImageResponseObserver> m_imageResponseObserver;
   facebook::react::ImageShadowNode::ConcreteState::Shared m_state;
 };

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageResponseImage.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageResponseImage.h
@@ -10,8 +10,8 @@
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 struct ImageResponseImage {
-    winrt::com_ptr<IWICBitmap> m_wicbmp;
-    winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory m_brushFactory{nullptr};
+  winrt::com_ptr<IWICBitmap> m_wicbmp;
+  winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory m_brushFactory{nullptr};
 };
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/ImageResponseImage.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/ImageResponseImage.h
@@ -1,0 +1,17 @@
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <wincodec.h>
+#include <winrt/Microsoft.ReactNative.Composition.Experimental.h>
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+struct ImageResponseImage {
+    winrt::com_ptr<IWICBitmap> m_wicbmp;
+    winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory m_brushFactory{nullptr};
+};
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
@@ -4,44 +4,38 @@
 #include "pch.h"
 #include "UriImageManager.h"
 
-#include "Composition.UriImageManager.g.cpp"
 #include "Composition.ImageSource.g.h"
+#include "Composition.UriImageManager.g.cpp"
 #include <ReactPropertyBag.h>
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-struct ImageSource : ImageSourceT<ImageSource>
-{
-  ImageSource(const facebook::react::ImageSource& source) :
-    m_size({source.size.width, source.size.height}),
-    m_scale(source.scale),
-    m_uri(::Microsoft::ReactNative::UriTryCreate(winrt::to_hstring(source.uri)))
-  {
-  }
+struct ImageSource : ImageSourceT<ImageSource> {
+  ImageSource(const facebook::react::ImageSource &source)
+      : m_size({source.size.width, source.size.height}),
+        m_scale(source.scale),
+        m_uri(::Microsoft::ReactNative::UriTryCreate(winrt::to_hstring(source.uri))) {}
 
-  winrt::Windows::Foundation::Uri Uri() noexcept
-  {
+  winrt::Windows::Foundation::Uri Uri() noexcept {
     return m_uri;
   }
 
-  winrt::Windows::Foundation::Size Size() noexcept
-  {
+  winrt::Windows::Foundation::Size Size() noexcept {
     return m_size;
   }
 
-  float Scale() noexcept
-  {
+  float Scale() noexcept {
     return m_scale;
   }
 
-private:
+ private:
   const winrt::Windows::Foundation::Uri m_uri;
   const winrt::Windows::Foundation::Size m_size;
   const float m_scale;
 };
 
-winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(const facebook::react::ImageSource& source) noexcept
-{
+winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(
+    const facebook::react::ImageSource &source) noexcept {
   return winrt::make<ImageSource>(source);
 }
 
@@ -51,27 +45,32 @@ static const ReactPropertyId<ReactNonAbiValue<winrt::com_ptr<UriImageManager>>> 
   return prop;
 }
 
-winrt::com_ptr<UriImageManager> UriImageManager::GetOrCreate(const winrt::Microsoft::ReactNative::ReactPropertyBag& properties) noexcept {
-  auto uriImageManager = winrt::Microsoft::ReactNative::ReactPropertyBag(properties).GetOrCreate(UriImageManagerPropertyId(), []() {
-    return winrt::make_self<UriImageManager>();
-  });
+winrt::com_ptr<UriImageManager> UriImageManager::GetOrCreate(
+    const winrt::Microsoft::ReactNative::ReactPropertyBag &properties) noexcept {
+  auto uriImageManager =
+      winrt::Microsoft::ReactNative::ReactPropertyBag(properties).GetOrCreate(UriImageManagerPropertyId(), []() {
+        return winrt::make_self<UriImageManager>();
+      });
   return uriImageManager.Value();
 }
 
-void UriImageManager::AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag& properties, const IUriImageProvider& provider) {
+void UriImageManager::AddUriImageProvider(
+    const winrt::Microsoft::ReactNative::IReactPropertyBag &properties,
+    const IUriImageProvider &provider) {
   if (!provider)
     winrt::throw_hresult(E_INVALIDARG);
   GetOrCreate(winrt::Microsoft::ReactNative::ReactPropertyBag(properties))->m_providers.push_back(provider);
 }
 
-IUriImageProvider UriImageManager::TryGetUriImageProvider(const IReactContext& context, winrt::Microsoft::ReactNative::Composition::ImageSource& source) noexcept {
+IUriImageProvider UriImageManager::TryGetUriImageProvider(
+    const IReactContext &context,
+    winrt::Microsoft::ReactNative::Composition::ImageSource &source) noexcept {
   auto uri = source.Uri();
-  if (!uri)
-  {
+  if (!uri) {
     return nullptr;
   }
 
-  for(auto& provider : m_providers) {
+  for (auto &provider : m_providers) {
     if (provider.CanLoadImageUri(context, source.Uri())) {
       return provider;
     }
@@ -79,6 +78,5 @@ IUriImageProvider UriImageManager::TryGetUriImageProvider(const IReactContext& c
 
   return nullptr;
 }
-
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "UriImageManager.h"
+
+#include "Composition.UriImageManager.g.cpp"
+#include "Composition.ImageSource.g.h"
+#include <ReactPropertyBag.h>
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+struct ImageSource : ImageSourceT<ImageSource>
+{
+  ImageSource(const facebook::react::ImageSource& source) :
+    m_size({source.size.width, source.size.height}),
+    m_scale(source.scale),
+    m_uri(::Microsoft::ReactNative::UriTryCreate(winrt::to_hstring(source.uri)))
+  {
+  }
+
+  winrt::Windows::Foundation::Uri Uri() noexcept
+  {
+    return m_uri;
+  }
+
+  winrt::Windows::Foundation::Size Size() noexcept
+  {
+    return m_size;
+  }
+
+  float Scale() noexcept
+  {
+    return m_scale;
+  }
+
+private:
+  const winrt::Windows::Foundation::Uri m_uri;
+  const winrt::Windows::Foundation::Size m_size;
+  const float m_scale;
+};
+
+winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(const facebook::react::ImageSource& source) noexcept
+{
+  return winrt::make<ImageSource>(source);
+}
+
+static const ReactPropertyId<ReactNonAbiValue<winrt::com_ptr<UriImageManager>>> &UriImageManagerPropertyId() noexcept {
+  static const ReactPropertyId<ReactNonAbiValue<winrt::com_ptr<UriImageManager>>> prop{
+      L"ReactNative", L"UriImageManager"};
+  return prop;
+}
+
+winrt::com_ptr<UriImageManager> UriImageManager::GetOrCreate(const winrt::Microsoft::ReactNative::ReactPropertyBag& properties) noexcept {
+  auto uriImageManager = winrt::Microsoft::ReactNative::ReactPropertyBag(properties).GetOrCreate(UriImageManagerPropertyId(), []() {
+    return winrt::make_self<UriImageManager>();
+  });
+  return uriImageManager.Value();
+}
+
+void UriImageManager::AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag& properties, const IUriImageProvider& provider) {
+  if (!provider)
+    winrt::throw_hresult(E_INVALIDARG);
+  GetOrCreate(winrt::Microsoft::ReactNative::ReactPropertyBag(properties))->m_providers.push_back(provider);
+}
+
+IUriImageProvider UriImageManager::TryGetUriImageProvider(const IReactContext& context, winrt::Microsoft::ReactNative::Composition::ImageSource& source) noexcept {
+  auto uri = source.Uri();
+  if (!uri)
+  {
+    return nullptr;
+  }
+
+  for(auto& provider : m_providers) {
+    if (provider.CanLoadImageUri(context, source.Uri())) {
+      return provider;
+    }
+  }
+
+  return nullptr;
+}
+
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#pragma once
+#include "Composition.UriImageManager.g.h"
+
+#include <winrt/Microsoft.ReactNative.Composition.h>
+#include <ReactPropertyBag.h>
+#include <Utils/ImageUtils.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+struct UriImageManager : UriImageManagerT<UriImageManager> {
+  UriImageManager() = default;
+
+  static void AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag& properties, const IUriImageProvider& provider);
+
+  static winrt::com_ptr<UriImageManager> GetOrCreate(const winrt::Microsoft::ReactNative::ReactPropertyBag& properties) noexcept;
+
+  IUriImageProvider TryGetUriImageProvider(const IReactContext& context, winrt::Microsoft::ReactNative::Composition::ImageSource& source) noexcept;
+
+private:
+  std::vector<IUriImageProvider> m_providers;
+};
+
+winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(const facebook::react::ImageSource& source) noexcept;
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation
+
+namespace winrt::Microsoft::ReactNative::Composition::factory_implementation {
+struct UriImageManager : UriImageManagerT<UriImageManager, implementation::UriImageManager> {};
+} // namespace winrt::Microsoft::ReactNative::Composition::factory_implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager.h
@@ -4,27 +4,33 @@
 #pragma once
 #include "Composition.UriImageManager.g.h"
 
-#include <winrt/Microsoft.ReactNative.Composition.h>
 #include <ReactPropertyBag.h>
 #include <Utils/ImageUtils.h>
 #include <react/renderer/imagemanager/primitives.h>
+#include <winrt/Microsoft.ReactNative.Composition.h>
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
 struct UriImageManager : UriImageManagerT<UriImageManager> {
   UriImageManager() = default;
 
-  static void AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag& properties, const IUriImageProvider& provider);
+  static void AddUriImageProvider(
+      const winrt::Microsoft::ReactNative::IReactPropertyBag &properties,
+      const IUriImageProvider &provider);
 
-  static winrt::com_ptr<UriImageManager> GetOrCreate(const winrt::Microsoft::ReactNative::ReactPropertyBag& properties) noexcept;
+  static winrt::com_ptr<UriImageManager> GetOrCreate(
+      const winrt::Microsoft::ReactNative::ReactPropertyBag &properties) noexcept;
 
-  IUriImageProvider TryGetUriImageProvider(const IReactContext& context, winrt::Microsoft::ReactNative::Composition::ImageSource& source) noexcept;
+  IUriImageProvider TryGetUriImageProvider(
+      const IReactContext &context,
+      winrt::Microsoft::ReactNative::Composition::ImageSource &source) noexcept;
 
-private:
+ private:
   std::vector<IUriImageProvider> m_providers;
 };
 
-winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(const facebook::react::ImageSource& source) noexcept;
+winrt::Microsoft::ReactNative::Composition::ImageSource MakeImageSource(
+    const facebook::react::ImageSource &source) noexcept;
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "pch.h"
+
+#include "CompositionUIService.h"
+#include "Composition.CompositionUIService.g.cpp"
+
+namespace winrt::Microsoft::ReactNative::Composition::implementation {
+
+void UriImageManager::AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag&, const IUriImageProvider&) {}
+
+} // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
@@ -3,8 +3,8 @@
 
 #include "pch.h"
 
-#include "Composition.CompositionUIService.g.cpp"
-#include "CompositionUIService.h"
+#include "Composition.UriImageManager.g.cpp"
+#include "UriImageManager.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
@@ -3,8 +3,9 @@
 
 #include "pch.h"
 
-#include "Composition.UriImageManager.g.cpp"
 #include "UriImageManager.h"
+
+#include "Composition.UriImageManager.g.cpp"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 

--- a/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/Composition/UriImageManager_emptyimpl.cpp
@@ -3,11 +3,13 @@
 
 #include "pch.h"
 
-#include "CompositionUIService.h"
 #include "Composition.CompositionUIService.g.cpp"
+#include "CompositionUIService.h"
 
 namespace winrt::Microsoft::ReactNative::Composition::implementation {
 
-void UriImageManager::AddUriImageProvider(const winrt::Microsoft::ReactNative::IReactPropertyBag&, const IUriImageProvider&) {}
+void UriImageManager::AddUriImageProvider(
+    const winrt::Microsoft::ReactNative::IReactPropertyBag &,
+    const IUriImageProvider &) {}
 
 } // namespace winrt::Microsoft::ReactNative::Composition::implementation

--- a/vnext/Microsoft.ReactNative/Fabric/ImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/ImageManager.cpp
@@ -9,8 +9,9 @@
 namespace facebook {
 namespace react {
 
-ImageManager::ImageManager(ContextContainer::Shared const &) {
-  self_ = new Microsoft::ReactNative::WindowsImageManager();
+ImageManager::ImageManager(ContextContainer::Shared const &contextContainer) {
+  auto reactContext = *contextContainer->find<winrt::Microsoft::ReactNative::ReactContext>("MSRN.ReactContext");
+  self_ = new Microsoft::ReactNative::WindowsImageManager(reactContext);
 }
 
 ImageManager::~ImageManager() {

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
@@ -5,6 +5,9 @@
 
 #include "WindowsImageManager.h"
 
+#include <Fabric/Composition/CompositionContextHelper.h>
+#include <Fabric/Composition/ImageResponseImage.h>
+#include <Fabric/Composition/UriImageManager.h>
 #include <Utils/ImageUtils.h>
 #include <shcore.h>
 #include <wincodec.h>
@@ -13,7 +16,11 @@ extern "C" HRESULT WINAPI WICCreateImagingFactory_Proxy(UINT SDKVersion, IWICIma
 
 namespace Microsoft::ReactNative {
 
-WindowsImageManager::WindowsImageManager() {}
+WindowsImageManager::WindowsImageManager(winrt::Microsoft::ReactNative::ReactContext reactContext)
+    : m_reactContext(reactContext) {
+  m_uriImageManager = winrt::Microsoft::ReactNative::Composition::implementation::UriImageManager::GetOrCreate(
+      reactContext.Properties());
+}
 
 winrt::com_ptr<IWICBitmapSource> wicBitmapSourceFromStream(
     const winrt::Windows::Storage::Streams::IRandomAccessStream &results) noexcept {
@@ -39,19 +46,12 @@ winrt::com_ptr<IWICBitmapSource> wicBitmapSourceFromStream(
   return decodedFrame;
 }
 
-void generateBitmap(
-    std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator> weakObserverCoordinator,
+std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage> generateBitmap(
     const winrt::Windows::Storage::Streams::IRandomAccessStream &results) noexcept {
-  auto observerCoordinator = weakObserverCoordinator.lock();
-  if (!observerCoordinator) {
-    return;
-  }
-
   winrt::com_ptr<IWICBitmapSource> decodedFrame = wicBitmapSourceFromStream(results);
 
   if (!decodedFrame) {
-    observerCoordinator->nativeImageResponseFailed();
-    return;
+    return nullptr;
   }
 
   winrt::com_ptr<IWICImagingFactory> imagingFactory;
@@ -70,32 +70,18 @@ void generateBitmap(
   winrt::com_ptr<IWICBitmap> wicbmp;
   winrt::check_hresult(imagingFactory->CreateBitmapFromSource(converter.get(), WICBitmapCacheOnLoad, wicbmp.put()));
 
-  // ImageResponse saves a shared_ptr<void> for its data, so we need to wrap the com_ptr in a shared_ptr...
-  auto sharedwicbmp = std::make_shared<winrt::com_ptr<IWICBitmap>>(wicbmp);
-
-  observerCoordinator->nativeImageResponseComplete(facebook::react::ImageResponse(sharedwicbmp, nullptr /*metadata*/));
+  auto image = std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+  image->m_wicbmp = wicbmp;
+  return image;
 }
 
-facebook::react::ImageRequest WindowsImageManager::requestImage(
-    const facebook::react::ImageSource &imageSource,
-    facebook::react::SurfaceId surfaceId) const {
-  auto imageRequest = facebook::react::ImageRequest(imageSource, nullptr, {});
-
-  auto weakObserverCoordinator = (std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator>)
-                                     imageRequest.getSharedObserverCoordinator();
-
-  ReactImageSource source;
-  source.uri = imageSource.uri;
-  source.height = imageSource.size.height;
-  source.width = imageSource.size.width;
-  source.sourceType = ImageSourceType::Download;
-
-  auto task = GetImageStreamAsync(source);
-
-  // TODO progress? - Can we register for progress off the download task?
-  // observerCoordinator->nativeImageResponseProgress((float)progress / (float)total);
-
-  task.Completed([weakObserverCoordinator](auto asyncOp, auto status) {
+template <typename T>
+void ProcessImageRequestTask(
+    std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator> &weakObserverCoordinator,
+    const winrt::IAsyncOperation<T> &task,
+    Mso::Functor<std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>(
+        const T &result)> &&onSuccess) {
+  task.Completed([weakObserverCoordinator, onSuccess = std::move(onSuccess)](auto asyncOp, auto status) {
     auto observerCoordinator = weakObserverCoordinator.lock();
     if (!observerCoordinator) {
       return;
@@ -103,7 +89,12 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
 
     switch (status) {
       case winrt::Windows::Foundation::AsyncStatus::Completed: {
-        generateBitmap(weakObserverCoordinator, asyncOp.GetResults());
+        auto imageResponseImage = onSuccess(asyncOp.GetResults());
+        if (imageResponseImage)
+          observerCoordinator.nativeImageResponseComplete(
+              facebook::react::ImageResponse(imageResponseImage, nullptr /*metadata*/));
+        else
+          observerCoordinator->nativeImageResponseFailed();
         break;
       }
       case winrt::Windows::Foundation::AsyncStatus::Canceled: {
@@ -118,6 +109,81 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
       }
     }
   });
+}
+
+facebook::react::ImageRequest WindowsImageManager::requestImage(
+    const facebook::react::ImageSource &imageSource,
+    facebook::react::SurfaceId surfaceId) const {
+  auto imageRequest = facebook::react::ImageRequest(imageSource, nullptr, {});
+
+  auto weakObserverCoordinator = (std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator>)
+                                     imageRequest.getSharedObserverCoordinator();
+
+  auto rnImageSource = winrt::Microsoft::ReactNative::Composition::implementation::MakeImageSource(imageSource);
+  auto provider = m_uriImageManager->TryGetUriImageProvider(m_reactContext.Handle(), rnImageSource);
+
+  if (auto bProvider = provider.try_as<winrt::Microsoft::ReactNative::Composition::IUriBrushProvider>()) {
+    ProcessImageRequestTask<winrt::Microsoft::ReactNative::Composition::UriBrushFactory>(
+        weakObserverCoordinator,
+        bProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource),
+        [](const winrt::Microsoft::ReactNative::Composition::UriBrushFactory &factory) noexcept {
+          auto image =
+              std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+
+          // Wrap the UriBrushFactory to provide the internal CompositionContext types
+          image->m_brushFactory =
+              [factory](
+                  const winrt::Microsoft::ReactNative::IReactContext &context,
+                  const winrt::Microsoft::ReactNative::Composition::Experimental::ICompositionContext
+                      &compositionContext) {
+                auto compositor = winrt::Microsoft::ReactNative::Composition::Experimental::
+                    MicrosoftCompositionContextHelper::InnerCompositor(compositionContext);
+                auto brush = factory(context, compositor);
+                return winrt::Microsoft::ReactNative::Composition::Experimental::implementation::
+                    MicrosoftCompositionContextHelper::WrapBrush(brush);
+              };
+          return image;
+        });
+
+    return imageRequest;
+  }
+
+  if (auto brushProvider =
+          provider.try_as<winrt::Microsoft::ReactNative::Composition::Experimental::IUriBrushProvider>()) {
+    ProcessImageRequestTask<winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory>(
+        weakObserverCoordinator,
+        brushProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource),
+        [](const winrt::Microsoft::ReactNative::Composition::Experimental::UriBrushFactory &factory) noexcept {
+          auto image =
+              std::make_shared<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>();
+          image->m_brushFactory = factory;
+          return image;
+        });
+
+    return imageRequest;
+  };
+
+  winrt::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> task;
+  if (auto imageStreamProvider =
+          provider.try_as<winrt::Microsoft::ReactNative::Composition::IUriImageStreamProvider>()) {
+    task = imageStreamProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource);
+  } else {
+    ReactImageSource source;
+    source.uri = imageSource.uri;
+    source.height = imageSource.size.height;
+    source.width = imageSource.size.width;
+    source.sourceType = ImageSourceType::Download;
+
+    task = GetImageStreamAsync(source);
+  }
+
+  // TODO progress? - Can we register for progress off the download task?
+  // observerCoordinator->nativeImageResponseProgress((float)progress / (float)total);
+
+  ProcessImageRequestTask<winrt::Windows::Storage::Streams::IRandomAccessStream>(
+      weakObserverCoordinator, task, [](const winrt::Windows::Storage::Streams::IRandomAccessStream &stream) {
+        return generateBitmap(stream);
+      });
 
   return imageRequest;
 }

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.cpp
@@ -9,6 +9,7 @@
 #include <Fabric/Composition/ImageResponseImage.h>
 #include <Fabric/Composition/UriImageManager.h>
 #include <Utils/ImageUtils.h>
+#include <functional/functor.h>
 #include <shcore.h>
 #include <wincodec.h>
 
@@ -78,7 +79,7 @@ std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::Imag
 template <typename T>
 void ProcessImageRequestTask(
     std::weak_ptr<const facebook::react::ImageResponseObserverCoordinator> &weakObserverCoordinator,
-    const winrt::IAsyncOperation<T> &task,
+    const winrt::Windows::Foundation::IAsyncOperation<T> &task,
     Mso::Functor<std::shared_ptr<winrt::Microsoft::ReactNative::Composition::implementation::ImageResponseImage>(
         const T &result)> &&onSuccess) {
   task.Completed([weakObserverCoordinator, onSuccess = std::move(onSuccess)](auto asyncOp, auto status) {
@@ -91,7 +92,7 @@ void ProcessImageRequestTask(
       case winrt::Windows::Foundation::AsyncStatus::Completed: {
         auto imageResponseImage = onSuccess(asyncOp.GetResults());
         if (imageResponseImage)
-          observerCoordinator.nativeImageResponseComplete(
+          observerCoordinator->nativeImageResponseComplete(
               facebook::react::ImageResponse(imageResponseImage, nullptr /*metadata*/));
         else
           observerCoordinator->nativeImageResponseFailed();
@@ -163,7 +164,7 @@ facebook::react::ImageRequest WindowsImageManager::requestImage(
     return imageRequest;
   };
 
-  winrt::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> task;
+  winrt::Windows::Foundation::IAsyncOperation<winrt::Windows::Storage::Streams::IRandomAccessStream> task;
   if (auto imageStreamProvider =
           provider.try_as<winrt::Microsoft::ReactNative::Composition::IUriImageStreamProvider>()) {
     task = imageStreamProvider.GetSourceAsync(m_reactContext.Handle(), rnImageSource);

--- a/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
+++ b/vnext/Microsoft.ReactNative/Fabric/WindowsImageManager.h
@@ -5,16 +5,21 @@
 
 #include <react/renderer/imagemanager/ImageRequest.h>
 
+#include <Fabric/Composition/UriImageManager.h>
 #include <ReactContext.h>
 
 namespace Microsoft::ReactNative {
 
 struct WindowsImageManager {
-  WindowsImageManager();
+  WindowsImageManager(winrt::Microsoft::ReactNative::ReactContext reactContext);
 
   facebook::react::ImageRequest requestImage(
       const facebook::react::ImageSource &imageSource,
       facebook::react::SurfaceId surfaceId) const;
+
+ private:
+  winrt::Microsoft::ReactNative::ReactContext m_reactContext;
+  winrt::com_ptr<winrt::Microsoft::ReactNative::Composition::implementation::UriImageManager> m_uriImageManager;
 };
 
 } // namespace Microsoft::ReactNative

--- a/vnext/Microsoft.ReactNative/UriImageManager.idl
+++ b/vnext/Microsoft.ReactNative/UriImageManager.idl
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import "IReactContext.idl";
+import "CompositionSwitcher.idl";
+
+#include "DocString.h"
+
+namespace Microsoft.ReactNative.Composition
+{
+  [default_interface]
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+    "Provides information about an image source requested by the application.")
+  runtimeclass ImageSource
+  {
+    Windows.Foundation.Uri Uri { get; };
+    Windows.Foundation.Size Size { get; };
+    Single Scale { get; };
+  };
+
+
+  [webhosthidden]
+  [experimental]
+  interface IUriImageProvider
+  {
+    DOC_STRING(
+      "This should return true if this provider will provide an image for the provided uri.")
+    Boolean CanLoadImageUri(Microsoft.ReactNative.IReactContext context, Windows.Foundation.Uri uri);
+  }
+
+  [webhosthidden]
+  [experimental]
+    DOC_STRING(
+      "This allows applications to provide their own image caching / storage pipelines. Or to generate images on the fly based on uri.")
+  interface IUriImageStreamProvider requires IUriImageProvider
+  {
+    DOC_STRING(
+      "Returns a stream of an image file that can be decoded by Windows Imaging Component - https://learn.microsoft.com/en-us/windows/win32/api/_wic/ ")
+    Windows.Foundation.IAsyncOperation<Windows.Storage.Streams.IRandomAccessStream> GetSourceAsync(Microsoft.ReactNative.IReactContext context, ImageSource imageSource);
+  }
+
+ 
+  [webhosthidden]
+  [experimental]
+  delegate Microsoft.UI.Composition.CompositionBrush UriBrushFactory(Microsoft.ReactNative.IReactContext reactContext, Microsoft.UI.Composition.Compositor compositor);
+
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+    "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
+  interface IUriBrushProvider requires IUriImageProvider
+  {
+  DOC_STRING(
+    "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
+    Windows.Foundation.IAsyncOperation<UriBrushFactory> GetSourceAsync(Microsoft.ReactNative.IReactContext context, Microsoft.ReactNative.Composition.ImageSource imageSource);
+  }
+
+  namespace Experimental {
+
+  [webhosthidden]
+  [experimental]
+  delegate Microsoft.ReactNative.Composition.Experimental.IBrush UriBrushFactory(Microsoft.ReactNative.IReactContext reactContext, Microsoft.ReactNative.Composition.Experimental.ICompositionContext compositionContext);
+
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+    "This allows applications to provide their own image rendering pipeline. Or to generate graphics on the fly based on uri.")
+  interface IUriBrushProvider requires Microsoft.ReactNative.Composition.IUriImageProvider
+  {
+    Windows.Foundation.IAsyncOperation<UriBrushFactory> GetSourceAsync(Microsoft.ReactNative.IReactContext context, Microsoft.ReactNative.Composition.ImageSource imageSource);
+  }
+  }
+
+  [default_interface]
+  [webhosthidden]
+  [experimental]
+  DOC_STRING(
+    "Ability to load images using custom Uri protocol handlers.  The provider should implement @IUriImageStreamProvider or @Experimental.IUriBrushProvider")
+  runtimeclass UriImageManager
+  {
+    static void AddUriImageProvider(Microsoft.ReactNative.IReactPropertyBag properties, IUriImageProvider provider);
+  }
+} // namespace Microsoft.ReactNative.Composition

--- a/vnext/Shared/Shared.vcxitems
+++ b/vnext/Shared/Shared.vcxitems
@@ -84,6 +84,16 @@
       <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\CompositionUIService.idl</DependentUpon>
       <SubType>Code</SubType>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UriImageManager.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\UriImageManager.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\UriImageManager_emptyimpl.cpp">
+      <ExcludedFromBuild Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' != 'true'">true</ExcludedFromBuild>
+      <DependentUpon>$(ReactNativeWindowsDir)Microsoft.ReactNative\UriImageManager.idl</DependentUpon>
+      <SubType>Code</SubType>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\Composition\CompositionViewComponentView.cpp">
       <ExcludedFromBuild Condition="'$(UseFabric)' != 'true'">true</ExcludedFromBuild>
     </ClCompile>
@@ -640,6 +650,7 @@
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactPackageBuilderFabric.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\IReactViewComponentBuilder.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\Theme.idl" />
+    <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\UriImageManager.idl" />
     <Midl Condition="'$(UseFabric)' == 'true' OR '$(IncludeFabricInterface)' == 'true'" Include="$(ReactNativeWindowsDir)Microsoft.ReactNative\ViewProps.idl" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
This provides hooks to allow applications to provide custom uri handers for loading images.  This can be used to integrate RN experiences with more custom image solutions.  For you could implement a handler for Uri's like `persona://userId`, which could 
load from a local image cache of user images.   Or `appicon://Play`, to load / render app icons.

This provides similar functionality to `RCTImageURLLoader` on iOS


### Why
In Office we make use of similar functionality on our internal RN implementation to render Office icons, and persona images.  This will replace that functionality in the fabric implementation.

### What
There a new API:

`UriImageManager::AddUriImageProvider(settings.Properties(), provider);`

where provider is one of either `IUriImageStreamProvider` which allows the app to return a stream of an image file, or `IUriBrushProvider` which allows the app to directly create a composition brush which is applied to the image.

I provided a sample implementation in the playground app for `ellipse://foo` which will draw a simple ellipse for the image.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13180)