### PR TITLE
fix(TextInput/isFocused): correctly handle null focused input

### DIFF
--- a/packages/@office-iss/react-native-win32/src-win/Libraries/Components/TextInput/TextInput.win32.js
+++ b/packages/@office-iss/react-native-win32/src-win/Libraries/Components/TextInput/TextInput.win32.js
@@ -1278,9 +1278,9 @@ function InternalTextInput(props: Props): React.Node {
               );
             }
           },
-          // TODO: Fix this returning true on null === null, when no input is focused
           isFocused(): boolean {
-            return TextInputState.currentlyFocusedInput() === inputRef.current;
+            const currentlyFocusedInput = TextInputState.currentlyFocusedInput();
+            return currentlyFocusedInput !== null && currentlyFocusedInput === inputRef.current;
           },
           getNativeRef(): ?React.ElementRef<HostComponent<mixed>> {
             return inputRef.current;

--- a/vnext/src-win/Libraries/Components/TextInput/TextInput.windows.js
+++ b/vnext/src-win/Libraries/Components/TextInput/TextInput.windows.js
@@ -1310,9 +1310,9 @@ function InternalTextInput(props: Props): React.Node {
               );
             }
           },
-          // TODO: Fix this returning true on null === null, when no input is focused
           isFocused(): boolean {
-            return TextInputState.currentlyFocusedInput() === inputRef.current;
+            const currentlyFocusedInput = TextInputState.currentlyFocusedInput();
+            return currentlyFocusedInput !== null && currentlyFocusedInput === inputRef.current;
           },
           getNativeRef(): ?React.ElementRef<HostComponent<mixed>> {
             return inputRef.current;


### PR DESCRIPTION
## Description

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Why

Resolves 2 TODO items.

### What
I've modified the `isFocused` function to correctly handle the case when there's no input focused. Previously, the function returned true when `TextInputState.currentlyFocusedInput()` was null, leading to incorrect behavior. The fix ensures that the function now returns false when there's no input focused.

## Changelog
Should this change be included in the release notes: _yes_

Summary: *Fixed `isFocused` function to handle null focused input correctly*
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13217)