### PR TITLE
Fixing crash when passing null children to view with no-hide-descendents

### DIFF
--- a/change/react-native-windows-4d35cfde-27d7-409c-903e-1e2bec97cb74.json
+++ b/change/react-native-windows-4d35cfde-27d7-409c-903e-1e2bec97cb74.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Preventing crash when passing null children to view with no-hide-descendents",
+  "packageName": "react-native-windows",
+  "email": "30809111+acoates-ms@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/vnext/src-win/Libraries/Components/View/View.windows.js
+++ b/vnext/src-win/Libraries/Components/View/View.windows.js
@@ -175,6 +175,9 @@ const View: React.AbstractComponent<
     // [Windows
     // $FlowFixMe - children typing
     const childrenWithImportantForAccessibility = children => {
+      if (children == null) {
+        return children;
+      }
       const updatedChildren = React.Children.map(children, child => {
         if (React.isValidElement(child)) {
           // $FlowFixMe[incompatible-use]


### PR DESCRIPTION
## Description

When passing null to the children prop of a view that uses `importantForAccessibility="no-hide-descendents"`, React Native Windows JS code wil crash due to the assumption that in this case, the children must be nonnull. React allows null and undefined on the type `ReactNode`, which is the go to type for declaring the type for the children prop on a component.

This is most likely a rare combination of props, though it is still valid. React.Children.map() has the following type:
`map<T, C>(children: C | readonly C[], fn: (child: C, index: number) => T): C extends null | undefined ? C : Exclude<T, boolean | null | undefined>[];`
 The fix proposed is to check for null or undefined before using React.Children.map().

### Type of Change
- Bug fix (non-breaking change which fixes an issue)

### Why
This fixes a crash that my team in Xbox has encountered when upgrading our RNW version to 0.73 from 0.69. This is a pre-emptive fix as we caught this prior to check-in.

### What
I've added defensive code to validate this codepath.

## Screenshots
Add any relevant screen captures here from before or after your changes. 

## Testing
This is the fix we have in Xbox. Our testing is that it doesn't crash in this scenario anymore.

## Changelog
yes if reasonable. This returns functionality that should be there.

"Fixed a crash that occurred when passing null to a View with `"no-hide-descendents"` set for `importantForAccessibility`.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/react-native-windows/pull/13224)