### PR TITLE
Update rnw-dependencies script to check for the correct Node version

### DIFF
--- a/change/react-native-windows-c908b5fb-05b3-4467-b516-200173e732f1.json
+++ b/change/react-native-windows-c908b5fb-05b3-4467-b516-200173e732f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update rnw-dependencies script to check for the correct Node version",
+  "packageName": "react-native-windows",
+  "email": "email not defined",
+  "dependentChangeType": "none"
+}

--- a/vnext/Scripts/rnw-dependencies.ps1
+++ b/vnext/Scripts/rnw-dependencies.ps1
@@ -240,8 +240,9 @@ function CheckNode {
     try {
         $nodeVersion = (Get-Command node -ErrorAction Stop).Version;
         Write-Verbose "Node version found: $nodeVersion";
-        $v = $nodeVersion.Major;
-        return ($v -ge 18) -and (($v % 2) -eq 0);
+        $major = $nodeVersion.Major;
+        $minor = $nodeVersion.Minor;
+        return ($major -ge 18) -and ($minor -ge 18);
     } catch { Write-Debug $_ }
 
     Write-Verbose "Node not found.";
@@ -437,7 +438,7 @@ $requirements = @(
     },
     @{
         Id=[CheckId]::Node;
-        Name = 'Node.js (LTS, >= 18.0)';
+        Name = 'Node.js (LTS, >= 18.18)';
         Tags = @('appDev');
         Valid = { CheckNode; }
         Install = { WinGetInstall OpenJS.NodeJS.LTS "18.18.0" };


### PR DESCRIPTION
Started seeing this after a sync to main:
![image](https://github.com/microsoft/react-native-windows/assets/1422161/fa1f626e-9fe7-408b-aef4-0a0afea9a629)

I ran rnw-dependencies.ps1 and noticed it was passing because it only checks that your Node version is >= 18 even though it installs 18.18. 
![image](https://github.com/microsoft/react-native-windows/assets/1422161/c9e7adb2-574e-407f-a0e1-0ac00e9820ca)

Updating script to check for 18.18
![image](https://github.com/microsoft/react-native-windows/assets/1422161/3b706c75-2f3f-415f-afde-2152534d8696)

## Changelog
Should this change be included in the release notes: no
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13211)