### PR TITLE
Update readme with some mention of new architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,44 +28,43 @@ Visit the official [React Native for Windows + macOS website](https://microsoft.
 
 ## Contents
 
-- [Requirements](#requirements)
+- [Roadmap](#status-and-roadmap)
 - [Getting Started](#getting-started)
-- [Contributing](#contributing)
 - [Documentation](#documentation)
+- [Contributing](#contributing)
 - [License](#license)
 - [Code of Conduct](#code-of-conduct)
 
-### Status and roadmap
-[Check out our blog](https://microsoft.github.io/react-native-windows/blog/) if you'd like to stay up to date on the status of React Native for Windows and check out current and past roadmaps. We will post all new releases, updates and general news about the project there.
+## Status and roadmap
+[Check out our blog](https://microsoft.github.io/react-native-windows/blog/) if you'd like to stay up to date on the status of React Native for Windows and check out current and past roadmaps.
 
-## Requirements
-You can run React Native Windows apps only on devices supported by the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads).
-
-For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies) documentation on our website.
+### New Architecture
+[Fabric](https://reactnative.dev/architecture/fabric-renderer) is the new rendering system for React Native, designed to share more rendering logic cross-platform. RNW's existing Paper renderer is built on UWP XAML, dropping down into native Composition as need be; the new RNW Fabric renderer targets Composition from the start but has the ability to host islands of XAML for advanced native controls. Apps on the new architecture will be [WinAppSDK](https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/) Win32 by default. For detailed on our roadmap to Fabric, check out [this pinned issue](https://github.com/microsoft/react-native-windows/issues/12042).
 
 ## Getting Started
 See the [Getting Started Guide](https://microsoft.github.io/react-native-windows/docs/getting-started) on our React Native for Windows + macOS website to build your first React Native for Windows app.
 
-### Logging Issues
-Search the [existing issues](https://github.com/microsoft/react-native-windows/issues) and try to make sure your problem doesn’t already exist before opening a new issue. If your issue doesn't exist yet, try to make sure you provide as much information as possible to us so we can help you sooner. It’s helpful if you include information like:
+### Requirements
+You can run React Native Windows apps only on devices supported by the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads).
 
-- The version of Windows, React Native, React Native Windows extension, and device family (i.e., mobile, desktop, Xbox, etc.) where you ran into the issue.
-- A stack trace and reduced repro case when possible.
-- Ensure the [appropriate template](https://github.com/microsoft/react-native-windows/issues/new/choose) is used when filing your issue(s).
+For a full and detailed list of the system requirements and how to set up your development platform, see our [System Requirements](https://microsoft.github.io/react-native-windows/docs/rnw-dependencies) documentation on our website.
+
+### Logging Issues
+Search the [existing issues](https://github.com/microsoft/react-native-windows/issues) and try to make sure your problem doesn’t already exist before opening a new issue. If your issue doesn't exist yet, provide as much information as possible so we can better help you. Include the information requested by the [appropriate issue template](https://github.com/microsoft/react-native-windows/issues/new/choose).
+
+## Documentation
+React Native has [great documentation](https://reactnative.dev/docs/getting-started). React Native for Windows adds it's own separate [Windows and macOS documentation](https://microsoft.github.io/react-native-windows/) for desktop platform information like API docs and blog updates.
+
+### Examples
+- Using the CLI in the [Getting Started](https://microsoft.github.io/react-native-windows/docs/getting-started) guide will set you up with a sample React Native for Windows app that you can begin editing right away.
+- Check the [samples repo](https://github.com/microsoft/react-native-windows-samples) for more standalone samples.
+- The [React Native Gallery](https://github.com/microsoft/react-native-gallery) app demonstrates various components in an interactive way.
+- For more sample code browse the [RNTester folder](https://github.com/microsoft/react-native-windows/tree/main/packages/e2e-test-app/windows/RNTesterApp) in the GitHub web UI
 
 ## Contributing
 See [Contributing guidelines](https://github.com/microsoft/react-native-windows/blob/main/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native for Windows.
 
-[good first issue](https://github.com/microsoft/react-native-windows/labels/good%20first%20issue) and [help wanted](https://github.com/microsoft/react-native-windows/labels/help%20wanted) are great starting points for PRs.
-
-## Documentation
-[React Native already has great documentation](https://reactnative.dev/docs/getting-started) and we're working to ensure the React Native Windows is part of that documentation story.
-
-[React Native for Windows](https://microsoft.github.io/react-native-windows/) has it's own separate documentation site where Windows and macOS specific information, like API docs and blog updates live.
-
-### Examples
-- Using the CLI in the [Getting Started](https://microsoft.github.io/react-native-windows/docs/getting-started) guide will set you up with a sample React Native for Windows app that you can begin editing right away.
-- If you're looking for sample code, just browse the RNTester folder in the GitHub web UI
+Not sure where to start? The [good first issue](https://github.com/microsoft/react-native-windows/labels/good%20first%20issue) and [help wanted](https://github.com/microsoft/react-native-windows/labels/help%20wanted) labels are the best starting points.
 
 ## License
 The React Native Windows extension, including modifications to the original Meta source code, and all newly contributed code is provided under the [MIT License](LICENSE). Portions of the React Native Windows extension derived from React Native are copyright Meta.

--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ For a full and detailed list of the system requirements and how to set up your d
 Search the [existing issues](https://github.com/microsoft/react-native-windows/issues) and try to make sure your problem doesn’t already exist before opening a new issue. If your issue doesn't exist yet, provide as much information as possible so we can better help you. Include the information requested by the [appropriate issue template](https://github.com/microsoft/react-native-windows/issues/new/choose).
 
 ## Documentation
-React Native has [great documentation](https://reactnative.dev/docs/getting-started). React Native for Windows adds it's own separate [Windows and macOS documentation](https://microsoft.github.io/react-native-windows/) for desktop platform information like API docs and blog updates.
+React Native has [great documentation](https://reactnative.dev/docs/getting-started). React Native for Windows adds its own separate [Windows and macOS documentation](https://microsoft.github.io/react-native-windows/) for desktop platform information like API docs and blog updates.
 
 ### Examples
 - Using the CLI in the [Getting Started](https://microsoft.github.io/react-native-windows/docs/getting-started) guide will set you up with a sample React Native for Windows app that you can begin editing right away.
 - Check the [samples repo](https://github.com/microsoft/react-native-windows-samples) for more standalone samples.
 - The [React Native Gallery](https://github.com/microsoft/react-native-gallery) app demonstrates various components in an interactive way.
-- For more sample code browse the [RNTester folder](https://github.com/microsoft/react-native-windows/tree/main/packages/e2e-test-app/windows/RNTesterApp) in the GitHub web UI
+- Check out the [React Native Developer Blog](https://devblogs.microsoft.com/react-native/) to see examples from past conference talks, blog posts, and more.
+- For more sample code browse the [RNTester folder](https://github.com/microsoft/react-native-windows/tree/main/packages/e2e-test-app/windows/RNTesterApp) in the GitHub web UI.
 
 ## Contributing
 See [Contributing guidelines](https://github.com/microsoft/react-native-windows/blob/main/CONTRIBUTING.md) for how to setup your fork of the repo and start a PR to contribute to React Native for Windows.


### PR DESCRIPTION

## Description

### Type of Change
Documentation only. No product changes.

### Why
Readme didn't cover some FAQs around new architecture, and was missing key links to helper repos.

### What
- Add summary of Fabric roadmap with link to pinned issue
- Move Requirements section to be a subsection of "Getting Started"
- Move "Documentation" before "Contributing"
- Flesh out "Examples" section with missing samples repo and gallery repo references
- Tighten up various language

## Changelog
Should this change be included in the release notes: No
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13192)