### PR TITLE
[0.73] Change Hermes package version to 0.1.21 (#13207) 

### DIFF
--- a/change/react-native-windows-bcdac51c-fc92-4116-9f26-94a1ffdc0071.json
+++ b/change/react-native-windows-bcdac51c-fc92-4116-9f26-94a1ffdc0071.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Change Hermes package version to 0.1.21",
+  "packageName": "react-native-windows",
+  "email": "vmorozov@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/PropertySheets/JSEngine.props
+++ b/vnext/PropertySheets/JSEngine.props
@@ -14,7 +14,7 @@
     <!-- Enabling this will (1) Include hermes glues in the Microsoft.ReactNative binaries AND (2) Make hermes the default engine -->
     <UseHermes Condition="'$(UseHermes)' == ''">true</UseHermes>
     <!-- This will be true if (1) the client want to use hermes by setting UseHermes to true OR (2) We are building for UWP where dynamic switching is enabled -->
-    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.18</HermesVersion>
+    <HermesVersion Condition="'$(HermesVersion)' == ''">0.1.21</HermesVersion>
     <HermesPackage Condition="'$(HermesPackage)' == '' And Exists('$(PkgMicrosoft_JavaScript_Hermes)')">$(PkgMicrosoft_JavaScript_Hermes)</HermesPackage>
     <HermesPackage Condition="'$(HermesPackage)' == ''">$(NuGetPackageRoot)\Microsoft.JavaScript.Hermes\$(HermesVersion)</HermesPackage>
     <EnableHermesInspectorInReleaseFlavor Condition="'$(EnableHermesInspectorInReleaseFlavor)' == ''">false</EnableHermesInspectorInReleaseFlavor>

--- a/vnext/Shared/Shared.vcxitems.filters
+++ b/vnext/Shared/Shared.vcxitems.filters
@@ -277,6 +277,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Modules\BlobCollector.cpp">
       <Filter>Source Files\Modules</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewProps.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\Microsoft.ReactNative\Fabric\platform\react\renderer\components\view\HostPlatformViewEventEmitter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Source Files">


### PR DESCRIPTION
## Description
Changes Hermes package version to 0.1.21
Cherry pick #13207 

### Type of Change
- New feature (non-breaking change which adds functionality)

### Why
The new Hermes version 0.1.21 matches to the code used by RN version 0.74.1:
- Catch up with Hermes changes done in the previous 9 months.
- Fix the debugger experience for 0.74, 0.73, 0.72, and 0.71 by enabling debug info in the JS byte code when the direct debugging is enabled for a RN instance.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13210)