### PR TITLE
 Change Hermes package version to 0.1.21

### DIFF
--- a/change/react-native-windows-2976e0bc-5fc3-4c0a-aa79-12b3577aaff6.json
+++ b/change/react-native-windows-2976e0bc-5fc3-4c0a-aa79-12b3577aaff6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change Hermes package version to 0.1.21",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -6,7 +6,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.18</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.21</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\Microsoft.JavaScript.Hermes\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>

--- a/vnext/Shared/HermesRuntimeHolder.cpp
+++ b/vnext/Shared/HermesRuntimeHolder.cpp
@@ -292,6 +292,10 @@ void NAPI_CDECL removeInspectorPage(int32_t pageId) noexcept {
 
 } // namespace
 
+//==============================================================================
+// HermesRuntimeHolder implementation
+//==============================================================================
+
 HermesRuntimeHolder::HermesRuntimeHolder(
     std::shared_ptr<facebook::react::DevSettings> devSettings,
     std::shared_ptr<facebook::react::MessageQueueThread> jsQueue,
@@ -393,6 +397,10 @@ void HermesRuntimeHolder::removeFromProfiling() const noexcept {
 /*static*/ void HermesRuntimeHolder::dumpSampledTraceToFile(const std::string &fileName) noexcept {
   CRASH_ON_ERROR(getHermesApi().hermes_sampling_profiler_dump_to_file(fileName.c_str()));
 }
+
+//==============================================================================
+// HermesJSRuntime implementation
+//==============================================================================
 
 HermesJSRuntime::HermesJSRuntime(std::shared_ptr<Microsoft::JSI::RuntimeHolderLazyInit> hermesRuntimeHolder)
     : m_holder(std::move(hermesRuntimeHolder)) {}


### PR DESCRIPTION
## Description
Changes Hermes package version to 0.1.21

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The new Hermes version 0.1.21 matches to the code used by RN version 0.74.1:
- Catch up with Hermes changes done in the previous 9 months.
- Fix the debugger experience for 0.74, 0.73, 0.72, and 0.71 by enabling debug info in the JS byte code when the direct debugging is enabled for a RN instance.

Note that the debugging story is still broken in main. It is going to be addressed in the next version.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13207)