### PR TITLE
UpgradeDependencies script should handle ^ dependencies

### DIFF
--- a/change/@rnw-scripts-integrate-rn-26cec256-11ae-49dd-a99b-8f14f22f8e92.json
+++ b/change/@rnw-scripts-integrate-rn-26cec256-11ae-49dd-a99b-8f14f22f8e92.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix upgradeDependencies when core has a ^ dependency",
+  "packageName": "@rnw-scripts/integrate-rn",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
+++ b/packages/@rnw-scripts/integrate-rn/src/upgradeDependencies.ts
@@ -493,7 +493,10 @@ function bumpSemver(origVersion: string, newVersion: string): string {
     throw new Error(`Unable to bump complicated semver '${origVersion}'`);
   }
 
-  if (origVersion.startsWith(`~`) || origVersion.startsWith('^')) {
+  if (
+    (origVersion.startsWith(`~`) || origVersion.startsWith('^')) &&
+    !(newVersion.startsWith(`~`) || newVersion.startsWith('^'))
+  ) {
     return `${origVersion[0]}${newVersion}`;
   } else {
     return newVersion;


### PR DESCRIPTION
When updating the 0.74 stable branch, the integrate-rn script tried to bump some package versions to ^^0.74.0.  This was caused by core moving their dependencies to be ^ dependencies, and our script always prepending ^.  
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13187)